### PR TITLE
refactor: patching ContainerImage to add repositories

### DIFF
--- a/pyxis/test_pyxis.py
+++ b/pyxis/test_pyxis.py
@@ -72,6 +72,37 @@ def test_post_error(mock_get_session: MagicMock) -> None:
         pyxis.post(API_URL, {})
 
 
+@patch("pyxis.session", None)
+@patch("pyxis._get_session")
+def test_patch(mock_get_session: MagicMock) -> None:
+    resp = pyxis.patch(API_URL, {})
+
+    assert resp == mock_get_session.return_value.patch.return_value
+    mock_get_session.assert_called_once_with()
+
+
+@patch("pyxis.session")
+@patch("pyxis._get_session")
+def test_patch_existing_session(mock_get_session, mock_session: MagicMock) -> None:
+    resp = pyxis.patch(API_URL, {})
+
+    assert resp == mock_session.patch.return_value
+    mock_get_session.assert_not_called()
+
+
+@patch("pyxis.session", None)
+@patch("pyxis._get_session")
+def test_patch_error(mock_get_session: MagicMock) -> None:
+    response = Response()
+    response.status_code = 400
+    mock_get_session.return_value.patch.return_value.raise_for_status.side_effect = HTTPError(
+        response=response
+    )
+
+    with pytest.raises(HTTPError):
+        pyxis.patch(API_URL, {})
+
+
 @patch("pyxis.post")
 def test_graphql_query__success(mock_post: MagicMock):
     mock_data = {


### PR DESCRIPTION
This is a followup of what was done in #303

Most notably:

- rename the image_already_exists to find_image to reflect what it does - it used to return bool, now it returns the image if found.
- only get the image from Pyxis once - no need to get it a second time with the repository in the filter, we can just search through the repositories in the image that we got from the first request
- only include the repositories field in the patch payload
- for consistency, create the same two repo entries when adding a new repository like we do when creating a brand new image

It seems this mostly covers https://issues.redhat.com/browse/RELEASE-1285 as well - I just need to add tests for pyxis.patch.