### PR TITLE
feat(CLOUDDST-22843): added signtractions python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN dnf -y --setopt=tsflags=nodocs install \
 
 RUN pip3 install jinja2 \
     jinja2-ansible-filters \
-    packageurl-python
+    packageurl-python \
+    signtractions
 
 ADD data/certs/2015-IT-Root-CA.pem data/certs/2022-IT-Root-CA.pem /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust


### PR DESCRIPTION
Signtractions is wrapper for pubtools-sign project which allows signing containers with cosign.
This commit is related to the https://github.com/konflux-ci/release-service-catalog/pull/442 which use project signtractions as tekton task for signing containers in release snapshots
