### PR TITLE
fix(KFLUXBUGS-1848): extend image_exists with repo

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -132,15 +132,18 @@ def setup_argparser() -> Any:  # pragma: no cover
     return parser
 
 
-def image_already_exists(args, digest: str) -> bool:
-    """Function to check if a containerImage with the given digest
+def image_already_exists(args, digest: str, repository: str) -> bool:
+    """Function to check if a containerImage with the given digest and repository
     already exists in the pyxis instance
 
     :return: True if one exists, else false
     """
 
     # quote is needed to urlparse the quotation marks
-    filter_str = quote(f'repositories.manifest_schema2_digest=="{digest}";not(deleted==true)')
+    filter_str = quote(
+        f'repositories.manifest_schema2_digest=="{digest}";'
+        f'not(deleted==true);repositories.repository=="{repository}"'
+    )
 
     check_url = urljoin(args.pyxis_url, f"v1/images?page_size=1&filter={filter_str}")
 
@@ -315,7 +318,7 @@ def main():  # pragma: no cover
 
     parsed_data = prepare_parsed_data(args)
 
-    if not image_already_exists(args, args.architecture_digest):
+    if not image_already_exists(args, args.architecture_digest, args.name):
         create_container_image(args, parsed_data)
 
 

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -21,12 +21,13 @@ def test_image_already_exists__image_does_exist(mock_get):
     args = MagicMock()
     args.pyxis_url = mock_pyxis_url
     args.architecture_digest = "some_digest"
+    args.name = "some/name"
 
     # Image already exists
     mock_rsp.json.return_value = {"data": [{"_id": 0}]}
 
     # Act
-    exists = image_already_exists(args, args.architecture_digest)
+    exists = image_already_exists(args, args.architecture_digest, args.name)
 
     # Assert
     assert exists
@@ -35,6 +36,7 @@ def test_image_already_exists__image_does_exist(mock_get):
         + "v1/images?page_size=1&filter="
         + "repositories.manifest_schema2_digest%3D%3D%22some_digest%22"
         + "%3Bnot%28deleted%3D%3Dtrue%29"
+        + "%3Brepositories.repository%3D%3D%22some/name%22"
     )
 
 
@@ -46,12 +48,13 @@ def test_image_already_exists__image_does_not_exist(mock_get):
     args = MagicMock()
     args.pyxis_url = mock_pyxis_url
     digest = "some_digest"
+    name = "some/name"
 
     # Image doesn't exist
     mock_rsp.json.return_value = {"data": []}
 
     # Act
-    exists = image_already_exists(args, digest)
+    exists = image_already_exists(args, digest, name)
 
     # Assert
     assert not exists


### PR DESCRIPTION
- some products may release an image to 2 locations in the catalog.
- rhel9/buildah and ubi9/buildah for example.
- this PR extends the image_exists function with the repo name