### PR TITLE
feat(ISV-5760): rework SBOM generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,11 @@ RUN pip3 install jinja2 \
     pubtools-exodus \
     pubtools-marketplacesvm \
     pubtools-sign \
-    pubtools-pyxis
+    pubtools-pyxis \
+    pydantic \
+    aiofiles \
+    types-aiofiles \
+    pytest-asyncio
 
 # remove gcc, required only for compiling gssapi indirect dependency of pubtools-pulp via pushsource
 RUN dnf -y remove gcc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-asyncio
 requests
 jinja2
 jinja2-ansible-filters
@@ -7,3 +8,6 @@ pubtools-pulp
 pubtools-exodus
 pubtools-content-gateway
 pubtools-marketplacesvm
+pydantic
+aiofiles
+types-aiofiles

--- a/sbom/README.md
+++ b/sbom/README.md
@@ -1,0 +1,30 @@
+# Konflux release-time SBOM generation
+This module contains scripts and libraries used to enrich SBOMs created at
+build-time (component-level) and create SBOMs (product-level) when a snapshot is
+being released.
+
+## Data sources
+### Snapshot spec
+The necessary data source for both component-level and product-level SBOM
+manipulation is the mapped snapshot spec in JSON format. This file is created by
+the `apply-mapping` Tekton Task, which exports a result containing the path to
+the file.
+
+The snapshot spec is parsed using the `sbom.sbomlib.make_snapshot` function into
+a Python representation of the snapshot. The `make_snapshot` function also
+handles multiarch images by fetching manifests of index images (using `oras`)
+and parsing them. The resulting object contains all component repositories and
+digests of images that are being released in the snapshot.
+     
+### Data file
+The product-level SBOM requires additional data to be constructed (such as the
+cpe id, product name and version). This data can be found in the data file,
+which is exported by the `collect-data` Tekton task as path to a file.
+
+## Component-level SBOM enrichment
+When component-level SBOMs are updated, the OCI PURLs generated during
+build-time are stripped and new PURLs are generated based on the parsed snapshot
+data. Non-OCI PURLs are preserved.
+
+## Product-level SBOM creation
+This should be filled once product-level SBOMs use the new inputs.

--- a/sbom/handlers/__init__.py
+++ b/sbom/handlers/__init__.py
@@ -1,0 +1,22 @@
+"""
+This module contains a function for picking a handler for an SBOM and exports
+the handlers.
+"""
+
+from typing import Any, Optional
+
+from sbom.sbomlib import SBOMHandler
+from sbom.handlers.spdx2 import SPDXVersion2
+
+
+def get_handler(sbom: dict[str, Any]) -> Optional[SBOMHandler]:
+    """
+    Get SBOM handler class based on the SBOM dict provided.
+    """
+    if sbom.get("spdxVersion") in SPDXVersion2.supported_versions:
+        return SPDXVersion2
+
+    if sbom.get("bomFormat") == "CycloneDX":
+        raise NotImplementedError()
+
+    return None

