### PR TITLE
chore: update checkout and python actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run yamllint
         uses: frenck/action-yamllint@v1
   gitlint:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: '${{ github.event.pull_request.head.sha }}'

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -16,11 +16,11 @@ jobs:
           sudo apt-get -y update
           sudo apt-get install -y libkrb5-dev
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Black Lint
         uses: psf/black@stable
       - name: Setup python environment for flake8 check
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"  # Same as in Dockerfile
       - name: flake8 Lint


### PR DESCRIPTION
There was a warning displayed along the workflow runs in Github: The following actions use a deprecated Node.js version and will be forced to run on node20:
actions/checkout@v3, actions/setup-python@v4