### PR TITLE
fix: add small delay to let the repo being created

### DIFF
--- a/hacbscopy.sh
+++ b/hacbscopy.sh
@@ -62,6 +62,8 @@ copy_application() {
     echo "Copying application '$application' to namespace '$WORKSPACE'"
     eval "kubectl get application $application --namespace=$namespace -o json | $CLEANUP_COMMAND | kubectl apply -n $WORKSPACE -f -"
 
+    sleep 5
+
     echo "Copying application '$application' components"
     copy_components "$namespace" "$application"
 }


### PR DESCRIPTION
There's an small race condition as the components need the application repo to be created before being processed. Sleeping for 5 seconds should be enough for now.

Signed-off-by: David Moreno García <damoreno@redhat.com>