### PR TITLE
fix: handle none-type values more carefully

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -301,9 +301,13 @@ def create_container_image(args, parsed_data: Dict[str, Any]):
         "architecture": parsed_data["architecture"],
         "parsed_data": parsed_data,
         "sum_layer_size_bytes": sum_layer_size_bytes,
-        "top_layer_id": top_layer_id,
-        "uncompressed_top_layer_id": uncompressed_top_layer_id,
     }
+
+    # Only supply these ids if they are not "None"
+    if top_layer_id:
+        container_image_payload["top_layer_id"] = top_layer_id
+    if uncompressed_top_layer_id:
+        container_image_payload["uncompressed_top_layer_id"] = uncompressed_top_layer_id
 
     container_image_payload["repositories"][0].update(
         repository_digest_values(args, docker_image_digest)

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -135,8 +135,6 @@ def test_create_container_image(mock_datetime, mock_post):
             "architecture": "ok",
             "parsed_data": {"architecture": "ok"},
             "sum_layer_size_bytes": 0,
-            "top_layer_id": None,
-            "uncompressed_top_layer_id": None,
         },
     )
 
@@ -246,8 +244,6 @@ def test_create_container_image_latest(mock_datetime, mock_post):
             "architecture": "ok",
             "parsed_data": {"architecture": "ok"},
             "sum_layer_size_bytes": 0,
-            "top_layer_id": None,
-            "uncompressed_top_layer_id": None,
         },
     )
 
@@ -326,8 +322,6 @@ def test_create_container_image_rh_push_multiple_tags(mock_datetime, mock_post):
             "architecture": "ok",
             "parsed_data": {"architecture": "ok"},
             "sum_layer_size_bytes": 0,
-            "top_layer_id": None,
-            "uncompressed_top_layer_id": None,
         },
     )
 


### PR DESCRIPTION
In the event that an image does not have any gzipped layers, then no uncompressed layer information will be handed to this tool and it will pass on the None value to pyxis. That fails pyxis' input validation, blocking containerImage creation.

In this change, simply drop these values if they happen to be none.