### PR TITLE
feat(KONFLUX-4892): supply layer size information to pyxis

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -178,10 +178,12 @@ def prepare_parsed_data(args) -> Dict[str, Any]:
         "name": args.name,
         "digest": args.architecture_digest,
         "architecture": args.architecture,
-        "layers": [layer["digest"] for layer in oras_manifest_fetch.get("layers", [])],
+        "layers": [
+            layer["digest"] for layer in reversed(oras_manifest_fetch.get("layers", []))
+        ],
         "uncompressed_layer_sizes": [
             {"layer_id": layer["digest"], "size_bytes": layer["size"]}
-            for layer in oras_manifest_fetch.get("uncompressed_layers", [])
+            for layer in reversed(oras_manifest_fetch.get("uncompressed_layers", []))
         ],
         "uncompressed_size_bytes": sum(
             [

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -306,7 +306,7 @@ def test_prepare_parsed_data__success(mock_open):
     assert parsed_data == {
         "architecture": "test",
         "digest": "sha:abc",
-        "layers": ["1", "2"],
+        "layers": ["2", "1"],
         "name": "quay.io/hacbs-release/release-service-utils",
         "files": [
             {"key": "buildfile", "filename": "Dockerfile", "content": dockerfile_content}
@@ -314,7 +314,7 @@ def test_prepare_parsed_data__success(mock_open):
         "sum_layer_size_bytes": 0,
         "uncompressed_layer_sizes": [],
         "uncompressed_size_bytes": 0,
-        "top_layer_id": "1",
+        "top_layer_id": "2",
         "uncompressed_top_layer_id": None,
     }
 
@@ -339,12 +339,12 @@ def test_prepare_parsed_data__success_no_dockerfile(mock_open):
     assert parsed_data == {
         "architecture": "test",
         "digest": "sha:abc",
-        "layers": ["1", "2"],
+        "layers": ["2", "1"],
         "name": "quay.io/hacbs-release/release-service-utils",
         "sum_layer_size_bytes": 0,
         "uncompressed_layer_sizes": [],
         "uncompressed_size_bytes": 0,
-        "top_layer_id": "1",
+        "top_layer_id": "2",
         "uncompressed_top_layer_id": None,
     }
 
@@ -379,17 +379,17 @@ def test_prepare_parsed_data__with_layer_sizes(mock_open):
     assert parsed_data == {
         "architecture": "test",
         "digest": "sha:abc",
-        "layers": ["1", "2"],
+        "layers": ["2", "1"],
         "name": "quay.io/hacbs-release/release-service-utils",
         "files": [
             {"key": "buildfile", "filename": "Dockerfile", "content": dockerfile_content}
         ],
         "sum_layer_size_bytes": 7,
         "uncompressed_layer_sizes": [
-            {"layer_id": "3", "size_bytes": 5},
             {"layer_id": "4", "size_bytes": 4},
+            {"layer_id": "3", "size_bytes": 5},
         ],
         "uncompressed_size_bytes": 9,
-        "top_layer_id": "1",
-        "uncompressed_top_layer_id": "3",
+        "top_layer_id": "2",
+        "uncompressed_top_layer_id": "4",
     }

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -104,6 +104,9 @@ def test_create_container_image(mock_datetime, mock_post):
             "image_id": "arch specific digest",
             "architecture": "ok",
             "parsed_data": {"architecture": "ok"},
+            "sum_layer_size_bytes": 0,
+            "top_layer_id": None,
+            "uncompressed_top_layer_id": None,
         },
     )
 
@@ -164,6 +167,9 @@ def test_create_container_image_latest(mock_datetime, mock_post):
             "image_id": "arch specific digest",
             "architecture": "ok",
             "parsed_data": {"architecture": "ok"},
+            "sum_layer_size_bytes": 0,
+            "top_layer_id": None,
+            "uncompressed_top_layer_id": None,
         },
     )
 
@@ -241,6 +247,9 @@ def test_create_container_image_rh_push_multiple_tags(mock_datetime, mock_post):
             "image_id": "arch specific digest",
             "architecture": "ok",
             "parsed_data": {"architecture": "ok"},
+            "sum_layer_size_bytes": 0,
+            "top_layer_id": None,
+            "uncompressed_top_layer_id": None,
         },
     )
 
@@ -302,6 +311,11 @@ def test_prepare_parsed_data__success(mock_open):
         "files": [
             {"key": "buildfile", "filename": "Dockerfile", "content": dockerfile_content}
         ],
+        "sum_layer_size_bytes": 0,
+        "uncompressed_layer_sizes": [],
+        "uncompressed_size_bytes": 0,
+        "top_layer_id": "1",
+        "uncompressed_top_layer_id": None,
     }
 
 
@@ -327,4 +341,55 @@ def test_prepare_parsed_data__success_no_dockerfile(mock_open):
         "digest": "sha:abc",
         "layers": ["1", "2"],
         "name": "quay.io/hacbs-release/release-service-utils",
+        "sum_layer_size_bytes": 0,
+        "uncompressed_layer_sizes": [],
+        "uncompressed_size_bytes": 0,
+        "top_layer_id": "1",
+        "uncompressed_top_layer_id": None,
+    }
+
+
+@patch("builtins.open")
+def test_prepare_parsed_data__with_layer_sizes(mock_open):
+    args = MagicMock()
+    args.architecture = "test"
+    args.architecture_digest = "sha:abc"
+    args.name = "quay.io/hacbs-release/release-service-utils"
+    args.dockerfile = "mydockerfile"
+    manifest_content = json.dumps(
+        {
+            "layers": [{"digest": "1", "size": 4}, {"digest": "2", "size": 3}],
+            "uncompressed_layers": [
+                {"digest": "3", "size": 5},
+                {"digest": "4", "size": 4},
+            ],
+        }
+    )
+    dockerfile_content = """FROM myimage\n\nRUN command\n"""
+    mock_open1 = MagicMock()
+    mock_open2 = MagicMock()
+    mock_open.side_effect = [mock_open1, mock_open2]
+    file1 = mock_open1.__enter__.return_value
+    file2 = mock_open2.__enter__.return_value
+    file1.read.return_value = manifest_content
+    file2.read.return_value = dockerfile_content
+
+    parsed_data = prepare_parsed_data(args)
+
+    assert parsed_data == {
+        "architecture": "test",
+        "digest": "sha:abc",
+        "layers": ["1", "2"],
+        "name": "quay.io/hacbs-release/release-service-utils",
+        "files": [
+            {"key": "buildfile", "filename": "Dockerfile", "content": dockerfile_content}
+        ],
+        "sum_layer_size_bytes": 7,
+        "uncompressed_layer_sizes": [
+            {"layer_id": "3", "size_bytes": 5},
+            {"layer_id": "4", "size_bytes": 4},
+        ],
+        "uncompressed_size_bytes": 9,
+        "top_layer_id": "1",
+        "uncompressed_top_layer_id": "3",
     }


### PR DESCRIPTION
Notably, this needs to be populated by `oras` in the task that invokes this script, but the test suite here verifies that the script will not break if this is rolled out before that task is modified.

https://issues.redhat.com/browse/KONFLUX-4892