### PR TITLE
fix(RELEASE-1025): stop cloning the repo, install library from pypi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,7 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     && dnf clean all
 
 RUN curl -LO https://github.com/release-engineering/exodus-rsync/releases/latest/download/exodus-rsync && \
-    chmod +x exodus-rsync && mv exodus-rsync /usr/local/bin/rsync && \
-    git clone https://github.com/release-engineering/pubtools-content-gateway.git
+    chmod +x exodus-rsync && mv exodus-rsync /usr/local/bin/rsync
 
 RUN pip3 install jinja2 \
     jinja2-ansible-filters \

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ jinja2-ansible-filters
 packageurl-python
 pubtools-pulp
 pubtools-exodus
+pubtools-content-gateway


### PR DESCRIPTION
pubtools-content-gateway was upgraded - https://github.com/release-engineering/pubtools-content-gateway/commit/82d7e652791e000616d6c8a6071d721a3019c588

This commit aims to install library directly from [pypi](https://pypi.org/project/pubtools-content-gateway/) instead of cloning the repo.

JIRA: RELEASE-1025