### PR TITLE
Tweak product SBOM generator

### DIFF
--- a/sbom/create_product_sbom.py
+++ b/sbom/create_product_sbom.py
@@ -5,7 +5,7 @@ data.json file.
 """
 import json
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 import argparse
 from collections import defaultdict
 from typing import DefaultDict, Dict, List
@@ -105,9 +105,7 @@ def create_sbom(data_path: str) -> Dict:
     # per SPDX spec, this URI does not have to be accessible, it's only used to
     # uniquely identify this SPDX document.
     # https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#65-spdx-document-namespace-field
-    document_namespace = (
-        f"https://redhat.com/spdxdocs/{product_name}-{product_version}-{uuid.uuid4()}"
-    )
+    document_namespace = f"https://redhat.com/{uuid.uuid4()}.spdx.json"
 
     packages = [create_product_package(product_name, product_version, cpe)]
     relationships = [create_product_relationship()]
@@ -121,13 +119,14 @@ def create_sbom(data_path: str) -> Dict:
     sbom = {
         "spdxVersion": "SPDX-2.3",
         "SPDXID": "SPDXRef-DOCUMENT",
-        "dataLicense": "CC0-1.0",
+        "dataLicense": "CC-BY-4.0",
         "documentNamespace": document_namespace,
         "creationInfo": {
-            "created": datetime.now().isoformat(),
-            "creator": "Organization: Red Hat",
+            # E.g. 2024-10-21T20:52:36+00:00
+            "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "creators": ["Organization: Red Hat", "Tool: Konflux CI"],
         },
-        "name": product_name,
+        "name": f"{product_name}_{product_version}",
         "packages": packages,
         "relationships": relationships,
     }

--- a/sbom/test_create_product_sbom.py
+++ b/sbom/test_create_product_sbom.py
@@ -1,12 +1,10 @@
 import datetime
 import json
-
 import unittest
-from unittest.mock import MagicMock, patch, mock_open
+from datetime import timezone
+from unittest.mock import MagicMock, mock_open, patch
 
-from create_product_sbom import (
-    create_sbom,
-)
+from create_product_sbom import create_sbom
 
 
 class TestCreateSBOM(unittest.TestCase):
@@ -15,7 +13,7 @@ class TestCreateSBOM(unittest.TestCase):
     def test_create_sbom_no_components(self, mock_datetime: MagicMock, mock_uuid: MagicMock):
         mock_uuid.uuid4.return_value = "039f091d-8790-41bc-b63e-251ec860e3db"
 
-        time = datetime.datetime.now()
+        time = datetime.datetime.now(timezone.utc)
         mock_datetime.now.return_value = time
 
         data = json.dumps(
@@ -34,14 +32,14 @@ class TestCreateSBOM(unittest.TestCase):
             assert sbom == {
                 "spdxVersion": "SPDX-2.3",
                 "SPDXID": "SPDXRef-DOCUMENT",
-                "dataLicense": "CC0-1.0",
-                "documentNamespace": "https://redhat.com/spdxdocs/"
-                "product-1.2.3-039f091d-8790-41bc-b63e-251ec860e3db",
+                "dataLicense": "CC-BY-4.0",
+                "documentNamespace": "https://redhat.com/039f091d-8790-41bc-b63e-251ec860e3db"
+                ".spdx.json",
                 "creationInfo": {
-                    "created": time.isoformat(),
-                    "creator": "Organization: Red Hat",
+                    "created": time.isoformat(timespec="seconds"),
+                    "creators": ["Organization: Red Hat", "Tool: Konflux CI"],
                 },
-                "name": "product",
+                "name": "product_1.2.3",
                 "packages": [
                     {
                         "SPDXID": "SPDXRef-product",
@@ -93,14 +91,14 @@ class TestCreateSBOM(unittest.TestCase):
             assert sbom == {
                 "spdxVersion": "SPDX-2.3",
                 "SPDXID": "SPDXRef-DOCUMENT",
-                "dataLicense": "CC0-1.0",
-                "documentNamespace": "https://redhat.com/spdxdocs/"
-                "product-1.2.3-039f091d-8790-41bc-b63e-251ec860e3db",
+                "dataLicense": "CC-BY-4.0",
+                "documentNamespace": "https://redhat.com/039f091d-8790-41bc-b63e-251ec860e3db"
+                ".spdx.json",
                 "creationInfo": {
-                    "created": time.isoformat(),
-                    "creator": "Organization: Red Hat",
+                    "created": time.isoformat(timespec="seconds"),
+                    "creators": ["Organization: Red Hat", "Tool: Konflux CI"],
                 },
-                "name": "product",
+                "name": "product_1.2.3",
                 "packages": [
                     {
                         "SPDXID": "SPDXRef-product",
@@ -173,14 +171,14 @@ class TestCreateSBOM(unittest.TestCase):
             assert sbom == {
                 "spdxVersion": "SPDX-2.3",
                 "SPDXID": "SPDXRef-DOCUMENT",
-                "dataLicense": "CC0-1.0",
-                "documentNamespace": "https://redhat.com/spdxdocs/"
-                "product-1.2.3-039f091d-8790-41bc-b63e-251ec860e3db",
+                "dataLicense": "CC-BY-4.0",
+                "documentNamespace": "https://redhat.com/039f091d-8790-41bc-b63e-251ec860e3db"
+                ".spdx.json",
                 "creationInfo": {
-                    "created": time.isoformat(),
-                    "creator": "Organization: Red Hat",
+                    "created": time.isoformat(timespec="seconds"),
+                    "creators": ["Organization: Red Hat", "Tool: Konflux CI"],
                 },
-                "name": "product",
+                "name": "product_1.2.3",
                 "packages": [
                     {
                         "SPDXID": "SPDXRef-product",


### PR DESCRIPTION
These guidelines are defined at:

https://redhatproductsecurity.github.io/security-data-guidelines/sbom/

Specific changes:

- Datetimes should always use UTC

- `documentNamespace` doesn't need to contain any product-specific information and serve only as an identifier (this information can be set in the `name` field")

- Data license should be `CC-BY-4.0`

- The `creators` field should note the Tool that is used to generate the SBOM. Also the SPDX 2.3 JSON schema requires the field to be called `creators` instead of `creator`: https://github.com/spdx/spdx-spec/blob/v2.3/schemas/spdx-schema.json