### PR TITLE
feat(RHELDST-24850): add pubtools-pulp-push wrapper script

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -10,6 +10,11 @@ jobs:
   python:
     runs-on: ubuntu-latest
     steps:
+      - name: Install OS packages
+        # libkrb5-dev is required for gssapi dependency installation (krb5-config command)
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y libkrb5-dev
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Black Lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     krb5-devel \
     krb5-workstation \
     rsync \
+    gcc \
     && dnf clean all
 
 RUN curl -LO https://github.com/release-engineering/exodus-rsync/releases/latest/download/exodus-rsync && \
@@ -41,7 +42,12 @@ RUN curl -LO https://github.com/release-engineering/exodus-rsync/releases/latest
 RUN pip3 install jinja2 \
     jinja2-ansible-filters \
     packageurl-python \
-    pubtools-content-gateway 
+    pubtools-content-gateway \
+    pubtools-pulp \
+    pubtools-exodus
+
+# remove gcc, required only for compiling gssapi indirect dependency of pubtools-pulp via pushsource
+RUN dnf -y remove gcc
 
 ADD data/certs/2015-IT-Root-CA.pem data/certs/2022-IT-Root-CA.pem /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust
@@ -49,6 +55,7 @@ RUN update-ca-trust
 COPY pyxis /home/pyxis
 COPY utils /home/utils
 COPY templates /home/templates
+COPY pubtools-pulp-wrapper /home/pubtools-pulp-wrapper
 
 # It is mandatory to set these labels
 LABEL name="Konflux Release Service Utils"
@@ -61,4 +68,4 @@ LABEL com.redhat.component="release-service-utils"
 
 # Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
 ENV HOME=/tekton/home
-ENV PATH="$PATH:/home/pyxis:/home/utils"
+ENV PATH="$PATH:/home/pyxis:/home/utils:/home/pubtools-pulp-wrapper"

--- a/pubtools-pulp-wrapper/pulp_push_wrapper
+++ b/pubtools-pulp-wrapper/pulp_push_wrapper
@@ -1,0 +1,1 @@
+pulp_push_wrapper.py

