### PR TITLE
fix(KONFLUX-4292): typo in rpm publisher field check

### DIFF
--- a/pyxis/test_upload_rpm_data.py
+++ b/pyxis/test_upload_rpm_data.py
@@ -36,7 +36,7 @@ COMPONENTS = [
     },
     {  # with RH publisher
         "purl": "pkg:rpm/rhel/pkg5?arch=noarch&upstream=pkg5-1-2.el8.src.rpm&distro=rhel-8.0",
-        "publisher": "Red Hat, inc.",
+        "publisher": "Red Hat, Inc.",
     },
     {  # with other publisher
         "purl": "pkg:rpm/rhel/pkg6?arch=noarch&upstream=pkg6-1-2.el8.src.rpm&distro=rhel-8.0",

--- a/pyxis/upload_rpm_data.py
+++ b/pyxis/upload_rpm_data.py
@@ -275,7 +275,7 @@ def construct_rpm_items_and_content_sets(
 
                 # XXX - temporary https://issues.redhat.com/browse/KONFLUX-4292
                 # Undo this in https://issues.redhat.com/browse/KONFLUX-4175
-                if component.get("publisher") == "Red Hat, inc.":
+                if component.get("publisher") == "Red Hat, Inc.":
                     rpm_item["gpg"] = "199e2f91fd431d51"
 
                 rpms_items.append(rpm_item)


### PR DESCRIPTION
We're looking for "Red Hat, Inc." in the publisher field to set a fixed gpg key (it's a temporary measure that will be removed later), but there was a typo
in the string, so it didn't work.