### PR TITLE
fix(RELEASE-1): get-image-architectures uses compact json

### DIFF
--- a/utils/get-image-architectures
+++ b/utils/get-image-architectures
@@ -25,9 +25,9 @@ if [ $(jq -r '.mediaType' <<< $RAW_OUTPUT) == "application/vnd.oci.image.manifes
     os=$(jq -r '.Os' <<< $RAW_OUTPUT)
     digest=$(jq -r '.Digest' <<< $RAW_OUTPUT)
 
-    jq -r -n --arg architecture "$architecture" --arg os "$os" --arg digest "$digest" \
+    jq -cr -n --arg architecture "$architecture" --arg os "$os" --arg digest "$digest" \
         '{"platform": {"architecture": $ARGS.named["architecture"], "os": $ARGS.named["os"]}, "digest": $ARGS.named["digest"]}'
 else
     # Multi arch
-    jq -r '.manifests[]' <<< $RAW_OUTPUT
+    jq -cr '.manifests[]' <<< $RAW_OUTPUT
 fi


### PR DESCRIPTION
The tekton tasks would all need to change the json to compact if we do not do it here.