### PR TITLE
fix(TEAMNADO-7734): don't mangle long strings when generating advisories

### DIFF
--- a/templates/advisory.yaml.jinja
+++ b/templates/advisory.yaml.jinja
@@ -19,10 +19,10 @@ spec:
     {{ advisory.spec.content | to_nice_yaml(indent=2) | indent(4) | trim }}
   synopsis: {{ advisory.spec.synopsis }}
   topic: >-
-    {{ advisory.spec.topic | wordwrap(76) | indent(4) }}
+    {{ advisory.spec.topic | indent(4) }}
   description: >-
-    {{ advisory.spec.description | wordwrap(76) | indent(4) }}
+    {{ advisory.spec.description | indent(4) }}
   solution: >-
-    {{ advisory.spec.solution | wordwrap(76) | indent(4) }}
+    {{ advisory.spec.solution | indent(4) }}
   references:
     {{ advisory.spec.references | to_nice_yaml | indent(4) }}

--- a/utils/test_apply_template.py
+++ b/utils/test_apply_template.py
@@ -1,4 +1,10 @@
+import tempfile
+import json
+import os
+import yaml
+
 import pytest
+
 from unittest.mock import patch, MagicMock
 from apply_template import setup_argparser, main
 
@@ -42,3 +48,60 @@ def test_apply_template_advisory_template(
     main()
 
     file.write.assert_called_once_with("applied template file")
+
+
+@patch("apply_template.setup_argparser")
+def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
+    _, filename = tempfile.mkstemp()
+
+    # Confirm that long strings with spaces aren't broken up in a weird way
+    solution = (
+        "a really long string with spaces that goes on and on and "
+        "on and on and on and on and on, it's so long that you would "
+        "expect that something is going to linewrap it at some point. so long."
+    )
+    # Confirm that long strings with no spaces aren't broken up in a weird way
+    topic = (
+        "a-really-long-string-with-dashes-that-goes-on-and-on-and-"
+        "on-and-on-and-on-and-on-and-on,-it's-so-long-that-you-would-"
+        "expect-that-something-is-going-to-linewrap-it-at-some-point.-so-long."
+    )
+    try:
+        args = MagicMock()
+        args.template = "templates/advisory.yaml.jinja"
+        args.data = json.dumps(
+            {
+                "advisory_name": "advisory",
+                "advisory_ship_date": "today",
+                "advisory": {
+                    "spec": {
+                        "product_id": 1,
+                        "product_name": "name",
+                        "product_version": "version",
+                        "product_stream": "stream",
+                        "cpe": "cpe:/id",
+                        "type": "RHEA",
+                        "topic": topic,
+                        "description": "description",
+                        "solution": solution,
+                        "synopsis": "synopsis",
+                        "references": ["testing"],
+                        "content": {},
+                    }
+                },
+            }
+        )
+
+        args.output = filename
+        mock_argparser.return_value = args
+
+        # Act
+        main()
+
+        with open(filename, "r") as f:
+            result = yaml.safe_load(f.read())
+
+        assert result["spec"]["solution"] == solution
+        assert result["spec"]["topic"] == topic
+    finally:
+        os.remove(filename)


### PR DESCRIPTION
This fixes a particular case with long urls which got split when over the 76 character limit. Those then got a space inserted in the middle of them because of the way markdown works when you split long strings.

The solution here is just to not wordwrap the advisory yaml output.

I figure, it is meant for machines anyways, not humans, so it doesn't matter if it has long lines.