### PR TITLE
feat(CLDX-134): add mac-signing-wrapper script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ RUN pip3 install jinja2 \
     packageurl-python \
     pubtools-content-gateway \
     pubtools-pulp \
-    pubtools-exodus
+    pubtools-exodus \
+    paramiko
 
 # remove gcc, required only for compiling gssapi indirect dependency of pubtools-pulp via pushsource
 RUN dnf -y remove gcc
@@ -56,6 +57,7 @@ COPY utils /home/utils
 COPY templates /home/templates
 COPY pubtools-pulp-wrapper /home/pubtools-pulp-wrapper
 COPY developer-portal-wrapper /home/developer-portal-wrapper
+COPY mac-signing-wrapper /home/mac-signing-wrapper
 
 # It is mandatory to set these labels
 LABEL name="Konflux Release Service Utils"
@@ -68,4 +70,4 @@ LABEL com.redhat.component="release-service-utils"
 
 # Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
 ENV HOME=/tekton/home
-ENV PATH="$PATH:/home/pyxis:/home/utils:/home/pubtools-pulp-wrapper:/home/developer-portal-wrapper"
+ENV PATH="$PATH:/home/pyxis:/home/utils:/home/pubtools-pulp-wrapper:/home/developer-portal-wrapper:/home/mac-signing-wrapper"

--- a/mac-signing-wrapper/example-config.yaml
+++ b/mac-signing-wrapper/example-config.yaml
@@ -1,0 +1,14 @@
+# Below secrets are needed for the mac-signing-wrapper to sign the macos binaries.
+---
+oci_registry_repo: <>
+quay_username:
+quay_password:
+mac_host:
+mac_user:
+mac_password:
+# key_filename: Either key_filename or mac_password must be set
+keychain_password:
+signing_identity:
+apple_id:
+app_specific_password:
+team_id:

--- a/mac-signing-wrapper/mac_signing_wrapper.py
+++ b/mac-signing-wrapper/mac_signing_wrapper.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+import argparse
+import logging
+import os
+import tempfile
+
+import yaml
+
+from macos_commands import MacOSCommands
+from oras_commands import OrasCommands
+from ssh_connection import SSHConnection
+from utils import zip_files
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="macOS Signing and Notarization Script")
+    parser.add_argument(
+        "config_file",
+        help="Path to the file containing the secrets of the mac host and the OCI registry",
+    )
+    parser.add_argument("digest", help="ORAS digest of the unsigned content")
+    return parser.parse_args()
+
+
+def load_config(config_file):
+    with open(config_file, "r") as f:
+        return yaml.safe_load(f)
+
+
+def main():
+    args = parse_arguments()
+    config = load_config(args.config_file)
+
+    try:
+        with SSHConnection(
+            config["mac_host"], config["mac_user"], config["mac_password"]
+        ) as ssh:
+            # with SSHConnection(
+            # config['mac_host'], config['mac_user'], config['key_filename']) as ssh:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                oras = OrasCommands(
+                    ssh,
+                    config["oci_registry_repo"],
+                    config["quay_username"],
+                    config["quay_password"],
+                )
+                macos = MacOSCommands(ssh)
+
+                logger.info("Pulling unsigned content...")
+                oras.pull_content(args.digest, temp_dir)
+
+                logger.info("Unlocking keychain...")
+                macos.unlock_keychain(config["keychain_password"])
+
+                logger.info("Signing binaries...")
+                signed_files = macos.sign_binaries(config["signing_identity"], temp_dir)
+
+                logger.info(f"Binaries signed: {signed_files}")
+
+                # Files needs to be zipped for the notarization command.
+                zip_file_name = "signed_binaries.zip"
+                zip_path = os.path.join(temp_dir, zip_file_name)
+                zip_files(ssh, temp_dir, zip_path)
+
+                logger.info("Submitting for notarization...")
+                notarization_result = macos.notarize_binaries(
+                    config["apple_id"],
+                    config["app_specific_password"],
+                    config["team_id"],
+                    zip_path,
+                )
+                logger.info(f"Notarization succesful, results: {notarization_result}")
+
+                logger.info("Pushing signed content...")
+                signed_digest = oras.push_zip(zip_path)
+
+                logger.info(f"Signed zipped file pushed. New digest: {signed_digest}")
+                return signed_digest
+
+    except Exception as e:
+        logger.error(f"Operation failed: {str(e)}")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/mac-signing-wrapper/macos_commands.py
+++ b/mac-signing-wrapper/macos_commands.py
@@ -1,0 +1,75 @@
+import json
+
+
+class MacOSCommands:
+    def __init__(self, ssh):
+        self.ssh = ssh
+
+    def unlock_keychain(self, keychain_password):
+        """
+        Unlock the login keychain
+
+        :param keychain_password: The password to unlock the keychain
+        :return: The output of the command
+        """
+        return self.ssh.run_command(
+            f"security unlock-keychain -p {keychain_password} login.keychain", sensitive=True
+        )
+
+    def sign_binaries(self, signing_identity, target_dir):
+        """
+        Sign all files in the target directory
+
+        :param signing_identity: The identity to sign the files with
+        :param target_dir: The directory containing the files to sign
+        :return: A list of signed files
+        """
+        signed_files = []
+        list_files_command = f"find {target_dir} -type f"
+        out, _ = self.ssh.run_command(list_files_command)
+        for file_path in out.splitlines():
+            command = (
+                f"xcrun codesign "
+                f"--sign 'Developer ID Application: {signing_identity}' "
+                f"--options runtime --timestamp --force {file_path}"
+            )
+            self.ssh.run_command(command, sensitive=True)
+            signed_files.append(file_path)
+        return signed_files
+
+    def notarize_binaries(self, username, password, team_id, zip_path):
+        """
+        Submit the zip file for notarization
+
+        :param username: The Apple ID username
+        :param password: The app-specific password
+        :param team_id: The team ID
+        :param zip_path: The path to the zip file to submit
+        :return: The notarization result
+
+        Raises an exception if the notarization fails
+        """
+        command = (
+            f"xcrun notarytool submit {zip_path} "
+            f"--output-format json "
+            f"--wait "
+            f"--apple-id {username} "
+            f"--team-id {team_id} "
+            f"--password {password}"
+        )
+
+        out, err = self.ssh.run_command(command, sensitive=True)
+        if err:
+            raise Exception(f"Notarization error: {err}")
+
+        notarization_result = json.loads(out)
+
+        if notarization_result["status"] != "Accepted":
+            error_message = f"Notarization failed. Status: {notarization_result['status']}"
+            if "issues" in notarization_result:
+                error_message += "\nIssues:"
+                for issue in notarization_result["issues"]:
+                    error_message += f"\n- {issue['message']}"
+            raise Exception(error_message)
+
+        return notarization_result

