### PR TITLE
fix: empty tags in create_container_image

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -395,7 +395,7 @@ def main():  # pragma: no cover
         return
 
     # Then, check if the tags are different. If they are, update them
-    existing_tags = [tag["name"] for tag in repositories[repo_index].get("tags", [])]
+    existing_tags = [tag["name"] for tag in repositories[repo_index]["tags"] or []]
     if existing_tags != tags:
         LOGGER.info(
             f"Image with given docker_image_digest exists as {identifier} and "


### PR DESCRIPTION
It turns out my previous fix did not work. The `tags` field is not missing, but it's None. This will ensure that in this case an empty list is used.