### PR TITLE
fix(RELEASE-1455): ignore purls without qualifiers in spdx sboms

### DIFF
--- a/pyxis/test_upload_rpm_data.py
+++ b/pyxis/test_upload_rpm_data.py
@@ -111,6 +111,14 @@ PACKAGES = [
             }
         ]
     },
+    {  # rpm purl, but no qualifiers, so it is skipped
+        "externalRefs": [
+            {
+                "referenceType": "purl",
+                "referenceLocator": "pkg:rpm/libtirpc@1.3.5-1.el10",
+            }
+        ]
+    },
 ]
 
 

--- a/pyxis/upload_rpm_data.py
+++ b/pyxis/upload_rpm_data.py
@@ -245,6 +245,8 @@ def construct_rpm_items_and_content_sets(
             purl_dict = PackageURL.from_string(externalRef["referenceLocator"]).to_dict()
             if purl_dict["name"] in IGNORED_PACKAGES:
                 continue
+            if "qualifiers" not in purl_dict or purl_dict["qualifiers"] is None:
+                continue
             rpm_item = {
                 "name": purl_dict["name"],
                 "summary": purl_dict["name"],


### PR DESCRIPTION
The script was failing for a user when it tried to access qualifiers for a purl dict and there were none. I discussed this with the build team and they agreed that we should ignore such entries. In most cases this will be a duplicate package entry anyway. More details in Jira.