--- a/sbom/handlers/spdx2.py
+++ b/sbom/handlers/spdx2.py
@@ -1,0 +1,253 @@
+"""
+This module contains the SBOM handler for SPDX version 2 SBOMs.
+"""
+
+from typing import Optional, Union, Any
+
+from packageurl import PackageURL
+
+from sbom.logging import get_sbom_logger
+from sbom.sbomlib import (
+    Component,
+    Image,
+    IndexImage,
+    SBOMError,
+    construct_purl,
+    get_purl_arch,
+    get_purl_digest,
+    make_reference,
+    without_sha_header,
+)
+
+logger = get_sbom_logger()
+
+
+class SPDXPackage:
+    """
+    Wrapper class for easier SPDX package manipulation.
+    """
+
+    def __init__(self, package: Any) -> None:
+        self.package = package
+
+    @property
+    def external_refs(self) -> list[dict[str, Any]]:
+        """
+        Get the externalRefs field of the package.
+        """
+        return self.package.get("externalRefs", [])
+
+    @external_refs.setter
+    def external_refs(self, value: list[Any]) -> None:
+        self.package["externalRefs"] = value
+
+    @property
+    def spdxid(self) -> str:
+        return self.package.get("SPDXID", "UNKNOWN")
+
+    @property
+    def checksums(self) -> list[dict[str, Any]]:
+        """
+        Get the checksums field of the package.
+        """
+        return self.package.get("checksums", [])
+
+    @property
+    def sha256_checksum(self) -> Optional[str]:
+        """
+        Extracts a sha256 checksum from an SPDX package. Returns None if no such
+        checksum is found.
+        """
+        checksums = self.checksums
+        if checksums is None:
+            return None
+
+        for checksum in checksums:
+            if checksum.get("algorithm") == "SHA256":
+                return checksum.get("checksumValue")
+
+        return None
+
+    def update_external_refs(
+        self,
+        digest: str,
+        repository: str,
+        tags: list[str],
+        arch: Optional[str] = None,
+    ) -> None:
+        """
+        Update the external refs of an SPDX package by creating new OCI PURL
+        references and stripping all old OCI PURL references. Other types of
+        externalRefs are preserved.
+        """
+        new_oci_refs = SPDXPackage._get_updated_oci_purl_external_refs(
+            digest,
+            repository,
+            tags,
+            arch=arch,
+        )
+
+        self._strip_oci_purls_external_refs()
+        self.external_refs[:0] = new_oci_refs
+
+    def _strip_oci_purls_external_refs(self) -> None:
+        """
+        Remove all OCI purl externalRefs from a package.
+        """
+
+        def is_oci_purl_ref(ref: dict) -> bool:
+            ptype = ref.get("referenceType")
+            if ptype != "purl":
+                return False
+            purl_str = ref.get("referenceLocator")
+            if purl_str is None:
+                return False
+
+            purl = PackageURL.from_string(purl_str)
+            return purl.type == "oci"
+
+        new_external_refs = [ref for ref in self.external_refs if not is_oci_purl_ref(ref)]
+        self.external_refs = new_external_refs
+
+    @staticmethod
+    def _get_updated_oci_purl_external_refs(
+        digest: str, repository: str, tags: list[str], arch: Optional[str] = None
+    ) -> list[dict]:
+        """
+        Gets new oci purl externalRefs value based on input information.
+        """
+        purls = (construct_purl(repository, digest, tag=tag, arch=arch) for tag in tags)
+        return [SPDXPackage._make_purl_ref(purl) for purl in purls]
+
+    @staticmethod
+    def _make_purl_ref(purl: str) -> dict[str, str]:
+        """
+        Create an SPDX externalRefs field from a PackageURL.
+        """
+        return {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": purl,
+        }
+
+
+class SPDXVersion2:  # pylint: disable=too-few-public-methods
+    """
+    Class containing methods for SPDX v2.x SBOM manipulation.
+    """
+
+    supported_versions = [
+        "SPDX-2.0",
+        "SPDX-2.1",
+        "SPDX-2.2",
+        "SPDX-2.2.1",
+        "SPDX-2.2.2",
+        "SPDX-2.3",
+    ]
+
+    @classmethod
+    def _find_purl_in_refs(cls, package: SPDXPackage, digest: str) -> Optional[str]:
+        """
+        Tries to find a purl in the externalRefs of a package the version of
+        which matches the passed digest.
+        """
+        for ref in filter(lambda rf: rf["referenceType"] == "purl", package.external_refs):
+            purl = ref["referenceLocator"]
+            if digest == get_purl_digest(purl):
+                return purl
+
+        return None
+
+    @classmethod
+    def _find_image_package(cls, sbom: dict, digest: str) -> Optional[SPDXPackage]:
+        """
+        Find the SPDX package for a digest, based on the package checksum.
+        """
+        for package in map(SPDXPackage, sbom.get("packages", [])):
+            if without_sha_header(digest) == package.sha256_checksum:
+                return package
+
+        return None
+
+    @classmethod
+    def _update_index_image_sbom(
+        cls, component: Component, index: IndexImage, sbom: dict
+    ) -> None:
+        """
+        Update the SBOM of an index image in a repository.
+        """
+        version = sbom["spdxVersion"]
+        if version not in cls.supported_versions:
+            raise ValueError(
+                f"Called update on unsupported version {version}, "
+                f"supported versions are {cls.supported_versions}"
+            )
+
+        sbom["name"] = make_reference(component.repository, index.digest)
+
+        index_package = cls._find_image_package(sbom, index.digest)
+        if not index_package:
+            raise SBOMError(f"Could not find SPDX package for index {index}")
+
+        index_package.update_external_refs(
+            index.digest,
+            component.repository,
+            component.tags,
+        )
+
+        for image in index.children:
+            package = cls._find_image_package(sbom, image.digest)
+            if package is None:
+                logger.warning("Could not find SPDX package for %s.", image.digest)
+                continue
+
+            original_purl = cls._find_purl_in_refs(package, image.digest)
+            if original_purl is None:
+                logger.warning(
+                    "Could not find OCI PURL for %s in package %s for index %s.",
+                    image.digest,
+                    package.spdxid,
+                    index.digest,
+                )
+                continue
+
+            arch = get_purl_arch(original_purl)
+            package.update_external_refs(
+                image.digest,
+                component.repository,
+                component.tags,
+                arch=arch,
+            )
+
+    @classmethod
+    def _update_image_sbom(cls, component: Component, image: Image, sbom: dict) -> None:
+        """
+        Update the SBOM of single-arch image in a repository.
+        """
+        version = sbom["spdxVersion"]
+        if version not in cls.supported_versions:
+            raise ValueError(
+                f"Called update on unsupported version {version}, "
+                f"supported versions are {cls.supported_versions}"
+            )
+
+        sbom["name"] = make_reference(component.repository, image.digest)
+
+        image_package = cls._find_image_package(sbom, image.digest)
+        if not image_package:
+            raise SBOMError(f"Could not find SPDX package in SBOM for image {image.digest}")
+
+        image_package.update_external_refs(
+            image.digest,
+            component.repository,
+            component.tags,
+        )
+
+    @classmethod
+    def update_sbom(
+        cls, component: Component, image: Union[IndexImage, Image], sbom: dict
+    ) -> None:
+        if isinstance(image, IndexImage):
+            cls._update_index_image_sbom(component, image, sbom)
+        elif isinstance(image, Image):
+            cls._update_image_sbom(component, image, sbom)

