### PR TITLE
fix: pulp wrapper logging to print to stdout

### DIFF
--- a/pubtools-pulp-wrapper/pulp_push_wrapper.py
+++ b/pubtools-pulp-wrapper/pulp_push_wrapper.py
@@ -31,6 +31,7 @@ import logging
 import os
 import re
 import subprocess
+import sys
 
 LOG = logging.getLogger("pubtools-pulp-wrapper")
 DEFAULT_LOG_FMT = "%(asctime)s [%(levelname)-8s] %(message)s"
@@ -152,10 +153,16 @@ def validate_args(args):
 def main():
     args = validate_args(parse_args())
 
+    loglevel = logging.DEBUG if args.debug else logging.INFO
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setLevel(loglevel)
+
     logging.basicConfig(
-        level=logging.DEBUG if args.debug else logging.INFO,
+        level=loglevel,
         format=DEFAULT_LOG_FMT,
         datefmt=DEFAULT_DATE_FMT,
+        handlers=[stream_handler],
     )
 
     if args.dry_run:


### PR DESCRIPTION
By default, logging goes to stderr in Python. This will change it to go to stdout. That makes it in line with our other Python scripts and also, it will help with debugging when this script runs in the Tekton task, because we suppress stderr there (and only print it if the script fails).

Here's where the script is called from: https://github.com/hacbs-release/app-interface-deployments/blob/main/internal-services/catalog/pulp-push-disk-images-task.yaml#L246