### PR TITLE
fix(RELEASE-999): check for existing Pyxis image

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -149,7 +149,7 @@ def proxymap(repository: str) -> str:
     return repository.split("/")[-1].replace("----", "/")
 
 
-def image_already_exists(args, digest: str, repository: str) -> Any:
+def image_already_exists(args, repository: str) -> Any:
     """Function to check if a containerImage with the given digest and repository
     already exists in the pyxis instance
 
@@ -157,11 +157,10 @@ def image_already_exists(args, digest: str, repository: str) -> Any:
 
     :return: the image id, if one exists, else None if not found
     """
-
-    # quote is needed to urlparse the quotation marks
-    raw_filter = f'repositories.manifest_schema2_digest=="{digest}";not(deleted==true)'
+    raw_filter = f'image_id=="{args.architecture_digest}";not(deleted==true)'
     if repository:
         raw_filter += f';repositories.repository=="{proxymap(repository)}"'
+    # quote is needed to urlparse the quotation marks
     filter_str = quote(raw_filter)
 
     check_url = urljoin(args.pyxis_url, f"v1/images?page_size=1&filter={filter_str}")
@@ -378,12 +377,12 @@ def main():  # pragma: no cover
 
     # First check if it exists at all
     LOGGER.info(f"Checking to see if digest {args.architecture_digest} exists in pyxis")
-    image = image_already_exists(args, args.architecture_digest, repository=None)
+    image = image_already_exists(args, repository=None)
     if image:
         # Then, check if it exists in association with the given repository
         identifier = image["_id"]
         LOGGER.info(f"It does! Checking to see if it's associated with {args.name}")
-        if image_already_exists(args, args.architecture_digest, repository=args.name):
+        if image_already_exists(args, repository=args.name):
             LOGGER.info(
                 f"Image with given docker_image_digest already exists as {identifier} "
                 f"and is associated with repository {args.name}. "

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -28,14 +28,14 @@ def test_image_already_exists__image_does_exist(mock_get):
     mock_rsp.json.return_value = {"data": [{"_id": 0}]}
 
     # Act
-    exists = image_already_exists(args, args.architecture_digest, args.name)
+    exists = image_already_exists(args, args.name)
 
     # Assert
     assert exists
     mock_get.assert_called_once_with(
         mock_pyxis_url
         + "v1/images?page_size=1&filter="
-        + "repositories.manifest_schema2_digest%3D%3D%22some_digest%22"
+        + "image_id%3D%3D%22some_digest%22"
         + "%3Bnot%28deleted%3D%3Dtrue%29"
         + "%3Brepositories.repository%3D%3D%22some_name%22"
     )
@@ -48,14 +48,13 @@ def test_image_already_exists__image_does_not_exist(mock_get):
     mock_get.return_value = mock_rsp
     args = MagicMock()
     args.pyxis_url = mock_pyxis_url
-    digest = "some_digest"
     name = "server/org/some----name"
 
     # Image doesn't exist
     mock_rsp.json.return_value = {"data": []}
 
     # Act
-    exists = image_already_exists(args, digest, name)
+    exists = image_already_exists(args, name)
 
     # Assert
     assert not exists
@@ -75,14 +74,14 @@ def test_image_already_exists__image_does_exist_but_no_repo(mock_get):
     mock_rsp.json.return_value = {"data": [{"_id": 0}]}
 
     # Act
-    exists = image_already_exists(args, args.architecture_digest, None)
+    exists = image_already_exists(args, None)
 
     # Assert
     assert exists
     mock_get.assert_called_once_with(
         mock_pyxis_url
         + "v1/images?page_size=1&filter="
-        + "repositories.manifest_schema2_digest%3D%3D%22some_digest%22"
+        + "image_id%3D%3D%22some_digest%22"
         + "%3Bnot%28deleted%3D%3Dtrue%29"
     )
 


### PR DESCRIPTION
The function that checks if the image already exists in Pyxis would always use `repositories.manifest_schema2_digest` in the query. But we only set that field for non-multiarch images. For multiarch, we set `repositories.manifest_list_digest`.

So that means that for multiarch images, I don't see how this could ever work.

The obvious fix would be to search for the right field for the particular image. The issue with that is that for multiarch images, we would have the same manifest list entry for each of the arch images, so we would only create the first one and all the rest would be skipped. So instead, let's use the image_id field which is set to the arch specific digest (for single arch, it's the main digest).