### PR TITLE
feat(RELEASE-1246): implement script to push files to CGW

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ COPY templates /home/templates
 COPY pubtools-pulp-wrapper /home/pubtools-pulp-wrapper
 COPY pubtools-marketplacesvm-wrapper /home/pubtools-marketplacesvm-wrapper
 COPY developer-portal-wrapper /home/developer-portal-wrapper
+COPY publish-to-cgw-wrapper /home/publish-to-cgw-wrapper
 COPY sbom /home/sbom
 
 # It is mandatory to set these labels
@@ -85,4 +86,5 @@ ENV PATH="$PATH:/home/utils"
 ENV PATH="$PATH:/home/pubtools-pulp-wrapper"
 ENV PATH="$PATH:/home/pubtools-marketplacesvm-wrapper"
 ENV PATH="$PATH:/home/developer-portal-wrapper"
+ENV PATH="$PATH:/home/publish-to-cgw-wrapper"
 ENV PATH="$PATH:/home/sbom"

--- a/publish-to-cgw-wrapper/publish_to_cgw_wrapper
+++ b/publish-to-cgw-wrapper/publish_to_cgw_wrapper
@@ -1,0 +1,1 @@
+publish_to_cgw_wrapper.py

--- a/publish-to-cgw-wrapper/publish_to_cgw_wrapper.py
+++ b/publish-to-cgw-wrapper/publish_to_cgw_wrapper.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+This script interacts with the Content Gateway (CGW) API to create and manage content files.
+It ensures each file is checked before creation and skips files that already exist.
+The script is idempotent,it can be executed multiple times as long as the label,
+short URL, and download URL remain unchanged.
+
+### **Functionality:**
+1. Reads a JSON metadata file and a directory containing content files.
+2. Retrieves the product ID using the provided product name and product code.
+3. Retrieves the version ID using the product version name.
+4. Generates metadata for each file in the content directory.
+5. Checks for existing files and skips them if they match the label, short URL, and download
+URL.
+6. Creates new files using the metadata.
+7. Rolls back created files if an error occurs during execution.
+8. Writes the final result, including processed, created, and skipped files, to a JSON file.
+9. Outputs the path of the generated result.json file to an output file.
+"""
+
+import os
+import argparse
+import json
+import hashlib
+import logging
+import requests
+from requests.auth import HTTPBasicAuth
+
+# Default values for each component,
+# values from data_file takes precedence over these
+default_values_per_component = {
+    "type": "FILE",
+    "hidden": False,
+    "invisible": False,
+}
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        prog="publish_to_cgw_wrapper", description="Publish content to the Content Gateway"
+    )
+    parser.add_argument(
+        "--cgw_host",
+        required=True,
+        help="The hostname of the content-gateway to publish the metadata to",
+    )
+    parser.add_argument(
+        "--data_file",
+        required=True,
+        help="Path to the JSON file containing merged data",
+    )
+    parser.add_argument(
+        "--content_dir",
+        required=True,
+        help="Path to the directory containing content to push",
+    )
+    parser.add_argument(
+        "--output_file",
+        required=True,
+        help="Path to the file which write the result.json file path",
+    )
+
+    return parser.parse_args()
+
+
+def call_cgw_api(*, host, method, endpoint, session, data=None):
+    """Make an API call to the Content Gateway service."""
+    try:
+        response = session.request(
+            method=method.upper(),
+            url=f"{host}{endpoint}",
+            json=data,
+        )
+
+        if not response.ok:
+            error_message = (
+                response.text.strip() or f"HTTP {response.status_code}:{response.reason}"
+            )
+            raise RuntimeError(f"API call failed: {error_message}")
+
+        return response
+    except requests.RequestException as e:
+        raise RuntimeError(f"API call failed: {e}")
+
+
+def get_product_id(*, host, session, product_name, product_code):
+    """Retrieve the product ID by name and product code."""
+    products = call_cgw_api(host=host, method="GET", endpoint="/products", session=session)
+    products = products.json()
+    for product in products:
+        if product.get("name") == product_name and product.get("productCode") == product_code:
+            logging.info(f"Found product: {product_name} with ID {product.get('id')}")
+            return product.get("id")
+    raise ValueError(f"Product {product_name} not found with product code {product_code}")
+
+
+def get_version_id(*, host, session, product_id, version_name):
+    """Retrieve the version ID for a specific product."""
+    versions = call_cgw_api(
+        host=host, method="GET", endpoint=f"/products/{product_id}/versions", session=session
+    )
+    versions = versions.json()
+    for version in versions:
+        if version.get("versionName") == version_name:
+            logging.info(f"Found version: {version_name} with ID {version.get('id')}")
+            return version.get("id")
+    raise ValueError(f"Version not found: {version_name}")
+
+
+def generate_download_url(content_dir, file_name):
+    """
+    Generate a download URL in this format:
+    /content/origin/files/sha256/{checksum[:2]}{checksum}/{file_name}
+    """
+    prefix = "/content/origin/files/sha256"
+    sha256_hash = hashlib.sha256()
+    with open(content_dir + "/" + file_name, "rb") as f:
+        for byte_block in iter(lambda: f.read(4096), b""):
+            sha256_hash.update(byte_block)
+    checksum = sha256_hash.hexdigest()
+    return f"{prefix}/{checksum[:2]}/{checksum}/{file_name}"
+
+
+def generate_metadata(
+    *, content_dir, components, product_Code, version_id, version_name, mirror_openshift_Push
+):
+    """
+    Generate metadata for each file in
+    content_list that starts with the component name
+    """
+    shortURL_base = "/pub/"
+    if mirror_openshift_Push:
+        shortURL_base = "/pub/cgw"
+    metadata = []
+    shasum_files_processed = []
+    logging.info(f"Generating metadata for files in {content_dir}")
+    for file in os.listdir(content_dir):
+        matching_component = None
+        for component in components:
+            if file.startswith(component["name"]):
+                matching_component = component.copy()
+                break
+
+        if matching_component:
+            logging.info(f"Processing file: {file}")
+            matching_component.update(
+                {
+                    "productVersionId": version_id,
+                    "downloadURL": generate_download_url(content_dir, file),
+                    "shortURL": f"{shortURL_base}/{product_Code}/{version_name}/{file}",
+                    "label": file,
+                }
+            )
+            del matching_component["name"]
+            metadata.append(
+                {"type": "file", **default_values_per_component, **matching_component}
+            )
+        else:
+            if file.startswith("sha256") and file not in shasum_files_processed:
+                shasum_files_processed.append(file)
+                logging.info(f"Processing file: {file}")
+                if file.endswith(".gpg"):
+                    label = "Checksum - GPG"
+                elif file.endswith(".sig"):
+                    label = "Checksum - Signature"
+                elif file.endswith(".txt"):
+                    label = "Checksum"
+
+                metadata.append(
+                    {
+                        "productVersionId": version_id,
+                        "downloadURL": generate_download_url(content_dir, file),
+                        "shortURL": f"{shortURL_base}/{product_Code}/{version_name}/{file}",
+                        "label": label,
+                        **default_values_per_component,
+                    }
+                )
+            else:
+                # Skip files that do not start with any component name or
+                # sha256
+                logging.info(
+                    f"Skipping file: {file} as it does not start with any component name"
+                )
+                continue
+
+    return metadata
+
+
+def file_already_exists(existing_files, new_file):
+    """Check if a file already exists"""
+    for file in existing_files:
+        if all(
+            file.get(key) == new_file.get(key) for key in ["label", "downloadURL", "shortURL"]
+        ):
+            return file
+    return None
+
+
+def rollback_files(*, host, session, product_id, version_id, created_file_ids):
+    """Rollback created files by listing and deleting them."""
+    if created_file_ids:
+        logging.warning("Rolling back created files due to failure")
+
+    for file_id in created_file_ids:
+        try:
+            call_cgw_api(
+                host=host,
+                method="DELETE",
+                endpoint=f"/products/{product_id}/versions/{version_id}/files/{file_id}",
+                session=session,
+            )
+        except Exception as e:
+            raise RuntimeError(f"Failed to rollback file: {e}")
+
+
+def create_files(*, host, session, product_id, version_id, metadata):
+    """Create files using the metadata created and rollback on failure."""
+    created_file_ids = []
+    skipped_files_ids = []
+    try:
+        existing_files = call_cgw_api(
+            host=host,
+            method="GET",
+            endpoint=f"/products/{product_id}/versions/{version_id}/files",
+            session=session,
+        )
+        existing_files = existing_files.json()
+
+        for file_metadata in metadata:
+            file_check = file_already_exists(existing_files, file_metadata)
+            if file_check:
+                skipped_files_ids.append(file_check.get("id"))
+                logging.info(
+                    "Skipping creation: File {} already exists with ShortURL {}".format(
+                        file_check["label"], file_check["shortURL"]
+                    )
+                )
+                continue
+            logging.info(
+                "Creating file: {} with ShortURL {}".format(
+                    file_metadata["label"], file_metadata["shortURL"]
+                )
+            )
+            created_file_id = call_cgw_api(
+                host=host,
+                method="POST",
+                endpoint=f"/products/{product_id}/versions/{version_id}/files",
+                session=session,
+                data=file_metadata,
+            )
+            created_file_id = created_file_id.json()
+            logging.info(f"Succesfully created file with ID: {created_file_id}")
+            created_file_ids.append(created_file_id)
+        return created_file_ids, skipped_files_ids
+    except Exception as e:
+        rollback_files(
+            host=host,
+            session=session,
+            product_id=product_id,
+            version_id=version_id,
+            created_file_ids=created_file_ids,
+        )
+        raise RuntimeError(f"Failed to create file: {e}")
+
+
+def main():
+    try:
+        args = parse_args()
+
+        USERNAME = os.getenv("CGW_USERNAME")
+        PASSWORD = os.getenv("CGW_PASSWORD")
+
+        if not USERNAME or not PASSWORD:
+            raise ValueError(
+                "CGW_USERNAME and CGW_PASSWORD environment variables are required"
+            )
+
+        session = requests.Session()
+        session.auth = HTTPBasicAuth(USERNAME, PASSWORD)
+        session.headers.update(
+            {
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            }
+        )
+
+        with open(args.data_file, "r") as file:
+            data = json.load(file)
+
+        productName = data["contentGateway"]["productName"]
+        productCode = data["contentGateway"]["productCode"]
+        productVersionName = data["contentGateway"]["productVersionName"]
+        mirrorOpenshiftPush = data["contentGateway"].get("mirrorOpenshiftPush")
+        components = data["contentGateway"]["components"]
+
+        product_id = get_product_id(
+            host=args.cgw_host,
+            session=session,
+            product_name=productName,
+            product_code=productCode,
+        )
+        product_version_id = get_version_id(
+            host=args.cgw_host,
+            session=session,
+            product_id=product_id,
+            version_name=productVersionName,
+        )
+        metadata = generate_metadata(
+            content_dir=args.content_dir,
+            components=components,
+            product_Code=productCode,
+            version_id=product_version_id,
+            version_name=productVersionName,
+            mirror_openshift_Push=mirrorOpenshiftPush,
+        )
+        created, skipped = create_files(
+            host=args.cgw_host,
+            session=session,
+            product_id=product_id,
+            version_id=product_version_id,
+            metadata=metadata,
+        )
+        logging.info(f"Created {len(created)} files and skipped {len(skipped)} files")
+
+        result_data = {
+            "no_of_files_processed": len(metadata),
+            "no_of_files_created": len(created),
+            "no_of_files_skipped": len(skipped),
+            "metadata": metadata,
+        }
+        result_file = os.path.join(os.path.dirname(args.data_file), "result.json")
+        with open(result_file, "w") as f:
+            json.dump(result_data, f)
+        with open(args.output_file, "w") as f:
+            f.write(result_file)
+
+    except Exception as e:
+        logging.error(e)
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/publish-to-cgw-wrapper/test_publish_to_cgw_integration.py
+++ b/publish-to-cgw-wrapper/test_publish_to_cgw_integration.py
@@ -1,0 +1,292 @@
+import os
+import json
+import pytest
+from unittest.mock import MagicMock, call, patch, ANY
+import publish_to_cgw_wrapper as cgw_wrapper
+
+
+@pytest.fixture
+def content_dir(tmpdir):
+    content_dir = tmpdir.mkdir("content_dir")
+    files = [
+        "checksum.sig",
+        "cosign",
+        "cosign-checksum.gpg",
+        "cosign-linux-amd64.gz",
+        "fake-name-linux-amd64.gz",
+        "gitsign-darwin-amd64.gz",
+        "ignored",
+        "sha256778877.txt",
+    ]
+    for filename in files:
+        content_dir.join(filename).write("")
+    return content_dir
+
+
+@pytest.fixture
+def data_file():
+    return {
+        "contentGateway": {
+            "mirrorOpenshiftPush": True,
+            "productName": "product_name_1",
+            "productCode": "product_code_1",
+            "productVersionName": "1.1",
+            "components": [
+                {
+                    "name": "cosign",
+                    "description": "Red Hat OpenShift Local Sandbox Test",
+                    "shortURL": "/cgw/product_code_1/1.1",
+                    "hidden": False,
+                },
+                {
+                    "name": "gitsign",
+                    "description": "Red Hat OpenShift Local Sandbox Test",
+                    "shortURL": "/cgw/product_code_1/1.1",
+                    "hidden": False,
+                },
+            ],
+        }
+    }
+
+
+@pytest.fixture
+def metadata():
+    return [
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.1/cosign-linux-amd64.gz",
+            "productVersionId": 4156067,
+            "downloadURL": (
+                "/content/origin/files/sha256/e3/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b9"
+                "34ca495991b7852b855/cosign-linux-amd64.gz"
+            ),
+            "label": "cosign-linux-amd64.gz",
+        },
+        {
+            "productVersionId": 4156067,
+            "downloadURL": (
+                "/content/origin/files/sha256/e3/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b9"
+                "34ca495991b7852b855/sha256778877.txt"
+            ),
+            "shortURL": "/pub/cgw/product_code_1/1.1/sha256778877.txt",
+            "label": "Checksum",
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+        },
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.1/cosign",
+            "productVersionId": 4156067,
+            "downloadURL": (
+                "/content/origin/files/sha256/e3/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b9"
+                "34ca495991b7852b855/cosign"
+            ),
+            "label": "cosign",
+        },
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.1/cosign-checksum.gpg",
+            "productVersionId": 4156067,
+            "downloadURL": (
+                "/content/origin/files/sha256/e3/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b9"
+                "34ca495991b7852b855/cosign-checksum.gpg"
+            ),
+            "label": "cosign-checksum.gpg",
+        },
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.1/gitsign-darwin-amd64.gz",
+            "productVersionId": 4156067,
+            "downloadURL": (
+                "/content/origin/files/sha256/e3/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b9"
+                "34ca495991b7852b855/gitsign-darwin-amd64.gz"
+            ),
+            "label": "gitsign-darwin-amd64.gz",
+        },
+    ]
+
+
+@pytest.fixture
+def temp_data_file(tmp_path, data_file):
+    """Create a temporary data file."""
+    data_file_path = tmp_path / "data.json"
+    data_file_path.write_text(json.dumps(data_file))
+    return data_file_path
+
+
+@pytest.fixture
+def temp_output_file(tmp_path):
+    """Create a temporary output file path."""
+    return tmp_path / "result.txt"
+
+
+@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch.dict(os.environ, {"CGW_USERNAME": "username", "CGW_PASSWORD": "password"})
+@patch("sys.argv", new_callable=lambda: ["publish_to_cgw_wrapper.py"])
+def test_main_creates_files(
+    mock_sys_argv, mock_call, temp_data_file, temp_output_file, content_dir, metadata
+):
+    """Test the main() function where all files are created."""
+
+    test_args = [
+        "--cgw_host",
+        "https://cgw.com/cgw/rest/admin",
+        "--data_file",
+        str(temp_data_file),
+        "--content_dir",
+        str(content_dir),
+        "--output_file",
+        str(temp_output_file),
+    ]
+    mock_sys_argv.extend(test_args)
+
+    mock_call.side_effect = [
+        MagicMock(
+            json=lambda: [
+                {"id": 356067, "name": "product_name_1", "productCode": "product_code_1"}
+            ]
+        ),  # Get products
+        MagicMock(json=lambda: [{"id": 4156067, "versionName": "1.1"}]),  # Get version
+        MagicMock(json=lambda: []),  # Get existing files
+        MagicMock(json=lambda: 4567),  # cosign-linux-amd64.gz (create)
+        MagicMock(json=lambda: 4568),  # sha256778877.txt (create)
+        MagicMock(json=lambda: 4569),  # cosign (create)
+        MagicMock(json=lambda: 4570),  # cosign-checksum.gpg (create)
+        MagicMock(json=lambda: 4571),  # gitsign-darwin-amd64.gz (create)
+    ]
+
+    cgw_wrapper.main()
+    assert temp_output_file.exists()
+    final_result_path = temp_output_file.read_text(encoding="utf-8")
+    assert final_result_path.endswith("result.json")
+    with open(final_result_path) as f:
+        result_json = json.load(f)
+    assert result_json["no_of_files_processed"] == 5
+    assert result_json["no_of_files_created"] == 5
+    assert result_json["no_of_files_skipped"] == 0
+
+
+@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch.dict(os.environ, {"CGW_USERNAME": "user", "CGW_PASSWORD": "password"})
+@patch("sys.argv", new_callable=lambda: ["publish_to_cgw_wrapper.py"])
+def test_main_skips_3_creates_2(
+    mock_sys_argv, mock_call, temp_data_file, temp_output_file, content_dir, metadata
+):
+    """Test for main() when 3 files are skipped and 2 are created."""
+    test_args = [
+        "--cgw_host",
+        "https://cgw.com/cgw/rest/admin",
+        "--data_file",
+        str(temp_data_file),
+        "--content_dir",
+        str(content_dir),
+        "--output_file",
+        str(temp_output_file),
+    ]
+    mock_sys_argv.extend(test_args)
+
+    mock_call.side_effect = [
+        MagicMock(
+            json=lambda: [
+                {"id": 356067, "name": "product_name_1", "productCode": "product_code_1"}
+            ]
+        ),  # Get products
+        MagicMock(json=lambda: [{"id": 4156067, "versionName": "1.1"}]),  # Get version
+        MagicMock(
+            json=lambda: [
+                {**metadata[0], "id": 4567},  # cosign-linux-amd64.gz (exists)
+                {**metadata[1], "id": 4568},  # sha256778877.txt (exists)
+                {**metadata[2], "id": 4569},  # cosign (exists)
+            ]  # Get existing files
+        ),
+        MagicMock(json=lambda: 4570),  # sha256778877.txt (create)
+        MagicMock(json=lambda: 4571),  # cosign-checksum.gpg (create)
+    ]
+
+    cgw_wrapper.main()
+
+    assert temp_output_file.exists()
+
+    final_result_path = temp_output_file.read_text(encoding="utf-8")
+    with open(final_result_path) as f:
+        result_json = json.load(f)
+
+    assert result_json["no_of_files_processed"] == 5
+    assert result_json["no_of_files_created"] == 2
+    assert result_json["no_of_files_skipped"] == 3
+
+
+@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch.dict(os.environ, {"CGW_USERNAME": "user", "CGW_PASSWORD": "password"})
+@patch("sys.argv", new_callable=lambda: ["publish_to_cgw_wrapper.py"])
+def test_main_partial_skip_fail_rollback(
+    mock_sys_argv, mock_call, temp_data_file, temp_output_file, content_dir, metadata
+):
+    """Test the main() where 5 file are tried to be created, 2 are skipped, 1
+    is created, 1 fails and 2 are rolled back."""
+
+    test_args = [
+        "--cgw_host",
+        "https://cgw.com/cgw/rest/admin",
+        "--data_file",
+        str(temp_data_file),
+        "--content_dir",
+        str(content_dir),
+        "--output_file",
+        str(temp_output_file),
+    ]
+    mock_sys_argv.extend(test_args)
+
+    mock_call.side_effect = [
+        MagicMock(
+            json=lambda: [
+                {"id": 356067, "name": "product_name_1", "productCode": "product_code_1"}
+            ]
+        ),  # Get products
+        MagicMock(json=lambda: [{"id": 4156067, "versionName": "1.1"}]),  # Get version
+        MagicMock(
+            json=lambda: [
+                {**metadata[0], "id": 4571},  # cosign-linux-amd64.gz (exists)
+                {**metadata[1], "id": 4572},  # sha256778877.txt (exists)
+            ]
+        ),
+        MagicMock(json=lambda: 4573),  # cosign (create)
+        MagicMock(json=lambda: 4574),  # cosign-checksum.gpg (create)
+        RuntimeError("File is already present in system"),  # Fail to create
+        MagicMock(),  # Delete for file ID 4573
+        MagicMock(),  # Delete for file ID 4574
+    ]
+
+    with pytest.raises(SystemExit) as exc:
+        cgw_wrapper.main()
+    assert exc.value.code == 1
+
+    expected_delete_calls = [
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="DELETE",
+            endpoint="/products/356067/versions/4156067/files/4573",
+            session=ANY,
+        ),
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="DELETE",
+            endpoint="/products/356067/versions/4156067/files/4574",
+            session=ANY,
+        ),
+    ]
+    mock_call.assert_has_calls(expected_delete_calls, any_order=True)
+    assert mock_call.call_count == 8

--- a/publish-to-cgw-wrapper/test_publish_to_cgw_wrapper.py
+++ b/publish-to-cgw-wrapper/test_publish_to_cgw_wrapper.py
@@ -1,0 +1,552 @@
+import hashlib
+import pytest
+import requests
+from unittest.mock import MagicMock, patch, call
+import publish_to_cgw_wrapper as cgw_wrapper
+
+
+@pytest.fixture
+def session():
+    return requests.Session()
+
+
+@pytest.fixture
+def content_dir(tmpdir):
+    content_dir = tmpdir.mkdir("content_dir")
+    files = [
+        "checksum.sig",
+        "cosign",
+        "cosign-checksum.gpg",
+        "cosign-linux-amd64.gz",
+        "fake-name-linux-amd64.gz",
+        "gitsign-darwin-amd64.gz",
+        "ignored",
+        "sha256778877.txt",
+    ]
+    for filename in files:
+        content_dir.join(filename).write("")
+    return content_dir
+
+
+@pytest.fixture
+def data_file():
+    return {
+        "contentGateway": {
+            "mirrorOpenshiftPush": True,
+            "productName": "product_name_1",
+            "productCode": "product_code_1",
+            "productVersionName": "1.1",
+            "components": [
+                {
+                    "name": "cosign",
+                    "description": "Red Hat OpenShift Local Sandbox Test",
+                    "shortURL": "/cgw/product_code_1/1.1",
+                    "hidden": False,
+                },
+                {
+                    "name": "gitsign",
+                    "description": "Red Hat OpenShift Local Sandbox Test",
+                    "shortURL": "/cgw/product_code_1/1.1",
+                    "hidden": False,
+                },
+            ],
+        }
+    }
+
+
+@pytest.fixture
+def metadata():
+    return [
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.1/cosign-linux-amd64.gz",
+            "productVersionId": 4156067,
+            "downloadURL": (
+                "/content/origin/files/sha256/e3/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b9"
+                "34ca495991b7852b855/cosign-linux-amd64.gz"
+            ),
+            "label": "cosign-linux-amd64.gz",
+        },
+        {
+            "productVersionId": 4156067,
+            "downloadURL": (
+                "/content/origin/files/sha256/e3/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b9"
+                "34ca495991b7852b855/sha256778877.txt"
+            ),
+            "shortURL": "/pub/cgw/product_code_1/1.1/sha256778877.txt",
+            "label": "Checksum",
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+        },
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.1/cosign",
+            "productVersionId": 4156067,
+            "downloadURL": (
+                "/content/origin/files/sha256/e3/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b9"
+                "34ca495991b7852b855/cosign"
+            ),
+            "label": "cosign",
+        },
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.1/cosign-checksum.gpg",
+            "productVersionId": 4156067,
+            "downloadURL": (
+                "/content/origin/files/sha256/e3/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b9"
+                "34ca495991b7852b855/cosign-checksum.gpg"
+            ),
+            "label": "cosign-checksum.gpg",
+        },
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.1/gitsign-darwin-amd64.gz",
+            "productVersionId": 4156067,
+            "downloadURL": (
+                "/content/origin/files/sha256/e3/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b9"
+                "34ca495991b7852b855/gitsign-darwin-amd64.gz"
+            ),
+            "label": "gitsign-darwin-amd64.gz",
+        },
+    ]
+
+
+def test_parse_args():
+    """Test parsing command line arguments."""
+    test_args = [
+        "--cgw_host",
+        "https://cgw.com/cgw/rest/admin",
+        "--data_file",
+        "./data.json",
+        "--content_dir",
+        "./content_dir",
+        "--output_file",
+        "./result.txt",
+    ]
+    with patch("sys.argv", ["publish_to_cgw_wrapper.py"] + test_args):
+        args = cgw_wrapper.parse_args()
+        assert args.cgw_host == "https://cgw.com/cgw/rest/admin"
+        assert args.data_file == "./data.json"
+        assert args.content_dir == "./content_dir"
+        assert args.output_file == "./result.txt"
+
+
+def test_parse_args_missing_required():
+    """Test parsing command line arguments with missing required arguments."""
+    test_args = []
+    with patch("sys.argv", ["publish_to_cgw_wrapper.py"] + test_args):
+        with pytest.raises(SystemExit) as excinfo:
+            cgw_wrapper.parse_args()
+        assert excinfo.value.code == 2
+
+
+@patch("requests.Session.request")
+def test_call_cgw_api_success(mock_request, session):
+    """Test successful API call"""
+    mock_response = MagicMock()
+    mock_response.ok = True
+    mock_response.json.return_value = {"result": "success"}
+    mock_request.return_value = mock_response
+
+    response = cgw_wrapper.call_cgw_api(
+        host="https://cgw.com/cgw/rest/admin",
+        method="GET",
+        endpoint="/endpoint",
+        session=session,
+    )
+
+    assert mock_request.call_count == 1
+    assert response.json() == {"result": "success"}
+
+
+@patch("requests.Session.request")
+def test_call_cgw_api_failure(mock_request, session):
+    """Test API call failure when response is not OK."""
+    mock_response = MagicMock()
+    mock_response.ok = False
+    mock_response.status_code = 401
+    mock_response.text = "Unauthorized"
+    mock_request.return_value = mock_response
+    with pytest.raises(RuntimeError, match="API call failed: Unauthorized"):
+        cgw_wrapper.call_cgw_api(
+            host="https://cgw.com/cgw/rest/admin",
+            method="GET",
+            endpoint="/endpoint",
+            session=session,
+        )
+
+
+@patch("requests.Session.request")
+def test_call_cgw_api_exception(mock_request, session):
+    """Test API call failure when an exception is raised."""
+    mock_request.side_effect = requests.exceptions.RequestException("Connection error")
+    with pytest.raises(RuntimeError, match="API call failed: Connection error"):
+        cgw_wrapper.call_cgw_api(
+            host="https://cgw.com/cgw/rest/admin",
+            method="GET",
+            endpoint="/endpoint",
+            session=session,
+        )
+
+
+@patch("publish_to_cgw_wrapper.call_cgw_api")
+def test_get_product_id(mock_call):
+    """Test getting product ID."""
+    mock_call.return_value.json.return_value = [
+        {"name": "product_name_1", "productCode": "code1", "id": 5468},
+        {"name": "product_name_2", "productCode": "code2", "id": 6789},
+    ]
+    product_id = cgw_wrapper.get_product_id(
+        host="https://cgw.com/cgw/rest/admin",
+        session=None,
+        product_name="product_name_1",
+        product_code="code1",
+    )
+    mock_call.assert_called_once_with(
+        host="https://cgw.com/cgw/rest/admin", method="GET", endpoint="/products", session=None
+    )
+    assert product_id == 5468
+
+
+@patch("publish_to_cgw_wrapper.call_cgw_api")
+def test_get_product_id_not_found(mock_call):
+    """Test getting product ID when product is not found."""
+    mock_call.return_value.json.return_value = [
+        {"name": "product_name_1", "productCode": "code1", "id": 5468},
+        {"name": "product_name_2", "productCode": "code2", "id": 6789},
+    ]
+    with pytest.raises(
+        ValueError, match="Product product_name_3 not found with product code code3"
+    ):
+        cgw_wrapper.get_product_id(
+            host="https://cgw.com/cgw/rest/admin",
+            session=None,
+            product_name="product_name_3",
+            product_code="code3",
+        )
+    mock_call.assert_called_once_with(
+        host="https://cgw.com/cgw/rest/admin", method="GET", endpoint="/products", session=None
+    )
+
+
+@patch("publish_to_cgw_wrapper.call_cgw_api")
+def test_get_version_id(mock_call):
+    """Test getting version ID."""
+    mock_call.return_value.json.return_value = [
+        {"id": 4156067, "versionName": "1.1"},
+        {"id": 4156068, "versionName": "1.2"},
+    ]
+    version_id = cgw_wrapper.get_version_id(
+        host="https://cgw.com/cgw/rest/admin",
+        session=None,
+        product_id="4010426",
+        version_name="1.2",
+    )
+    mock_call.assert_called_once_with(
+        host="https://cgw.com/cgw/rest/admin",
+        method="GET",
+        endpoint="/products/4010426/versions",
+        session=None,
+    )
+    assert version_id == 4156068
+
+
+@patch("publish_to_cgw_wrapper.call_cgw_api")
+def test_get_version_id_not_found(mock_call):
+    """Test getting version ID when version is not found."""
+    mock_call.return_value.json.return_value = [
+        {"id": 4156067, "versionName": "1.1"},
+        {"id": 4156068, "versionName": "1.2"},
+    ]
+    with pytest.raises(ValueError, match="Version not found: 1.3"):
+        cgw_wrapper.get_version_id(
+            host="https://cgw.com/cgw/rest/admin",
+            session=None,
+            product_id="4010426",
+            version_name="1.3",
+        )
+    mock_call.assert_called_once_with(
+        host="https://cgw.com/cgw/rest/admin",
+        method="GET",
+        endpoint="/products/4010426/versions",
+        session=None,
+    )
+
+
+def test_generate_download_url(tmpdir):
+    """Test generating download URL."""
+    file_path = tmpdir.join("cosign-linux-amd64.gz")
+    file_path.write(b"")
+    expected_hash = hashlib.sha256(b"").hexdigest()
+    expected_url = (
+        f"/content/origin/files/sha256/{expected_hash[:2]}/{expected_hash}/"
+        "cosign-linux-amd64.gz"
+    )
+    assert (
+        cgw_wrapper.generate_download_url(str(tmpdir), "cosign-linux-amd64.gz") == expected_url
+    )
+
+
+def test_generate_metadata(content_dir, data_file, metadata):
+    """Test generating metadata."""
+    components = data_file["contentGateway"]["components"]
+    output_metadata = cgw_wrapper.generate_metadata(
+        content_dir=str(content_dir),
+        components=components,
+        product_Code="product_code_1",
+        version_id=4156067,
+        version_name="1.1",
+        mirror_openshift_Push=True,
+    )
+    assert len(output_metadata) is len(metadata)
+    for expected_file in metadata:
+        assert expected_file in output_metadata
+
+
+def test_file_already_exists(metadata):
+    """Test checking if a file already exists."""
+    new_file = metadata[0]
+    assert cgw_wrapper.file_already_exists(metadata, new_file) is metadata[0]
+
+
+def test_file_does_not_exist(metadata):
+    """Test checking if a file does not exist."""
+    new_file = metadata[0].copy()
+    new_file["label"] = "nonexistent-file.gz"
+    new_file["shortURL"] = "/pub/cgw/product_name_1/1.2/nonexistent-file.gz"
+    new_file["downloadURL"] = "/content/origin/files/sha256/0d/somehash/nonexistent-file.gz"
+    assert cgw_wrapper.file_already_exists(metadata, new_file) is None
+
+
+@patch("publish_to_cgw_wrapper.call_cgw_api")
+def test_rollback_files(mock_call):
+    """Test rolling back created files."""
+    response = cgw_wrapper.rollback_files(
+        host="https://cgw.com/cgw/rest/admin",
+        session=None,
+        product_id="101",
+        version_id="201",
+        created_file_ids=[4567, 5678],
+    )
+    mock_call.assert_has_calls(
+        [
+            call(
+                host="https://cgw.com/cgw/rest/admin",
+                method="DELETE",
+                endpoint="/products/101/versions/201/files/4567",
+                session=None,
+            ),
+            call(
+                host="https://cgw.com/cgw/rest/admin",
+                method="DELETE",
+                endpoint="/products/101/versions/201/files/5678",
+                session=None,
+            ),
+        ]
+    )
+    assert mock_call.call_count == 2
+    assert response is None
+
+
+@patch("publish_to_cgw_wrapper.call_cgw_api")
+def test_rollback_files_exception(mock_call):
+    """Test rolling back created files when an exception is raised."""
+    mock_call.side_effect = [None, RuntimeError("File can not be deleted")]
+
+    with pytest.raises(RuntimeError, match="File can not be deleted"):
+        cgw_wrapper.rollback_files(
+            host="https://cgw.com/cgw/rest/admin",
+            session=None,
+            product_id="101",
+            version_id="201",
+            created_file_ids=[4567, 5678],
+        )
+    mock_call.assert_has_calls(
+        [
+            call(
+                host="https://cgw.com/cgw/rest/admin",
+                method="DELETE",
+                endpoint="/products/101/versions/201/files/4567",
+                session=None,
+            ),
+            call(
+                host="https://cgw.com/cgw/rest/admin",
+                method="DELETE",
+                endpoint="/products/101/versions/201/files/5678",
+                session=None,
+            ),
+        ]
+    )
+    assert mock_call.call_count == 2
+
+
+@patch("publish_to_cgw_wrapper.call_cgw_api")
+def test_create_files_success(mock_call, metadata):
+    """Test successful file creation with no existing files."""
+    mock_call.side_effect = [
+        MagicMock(json=lambda: []),  # No existing files
+        MagicMock(json=lambda: 4567),  # cosign-linux-amd64.gz (created)
+        MagicMock(json=lambda: 4568),  # sha256778877.txt (created)
+    ]
+    metadata = metadata[:2]
+
+    created, skipped = cgw_wrapper.create_files(
+        host="https://cgw.com/cgw/rest/admin",
+        session=None,
+        product_id="101",
+        version_id="201",
+        metadata=metadata,
+    )
+
+    mock_call.assert_has_calls(
+        [
+            call(
+                host="https://cgw.com/cgw/rest/admin",
+                method="GET",
+                endpoint="/products/101/versions/201/files",
+                session=None,
+            ),
+            call(
+                host="https://cgw.com/cgw/rest/admin",
+                method="POST",
+                endpoint="/products/101/versions/201/files",
+                session=None,
+                data=metadata[0],
+            ),
+            call(
+                host="https://cgw.com/cgw/rest/admin",
+                method="POST",
+                endpoint="/products/101/versions/201/files",
+                session=None,
+                data=metadata[1],
+            ),
+        ]
+    )
+
+    assert mock_call.call_count == 3
+    assert created == [4567, 4568]
+    assert skipped == []
+
+
+@patch("publish_to_cgw_wrapper.call_cgw_api")
+def test_create_files_with_existing(mock_call, metadata):
+    """Test file creation when some files already exist."""
+    existing_files = [
+        {**metadata[0], "id": 4566},  # cosign-linux-amd64.gz (exists)
+        {**metadata[1], "id": 4567},  # sha256778877.txt (exists)
+    ]
+
+    mock_call.side_effect = [
+        MagicMock(json=lambda: existing_files),
+        MagicMock(json=lambda: 4568),  # cosign (created)
+        MagicMock(json=lambda: 4569),  # cosign-checksum.gpg (created)
+        MagicMock(json=lambda: 4570),  # gitsign-darwin-amd64.gz (created)
+    ]
+
+    created, skipped = cgw_wrapper.create_files(
+        host="https://cgw.com/cgw/rest/admin",
+        session=None,
+        product_id="101",
+        version_id="202",
+        metadata=metadata,
+    )
+
+    expected_calls = [
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="GET",
+            endpoint="/products/101/versions/202/files",
+            session=None,
+        ),
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="POST",
+            endpoint="/products/101/versions/202/files",
+            session=None,
+            data=metadata[2],
+        ),
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="POST",
+            endpoint="/products/101/versions/202/files",
+            session=None,
+            data=metadata[3],
+        ),
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="POST",
+            endpoint="/products/101/versions/202/files",
+            session=None,
+            data=metadata[4],
+        ),
+    ]
+
+    mock_call.assert_has_calls(expected_calls)
+    assert mock_call.call_count == 4
+    assert created == [4568, 4569, 4570]
+    assert skipped == [4566, 4567]
+
+
+@patch("publish_to_cgw_wrapper.call_cgw_api")
+def test_create_files_exception(mock_call, metadata):
+    """Test file creation when an exception is raised and check rollback is successful."""
+    mock_call.side_effect = [
+        MagicMock(json=lambda: []),
+        MagicMock(json=lambda: 4567),
+        RuntimeError("File can not be created"),
+        None,
+    ]
+
+    with pytest.raises(RuntimeError, match="File can not be created"):
+        cgw_wrapper.create_files(
+            host="https://cgw.com/cgw/rest/admin",
+            session=None,
+            product_id="101",
+            version_id="201",
+            metadata=metadata[:2],
+        )
+
+    expected_calls = [
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="GET",
+            endpoint="/products/101/versions/201/files",
+            session=None,
+        ),
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="POST",
+            endpoint="/products/101/versions/201/files",
+            session=None,
+            data=metadata[0],
+        ),
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="POST",
+            endpoint="/products/101/versions/201/files",
+            session=None,
+            data=metadata[1],
+        ),
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="DELETE",
+            endpoint="/products/101/versions/201/files/4567",
+            session=None,
+        ),
+    ]
+
+    mock_call.assert_has_calls(expected_calls, any_order=False)
+    assert mock_call.call_count == 4


### PR DESCRIPTION
This script automates pushing files to the CGW:

- Reads metadata and processes files from the content directory.
- Checks if a file already exists in the product version based on the label, short URL, and download URL, skipping duplicates to avoid failure.
- Creates new files and returns their IDs upon success.
- Generates a JSON report summarising the number of files created, skipped, and the metadata used.

RELATES TO: https://github.com/konflux-ci/release-service-catalog/pull/781