--- a/sbom/logging.py
+++ b/sbom/logging.py
@@ -1,0 +1,25 @@
+import logging
+import logging.config
+
+logconfig = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {"simple": {"format": "%(asctime)s - %(levelname)s - %(message)s"}},
+    "handlers": {
+        "stdout": {
+            "class": "logging.StreamHandler",
+            "formatter": "simple",
+            "stream": "ext://sys.stdout",
+        }
+    },
+    "loggers": {"sbom": {"level": "DEBUG"}},
+    "root": {"level": "WARNING", "handlers": ["stdout"]},
+}
+
+
+def setup_sbom_logger():
+    logging.config.dictConfig(config=logconfig)
+
+
+def get_sbom_logger():
+    return logging.getLogger("sbom")

--- a/sbom/sbomlib.py
+++ b/sbom/sbomlib.py
@@ -1,0 +1,368 @@
+"""
+This library contains utility functions for SBOM generation and enrichment.
+"""
+
+from contextlib import contextmanager
+import json
+from typing import Optional, Any, Protocol, Union, Generator
+from pathlib import Path
+from dataclasses import dataclass
+import re
+import asyncio
+import tempfile
+import os
+
+
+from packageurl import PackageURL
+import pydantic as pdc
+
+from sbom.logging import get_sbom_logger
+
+
+logger = get_sbom_logger()
+
+
+@dataclass
+class Image:
+    """
+    Object representing a single image in some repository.
+    """
+
+    digest: str
+
+
+@dataclass
+class IndexImage:
+    """
+    Object representing an index image in some repository. It also contains
+    references to child images.
+    """
+
+    digest: str
+    children: list[Image]
+
+
+@dataclass
+class Component:
+    """
+    Internal representation of a Component for SBOM generation purposes.
+    """
+
+    repository: str
+    image: Union[Image, IndexImage]
+    tags: list[str]
+
+
+@dataclass
+class Snapshot:
+    """
+    Internal representation of a Snapshot for SBOM generation purposes.
+    """
+
+    components: list[Component]
+
+
+class SBOMError(Exception):
+    """
+    Exception that can be raised during SBOM generation and enrichment.
+    """
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class ComponentModel(pdc.BaseModel):
+    """
+    Model representing a component from the Snapshot.
+    """
+
+    image_digest: str = pdc.Field(alias="containerImage")
+    rh_registry_repo: str = pdc.Field(alias="rh-registry-repo")
+    tags: list[str]
+
+    @pdc.field_validator("image_digest", mode="after")
+    @classmethod
+    def is_valid_digest_reference(cls, value: str) -> str:
+        """
+        Validates that the digest reference is in the correct format. Does NOT
+        support references with a registry port.
+        """
+        if not re.match(r"^[^:]+@sha256:[0-9a-f]+$", value):
+            raise ValueError(f"{value} is not a valid digest reference.")
+
+        # strip repository
+        return value.split("@")[1]
+
+
+class SnapshotModel(pdc.BaseModel):
+    """
+    Model representing a Snapshot spec file after the apply-mapping task.
+    Only the parts relevant to component sboms are parsed.
+    """
+
+    components: list[ComponentModel]
+
+
+class SBOMHandler(Protocol):
+    """
+    Protocol ensuring that SBOM handlers implement the correct method.
+    """
+
+    @classmethod
+    def update_sbom(
+        cls, component: Component, image: Union[IndexImage, Image], sbom: dict[str, Any]
+    ) -> None:
+        """
+        Update the specified SBOM in-place based on the provided component information.
+        """
+        raise NotImplementedError()
+
+
+async def construct_image(repository: str, image_digest: str) -> Union[Image, IndexImage]:
+    """
+    Creates an Image or IndexImage object based on an image reference. Performs
+    a registry call for index images, to parse all their child digests.
+    """
+    manifest = await get_image_manifest(repository, image_digest)
+    media_type = manifest["mediaType"]
+
+    if media_type in {
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    }:
+        return Image(digest=image_digest)
+
+    if media_type in {
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+    }:
+        children = []
+        for submanifest in manifest["manifests"]:
+            child_digest = submanifest["digest"]
+            children.append(Image(child_digest))
+
+        return IndexImage(digest=image_digest, children=children)
+
+    raise SBOMError(f"Unsupported mediaType: {media_type}")
+
+
+async def make_component(repository: str, image_digest: str, tags: list[str]) -> Component:
+    """
+    Creates a component object from input data.
+    """
+    image: Union[Image, IndexImage] = await construct_image(repository, image_digest)
+    return Component(repository=repository, image=image, tags=tags)
+
+
+async def make_snapshot(snapshot_spec: Path) -> Snapshot:
+    """
+    Parse a snapshot spec from a JSON file and create an object representation
+    of it. Multiarch images are handled by fetching their index image manifests
+    and parsing their children as well.
+
+    Args:
+        snapshot_spec (Path): Path to a snapshot spec JSON file
+    """
+    with open(snapshot_spec, mode="r", encoding="utf-8") as snapshot_file:
+        snapshot_model = SnapshotModel.model_validate_json(snapshot_file.read())
+
+    component_tasks = []
+    for component_model in snapshot_model.components:
+        repository = component_model.rh_registry_repo
+        image_digest = component_model.image_digest
+        tags = component_model.tags
+
+        component_tasks.append(make_component(repository, image_digest, tags))
+
+    components = await asyncio.gather(*component_tasks)
+
+    return Snapshot(components=components)
+
+
+def construct_purl(
+    repository: str, digest: str, arch: Optional[str] = None, tag: Optional[str] = None
+) -> str:
+    """
+    Construct an OCI PackageURL from image data.
+    """
+    repo_name = repository.split("/")[-1]
+
+    optional_qualifiers = {}
+    if arch is not None:
+        optional_qualifiers["arch"] = arch
+
+    if tag is not None:
+        optional_qualifiers["tag"] = tag
+
+    return PackageURL(
+        type="oci",
+        name=repo_name,
+        version=digest,
+        qualifiers={"repository_url": repository, **optional_qualifiers},
+    ).to_string()
+
+
+async def run_async_subprocess(
+    cmd: list[str], env: Optional[dict[str, str]] = None, retry_times: int = 0
+) -> tuple[int, bytes, bytes]:
+    """
+    Run command in subprocess asynchronously.
+
+    Args:
+        cmd (list[str]): command to run in subprocess.
+        env (dict[str, str] | None): environ dict
+        retry_times (int): number of retries if the process ends with non-zero return code
+    """
+    if retry_times < 0:
+        raise ValueError("Retry count cannot be negative.")
+
+    for _ in range(1 + retry_times):
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+
+        stdout, stderr = await proc.communicate()
+        assert proc.returncode is not None  # can't be None after proc.communicate is awaited
+        code = proc.returncode
+        if code == 0:
+            return code, stdout, stderr
+
+    # guaranteed to be bound, the loop runs at least once
+    return code, stdout, stderr
+
+
+async def get_image_manifest(repository: str, image_digest: str) -> dict[str, Any]:
+    """
+    Gets a dictionary containing the data from a manifest for an image in a
+    repository.
+
+    Args:
+        repository (str): image repository URL
+        image_digest (str): an image digest in the form sha256:<sha>
+    """
+    reference = make_reference(repository, image_digest)
+    logger.info("Fetching manifest for %s", reference)
+
+    with make_oci_auth_file(reference) as authfile:
+        code, stdout, stderr = await run_async_subprocess(
+            [
+                "oras",
+                "manifest",
+                "fetch",
+                "--registry-config",
+                authfile,
+                reference,
+            ],
+            retry_times=3,
+        )
+    if code != 0:
+        raise SBOMError(f"Could not get manifest of {reference}: {stderr.decode()}")
+
+    return json.loads(stdout)
+
+
+def make_reference(repository: str, image_digest: str) -> str:
+    """
+    Create a full reference to an image using a repository and image digest.
+
+    Args:
+        repository (str): image repository URL
+        image_digest (str): an image digest in the form sha256:<sha>
+
+    Examples:
+        >>> make_reference("registry.redhat.io/repo", "sha256:deadbeef")
+        'registry.redhat.io/repo@sha256:deadbeef'
+
+    """
+    return f"{repository}@{image_digest}"
+
+
+@contextmanager
+def make_oci_auth_file(
+    reference: str, auth: Optional[Path] = None
+) -> Generator[str, Any, None]:
+    """
+    Gets path to a temporary file containing the docker config JSON for
+    <reference>.  Deletes the file after the with statement. If no path to the
+    docker config is provided, tries using ~/.docker/config.json . Ports in the
+    registry are NOT supported.
+
+    Args:
+        reference (str): Reference to an image in the form registry/repo@sha256-deadbeef
+        auth (Path | None): Existing docker config.json
+
+    Example:
+        >>> with make_oci_auth_file(ref) as auth_path:
+                perform_work_in_oci()
+    """
+    if auth is None:
+        auth = Path(os.path.expanduser("~/.docker/config.json"))
+
+    if not auth.is_file():
+        raise ValueError(f"No docker config file at {auth}")
+
+    if reference.count(":") > 1:
+        logger.warning(
+            "Multiple ':' symbols in %s. Registry ports are not supported.", reference
+        )
+
+    # Remove digest (e.g. @sha256:...)
+    ref = reference.split("@", 1)[0]
+
+    # Registry is up to the first slash
+    registry = ref.split("/", 1)[0]
+
+    with open(auth, mode="r", encoding="utf-8") as f:
+        config = json.load(f)
+    auths = config.get("auths", {})
+
+    current_ref = ref
+
+    try:
+        tmpfile = tempfile.NamedTemporaryFile(mode="w", delete=False)
+        while True:
+            token = auths.get(current_ref)
+            if token is not None:
+                json.dump({"auths": {registry: token}}, tmpfile)
+                tmpfile.close()
+                yield tmpfile.name
+                return
+
+            if "/" not in current_ref:
+                break
+            current_ref = current_ref.rsplit("/", 1)[0]
+
+        json.dump({"auths": {}}, tmpfile)
+        tmpfile.close()
+        yield tmpfile.name
+    finally:
+        # this also deletes the file
+        tmpfile.close()
+
+
+def without_sha_header(digest: str) -> str:
+    """
+    Returns a digest without the "sha256:" header.
+    """
+    return digest.removeprefix("sha256:")
+
+
+def get_purl_arch(purl_str: str) -> Optional[str]:
+    """
+    Get the arch qualifier from a PackageURL.
+    """
+    purl = PackageURL.from_string(purl_str).to_dict()
+    return purl["qualifiers"].get("arch")
+
+
+def get_purl_digest(purl_str: str) -> str:
+    """
+    Get the image digest from a PackageURL.
+    """
+    purl = PackageURL.from_string(purl_str)
+    if purl.version is None:
+        raise ValueError("SBOM contains invalid OCI Purl: %s", purl_str)
+    return purl.version

