### PR TITLE
feat(RELEASE-987): add `check-jsonschema` dependency to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN curl -LO https://github.com/release-engineering/exodus-rsync/releases/latest
     chmod +x exodus-rsync && mv exodus-rsync /usr/local/bin/rsync
 
 RUN pip3 install jinja2 \
+    check-jsonschema \
     jinja2-ansible-filters \
     packageurl-python \
     pubtools-content-gateway \


### PR DESCRIPTION
Add check-jsonschema to be used in the check-data-keys task in RSC.

Open PR that need this dependency  [PR](https://github.com/konflux-ci/release-service-catalog/pull/603)