### PR TITLE
fix: update codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @redhat-appstudio/konflux-release-team will be requested for
+# @konflux-ci/release-service-maintainers will be requested for
 # review when someone opens a pull request.
-*       @redhat-appstudio/konflux-release-team
+*       @konflux-ci/release-service-maintainers


### PR DESCRIPTION
- The team name changed after migration to konflux-ci. 
The CODEOWNER requires an update to match the new name.