### PR TITLE
feat(RELEASE-971): add required packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,10 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     diffutils \
     python3-pip \
     python3-requests \
+    python3-rpm \
     skopeo \
+    krb5-libs \
+    krb5-devel \
     krb5-workstation \
     rsync \
     && dnf clean all


### PR DESCRIPTION
This commit adds the python3-rpm, krb5-libs, and krb5-devel packages to the image as required by the script that will be used for RELEASE-971 to push content with pub tools pulp push.