### PR TITLE
fix: add missing get-reference-base script for select-oci-auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN curl -L https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_
 
 COPY --from=oras /usr/bin/oras /usr/bin/oras
 COPY --from=oras /usr/local/bin/select-oci-auth /usr/local/bin/select-oci-auth
+COPY --from=oras /usr/local/bin/get-reference-base /usr/local/bin/get-reference-base
 COPY --from=cosign /usr/local/bin/cosign /usr/local/bin/cosign
 
 RUN dnf -y --setopt=tsflags=nodocs install \


### PR DESCRIPTION
`select-oci-auth` stopped working when the oras image ref was updated to the latest one.

The `select-oci-auth` in the oras-container repo was refactored and part of the logic was moved to a new `get-reference-base` script, which it uses. So we need to add that script.

Related PR:
https://github.com/konflux-ci/oras-container/pull/133