### PR TITLE
fix(KFLUXBUGS-1294): add cleanup_tags script for cleaning up tags

### DIFF
--- a/pyxis/cleanup_tags
+++ b/pyxis/cleanup_tags
@@ -1,0 +1,1 @@
+cleanup_tags.py

--- a/pyxis/cleanup_tags.py
+++ b/pyxis/cleanup_tags.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""
+Python script to clean up tags from previous Container Image objects in Pyxis
+
+It takes a Pyxis image id for input and it will check the tags this image has
+and then it will look for all other images with the same arch and repo
+and it will remove all the tags that are present in the image provided as input.
+
+Required env vars:
+PYXIS_KEY_PATH
+PYXIS_CERT_PATH
+
+Optional env vars:
+PYXIS_GRAPHQL_API
+"""
+import argparse
+import logging
+import string
+import os
+import time
+from typing import List, Dict, Any
+
+import pyxis
+
+LOGGER = logging.getLogger("cleanup_tags")
+
+
+def parse_arguments() -> argparse.Namespace:  # pragma: no cover
+    """Parse CLI arguments
+
+    :return: Dictionary of parsed arguments
+    """
+
+    parser = argparse.ArgumentParser(description="Clean up tags from previous images in Pyxis")
+
+    parser.add_argument(
+        "--pyxis-graphql-api",
+        default=os.environ.get(
+            "PYXIS_GRAPHQL_API", "https://graphql-pyxis.api.redhat.com/graphql/"
+        ),
+        help="Pyxis Graphql endpoint",
+    )
+    parser.add_argument(
+        "image_id",
+        help="Pyxis Container Image ID",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    parser.add_argument(
+        "--retry",
+        "-r",
+        action="store_true",
+        help="If set, retry the upload in case it fails",
+    )
+
+    return parser.parse_args()
+
+
+def cleanup_tags_with_retry(
+    graphql_api: str,
+    image_id: str,
+    retries: int = 3,
+    backoff_factor: float = 5.0,
+):
+    last_err = RuntimeError()
+    for attempt in range(retries):
+        try:
+            time.sleep(backoff_factor * attempt)
+            cleanup_tags(graphql_api, image_id)
+            return
+        except RuntimeError as e:
+            LOGGER.warning(f"Attempt {attempt+1} failed.")
+            last_err = e
+    LOGGER.error("Out of attempts. Raising the error.")
+    raise last_err
+
+
+def cleanup_tags(graphql_api, image_id: str):
+    image = get_image(graphql_api, image_id)
+
+    registry, repository, tags = get_rh_registry_image_properties(image)
+
+    LOGGER.info(f"Image id: {image['_id']}")
+    LOGGER.info(f"Image architecture: {image['architecture']}")
+    LOGGER.info(f"Image tags: {tags}")
+
+    images_for_cleanup = {}
+
+    for tag in tags:
+        candidates = get_candidates_for_cleanup(
+            graphql_api,
+            registry,
+            repository,
+            tag,
+        )
+        for candidate in candidates:
+            id = candidate["_id"]
+            if (
+                id != image["_id"]
+                and id not in images_for_cleanup
+                and candidate["architecture"] == image["architecture"]
+            ):
+                images_for_cleanup[id] = candidate
+
+    LOGGER.info(f"Found {len(images_for_cleanup)} images for cleanup.")
+    update_images(graphql_api, tags, images_for_cleanup)
+
+
+def get_image(graphql_api: str, image_id: str) -> dict:
+    """Get ContainerImage object from Pyxis using GraphQL API"""
+    query = """
+query ($id: ObjectIDFilterScalar!) {
+    get_image(id: $id) {
+        data {
+            _id
+            architecture
+            repositories {
+                registry
+                repository
+                tags {
+                    name
+                }
+            }
+        }
+        error {
+            status
+            detail
+        }
+    }
+}
+    """
+    variables = {"id": image_id}
+    body = {"query": query, "variables": variables}
+
+    data = pyxis.graphql_query(graphql_api, body)
+    image = data["get_image"]["data"]
+
+    return image
+
+
+def get_rh_registry_image_properties(image: Dict):
+    """Get the registry.access.redhat.com repository properties of the image
+    needed to search for related images.
+
+    Returns (registry, repository, tags)
+    """
+    for repo in image["repositories"]:
+        if repo["registry"] == "registry.access.redhat.com":
+            tags = [tag["name"] for tag in repo["tags"]]
+            return repo["registry"], repo["repository"], tags
+    raise RuntimeError(
+        "Cannot find the registry.access.redhat.com repository entry for the image"
+    )
+
+
+def get_candidates_for_cleanup(
+    graphql_api, registry, repository, tag: str, page_size: int = 50
+):
+    """Get ContainerImage objects from Pyxis using GraphQL API
+
+    The function will get all the images based on the registry, repository and tag
+    and it will return a list of them.
+    """
+    # Get all ContainerImage.Repositories fields
+    # See https://catalog.redhat.com/api/containers/docs/objects/ContainerImageRepo.html
+    query = """
+query (
+    $registry: String!, $repository: String!, $tag: String!,
+    $page: Int!, $page_size: Int!) {
+    find_repository_images_by_registry_path_tag(
+        registry: $registry,
+        repository: $repository,
+        tag: $tag,
+        page: $page,
+        page_size: $page_size) {
+        data {
+            _id
+            architecture
+            repositories {
+                published
+                registry
+                repository
+                tags {
+                    name
+                    added_date
+                    manifest_schema1_digest
+                    removed_date
+                }
+                comparison {
+                    advisory_rpm_mapping {
+                        advisory_ids
+                        nvra
+                    }
+                    reason
+                    reason_text
+                    rpms {
+                        downgrade
+                        new
+                        remove
+                        upgrade
+                    }
+                    with_nvr
+                }
+                content_advisory_ids
+                image_advisory_id
+                manifest_list_digest
+                manifest_schema2_digest
+                published_date
+                push_date
+                signatures {
+                    key_long_id
+                    tags
+                }
+            }
+        }
+        error {
+            status
+            detail
+        }
+    }
+}
+    """
+    has_more = True
+    page = 0
+    images = []
+
+    while has_more:
+        variables = {
+            "registry": registry,
+            "repository": repository,
+            "tag": tag,
+            "page": page,
+            "page_size": page_size,
+        }
+        body = {"query": query, "variables": variables}
+
+        data = pyxis.graphql_query(graphql_api, body)
+        images_batch = data["find_repository_images_by_registry_path_tag"]["data"]
+        images.extend(images_batch)
+
+        has_more = len(images_batch) == page_size
+        page += 1
+
+    return images
+
+
+def update_images(graphql_api: str, tags: List[str], images: Dict):
+    """Update images to remove unwanted tags from them
+
+    For each image in `images` it will remove all `tags`
+    from its repositories and then it will update the image
+    using graphql mutation update_image.
+    """
+    for image in images.values():
+        LOGGER.info(f"Updating image {image['_id']} with architecture {image['architecture']}")
+        LOGGER.info("Repositories and tags before update:")
+        for repository in image["repositories"]:
+            repo_tags = [tag["name"] for tag in repository["tags"]]
+            LOGGER.info(f"  {repository['registry']}/{repository['repository']}: {repo_tags}")
+        for i in range(len(image["repositories"])):
+            repo_tags = image["repositories"][i]["tags"]
+            image["repositories"][i]["tags"] = [
+                tag for tag in repo_tags if tag["name"] not in tags
+            ]
+        # When we load the images for patching, we request all fields of
+        # the ContainerRepository objects because otherwise we might remove some data with
+        # the update. But that means that fields that are not used will be null/None and
+        # if you try to include those in the update request, Pyxis will fail with errors like:
+        # 'signatures': ['Field may not be null.']
+        # So these null items must be removed before making the update request.
+        image = remove_none_values(image)
+        updated_image = update_image(graphql_api, image)
+        LOGGER.info("Repositories and tags after update:")
+        for repository in updated_image["repositories"]:
+            repo_tags = (
+                [tag["name"] for tag in repository["tags"]]
+                if repository["tags"] is not None
+                else []
+            )
+            LOGGER.info(f"  {repository['registry']}/{repository['repository']}: {repo_tags}")
+
+
+def update_image(graphql_api: str, image: Dict):
+    """Update image using Pyxis GraphQL API"""
+    mutation = """
+mutation ($id: ObjectIDFilterScalar!, $input: ContainerImageInput!) {
+    update_image(id: $id, input: $input) {
+        data {
+            _id
+            architecture
+            repositories {
+                registry
+                repository
+                tags {
+                    name
+                }
+            }
+        }
+        error {
+            status
+            detail
+        }
+    }
+}
+    """
+    variables = {"id": image["_id"], "input": image}
+    body = {"query": mutation, "variables": variables}
+
+    data = pyxis.graphql_query(graphql_api, body)
+    updated_image = data["update_image"]["data"]
+
+    return updated_image
+
+
+def remove_none_values(d: Any):
+    """
+    Recursively remove all items from the dictionary (or nested dictionaries) which are None.
+    """
+    if not isinstance(d, dict):
+        return d
+
+    cleaned_dict = {}
+    for key, value in d.items():
+        if isinstance(value, dict):
+            # Recursively clean the nested dictionary
+            cleaned_value = remove_none_values(value)
+            if cleaned_value:  # Add only if the nested dictionary is not empty
+                cleaned_dict[key] = cleaned_value
+        elif isinstance(value, list):
+            # Recursively clean the list
+            cleaned_list = [remove_none_values(item) for item in value if item is not None]
+            if cleaned_list:  # Add only if the list is not empty
+                cleaned_dict[key] = cleaned_list
+        elif value is not None:
+            cleaned_dict[key] = value
+
+    return cleaned_dict
+
+
+def main():  # pragma: no cover
+    """Main func"""
+    args = parse_arguments()
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    pyxis.setup_logger(level=log_level)
+
+    if not all(c in string.hexdigits for c in args.image_id):
+        raise ValueError(
+            f"image-id is invalid, hexadecimal value is expected: {args.image_id}"
+        )
+    LOGGER.debug(f"Image ID: {args.image_id}")
+
+    LOGGER.debug(f"Pyxis GraphQL API: {args.pyxis_graphql_api}")
+
+    if args.retry:
+        cleanup_tags_with_retry(args.pyxis_graphql_api, args.image_id)
+    else:
+        cleanup_tags(args.pyxis_graphql_api, args.image_id)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyxis/test_cleanup_tags.py
+++ b/pyxis/test_cleanup_tags.py
@@ -1,0 +1,268 @@
+import pytest
+from unittest.mock import patch, call
+
+from cleanup_tags import (
+    cleanup_tags_with_retry,
+    cleanup_tags,
+    get_image,
+    get_rh_registry_image_properties,
+    get_candidates_for_cleanup,
+    update_images,
+    update_image,
+    remove_none_values,
+)
+
+GRAPHQL_API = "myapiurl"
+IMAGE_ID = "1111"
+REGISTRY = "registry.access.redhat.com"
+REPOSITORY = "myproduct/myimage"
+
+
+@patch("cleanup_tags.cleanup_tags")
+def test_cleanup_tags_with_retry__success(mock_cleanup_tags):
+    """cleanup_tags succeeds on first attempt"""
+    cleanup_tags_with_retry(GRAPHQL_API, IMAGE_ID)
+
+    mock_cleanup_tags.assert_called_once_with(GRAPHQL_API, IMAGE_ID)
+
+
+@patch("cleanup_tags.cleanup_tags")
+def test_cleanup_tags_with_retry__success_after_one_attempt(mock_cleanup_tags):
+    """cleanup_tags succeeds after one retry"""
+    mock_cleanup_tags.side_effect = [RuntimeError("error"), None]
+
+    cleanup_tags_with_retry(GRAPHQL_API, IMAGE_ID, backoff_factor=0)
+
+    assert mock_cleanup_tags.call_count == 2
+
+
+@patch("cleanup_tags.cleanup_tags")
+def test_cleanup_tags_with_retry__fails(mock_cleanup_tags):
+    """cleanup_tags fails constantly, so the retry eventually fails"""
+    mock_cleanup_tags.side_effect = RuntimeError("error")
+
+    with pytest.raises(RuntimeError):
+        cleanup_tags_with_retry(GRAPHQL_API, IMAGE_ID, retries=2, backoff_factor=0)
+
+    assert mock_cleanup_tags.call_count == 2
+
+
+@patch("cleanup_tags.update_images")
+@patch("cleanup_tags.get_candidates_for_cleanup")
+@patch("cleanup_tags.get_image")
+def test_cleanup_tags__success(
+    mock_get_image,
+    mock_get_candidates_for_cleanup,
+    mock_update_images,
+):
+    """
+    Most common use case - there are 4 candidates for cleanup in total:
+    - 1 is the very same image we use as input, so it's skipped
+    - 1 has tags to be removed
+    - 2 are a different arch, so they are skipped
+    """
+    image1 = generate_image("1111", "amd64", ["latest", "9.4", "9.4-1111"])
+    image2 = generate_image("2222", "amd64", ["latest", "9.4", "9.4-2222"])
+    image3 = generate_image("3333", "arm64", ["latest", "9.4", "9.4-1111"])
+    image4 = generate_image("4444", "arm64", ["latest", "9.4", "9.4-2222"])
+    mock_get_image.return_value = image1
+    mock_get_candidates_for_cleanup.side_effect = [
+        [image1, image2, image3, image4],
+        [image1, image2, image3, image4],
+        [image1, image3],
+    ]
+
+    cleanup_tags(GRAPHQL_API, "1111")
+
+    mock_get_image.assert_called_once_with(GRAPHQL_API, "1111")
+    assert mock_get_candidates_for_cleanup.call_args_list == [
+        call(GRAPHQL_API, REGISTRY, REPOSITORY, "latest"),
+        call(GRAPHQL_API, REGISTRY, REPOSITORY, "9.4"),
+        call(GRAPHQL_API, REGISTRY, REPOSITORY, "9.4-1111"),
+    ]
+    mock_update_images.assert_called_once_with(
+        GRAPHQL_API, ["latest", "9.4", "9.4-1111"], {image2["_id"]: image2}
+    )
+
+
+@patch("cleanup_tags.update_images")
+@patch("cleanup_tags.get_candidates_for_cleanup")
+@patch("cleanup_tags.get_image")
+def test_cleanup_tags__nothing_to_cleanup(
+    mock_get_image,
+    mock_get_candidates_for_cleanup,
+    mock_update_images,
+):
+    """
+    A case when no other image (with the same architecture) has any tags in common
+    - 1 is the very same image we use as input, so it's skipped
+    - 1 has tags to be removed
+    - 2 are a different arch, so they are skipped
+    """
+    image1 = generate_image("1111", "amd64", ["latest", "9.4", "9.4-1111"])
+    image2 = generate_image("2222", "arm64", ["latest", "9.4", "9.4-1111"])
+    mock_get_image.return_value = image1
+    mock_get_candidates_for_cleanup.side_effect = [
+        [image1, image2],
+        [image1, image2],
+        [image1, image2],
+    ]
+
+    cleanup_tags(GRAPHQL_API, "1111")
+
+    mock_get_image.assert_called_once_with(GRAPHQL_API, "1111")
+    assert mock_get_candidates_for_cleanup.call_args_list == [
+        call(GRAPHQL_API, REGISTRY, REPOSITORY, "latest"),
+        call(GRAPHQL_API, REGISTRY, REPOSITORY, "9.4"),
+        call(GRAPHQL_API, REGISTRY, REPOSITORY, "9.4-1111"),
+    ]
+    mock_update_images.assert_called_once_with(GRAPHQL_API, ["latest", "9.4", "9.4-1111"], {})
+
+
+@patch("pyxis.graphql_query")
+def test_get_image__success(mock_graphql_query):
+    """The Pyxis query is called once"""
+    image1 = generate_image("1111", "amd64", ["latest", "9.4", "9.4-1111"])
+    mock_graphql_query.return_value = generate_pyxis_response("get_image", image1)
+
+    image = get_image(GRAPHQL_API, "1111")
+
+    assert image == image1
+    mock_graphql_query.assert_called_once()
+
+
+def test_get_rh_registry_image_properties__success():
+    """Basic scenario where the function parses the image and returns
+    the expected values
+    """
+    image = generate_image("1111", "amd64", ["latest"])
+
+    registry, repository, tags = get_rh_registry_image_properties(image)
+
+    assert registry == REGISTRY
+    assert repository == REPOSITORY
+    assert tags == ["latest"]
+
+
+def test_get_rh_registry_image_properties__failure():
+    """The Red Hat registry repository is not found in the image,
+    so an exception is raised
+    """
+    image = generate_image("1111", "amd64", ["latest"])
+    image["repositories"] = [
+        {
+            "registry": "quay.io",
+            "repository": "myrepo",
+            "tags": [
+                {"name": "latest"},
+                {"name": "9.4"},
+            ],
+        }
+    ]
+
+    with pytest.raises(RuntimeError):
+        get_rh_registry_image_properties(image)
+
+
+@patch("pyxis.graphql_query")
+def test_get_candidates_for_cleanup__success(mock_graphql_query):
+    """Basic happy path scenario. The pyxis result has two pages, so there are two calls"""
+    image1 = generate_image("1111", "amd64", ["latest", "9.4", "9.4-1111"])
+    image2 = generate_image("2222", "amd64", ["latest", "9.4", "9.4-2222"])
+    image3 = generate_image("3333", "amd64", ["9.4-3333"])
+    mock_graphql_query.side_effect = [
+        generate_pyxis_response(
+            "find_repository_images_by_registry_path_tag", [image1, image2]
+        ),
+        generate_pyxis_response("find_repository_images_by_registry_path_tag", [image3]),
+    ]
+
+    images = get_candidates_for_cleanup(GRAPHQL_API, REGISTRY, REPOSITORY, "latest", 2)
+
+    assert images == [image1, image2, image3]
+    assert mock_graphql_query.call_count == 2
+
+
+@patch("cleanup_tags.update_image")
+def test_update_images__success(mock_update_image):
+    """Happy path scenario:
+    There are 2 images on input and both have the correct tags removed
+    """
+    image1 = generate_image("1111", "amd64", ["latest", "9.4", "9.4-1111"])
+    image1_new = generate_image("1111", "amd64", ["9.4-1111"])
+    image2 = generate_image("2222", "amd64", ["9.4", "9.4-2222"])
+    image2_new = generate_image("2222", "amd64", ["9.4-2222"])
+    images = {
+        image1["_id"]: image1,
+        image2["_id"]: image2,
+    }
+
+    update_images(GRAPHQL_API, ["latest", "9.4", "9.4-0000"], images)
+
+    assert mock_update_image.call_args_list == [
+        call(GRAPHQL_API, image1_new),
+        call(GRAPHQL_API, image2_new),
+    ]
+
+
+@patch("pyxis.graphql_query")
+def test_update_image__success(mock_graphql_query):
+    """The Pyxis query is called once"""
+    image1 = generate_image("1111", "amd64", ["latest", "9.4", "9.4-1111"])
+    mock_graphql_query.return_value = generate_pyxis_response("update_image", image1)
+
+    image = update_image(GRAPHQL_API, image1)
+
+    assert image == image1
+    mock_graphql_query.assert_called_once()
+
+
+def test_remove_none_values__success():
+    """This test will verify that None values are removed correctly"""
+    data = {
+        "a": 1,
+        "b": None,
+        "c": {"d": 2, "e": None, "f": {"g": 3, "h": None}},
+        "i": [None, 4, 5, None],
+        "j": ["text", None, {"k": None, "l": 6}],
+    }
+
+    expected_result = {
+        "a": 1,
+        "c": {"d": 2, "f": {"g": 3}},
+        "i": [4, 5],
+        "j": ["text", {"l": 6}],
+    }
+
+    assert remove_none_values(data) == expected_result
+
+
+def generate_image(id, architecture, tags):
+    image = {
+        "_id": id,
+        "architecture": architecture,
+        "repositories": [
+            {
+                "registry": "quay.io",
+                "repository": "redhat-prod/myproduct----myimage",
+                "tags": [{"name": tag} for tag in tags],
+            },
+            {
+                "registry": REGISTRY,
+                "repository": REPOSITORY,
+                "tags": [{"name": tag} for tag in tags],
+            },
+        ],
+    }
+    return image
+
+
+def generate_pyxis_response(query_name, data):
+    response_json = {
+        query_name: {
+            "data": data,
+            "error": None,
+        }
+    }
+
+    return response_json


### PR DESCRIPTION
This script will take a Pyxis Container Image ID as input and it will remove all its tags from all previous images that use the Red Hat registry and the same repository and architecture.