### PR TITLE
feat: show help message without requiring oc

### DIFF
--- a/copy-application.sh
+++ b/copy-application.sh
@@ -192,6 +192,6 @@ show_help() {
     echo -e "\n  -h, --help        display this help"
 }
 
-check_requirements
 parse_arguments
+check_requirements
 copy_applications


### PR DESCRIPTION
The execution order for the functions was not right and it was forcing some tools being present even for showing the help message. This change fixes the order.

Signed-off-by: David Moreno García <damoreno@redhat.com>