### PR TITLE
fix(RELEASE-998): use arch specific digest for image_id in Pyxis

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -205,7 +205,7 @@ def create_container_image(args, parsed_data: Dict[str, Any]):
             }
         ],
         "certified": json.loads(args.certified.lower()),
-        "image_id": docker_image_digest,
+        "image_id": args.architecture_digest,
         "architecture": parsed_data["architecture"],
         "parsed_data": parsed_data,
     }

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -100,7 +100,7 @@ def test_create_container_image(mock_datetime, mock_post):
                 }
             ],
             "certified": False,
-            "image_id": "some_digest",
+            "image_id": "arch specific digest",
             "architecture": "ok",
             "parsed_data": {"architecture": "ok"},
         },
@@ -160,7 +160,7 @@ def test_create_container_image_latest(mock_datetime, mock_post):
                 }
             ],
             "certified": False,
-            "image_id": "some_digest",
+            "image_id": "arch specific digest",
             "architecture": "ok",
             "parsed_data": {"architecture": "ok"},
         },
@@ -237,7 +237,7 @@ def test_create_container_image_rh_push_multiple_tags(mock_datetime, mock_post):
                 },
             ],
             "certified": False,
-            "image_id": "some_digest",
+            "image_id": "arch specific digest",
             "architecture": "ok",
             "parsed_data": {"architecture": "ok"},
         },


### PR DESCRIPTION
It turns out using the main digest was wrong and as a result clair was failing to grade our images.