### PR TITLE
fix: key error if Pyxis image repository has no tags

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -395,7 +395,7 @@ def main():  # pragma: no cover
         return
 
     # Then, check if the tags are different. If they are, update them
-    existing_tags = [tag["name"] for tag in repositories[repo_index]["tags"]]
+    existing_tags = [tag["name"] for tag in repositories[repo_index].get("tags", [])]
     if existing_tags != tags:
         LOGGER.info(
             f"Image with given docker_image_digest exists as {identifier} and "


### PR DESCRIPTION
Sometimes an image can end up with no tags. That might happen if it only has floating tags and those were reused in another image and so the tags would be removed from this image.

A user encountered this recently and we also saw this in e2e.

Related support case: [KONFLUX-7267](https://issues.redhat.com/browse/KONFLUX-7267)