--- a/sbom/test_create_product_sbom.py
+++ b/sbom/test_create_product_sbom.py
@@ -4,12 +4,12 @@ import unittest
 from datetime import timezone
 from unittest.mock import MagicMock, mock_open, patch
 
-from create_product_sbom import create_sbom
+from sbom.create_product_sbom import create_sbom
 
 
 class TestCreateSBOM(unittest.TestCase):
-    @patch("create_product_sbom.uuid")
-    @patch("create_product_sbom.datetime")
+    @patch("sbom.create_product_sbom.uuid")
+    @patch("sbom.create_product_sbom.datetime")
     def test_create_sbom_no_components(self, mock_datetime: MagicMock, mock_uuid: MagicMock):
         mock_uuid.uuid4.return_value = "039f091d-8790-41bc-b63e-251ec860e3db"
 
@@ -67,8 +67,8 @@ class TestCreateSBOM(unittest.TestCase):
                 ],
             }
 
-    @patch("create_product_sbom.uuid")
-    @patch("create_product_sbom.datetime")
+    @patch("sbom.create_product_sbom.uuid")
+    @patch("sbom.create_product_sbom.datetime")
     def test_create_sbom_single_component(
         self, mock_datetime: MagicMock, mock_uuid: MagicMock
     ):
@@ -145,8 +145,8 @@ class TestCreateSBOM(unittest.TestCase):
                 ],
             }
 
