### PR TITLE
feat(RELEASE-1353): add severity to advisory template

### DIFF
--- a/templates/advisory.yaml.jinja
+++ b/templates/advisory.yaml.jinja
@@ -11,6 +11,9 @@ spec:
   product_stream: {{ advisory.spec.product_stream }}
   cpe: {{ advisory.spec.cpe }}
   type: {{ advisory.spec.type }}
+{%- if 'severity' in advisory.spec %}
+  severity: {{ advisory.spec.severity }}
+{%- endif %}
 {%- if 'issues' in advisory.spec %}
   issues:
     {{ advisory.spec.issues | to_nice_yaml(indent=2) | indent(4) | trim }}


### PR DESCRIPTION
This commit adds severity to the advisory template so that we can start adding it to our advisories. It is in an if statement as only certain types of advisories should have it set.