### PR TITLE
fix(KFLUXBUGS-1848): wrong name used in imageexist

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -139,10 +139,21 @@ def image_already_exists(args, digest: str, repository: str) -> bool:
     :return: True if one exists, else false
     """
 
+    # we need the repository name without the registry and organization
+    # given:
+    #   quay.io/redhat-pending/ubi9----buildah
+    # we need
+    #   ubi9/buildah
+    #
+    # is we are given:
+    #  quay.io/konflux-ci/release-service-utils
+    # then we need:
+    #  release-service-utils
+    repo = repository.split("/")[2].replace("----", "/")
     # quote is needed to urlparse the quotation marks
     filter_str = quote(
         f'repositories.manifest_schema2_digest=="{digest}";'
-        f'not(deleted==true);repositories.repository=="{repository}"'
+        f'not(deleted==true);repositories.repository=="{repo}"'
     )
 
     check_url = urljoin(args.pyxis_url, f"v1/images?page_size=1&filter={filter_str}")

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -21,7 +21,7 @@ def test_image_already_exists__image_does_exist(mock_get):
     args = MagicMock()
     args.pyxis_url = mock_pyxis_url
     args.architecture_digest = "some_digest"
-    args.name = "some/name"
+    args.name = "server/org/some_name"
 
     # Image already exists
     mock_rsp.json.return_value = {"data": [{"_id": 0}]}
@@ -36,7 +36,7 @@ def test_image_already_exists__image_does_exist(mock_get):
         + "v1/images?page_size=1&filter="
         + "repositories.manifest_schema2_digest%3D%3D%22some_digest%22"
         + "%3Bnot%28deleted%3D%3Dtrue%29"
-        + "%3Brepositories.repository%3D%3D%22some/name%22"
+        + "%3Brepositories.repository%3D%3D%22some_name%22"
     )
 
 
@@ -48,7 +48,7 @@ def test_image_already_exists__image_does_not_exist(mock_get):
     args = MagicMock()
     args.pyxis_url = mock_pyxis_url
     digest = "some_digest"
-    name = "some/name"
+    name = "server/org/some----name"
 
     # Image doesn't exist
     mock_rsp.json.return_value = {"data": []}


### PR DESCRIPTION
- we need to ensure we use the repo name in the form 'ubi9/buildah' given a passed name arg of 'quay.io/pending/ubi9----buildah'