### PR TITLE
fix(RELEASE-1108): logging should go to stdout

### DIFF
--- a/developer-portal-wrapper/developer_portal_wrapper.py
+++ b/developer-portal-wrapper/developer_portal_wrapper.py
@@ -8,6 +8,7 @@ Run push-cgw-metadata command to push metadata to CGW:
 6. Run push-cgw-metadata to push the metadata
 """
 import os
+import sys
 import yaml
 import hashlib
 import subprocess
@@ -142,13 +143,19 @@ def parse_args():
 
 def main():
     args = parse_args()
-    validate_env_vars()
+
+    loglevel = logging.DEBUG if args.debug else logging.INFO
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setLevel(loglevel)
 
     logging.basicConfig(
-        level=logging.DEBUG if args.debug else logging.INFO,
+        level=loglevel,
         format=DEFAULT_LOG_FMT,
         datefmt=DEFAULT_DATE_FMT,
+        handlers=[stream_handler],
     )
+    validate_env_vars()
 
     if args.dry_run:
         LOG.info("This is a dry-run!")


### PR DESCRIPTION
By default, logging goes to stderr in Python. This will change it to go to stdout. That makes it in line with our other Python scripts and also, it will help with debugging when this script runs in the Tekton task, because we suppress stderr there (and only print it if the script fails).