### PR TITLE
fix(KONFLUX-4292): handle case where SBOM has no publisher

### DIFF
--- a/pyxis/test_upload_rpm_data.py
+++ b/pyxis/test_upload_rpm_data.py
@@ -48,6 +48,9 @@ COMPONENTS = [
     {  # no purl
         "bom_ref": "ref",
     },
+    {  # with redhat namespace, but no publisher
+        "purl": "pkg:rpm/redhat/pkg7@1.2.3-4.el9000?arch=noarch",
+    },
 ]
 
 
@@ -408,6 +411,15 @@ def test_construct_rpm_items_and_content_sets__success():
             "summary": "pkg6",
             "architecture": "noarch",
             "srpm_name": "pkg6-1-2.el8.src.rpm",
+        },
+        {
+            "name": "pkg7",
+            "gpg": "199e2f91fd431d51",
+            "summary": "pkg7-1.2.3-4.el9000.noarch",
+            "release": "4.el9000",
+            "version": "1.2.3",
+            "architecture": "noarch",
+            "nvra": "pkg7-1.2.3-4.el9000.noarch",
         },
     ]
 

--- a/pyxis/upload_rpm_data.py
+++ b/pyxis/upload_rpm_data.py
@@ -275,7 +275,10 @@ def construct_rpm_items_and_content_sets(
 
                 # XXX - temporary https://issues.redhat.com/browse/KONFLUX-4292
                 # Undo this in https://issues.redhat.com/browse/KONFLUX-4175
-                if component.get("publisher") == "Red Hat, Inc.":
+                if (
+                    component.get("publisher") == "Red Hat, Inc."
+                    or purl_dict["namespace"] == "redhat"
+                ):
                     rpm_item["gpg"] = "199e2f91fd431d51"
 
                 rpms_items.append(rpm_item)


### PR DESCRIPTION
We found that only syft SBOM entries contain the publisher field.

Here, extend the workaround logic to assume that every rpm in the redhat namespace bears the right key.