### PR TITLE
fix(RELEASE-980): populate nvra and summary in Pyxis RpmsItems

### DIFF
--- a/pyxis/test_upload_rpm_manifest.py
+++ b/pyxis/test_upload_rpm_manifest.py
@@ -197,19 +197,36 @@ def test_construct_rpm_items__success():
     assert rpms == [
         {
             "name": "pkg1",
+            "summary": "pkg1-1-2.el8.x86_64",
+            "nvra": "pkg1-1-2.el8.x86_64",
             "version": "1",
             "release": "2.el8",
             "architecture": "x86_64",
             "srpm_name": "pkg1-1-2.el8.src.rpm",
         },
-        {"name": "pkg2", "architecture": "noarch", "srpm_name": "pkg2-1-2.el8.src.rpm"},
+        {
+            "name": "pkg2",
+            "summary": "pkg2",
+            "architecture": "noarch",
+            "srpm_name": "pkg2-1-2.el8.src.rpm",
+        },
         {
             "name": "pkg3",
+            "summary": "pkg3-9-8.el8.noarch",
+            "nvra": "pkg3-9-8.el8.noarch",
             "version": "9",
             "release": "8.el8",
+            "architecture": "noarch",
             "srpm_name": "pkg3-9-8.el8.src.rpm",
         },
-        {"name": "pkg4", "version": "1", "release": "2.el8", "architecture": "x86_64"},
+        {
+            "name": "pkg4",
+            "summary": "pkg4-1-2.el8.x86_64",
+            "nvra": "pkg4-1-2.el8.x86_64",
+            "version": "1",
+            "release": "2.el8",
+            "architecture": "x86_64",
+        },
     ]
 
 

--- a/pyxis/upload_rpm_manifest.py
+++ b/pyxis/upload_rpm_manifest.py
@@ -134,12 +134,18 @@ def construct_rpm_items(components: list[dict]) -> list[dict]:
         if "purl" in component:
             purl_dict = PackageURL.from_string(component["purl"]).to_dict()
             if purl_dict["type"] == "rpm":
-                rpm_item = {"name": purl_dict["name"]}
+                rpm_item = {
+                    "name": purl_dict["name"],
+                    "summary": purl_dict["name"],
+                    "architecture": purl_dict["qualifiers"].get("arch", "noarch"),
+                }
                 if purl_dict["version"] is not None:
                     rpm_item["version"] = purl_dict["version"].split("-")[0]
                     rpm_item["release"] = purl_dict["version"].split("-")[1]
-                if "arch" in purl_dict["qualifiers"]:
-                    rpm_item["architecture"] = purl_dict["qualifiers"]["arch"]
+                    rpm_item["nvra"] = (
+                        f"{rpm_item['name']}-{purl_dict['version']}.{rpm_item['architecture']}"
+                    )
+                    rpm_item["summary"] = rpm_item["nvra"]
                 if "upstream" in purl_dict["qualifiers"]:
                     rpm_item["srpm_name"] = purl_dict["qualifiers"]["upstream"]
                 rpms_items.append(rpm_item)


### PR DESCRIPTION
Without these fields the rpms do not get displayed in Red Hat Catalog. Unfortunately, currently we cannot get the real summary anywhere, so for now at least put the nvra or name value in that field - better to display something than nothing.