--- a/pubtools-pulp-wrapper/pulp_push_wrapper.py
+++ b/pubtools-pulp-wrapper/pulp_push_wrapper.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Python script to push staged content to CDN using rhsm-pulp and exodus-gw integration.
+
+This is a simple wrapper pubtools-pulp-push command that is able to push and publish
+content via Pulp. This wrapper supports pushing content only from staged source
+with unit types supported in rhsm-pulp (as of July 2024).
+
+For more information please refer to documentation:
+* https://release-engineering.github.io/pubtools-pulp/
+* https://release-engineering.github.io/pubtools-exodus/
+* https://release-engineering.github.io/pushsource/
+
+Required env vars for exodus-gw integration:
+* EXODUS_PULP_HOOK_ENABLED
+* EXODUS_GW_CERT
+* EXODUS_GW_KEY
+* EXODUS_GW_URL
+* EXODUS_GW_ENV
+
+Optional env vars:
+* EXODUS_GW_TIMEOUT
+
+UD cache flush credentials:
+* either use username/password via CLI args
+* or set path to cert/key with env vars: UDCACHE_CERT and UDCACHE_KEY
+
+"""
+import argparse
+import logging
+import os
+import re
+import subprocess
+
+LOG = logging.getLogger("pubtools-pulp-wrapper")
+DEFAULT_LOG_FMT = "%(asctime)s [%(levelname)-8s] %(message)s"
+DEFAULT_DATE_FMT = "%Y-%m-%d %H:%M:%S %z"
+COMMAND = "pubtools-pulp-push"
+EXODUS_ENV_VARS_STRICT = (
+    "EXODUS_PULP_HOOK_ENABLED",
+    "EXODUS_GW_CERT",
+    "EXODUS_GW_KEY",
+    "EXODUS_GW_URL",
+    "EXODUS_GW_ENV",
+)
+EXODUS_ENV_VARS_OTHERS = ("EXODUS_GW_TIMEOUT",)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="pulp_push_wrapper",
+        description="Push staged content to CDN via rhsm-pulp and exodus-gw.",
+    )
+
+    parser.add_argument("--dry-run", action="store_true", help="Log command to be executed")
+    parser.add_argument(
+        "--debug",
+        "-d",
+        action="count",
+        default=0,
+        help=("Show debug logs; can be provided up to three times to enable more logs"),
+    )
+
+    parser.add_argument(
+        "--source",
+        action="append",
+        help="Path(s) to staging directory",
+        required=True,
+    )
+
+    pulp = parser.add_argument_group("Pulp settings")
+    pulp.add_argument("--pulp-url", help="Pulp server URL", required=True)
+    pulp.add_argument(
+        "--pulp-cert",
+        help="Pulp certificate. Can also be a single file (.pem)",
+        default=None,
+    )
+    pulp.add_argument(
+        "--pulp-key",
+        help="Pulp certificate key",
+        default=None,
+    )
+
+    ud = parser.add_argument_group(
+        "UD Cache settings",
+        (
+            "Set UDCACHE_CERT and UDCACHE_KEY for cert/key auth."
+            " or only UDCACHE_CERT if cert in PEM format"
+        ),
+    )
+    ud.add_argument(
+        "--udcache-url",
+        help=(
+            "Base URL of UD cache flush API; "
+            "if omitted, UD cache flush features are disabled."
+        ),
+    )
+    ud.add_argument("--udcache-user", help="Username for UD cache flush")
+    ud.add_argument(
+        "--udcache-password",
+        help="Password for UD cache flush (or set UDCACHE_PASSWORD)",
+        default="",
+    )
+
+    return parser.parse_args()
+
+
+def get_source_url(stagedirs):
+    for item in stagedirs:
+        if not re.match(r"^/[^,]{1,4000}$", item):
+            raise ValueError("Not a valid staging directory: %s" % item)
+
+    return f"staged:{','.join(stagedirs)}"
+
+
+def settings_to_args(parsed):
+    settings_to_arg_map = {
+        "pulp_url": "--pulp-url",
+        "pulp_cert": "--pulp-certificate",
+        "pulp_key": "--pulp-certificate-key",
+        "udcache_url": "--udcache-url",
+        "udcache_user": "--udcache-user",
+        "udcache_password": "--udcache-password",
+        "source": "--source",
+    }
+    out = []
+    for setting, arg in settings_to_arg_map.items():
+        if value := getattr(parsed, setting):
+            out.extend([arg, value])
+
+    for _ in range(parsed.debug):
+        out.append("--debug")
+
+    return out
+
+
+def log_exodus_env():
+    for item in EXODUS_ENV_VARS_STRICT + EXODUS_ENV_VARS_OTHERS:
+        LOG.debug("%s:%s", item, os.getenv(item, "UNSET"))
+
+
+def validate_args(args):
+    assert all([os.getenv(item) for item in EXODUS_ENV_VARS_STRICT]), (
+        f"Provide all required exodus-gw environment variables: "
+        f"{', '.join(EXODUS_ENV_VARS_STRICT)}"
+    )
+
+    args.source = get_source_url(args.source)
+    return args
+
+
+def main():
+    args = validate_args(parse_args())
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format=DEFAULT_LOG_FMT,
+        datefmt=DEFAULT_DATE_FMT,
+    )
+
+    if args.dry_run:
+        LOG.info("This is a dry-run!")
+
+    if args.debug:
+        log_exodus_env()
+
+    cmd_args = settings_to_args(args)
+    command = [COMMAND] + cmd_args
+    cmd_str = " ".join(command)
+
+    if args.dry_run:
+        LOG.info("Would have run: %s", cmd_str)
+    else:
+        try:
+            LOG.info("Running %s", cmd_str)
+            subprocess.run(command, check=True)
+        except subprocess.CalledProcessError:
+            LOG.exception("Command %s failed, check exception for details", cmd_str)
+            raise
+        except Exception as exc:
+            LOG.exception("Unknown error occurred")
+            raise RuntimeError from exc
+
+
+def entrypoint():
+    main()
+
+
+if __name__ == "__main__":
+    entrypoint()

--- a/pubtools-pulp-wrapper/test_pulp_push_wrapper.py
+++ b/pubtools-pulp-wrapper/test_pulp_push_wrapper.py
@@ -1,0 +1,80 @@
+import logging
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+import pulp_push_wrapper
+
+
+@pytest.fixture()
+def mock_gw_env_vars():
+    with patch.dict(os.environ, {k: "test" for k in pulp_push_wrapper.EXODUS_ENV_VARS_STRICT}):
+        yield
+
+
+def test_no_args(capsys):
+    with pytest.raises(SystemExit):
+        pulp_push_wrapper.main()
+
+    _, err = capsys.readouterr()
+    assert (
+        "pulp_push_wrapper: error: the following arguments are required: --source, --pulp-url"
+        in err
+    )
+
+
+def test_dry_run(caplog, mock_gw_env_vars):
+    args = [
+        "",
+        "--dry-run",
+        "--source",
+        "/test/1",
+        "--source",
+        "/test/2",
+        "--pulp-url",
+        "https://pulp-test.dev",
+    ]
+
+    with patch.object(sys, "argv", args):
+        with caplog.at_level(logging.INFO):
+            pulp_push_wrapper.main()
+            assert "This is a dry-run!" in caplog.messages
+            assert (
+                "Would have run: pubtools-pulp-push --pulp-url https://pulp-test.dev"
+                " --source staged:/test/1,/test/2"
+            ) in caplog.messages
+
+
+@patch("subprocess.run")
+def test_basic_command(mock_run, caplog, mock_gw_env_vars):
+    args = [
+        "",
+        "--source",
+        "/test/1",
+        "--source",
+        "/test/2",
+        "--pulp-url",
+        "https://pulp-test.dev",
+    ]
+
+    with patch.object(sys, "argv", args):
+        with caplog.at_level(logging.INFO):
+            pulp_push_wrapper.main()
+            assert "This is a dry-run!" not in caplog.messages
+            assert (
+                "Running pubtools-pulp-push --pulp-url https://pulp-test.dev"
+                " --source staged:/test/1,/test/2"
+            ) in caplog.messages
+
+    mock_run.assert_called_once_with(
+        [
+            "pubtools-pulp-push",
+            "--pulp-url",
+            "https://pulp-test.dev",
+            "--source",
+            "staged:/test/1,/test/2",
+        ],
+        check=True,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ requests
 jinja2
 jinja2-ansible-filters
 packageurl-python
+pubtools-pulp
+pubtools-exodus


### PR DESCRIPTION
This change adds and new script stored in dedicated directory.
This script will be used for pushing content for RELEASE-971.

Necessary updates to Dockerfile and requirements.txt were done
as well to allow the same execution conventions for new script
as there are already for `pyxis` scripts.

Signed-off-by: Robert Bikar <rbikar@redhat.com>