--- a/mac-signing-wrapper/oras_commands.py
+++ b/mac-signing-wrapper/oras_commands.py
@@ -1,0 +1,62 @@
+class OrasCommands:
+    def __init__(self, ssh, registry, username, password):
+        self.ssh = ssh
+        self.registry = registry
+        self.username = username
+        self.password = password
+        self.set_env_vars()
+
+    def set_env_vars(self):
+        """
+        Set environment variables for the ORAS commands.
+        """
+        env_vars = (
+            f"export ORAS_USERNAME='{self.username}' && export ORAS_PASSWORD='{self.password}'"
+        )
+        self.ssh.run_command(env_vars, sensitive=True)
+
+    def pull_content(self, digest, target_dir):
+        """
+        Pull content from registry using the digest inside a target directory.
+        """
+        create_and_enter_dir = f"mkdir -p {target_dir} && cd {target_dir}"
+        pull_command = f"oras pull {self.registry}@sha256:{digest}"
+        check_files_command = f"ls -1 {target_dir} | wc -l"
+
+        self.ssh.run_command(create_and_enter_dir)
+        pull_output, err = self.ssh.run_command(pull_command)
+        if err:
+            raise Exception(f"Error pulling content: {err}")
+
+        file_count, _ = self.ssh.run_command(check_files_command)
+        if int(file_count) == 0:
+            raise Exception("ORAS pull command did not retrieve any files")
+
+        return pull_output
+
+    def push_zip(self, zip_path):
+        """
+        Push a zip file to the registry and return the digest.
+        ONLY ZIP FILES ARE SUPPORTED, can we extended later.
+        """
+        if not zip_path.endswith(".zip"):
+            raise ValueError("The provided file must be a zip file")
+
+        push_command = f"oras push {self.registry} {zip_path}"
+
+        output, _ = self.ssh.run_command(push_command)
+        digest = get_sha256(output)
+
+        if digest:
+            return digest
+        else:
+            raise ValueError(f"No SHA256 found in the oras push output. Full output: {output}")
+
+
+def get_sha256(a_string: str):
+    for line in a_string.splitlines():
+        if "sha256:" in line:
+            parts = line.split("sha256:")
+            if len(parts) > 1:
+                return parts[1].strip()
+    return None

