### PR TITLE
feat(RHTAPREL-803): update operator toolkit reference

### DIFF
--- a/.tekton/release-service-utils-pull-request.yaml
+++ b/.tekton/release-service-utils-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/redhat-appstudio/release-service-utils?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/konflux-ci/release-service-utils?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/release-service-utils-push.yaml
+++ b/.tekton/release-service-utils-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/redhat-appstudio/release-service-utils?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/konflux-ci/release-service-utils?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"


### PR DESCRIPTION
 This commit updates the `release-service-utils` refrence
 as result of migration to `konflux-ci` from `redhat-appstudio`
 more details parent EPIC:
 https://issues.redhat.com/browse/RHTAPREL-800