### PR TITLE
fix: properly check for oc status

### DIFF
--- a/hacbscopy.sh
+++ b/hacbscopy.sh
@@ -39,7 +39,7 @@ check_requirements() {
         fi
     done
 
-    oc status &>/dev/null || echo "Error: Not logged in into a cluster" >&2 && exit 4
+    oc status &>/dev/null || (echo "Error: Not logged in into a cluster" >&2 && exit 4)
 }
 
 #######################################


### PR DESCRIPTION
The code was missing parenthesis to make a proper check of the connection to the cluster.

Signed-off-by: David Moreno García <damoreno@redhat.com>