### PR TITLE
feat(ISV-5127): add syft to release-service-utils image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,14 @@ ARG OPM_VERSION=v1.38.0
 ARG YQ_VERSION=4.34.1
 ARG GLAB_VERSION=1.31.0
 ARG GH_VERSION=2.32.1
+ARG SYFT_VERSION=1.12.2
 
 RUN curl -L https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 -o /usr/bin/yq &&\
     curl -L https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/bin/kubectl &&\
     curl -L https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm -o /usr/bin/opm &&\
     curl -L https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_Linux_x86_64.tar.gz | tar -C /usr -xzf - bin/glab &&\
     curl -L https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz  | tar -C /usr -xzf - --strip=1 gh_${GH_VERSION}_linux_amd64/bin/gh &&\
+    curl -L https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz | tar -C /usr/bin/ -xzf - syft &&\
     chmod +x /usr/bin/{yq,kubectl,opm,glab,gh} &&\
     rpm -ivh https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-${COSIGN_VERSION}-1.x86_64.rpm
 


### PR DESCRIPTION
This PR is adding syft (tool for generation and conversion of SBOM-s) into release-service-utils image
Syft: https://github.com/anchore/syft