### PR TITLE
fix: supply manifest list digest to pyxis

### DIFF
--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -202,6 +202,7 @@ def test_create_container_image_latest(mock_datetime, mock_post):
     args.certified = "false"
     args.is_latest = "true"
     args.rh_push = "false"
+    args.digest = "some_digest"
     args.architecture_digest = "arch specific digest"
     args.media_type = "application/vnd.oci.image.index.v1+json"
 
@@ -262,6 +263,7 @@ def test_create_container_image_rh_push_multiple_tags(mock_datetime, mock_post):
     args.tags = "tagprefix tagprefix-timestamp"
     args.certified = "false"
     args.rh_push = "true"
+    args.digest = "some_digest"
     args.architecture_digest = "arch specific digest"
     args.media_type = "application/vnd.oci.image.index.v1+json"
 


### PR DESCRIPTION
We're populating containerImage entities incorrectly.

I think this has no real effect, but if you look at one that we generate, the manifest_list_digest and manifest_schema2_digest are always the same, but they're not supposed to be. We currently incorrectly always set them to the value of the arch-specific image manifest, when the point is to provide both values, the multi-arch image index manifest as the manifest_list_digest and the arch-specific image manifest as the manifest_schema2_digest.