-    @patch("create_product_sbom.uuid")
-    @patch("create_product_sbom.datetime")
+    @patch("sbom.create_product_sbom.uuid")
+    @patch("sbom.create_product_sbom.datetime")
     def test_create_sbom_multiple_components_multiple_purls(
         self, mock_datetime: MagicMock, mock_uuid: MagicMock
     ):

--- a/sbom/test_sbomlib.py
+++ b/sbom/test_sbomlib.py
@@ -1,0 +1,141 @@
+from typing import Any, Optional
+import json
+import tempfile
+import pytest
+from pathlib import Path
+
+from unittest.mock import mock_open, patch
+
+import sbom.sbomlib as sbomlib
+from sbom.sbomlib import IndexImage, Snapshot, Component, Image, construct_purl
+
+
+@pytest.mark.parametrize(
+    ["auths", "reference", "expected_auths"],
+    [
+        pytest.param(
+            {
+                "registry.local/repo": {"auth": "some_token"},
+                "another.io/repo": {"auth": "some_token"},
+            },
+            "registry.local/repo@sha256:deadbeef",
+            {"registry.local": {"auth": "some_token"}},
+            id="simple",
+        ),
+        pytest.param(
+            {"registry.local/org/repo": {"auth": "some_token"}},
+            "registry.local/org/repo@sha256:deadbeef",
+            {"registry.local": {"auth": "some_token"}},
+            id="nested",
+        ),
+    ],
+)
+def test_get_oci_auth_file(auths, reference, expected_auths):
+    test_config = {"auths": auths}
+
+    with tempfile.NamedTemporaryFile(mode="w") as config:
+        json.dump(test_config, config)
+        config.flush()
+
+        with sbomlib.make_oci_auth_file(reference, auth=Path(config.name)) as authfile:
+            with open(authfile, "r") as fp:
+                data = json.loads(fp.read())
+                assert data["auths"] == expected_auths
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ["index_manifest"],
+    [
+        pytest.param({"mediaType": "application/vnd.oci.image.index.v1+json"}, id="oci-index"),
+        pytest.param(
+            {"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json"},
+            id="docker-manifest-list",
+        ),
+    ],
+)
+async def test_make_snapshot(index_manifest: dict[str, str]) -> None:
+    snapshot_raw = json.dumps(
+        {
+            "components": [
+                {
+                    "containerImage": "quay.io/repo1@sha256:deadbeef",
+                    "rh-registry-repo": "registry.redhat.io/repo1",
+                    "tags": ["1.0"],
+                },
+                {
+                    "containerImage": "quay.io/repo2@sha256:ffffffff",
+                    "rh-registry-repo": "registry.redhat.io/repo2",
+                    "tags": ["2.0", "latest"],
+                },
+            ]
+        }
+    )
+
+    expected_snapshot = Snapshot(
+        components=[
+            Component(
+                "registry.redhat.io/repo1",
+                image=IndexImage("sha256:deadbeef", children=[Image("sha256:aaaaffff")]),
+                tags=["1.0"],
+            ),
+            Component(
+                "registry.redhat.io/repo2",
+                image=IndexImage("sha256:ffffffff", children=[Image("sha256:bbbbffff")]),
+                tags=["2.0", "latest"],
+            ),
+        ],
+    )
+
+    def fake_get_image_manifest(repository: str, _: str) -> dict[str, Any]:
+        if repository == "registry.redhat.io/repo1":
+            child_digest = "sha256:aaaaffff"
+
+            return {
+                **index_manifest,
+                "manifests": [{"digest": child_digest}],
+            }
+
+        child_digest = "sha256:bbbbffff"
+        return {
+            **index_manifest,
+            "manifests": [{"digest": child_digest}],
+        }
+
+    with patch("sbom.sbomlib.get_image_manifest", side_effect=fake_get_image_manifest):
+        with patch("builtins.open", mock_open(read_data=snapshot_raw)):
+            snapshot = await sbomlib.make_snapshot(Path(""))
+            assert snapshot == expected_snapshot
+
+
+@pytest.mark.parametrize(
+    ["repository", "digest", "arch", "tag", "expected"],
+    [
+        pytest.param(
+            "registry.redhat.io/test",
+            "sha256:deadbeef",
+            "amd64",
+            "1.0",
+            "pkg:oci/test@sha256:deadbeef?arch=amd64&"
+            "repository_url=registry.redhat.io/test&tag=1.0",
+        ),
+        pytest.param(
+            "registry.redhat.io/test",
+            "sha256:deadbeef",
+            None,
+            None,
+            "pkg:oci/test@sha256:deadbeef?repository_url=registry.redhat.io/test",
+        ),
+        pytest.param(
+            "registry.redhat.io/org/test",
+            "sha256:deadbeef",
+            None,
+            None,
+            "pkg:oci/test@sha256:deadbeef?repository_url=registry.redhat.io/org/test",
+        ),
+    ],
+)
+def test_construct_purl(
+    repository: str, digest: str, arch: Optional[str], tag: Optional[str], expected: str
+) -> None:
+    assert construct_purl(repository, digest, arch, tag) == expected

