### PR TITLE
fix(RELEASE-1000): prevent failure if no components key found

### DIFF
--- a/pyxis/upload_sbom.py
+++ b/pyxis/upload_sbom.py
@@ -276,7 +276,7 @@ def load_sbom_components(sbom_path: str) -> list[dict]:
     try:
         with open(sbom_path) as f:
             sbom = json.load(f)
-        components = sbom["components"]
+        components = sbom["components"] if "components" in sbom else []
     except Exception:
         LOGGER.error("Unable to load components from sbom file")
         raise


### PR DESCRIPTION
It seems that bundles could no contain the components key in the sbom. This causes the upload_sbom script to fail whenever the components are loaded.