### PR TITLE
fix(KFLUXBUGS-1480): retry upload_container_rpm_manifest on HTTPErrors

### DIFF
--- a/pyxis/upload_rpm_manifest.py
+++ b/pyxis/upload_rpm_manifest.py
@@ -19,6 +19,7 @@ import string
 import os
 from pathlib import Path
 import time
+from urllib.error import HTTPError
 from packageurl import PackageURL
 from upload_sbom import load_sbom_components, parse_arguments
 
@@ -44,6 +45,12 @@ def upload_container_rpm_manifest_with_retry(
         except RuntimeError as e:
             LOGGER.warning(f"Attempt {attempt+1} failed.")
             last_err = e
+        except HTTPError as e:
+            if e.code == 504:
+                LOGGER.warning(f"Attempt {attempt+1} failed with HTTPError code 504.")
+                last_err = e
+            else:
+                raise e
     LOGGER.error("Out of attempts. Raising the error.")
     raise last_err
 


### PR DESCRIPTION
This commit modifies the upload_container_rpm_manifest_with_retry function to retry if the exception is an HTTPError with code 504. Other HTTPErrors will fail immediately, as is currently the case for all HTTPErrors.