### PR TITLE
fix(ISV-5685): fix component-product relationship

### DIFF
--- a/sbom/create_product_sbom.py
+++ b/sbom/create_product_sbom.py
@@ -85,9 +85,9 @@ def get_component_relationships(packages: List[Dict]):
     """Get SPDX relationship for each SPDX component package."""
     return [
         {
-            "spdxElementId": "SPDXRef-product",
+            "spdxElementId": package["SPDXID"],
             "relationshipType": "PACKAGE_OF",
-            "relatedSpdxElement": package["SPDXID"],
+            "relatedSpdxElement": "SPDXRef-product",
         }
         for package in packages
     ]

--- a/sbom/test_create_product_sbom.py
+++ b/sbom/test_create_product_sbom.py
@@ -138,9 +138,9 @@ class TestCreateSBOM(unittest.TestCase):
                         "relatedSpdxElement": "SPDXRef-product",
                     },
                     {
-                        "spdxElementId": "SPDXRef-product",
+                        "spdxElementId": "SPDXRef-component-0",
                         "relationshipType": "PACKAGE_OF",
-                        "relatedSpdxElement": "SPDXRef-component-0",
+                        "relatedSpdxElement": "SPDXRef-product",
                     },
                 ],
             }
@@ -237,14 +237,14 @@ class TestCreateSBOM(unittest.TestCase):
                         "relatedSpdxElement": "SPDXRef-product",
                     },
                     {
-                        "spdxElementId": "SPDXRef-product",
+                        "spdxElementId": "SPDXRef-component-0",
                         "relationshipType": "PACKAGE_OF",
-                        "relatedSpdxElement": "SPDXRef-component-0",
+                        "relatedSpdxElement": "SPDXRef-product",
                     },
                     {
-                        "spdxElementId": "SPDXRef-product",
+                        "spdxElementId": "SPDXRef-component-1",
                         "relationshipType": "PACKAGE_OF",
-                        "relatedSpdxElement": "SPDXRef-component-1",
+                        "relatedSpdxElement": "SPDXRef-product",
                     },
                 ],
             }


### PR DESCRIPTION
The relationship in the product-level SBOM was the wrong way around. I will update the image tags in release-service-catalog when this is merged.