### PR TITLE
fix: handle empty tags in cleanup_tags script

### DIFF
--- a/pyxis/cleanup_tags.py
+++ b/pyxis/cleanup_tags.py
@@ -145,7 +145,10 @@ def get_rh_registry_image_properties(image: Dict):
     """
     for repo in image["repositories"]:
         if repo["registry"] == "registry.access.redhat.com":
-            tags = [tag["name"] for tag in repo["tags"]]
+            if repo["tags"] is None:
+                tags = []
+            else:
+                tags = [tag["name"] for tag in repo["tags"]]
             return repo["registry"], repo["repository"], tags
     raise RuntimeError(
         "Cannot find the registry.access.redhat.com repository entry for the image"

--- a/pyxis/test_cleanup_tags.py
+++ b/pyxis/test_cleanup_tags.py
@@ -144,6 +144,21 @@ def test_get_rh_registry_image_properties__success():
     assert tags == ["latest"]
 
 
+def test_get_rh_registry_image_properties__no_tags():
+    """Scenario where the access.rh.c repository in the image has no tags,
+    so the returned tags should be empty
+    """
+    image = generate_image("1111", "amd64", [])
+    image["repositories"][0]["tags"] = None
+    image["repositories"][1]["tags"] = None
+
+    registry, repository, tags = get_rh_registry_image_properties(image)
+
+    assert registry == REGISTRY
+    assert repository == REPOSITORY
+    assert tags == []
+
+
 def test_get_rh_registry_image_properties__failure():
     """The Red Hat registry repository is not found in the image,
     so an exception is raised


### PR DESCRIPTION
Before this fix, if there were no tags in the repository of the ContainerImage object, the script would fail on: TypeError: 'NoneType' object is not iterable

That's because in the returned image object,
tags would be null/None instead of an empty list.

Now we handle this use case.