### PR TITLE
fix: ignore gitlint checks for bots

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -12,3 +12,7 @@ line-length=72
 [body-first-line-empty]
 
 [contrib-title-conventional-commits]
+
+[ignore-by-author-name]
+regex=(.*)\[bot\](.*)
+ignore=T1,B1


### PR DESCRIPTION
This commit modifies the gitlint configuration to ignore the max title length and max body line length rules for bot accounts. This should encompass both dependabot commits and red-hat-konflux-bot commits.