### PR TITLE
fix(KFLUXBUGS-1848): associate existing images with a new repository

### DIFF
--- a/pyxis/pyxis.py
+++ b/pyxis/pyxis.py
@@ -82,6 +82,34 @@ def post(url: str, body: Dict[str, Any]) -> requests.Response:
     return resp
 
 
+def patch(url: str, body: Dict[str, Any]) -> requests.Response:
+    """PATCH pyxis API request to given URL with given payload
+
+    Args:
+        url (str): Pyxis API URL
+        body (Dict[str, Any]): Request payload
+
+    :return: Pyxis response
+    """
+    global session
+    if session is None:
+        session = _get_session()
+
+    LOGGER.debug(f"PATCH request URL: {url}")
+    LOGGER.debug(f"PATCH request body: {body}")
+    resp = session.patch(url, json=body)
+
+    try:
+        LOGGER.debug(f"PATCH request response: {resp.text}")
+        resp.raise_for_status()
+    except requests.HTTPError:
+        LOGGER.exception(
+            f"Pyxis PATCH query failed with {url} - {resp.status_code} - {resp.text}"
+        )
+        raise
+    return resp
+
+
 def graphql_query(graphql_api: str, body: Dict[str, Any]) -> Dict[str, Any]:
     """Make a request to Pyxis GraphQL API
 


### PR DESCRIPTION
This adds a new behavior.

If asked to create an image associated with a repository, and the image does not exist at all - then create it, as before.

If the image does exist, but is not associated with the desired repository, then submit a PATCH request to update it, adding the desired repository.

This is related to https://github.com/konflux-ci/release-service-utils/pull/300 and KFLUXBUGS-1848.