--- a/sbom/testdata/single-component-multiarch/spdx/build_image_sbom.json
+++ b/sbom/testdata/single-component-multiarch/spdx/build_image_sbom.json
@@ -1,0 +1,47 @@
+{
+    "spdxVersion": "SPDX-2.3",
+    "dataLicense": "CC0-1.0",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "quay.io/org/tenant/test@sha256:84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921",
+    "documentNamespace": "https://redhat.com/",
+    "creationInfo": {
+        "licenseListVersion": "3.25",
+        "creators": [],
+        "created": "2025-03-19T10:19:11Z"
+    },
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-image",
+            "name": "test",
+            "versionInfo": "on-pr-c91a8608fdf4eff697652f37ee0cf21bc490858e-linux-x86-64",
+            "downloadLocation": "NOASSERTION",
+            "licenseConcluded": "NOASSERTION",
+            "supplier": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceLocator": "pkg:oci/test@sha256:84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921?repository_url=quay.io/org/tenant/test",
+                    "referenceType": "purl",
+                    "referenceCategory": "PACKAGE-MANAGER"
+                },
+                {
+                    "referenceLocator": "https://github.com/doc.md",
+                    "referenceType": "url",
+                    "referenceCategory": "SECURITY"
+                }
+            ],
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921"
+                }
+            ]
+        }
+    ],
+    "relationships": [
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relationshipType": "DESCRIBES",
+            "relatedSpdxElement": "SPDXRef-image"
+        }
+    ]
+}

