### PR TITLE
fix(KONFLUX-4292): upload a fixed gpg key id to pyxis

### DIFF
--- a/pyxis/test_upload_rpm_manifest.py
+++ b/pyxis/test_upload_rpm_manifest.py
@@ -28,6 +28,14 @@ COMPONENTS = [
     {  # no upstream
         "purl": "pkg:rpm/rhel/pkg4@1-2.el8?arch=x86_64&distro=rhel-8.0",
     },
+    {  # with RH publisher
+        "purl": "pkg:rpm/rhel/pkg5?arch=noarch&upstream=pkg5-1-2.el8.src.rpm&distro=rhel-8.0",
+        "publisher": "Red Hat, inc.",
+    },
+    {  # with other publisher
+        "purl": "pkg:rpm/rhel/pkg6?arch=noarch&upstream=pkg6-1-2.el8.src.rpm&distro=rhel-8.0",
+        "publisher": "Blue Shoe, inc.",
+    },
     {  # not an rpm
         "purl": "pkg:golang/./staging/src@(devel)#k8s.io/api",
     },
@@ -272,6 +280,19 @@ def test_construct_rpm_items__success():
             "version": "1",
             "release": "2.el8",
             "architecture": "x86_64",
+        },
+        {
+            "name": "pkg5",
+            "gpg": "199e2f91fd431d51",
+            "summary": "pkg5",
+            "architecture": "noarch",
+            "srpm_name": "pkg5-1-2.el8.src.rpm",
+        },
+        {
+            "name": "pkg6",
+            "summary": "pkg6",
+            "architecture": "noarch",
+            "srpm_name": "pkg6-1-2.el8.src.rpm",
         },
     ]
 

--- a/pyxis/upload_rpm_manifest.py
+++ b/pyxis/upload_rpm_manifest.py
@@ -155,6 +155,12 @@ def construct_rpm_items(components: list[dict]) -> list[dict]:
                     rpm_item["summary"] = rpm_item["nvra"]
                 if "upstream" in purl_dict["qualifiers"]:
                     rpm_item["srpm_name"] = purl_dict["qualifiers"]["upstream"]
+
+                # XXX - temporary https://issues.redhat.com/browse/KONFLUX-4292
+                # Undo this in https://issues.redhat.com/browse/KONFLUX-4175
+                if component.get("publisher") == "Red Hat, inc.":
+                    rpm_item["gpg"] = "199e2f91fd431d51"
+
                 rpms_items.append(rpm_item)
     return rpms_items
 


### PR DESCRIPTION
To fix KONFLUX-4175, we need to upload a gpg key id to pyxis.

The right way to do this is for the SBOM itself to contain the gpg key id. Our task here would simply copy it to pyxis.  However, to do that fully, we'll need to get a change into both syft and cachi2, which may take some time.

As a stopgap, this change inspects the "publisher" field of the sbom. If it is set to Red Hat, we'll publish the Red Hat release2 key id to pyxis.

You might ask, what if the rpms are not actually signed by Red Hat keys? We have a separate layer of protection against that in KONFLUX-3149, but the data about which rpms are signed by which keys will not be exposed by that work in the way that the release process can use here.

* https://issues.redhat.com/browse/KONFLUX-4292
* https://issues.redhat.com/browse/KONFLUX-4175

This change should be reverted as a part of completing KONFLUX-4175.