### PR TITLE
fix(ISV-5128): also update sbom metadata component purl

### DIFF
--- a/sbom/test_update_component_sbom.py
+++ b/sbom/test_update_component_sbom.py
@@ -27,10 +27,16 @@ class TestUpdateComponentSBOM(unittest.TestCase):
 
     def test_update_cyclonedx_sbom(self) -> None:
         sbom = {
+            "metadata": {
+                "component": {
+                    "name": "comp1",
+                    "purl": "purl1",
+                }
+            },
             "components": [
                 {"name": "comp1", "purl": "purl1"},
                 {"name": "comp2", "purl": "purl2"},
-            ]
+            ],
         }
         mapping = {
             "comp1": ["updated_purl1"],
@@ -38,10 +44,16 @@ class TestUpdateComponentSBOM(unittest.TestCase):
         }
         update_cyclonedx_sbom(sbom, mapping)
         assert sbom == {
+            "metadata": {
+                "component": {
+                    "name": "comp1",
+                    "purl": "updated_purl1",
+                }
+            },
             "components": [
                 {"name": "comp1", "purl": "updated_purl1"},
                 {"name": "comp2", "purl": "updated_purl2"},
-            ]
+            ],
         }
 
     def test_update_spdx_sbom(self) -> None:

--- a/sbom/update_component_sbom.py
+++ b/sbom/update_component_sbom.py
@@ -42,6 +42,12 @@ def update_cyclonedx_sbom(sbom: Dict, component_to_purls_map: Dict[str, List[str
         component_to_purls_map: dictionary mapping of component names to list of purls.
     """
     LOG.info("Updating CycloneDX sbom")
+
+    component_name = sbom["metadata"]["component"]["name"]
+    if component_name in component_to_purls_map:
+        # only one purl is supported for CycloneDX
+        sbom["metadata"]["component"]["purl"] = component_to_purls_map[component_name][0]
+
     for component in sbom["components"]:
         if component["name"] in component_to_purls_map:
             # only one purl is supported for CycloneDX


### PR DESCRIPTION
Previously the update-component-sbom script is only updating the component purl in the list of components. But in CycloneDX, there is also a component purl in the metadata.