--- a/sbom/testdata/single-component-multiarch/spdx/build_index_sbom.json
+++ b/sbom/testdata/single-component-multiarch/spdx/build_index_sbom.json
@@ -1,0 +1,70 @@
+{
+    "spdxVersion": "SPDX-2.3",
+    "dataLicense": "CC0-1.0",
+    "documentNamespace": "https://konflux-ci.dev/spdxdocs/demo-on-pr-c91a8608fdf4eff697652f37ee0cf21bc490858e-68afdb3a-d057-4acd-bcdb-f32225ddaa9a",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "creationInfo": {
+        "created": "2025-03-19T10:19:32+00:00",
+        "creators": [
+            "Tool: Konflux"
+        ],
+        "licenseListVersion": "3.25"
+    },
+    "name": "quay.io/redhat-user-workloads/mjediny-tenant/demo@sha256:fae7e52c95ee8d24ad9e64b54e693047b94e1b1ef98be3e3b4b9859f986e5b1d",
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-image-index",
+            "name": "demo",
+            "versionInfo": "on-pr-c91a8608fdf4eff697652f37ee0cf21bc490858e",
+            "supplier": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": "pkg:oci/demo@sha256:fae7e52c95ee8d24ad9e64b54e693047b94e1b1ef98be3e3b4b9859f986e5b1d?repository_url=quay.io/redhat-user-workloads/mjediny-tenant/demo"
+                }
+            ],
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "fae7e52c95ee8d24ad9e64b54e693047b94e1b1ef98be3e3b4b9859f986e5b1d"
+                }
+            ]
+        },
+        {
+            "SPDXID": "SPDXRef-image-demo-99eb583f9f6956aa94a708a9506747a92ab1bb94b2811adabcf48e7353857eeb",
+            "name": "demo_amd64",
+            "versionInfo": "on-pr-c91a8608fdf4eff697652f37ee0cf21bc490858e",
+            "supplier": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": "pkg:oci/demo@sha256:84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921?arch=amd64&repository_url=quay.io/redhat-user-workloads/mjediny-tenant/demo"
+                }
+            ],
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921"
+                }
+            ]
+        }
+    ],
+    "relationships": [
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relationshipType": "DESCRIBES",
+            "relatedSpdxElement": "SPDXRef-image-index"
+        },
+        {
+            "spdxElementId": "SPDXRef-image-demo-99eb583f9f6956aa94a708a9506747a92ab1bb94b2811adabcf48e7353857eeb",
+            "relationshipType": "VARIANT_OF",
+            "relatedSpdxElement": "SPDXRef-image-index"
+        }
+    ]
+}

--- a/sbom/testdata/single-component-multiarch/spdx/release_image_sbom.json
+++ b/sbom/testdata/single-component-multiarch/spdx/release_image_sbom.json
@@ -1,0 +1,52 @@
+{
+    "spdxVersion": "SPDX-2.3",
+    "dataLicense": "CC0-1.0",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "registry.redhat.io/org/tenant/test@sha256:84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921",
+    "documentNamespace": "https://redhat.com/",
+    "creationInfo": {
+        "licenseListVersion": "3.25",
+        "creators": [],
+        "created": "2025-03-19T10:19:11Z"
+    },
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-image",
+            "name": "test",
+            "versionInfo": "on-pr-c91a8608fdf4eff697652f37ee0cf21bc490858e-linux-x86-64",
+            "downloadLocation": "NOASSERTION",
+            "licenseConcluded": "NOASSERTION",
+            "supplier": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceLocator": "pkg:oci/test@sha256:84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921?repository_url=registry.redhat.io/org/tenant/test&tag=1.0",
+                    "referenceType": "purl",
+                    "referenceCategory": "PACKAGE-MANAGER"
+                },
+                {
+                    "referenceLocator": "pkg:oci/test@sha256:84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921?repository_url=registry.redhat.io/org/tenant/test&tag=latest",
+                    "referenceType": "purl",
+                    "referenceCategory": "PACKAGE-MANAGER"
+                },
+                {
+                    "referenceLocator": "https://github.com/doc.md",
+                    "referenceType": "url",
+                    "referenceCategory": "SECURITY"
+                }
+            ],
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921"
+                }
+            ]
+        }
+    ],
+    "relationships": [
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relationshipType": "DESCRIBES",
+            "relatedSpdxElement": "SPDXRef-image"
+        }
+    ]
+}

--- a/sbom/testdata/single-component-multiarch/spdx/release_index_sbom.json
+++ b/sbom/testdata/single-component-multiarch/spdx/release_index_sbom.json
@@ -1,0 +1,80 @@
+{
+    "spdxVersion": "SPDX-2.3",
+    "dataLicense": "CC0-1.0",
+    "documentNamespace": "https://konflux-ci.dev/spdxdocs/demo-on-pr-c91a8608fdf4eff697652f37ee0cf21bc490858e-68afdb3a-d057-4acd-bcdb-f32225ddaa9a",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "creationInfo": {
+        "created": "2025-03-19T10:19:32+00:00",
+        "creators": [
+            "Tool: Konflux"
+        ],
+        "licenseListVersion": "3.25"
+    },
+    "name": "registry.redhat.io/org/tenant/test@sha256:fae7e52c95ee8d24ad9e64b54e693047b94e1b1ef98be3e3b4b9859f986e5b1d",
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-image-index",
+            "name": "demo",
+            "versionInfo": "on-pr-c91a8608fdf4eff697652f37ee0cf21bc490858e",
+            "supplier": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": "pkg:oci/test@sha256:fae7e52c95ee8d24ad9e64b54e693047b94e1b1ef98be3e3b4b9859f986e5b1d?repository_url=registry.redhat.io/org/tenant/test&tag=1.0"
+                },
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": "pkg:oci/test@sha256:fae7e52c95ee8d24ad9e64b54e693047b94e1b1ef98be3e3b4b9859f986e5b1d?repository_url=registry.redhat.io/org/tenant/test&tag=latest"
+                }
+            ],
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "fae7e52c95ee8d24ad9e64b54e693047b94e1b1ef98be3e3b4b9859f986e5b1d"
+                }
+            ]
+        },
+        {
+            "SPDXID": "SPDXRef-image-demo-99eb583f9f6956aa94a708a9506747a92ab1bb94b2811adabcf48e7353857eeb",
+            "name": "demo_amd64",
+            "versionInfo": "on-pr-c91a8608fdf4eff697652f37ee0cf21bc490858e",
+            "supplier": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": "pkg:oci/test@sha256:84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921?arch=amd64&repository_url=registry.redhat.io/org/tenant/test&tag=1.0"
+                },
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": "pkg:oci/test@sha256:84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921?arch=amd64&repository_url=registry.redhat.io/org/tenant/test&tag=latest"
+                }
+            ],
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921"
+                }
+            ]
+        }
+    ],
+    "relationships": [
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relationshipType": "DESCRIBES",
+            "relatedSpdxElement": "SPDXRef-image-index"
+        },
+        {
+            "spdxElementId": "SPDXRef-image-demo-99eb583f9f6956aa94a708a9506747a92ab1bb94b2811adabcf48e7353857eeb",
+            "relationshipType": "VARIANT_OF",
+            "relatedSpdxElement": "SPDXRef-image-index"
+        }
+    ]
+}