--- a/mac-signing-wrapper/ssh_connection.py
+++ b/mac-signing-wrapper/ssh_connection.py
@@ -1,0 +1,56 @@
+import logging
+
+from paramiko import AutoAddPolicy, SSHClient
+
+logger = logging.getLogger(__name__)
+
+
+class SSHConnection:
+    def __init__(self, hostname, username, password=None, key_filename=None):
+        self.ssh = SSHClient()
+        self.ssh.set_missing_host_key_policy(AutoAddPolicy())
+
+        if password is None and key_filename is None:
+            raise ValueError("Either password or key_filename must be provided")
+
+        if key_filename:
+            self.ssh.connect(hostname, username=username, key_filename=key_filename)
+        else:
+            self.ssh.connect(hostname, username=username, password=password)
+
+    def run_command(self, command, sensitive=False):
+        """
+        Run a command on the remote machine
+
+        :param command: The command to run
+        :param sensitive: If the command is sensitive, only log at debug level. Still logs errors at info level.
+        :return: The output and error of the command
+        """
+        if sensitive:
+            logger.info("Running sensitive command")
+        else:
+            logger.info(f"Running command: {command}")
+        stdin, stdout, stderr = self.ssh.exec_command(command)
+        exit_status = stdout.channel.recv_exit_status()
+        out = stdout.read().decode().strip()
+        err = stderr.read().decode().strip()
+        if out:
+            if sensitive:
+                logger.info("Sensitive command output is not logged")
+                # Only log sensitive command output at debug level
+                logger.debug(f"Command output: {out}")
+            else:
+                logger.info(f"Command output: {out}")
+        if err:
+            logger.error(f"Command error: {err}")
+        logger.info(f"Command exit status: {exit_status}")
+        return out, err
+
+    def _close(self):
+        self.ssh.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._close()

--- a/mac-signing-wrapper/test_mac_signing_wrapper.py
+++ b/mac-signing-wrapper/test_mac_signing_wrapper.py
@@ -1,0 +1,89 @@
+import os
+import tempfile
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+import yaml
+
+import mac_signing_wrapper
+
+
+@pytest.fixture
+def mock_config():
+    return {
+        "mac_host": "example_mac_host",
+        "mac_user": "mac_user",
+        "mac_password": "mac_password",
+        "oci_registry_repo": "example_registry.com",
+        "quay_username": "quay_user",
+        "quay_password": "quay_pass",
+        "keychain_password": "keychain_pass",
+        "signing_identity": "Test Signing Identity",
+        "apple_id": "apple@example.com",
+        "app_specific_password": "app_pass",
+        "team_id": "KONFLUX",
+    }
+
+
+@pytest.fixture
+def mock_args():
+    args = Mock()
+    args.config_file = "config.yaml"
+    args.digest = "unsigned_digest"
+    return args
+
+
+def test_load_config():
+    yaml_date = {"OS": "mac"}
+    mock_config_data = yaml.dump(yaml_date)
+    with patch("builtins.open", mock_open(read_data=mock_config_data)):
+        config = mac_signing_wrapper.load_config("some/path")
+    assert config == yaml_date
+
+
+@patch("argparse.ArgumentParser.parse_args")
+def test_parse_arguments(mock_parse_args):
+    mock_parse_args.return_value = Mock(config_file="config.yaml", digest="unsigned_digest")
+    args = mac_signing_wrapper.parse_arguments()
+    assert args.config_file == "config.yaml"
+    assert args.digest == "unsigned_digest"
+
+
+@patch("mac_signing_wrapper.SSHConnection")
+@patch("mac_signing_wrapper.OrasCommands")
+@patch("mac_signing_wrapper.MacOSCommands")
+@patch("mac_signing_wrapper.zip_files")
+@patch("mac_signing_wrapper.tempfile.TemporaryDirectory")
+@patch("mac_signing_wrapper.parse_arguments")
+@patch("mac_signing_wrapper.load_config")
+def test_main_success(
+    mock_load_config,
+    mock_parse_args,
+    mock_temp_dir,
+    mock_zip_files,
+    MockMacOSCommands,
+    MockOrasCommands,
+    MockSSHConnection,
+    mock_config,
+    mock_args,
+):
+    mock_parse_args.return_value = mock_args
+    mock_load_config.return_value = mock_config
+    mock_temp_dir.return_value.__enter__.return_value = "/tmp/test_dir"
+
+    mock_ssh = MockSSHConnection.return_value.__enter__.return_value
+    mock_oras = MockOrasCommands.return_value
+    mock_macos = MockMacOSCommands.return_value
+    mock_oras.push_zip.return_value = "new_digest"
+
+    result = mac_signing_wrapper.main()
+
+    assert result == "new_digest"
+    mock_oras.pull_content.assert_called_once_with("unsigned_digest", "/tmp/test_dir")
+    mock_macos.unlock_keychain.assert_called_once_with("keychain_pass")
+    mock_macos.sign_binaries.assert_called_once_with("Test Signing Identity", "/tmp/test_dir")
+    mock_zip_files.assert_called_once()
+    mock_macos.notarize_binaries.assert_called_once_with(
+        "apple@example.com", "app_pass", "KONFLUX", "/tmp/test_dir/signed_binaries.zip"
+    )
+    mock_oras.push_zip.assert_called_once()

