### PR TITLE
fix(KFLUXBUGS-1846): fail get-image-architectures if skopeo failed

### DIFF
--- a/utils/get-image-architectures
+++ b/utils/get-image-architectures
@@ -1,22 +1,28 @@
 #!/bin/bash
 #
 # script:      get-image-architectures
-# 
+#
 # description: This script fetches all architectures and their digests for a passed image.
 #              It will output each arch on its own line, as json.
 #
-# example command:  
+# example command:
 #              get-image-architectures IMAGE where IMAGE is quay.io/org/repo@sha256:abcde for example
 #
 
 IMAGE=$1
 
 if [ -z "${IMAGE}" ] || [[ "${IMAGE}" == docker://* ]] ; then
-    echo -e "Please pass an image (without the docker:// prefix) to find the architectures for"
+    echo "Please pass an image (without the docker:// prefix) to find the architectures for" >&2
     exit 1
 fi
 
 RAW_OUTPUT=$(skopeo inspect --no-tags --raw docker://${IMAGE})
+
+if [ -z "$RAW_OUTPUT" ]; then
+    echo "Error: Unable to fetch image details with skopeo inspect" >&2
+    exit 1
+fi
+
 
 ARTIFACT_TYPE=$(jq -r '.artifactType' <<< $RAW_OUTPUT)
 if [ "$ARTIFACT_TYPE" != "null" ] ; then


### PR DESCRIPTION
If skopeo inspect fails, the variable would be empty and then the jq query would return an empty string instead of null, so we would assume it's an oci artifact and run oras resolve.

If we were unable to fetch the image details with skopeo inspect we should just fail the script.