--- a/sbom/testdata/single-component-single-arch/spdx/build_sbom.json
+++ b/sbom/testdata/single-component-single-arch/spdx/build_sbom.json
@@ -1,0 +1,47 @@
+{
+    "spdxVersion": "SPDX-2.3",
+    "dataLicense": "CC0-1.0",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "quay.io/org/tenant/test@sha256:deadbeef",
+    "documentNamespace": "https://redhat.com/",
+    "creationInfo": {
+        "licenseListVersion": "3.25",
+        "creators": [],
+        "created": "2025-03-19T10:19:11Z"
+    },
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-image",
+            "name": "test",
+            "versionInfo": "on-pr-c91a8608fdf4eff697652f37ee0cf21bc490858e-linux-x86-64",
+            "downloadLocation": "NOASSERTION",
+            "licenseConcluded": "NOASSERTION",
+            "supplier": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceLocator": "pkg:oci/test@sha256:deadbeef?repository_url=quay.io/org/tenant/test",
+                    "referenceType": "purl",
+                    "referenceCategory": "PACKAGE-MANAGER"
+                },
+                {
+                    "referenceLocator": "https://github.com/doc.md",
+                    "referenceType": "url",
+                    "referenceCategory": "SECURITY"
+                }
+            ],
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "deadbeef"
+                }
+            ]
+        }
+    ],
+    "relationships": [
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relationshipType": "DESCRIBES",
+            "relatedSpdxElement": "SPDXRef-image"
+        }
+    ]
+}

--- a/sbom/testdata/single-component-single-arch/spdx/release_sbom.json
+++ b/sbom/testdata/single-component-single-arch/spdx/release_sbom.json
@@ -1,0 +1,52 @@
+{
+    "spdxVersion": "SPDX-2.3",
+    "dataLicense": "CC0-1.0",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "registry.redhat.io/org/tenant/test@sha256:deadbeef",
+    "documentNamespace": "https://redhat.com/",
+    "creationInfo": {
+        "licenseListVersion": "3.25",
+        "creators": [],
+        "created": "2025-03-19T10:19:11Z"
+    },
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-image",
+            "name": "test",
+            "versionInfo": "on-pr-c91a8608fdf4eff697652f37ee0cf21bc490858e-linux-x86-64",
+            "downloadLocation": "NOASSERTION",
+            "licenseConcluded": "NOASSERTION",
+            "supplier": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceLocator": "pkg:oci/test@sha256:deadbeef?repository_url=registry.redhat.io/org/tenant/test&tag=1.0",
+                    "referenceType": "purl",
+                    "referenceCategory": "PACKAGE-MANAGER"
+                },
+                {
+                    "referenceLocator": "pkg:oci/test@sha256:deadbeef?repository_url=registry.redhat.io/org/tenant/test&tag=latest",
+                    "referenceType": "purl",
+                    "referenceCategory": "PACKAGE-MANAGER"
+                },
+                {
+                    "referenceLocator": "https://github.com/doc.md",
+                    "referenceType": "url",
+                    "referenceCategory": "SECURITY"
+                }
+            ],
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "deadbeef"
+                }
+            ]
+        }
+    ],
+    "relationships": [
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relationshipType": "DESCRIBES",
+            "relatedSpdxElement": "SPDXRef-image"
+        }
+    ]
+}


### PR DESCRIPTION
In this PR, the component-level SBOM update process for SPDX-2.X is rewritten. While before we relied on data from non-SBOM related tasks, now we work with inputs that are defined better.

The only input required to update component-level SBOMs is now the mapped snapshot spec (exported by the `apply-mapping` task).

The snapshot is then parsed into a Python object that contains references to all images (with arch-specific images in the case of multiarch).

This object is then used to asynchronously download the SBOMs for all images and update them based on the snapshot being released.