--- a/mac-signing-wrapper/test_macos_commands.py
+++ b/mac-signing-wrapper/test_macos_commands.py
@@ -1,0 +1,94 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from macos_commands import MacOSCommands
+
+
+@pytest.fixture
+def mock_ssh():
+    return Mock()
+
+
+@pytest.fixture
+def macos_commands(mock_ssh):
+    return MacOSCommands(mock_ssh)
+
+
+@pytest.fixture
+def notarize_params():
+    return {
+        "username": "mac_user",
+        "password": "mac_password",
+        "team_id": "KONFLUX",
+        "zip_path": "/test/signed_binaries.zip",
+    }
+
+
+def test_unlock_keychain(macos_commands, mock_ssh):
+    keychain_password = "mac_password"
+    macos_commands.unlock_keychain(keychain_password)
+    mock_ssh.run_command.assert_called_once_with(
+        f"security unlock-keychain -p {keychain_password} login.keychain", sensitive=True
+    )
+
+
+def test_sign_binaries(macos_commands, mock_ssh):
+    mock_ssh.run_command.side_effect = [
+        ("test_binary_1\ntest_binary_2", None),  # mock output of find command
+        None,
+        None,  # mock output of codesign command
+    ]
+
+    signing_identity = "Test Signing Identity"
+    target_dir = "/test/target_dir"
+    signed_files = macos_commands.sign_binaries(signing_identity, target_dir)
+
+    assert signed_files == ["test_binary_1", "test_binary_2"]
+    assert mock_ssh.run_command.call_count == 3
+    mock_ssh.run_command.assert_any_call(f"find {target_dir} -type f")
+    for file in signed_files:
+        mock_ssh.run_command.assert_any_call(
+            f"xcrun codesign --sign 'Developer ID Application: {signing_identity}' "
+            f"--options runtime --timestamp --force {file}",
+            sensitive=True,
+        )
+
+
+def test_notarize_binaries_success(macos_commands, mock_ssh, notarize_params):
+    mock_ssh.run_command.return_value = ('{"status": "Accepted", "id": "test_id"}', None)
+    result = macos_commands.notarize_binaries(**notarize_params)
+
+    assert result == {"status": "Accepted", "id": "test_id"}
+    mock_ssh.run_command.assert_called_once_with(
+        f"xcrun notarytool submit {notarize_params['zip_path']} "
+        f"--output-format json "
+        f"--wait "
+        f"--apple-id {notarize_params['username']} "
+        f"--team-id {notarize_params['team_id']} "
+        f"--password {notarize_params['password']}",
+        sensitive=True,
+    )
+
+
+def test_notarize_binaries_failure(macos_commands, mock_ssh, notarize_params):
+    mock_ssh.run_command.return_value = (
+        json.dumps({"status": "Invalid", "issues": [{"message": "Test error message"}]}),
+        None,
+    )
+
+    with pytest.raises(Exception) as failure_exception:
+        macos_commands.notarize_binaries(**notarize_params)
+
+    assert "Notarization failed" in str(failure_exception.value)
+    assert "Test error message" in str(failure_exception.value)
+
+
+def test_notarize_binaries_error(macos_commands, mock_ssh, notarize_params):
+    mock_ssh.run_command.return_value = (None, "Command failed")
+
+    with pytest.raises(Exception) as failure_exception:
+        macos_commands.notarize_binaries(**notarize_params)
+
+    assert "Notarization error: Command failed" in str(failure_exception.value)

--- a/mac-signing-wrapper/utils.py
+++ b/mac-signing-wrapper/utils.py
@@ -1,0 +1,18 @@
+import os
+
+
+def zip_files(ssh, target_dir, zip_name):
+    zip_path = os.path.join(target_dir, zip_name)
+    command = f"cd {target_dir} && zip -r {zip_path} ."
+    ssh.run_command(command)
+    return zip_path
+
+
+def unzip_files(ssh, zip_path, output_dir):
+    command = f"unzip -o {zip_path} -d {output_dir}"
+    ssh.run_command(command)
+
+
+def cleanup(ssh, target_dir):
+    command = f"rm -rf {target_dir}"
+    ssh.run_command(command)


### PR DESCRIPTION
This commit adds a wrapper script to sign mac binaries. The script will be called inside a tekton task (step) to sign mac binaries. Does the following:

1. Establish SSH connection to a mac vm.
2. Pull unsigned binaries using oras from a given unsigned digest
3. Sign and notarize binaries inside.
4. Push signed content to oras and return the signed digest. 

JIRA: CLDX-134