### PR TITLE
fix: empty tags in create_container_image

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -395,7 +395,7 @@ def main():  # pragma: no cover
         return
 
     # Then, check if the tags are different. If they are, update them
-    existing_tags = [tag["name"] for tag in repositories[repo_index]["tags"] or []]
+    existing_tags = [tag["name"] for tag in repositories[repo_index].get("tags") or []]
     if existing_tags != tags:
         LOGGER.info(
             f"Image with given docker_image_digest exists as {identifier} and "


### PR DESCRIPTION
It seems that this is still failing for users.

The latest report had this error:

KeyError: 'tags'

In a previous report, the error was that tags was None, so it was not iterable.

So we should be ready for both situations.

Here's a proof that it works with the use cases now:
```
>>> repo_index=0
>>> repositories = [{"tags": None}]
>>> [tag["name"] for tag in repositories[repo_index].get("tags") or []]
[]
>>> repositories = [{}]
>>> [tag["name"] for tag in repositories[repo_index].get("tags") or []]
[]
>>> repositories = [{"tags": [{"name": "mytag"}]}]
>>> [tag["name"] for tag in repositories[repo_index].get("tags") or []]
['mytag']
```