### PR TITLE
feat(ISV-5785): rewrite CycloneDX update logic

### DIFF
--- a/sbom/handlers/__init__.py
+++ b/sbom/handlers/__init__.py
@@ -1,22 +1,11 @@
 """
-This module contains a function for picking a handler for an SBOM and exports
-the handlers.
+This module exports SBOM handlers.
 """
 
-from typing import Any, Optional
+__all__ = [
+    "SPDXVersion2",
+    "CycloneDXVersion1",
+]
 
-from sbom.sbomlib import SBOMHandler
 from sbom.handlers.spdx2 import SPDXVersion2
-
-
-def get_handler(sbom: dict[str, Any]) -> Optional[SBOMHandler]:
-    """
-    Get SBOM handler class based on the SBOM dict provided.
-    """
-    if sbom.get("spdxVersion") in SPDXVersion2.supported_versions:
-        return SPDXVersion2
-
-    if sbom.get("bomFormat") == "CycloneDX":
-        raise NotImplementedError()
-
-    return None
+from sbom.handlers.cyclonedx1 import CycloneDXVersion1

--- a/sbom/handlers/cyclonedx1.py
+++ b/sbom/handlers/cyclonedx1.py
@@ -87,11 +87,12 @@ class CycloneDXVersion1(SBOMHandler):
         if len(kflx_component.tags) <= 1:
             return
 
+        new_identity = []
         for tag in kflx_component.tags:
             purl = construct_purl(
                 kflx_component.repository, kflx_component.image.digest, arch=arch, tag=tag
             )
-            purl_identity = {"field": "purl", "concludedValue": purl}
+            new_identity.append({"field": "purl", "concludedValue": purl})
 
         if cdx_component.get("evidence") is None:
             cdx_component["evidence"] = {}
@@ -102,9 +103,10 @@ class CycloneDXVersion1(SBOMHandler):
         # The identity can either be an array or a single object. In both cases
         # we preserve the original identity.
         if isinstance(identity, list):
-            identity.extend(purl_identity)
+            identity.extend(new_identity)
+            evidence["identity"] = identity
         else:
-            evidence["identity"] = [identity, *purl_identity]
+            evidence["identity"] = [identity, *new_identity]
 
     def _update_container_component(
         self, kflx_component: Component, cdx_component: dict

--- a/sbom/handlers/cyclonedx1.py
+++ b/sbom/handlers/cyclonedx1.py
@@ -1,0 +1,167 @@
+from functools import total_ordering
+from typing import Union, Optional
+from enum import Enum
+from packaging.version import Version
+
+
+from sbom.logging import get_sbom_logger
+from sbom.sbomlib import (
+    Component,
+    IndexImage,
+    Image,
+    SBOMHandler,
+    construct_purl,
+    get_purl_arch,
+    get_purl_digest,
+)
+
+
+logger = get_sbom_logger()
+
+
+@total_ordering
+class CDXSpec(Enum):
+    """
+    Enum containing all recognized CycloneDX versions.
+    """
+
+    v1_4 = "1.4"
+    v1_5 = "1.5"
+    v1_6 = "1.6"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, CDXSpec):
+            return Version(self.value) == Version(other.value)
+
+        return NotImplemented
+
+    def __lt__(self, other: object):
+        if isinstance(other, CDXSpec):
+            return Version(self.value) < Version(other.value)
+
+        return NotImplemented
+
+
+class CycloneDXVersion1(SBOMHandler):
+    supported_versions = [
+        CDXSpec.v1_4,
+        CDXSpec.v1_5,
+        CDXSpec.v1_6,
+    ]
+
+    def __init__(self, version: str) -> None:
+        self.version = CDXSpec(version)
+
+    @classmethod
+    def supports(cls, sbom: dict) -> bool:
+        if "bomFormat" not in sbom:
+            return False
+
+        raw = sbom.get("specVersion")
+        if raw is None:
+            return False
+
+        try:
+            spec = CDXSpec(raw)
+        except ValueError:
+            logger.warning("CDX spec %s not recognized.")
+            return False
+
+        return spec in cls.supported_versions
+
+    def update_sbom(
+        self, component: Component, image: Union[IndexImage, Image], sbom: dict
+    ) -> None:
+        self._update_sbom(component, image, sbom)
+
+    def _update_component_purl_identity(
+        self,
+        kflx_component: Component,
+        arch: Optional[str],
+        cdx_component: dict,
+    ) -> None:
+        if self.version < CDXSpec.v1_6:
+            logger.warning(
+                "Updating the evidence.identity field is only supported for CDX version 1.6."
+            )
+            return
+
+        if len(kflx_component.tags) <= 1:
+            return
+
+        for tag in kflx_component.tags:
+            purl = construct_purl(
+                kflx_component.repository, kflx_component.image.digest, arch=arch, tag=tag
+            )
+            purl_identity = {"field": "purl", "concludedValue": purl}
+
+        if cdx_component.get("evidence") is None:
+            cdx_component["evidence"] = {}
+
+        evidence = cdx_component["evidence"]
+        identity = evidence.get("identity", [])
+
+        # The identity can either be an array or a single object. In both cases
+        # we preserve the original identity.
+        if isinstance(identity, list):
+            identity.extend(purl_identity)
+        else:
+            evidence["identity"] = [identity, *purl_identity]
+
+    def _update_container_component(
+        self, kflx_component: Component, cdx_component: dict
+    ) -> None:
+        if cdx_component.get("type") != "container":
+            logger.warning(
+                'Called update method on CDX package with type %s instead of "container".'
+            )
+            return
+
+        purl = cdx_component.get("purl")
+        if not purl:
+            return
+
+        arch = get_purl_arch(purl)
+        digest = get_purl_digest(purl)
+        tag = kflx_component.tags[0] if kflx_component.tags else None
+        new_purl = construct_purl(kflx_component.repository, digest, arch=arch, tag=tag)
+        cdx_component["purl"] = new_purl
+
+        # Only CDX 1.6 supports multiple identity objects
+        if self.version >= CDXSpec.v1_6:
+            self._update_component_purl_identity(kflx_component, arch, cdx_component)
+
+        if isinstance(kflx_component.image, IndexImage):
+            variants = cdx_component.get("pedigree", {}).get("variants", [])
+            child_digests = [img.digest for img in kflx_component.image.children]
+            for component in variants:
+                purl = component.get("purl")
+                if purl is None or get_purl_digest(purl) not in child_digests:
+                    continue
+
+                self._update_container_component(kflx_component, component)
+
+    def _update_metadata_component(self, kflx_component: Component, sbom: dict) -> None:
+        component = sbom.get("metadata", {}).get("component", {})
+        self._update_container_component(kflx_component, component)
+
+        if "metadata" in sbom:
+            sbom["metadata"]["component"] = component
+        else:
+            metadata = {"component": component}
+            sbom["metadata"] = metadata
+
+    def _update_sbom(
+        self, kflx_component: Component, image: Union[IndexImage, Image], sbom: dict
+    ) -> None:
+        self._update_metadata_component(kflx_component, sbom)
+
+        for cdx_component in sbom.get("components", []):
+            if cdx_component.get("type") != "container":
+                continue
+
+            purl = cdx_component.get("purl")
+            if purl is None or get_purl_digest(purl) != image.digest:
+                continue
+
+            self._update_container_component(kflx_component, cdx_component)

--- a/sbom/handlers/spdx2.py
+++ b/sbom/handlers/spdx2.py
@@ -262,7 +262,6 @@ class SPDXVersion2(SBOMHandler):  # pylint: disable=too-few-public-methods
         self, component: Component, image: Union[IndexImage, Image], sbom: dict
     ) -> None:
         if isinstance(image, IndexImage):
-            # breakpoint()
             SPDXVersion2._update_index_image_sbom(component, image, sbom)
         elif isinstance(image, Image):
             SPDXVersion2._update_image_sbom(component, image, sbom)

--- a/sbom/sbomlib.py
+++ b/sbom/sbomlib.py
@@ -110,12 +110,18 @@ class SBOMHandler(Protocol):
     Protocol ensuring that SBOM handlers implement the correct method.
     """
 
-    @classmethod
     def update_sbom(
-        cls, component: Component, image: Union[IndexImage, Image], sbom: dict[str, Any]
+        self, component: Component, image: Union[IndexImage, Image], sbom: dict[str, Any]
     ) -> None:
         """
         Update the specified SBOM in-place based on the provided component information.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def supports(cls, sbom: dict) -> bool:
+        """
+        Returns true if the provided SBOM is supported by this handler.
         """
         raise NotImplementedError()
 
@@ -373,5 +379,4 @@ def get_purl_digest(purl_str: str) -> str:
     """
     purl = PackageURL.from_string(purl_str)
     if purl.version is None:
-        raise SBOMError("SBOM contains invalid OCI Purl: %s", purl_str)
-    return purl.version
+        raise SBOMError(f"SBOM contains invalid OCI Purl: {purl_str}")

--- a/sbom/sbomlib.py
+++ b/sbom/sbomlib.py
@@ -194,6 +194,16 @@ def construct_purl(
     repository: str, digest: str, arch: Optional[str] = None, tag: Optional[str] = None
 ) -> str:
     """
+    Construct an OCI PackageURL string from image data.
+    """
+    purl = construct_purl_object(repository, digest, arch, tag)
+    return purl.to_string()
+
+
+def construct_purl_object(
+    repository: str, digest: str, arch: Optional[str] = None, tag: Optional[str] = None
+) -> PackageURL:
+    """
     Construct an OCI PackageURL from image data.
     """
     repo_name = repository.split("/")[-1]
@@ -210,7 +220,7 @@ def construct_purl(
         name=repo_name,
         version=digest,
         qualifiers={"repository_url": repository, **optional_qualifiers},
-    ).to_string()
+    )
 
 
 async def run_async_subprocess(

--- a/sbom/sbomlib.py
+++ b/sbom/sbomlib.py
@@ -390,3 +390,4 @@ def get_purl_digest(purl_str: str) -> str:
     purl = PackageURL.from_string(purl_str)
     if purl.version is None:
         raise SBOMError(f"SBOM contains invalid OCI Purl: {purl_str}")
+    return purl.version

--- a/sbom/test_update_component_sbom.py
+++ b/sbom/test_update_component_sbom.py
@@ -149,10 +149,6 @@ class TestSPDXVersion23:
 class TestCycloneDX:
     @staticmethod
     def verify_purl(purl: PackageURL, kflx_component: Component) -> None:
-        """
-        Verify that the PURL in a CDX component matches the expected PURL based
-        on the Konflux component.
-        """
         assert purl.qualifiers is not None
         assert (
             purl.qualifiers.get("repository_url") == kflx_component.repository  # type: ignore
@@ -208,9 +204,6 @@ class TestCycloneDX:
         cdx_component: dict,
         verify_tags: bool,
     ) -> None:
-        """
-        Verify that CDX component with a matching Konflux component is updated.
-        """
         if (purl_str := cdx_component.get("purl")) is None:
             return
 
@@ -227,8 +220,8 @@ class TestCycloneDX:
     @staticmethod
     def verify_components_updated(snapshot: Snapshot, sbom: dict) -> None:
         """
-        Verify that all CycloneDX container components that have a matching
-        Konflux component in the release are updated.
+        This method verifies that all CycloneDX container components that have a
+        matching Konflux component in the release are updated.
         """
         TestCycloneDX.verify_component_updated(
             snapshot, sbom["metadata"]["component"], verify_tags=False
@@ -262,14 +255,17 @@ class TestCycloneDX:
         async def fake_load_sbom(reference: str, _) -> tuple[dict, str]:
             with open(data_path.joinpath("build_sbom.json")) as f:
                 build_sbom = json.load(f)
-                # we can do this because our build sbom should not contain any
+                # we can do this, because our build sbom should not contain any
                 # version-specific structure
                 build_sbom["specVersion"] = spec.value
+                # TODO: change evidence.identity to make sure that the original
+                # value is kept in the case of CDX 1.6
                 return build_sbom, ""
 
         snapshot = Snapshot(
             components=[
                 Component(
+                    name="component",
                     repository="registry.redhat.io/org/tenant/test",
                     image=Image("sha256:deadbeef"),
                     tags=tags,

--- a/sbom/test_update_component_sbom.py
+++ b/sbom/test_update_component_sbom.py
@@ -258,8 +258,6 @@ class TestCycloneDX:
                 # we can do this, because our build sbom should not contain any
                 # version-specific structure
                 build_sbom["specVersion"] = spec.value
-                # TODO: change evidence.identity to make sure that the original
-                # value is kept in the case of CDX 1.6
                 return build_sbom, ""
 
         snapshot = Snapshot(

--- a/sbom/test_update_component_sbom.py
+++ b/sbom/test_update_component_sbom.py
@@ -1,10 +1,14 @@
 import json
+import tempfile
 from unittest.mock import patch, AsyncMock, call, ANY
+from typing import Optional
+from packageurl import PackageURL
 import pytest
 from pathlib import Path
 
+from sbom.handlers.cyclonedx1 import CDXSpec
 from sbom.update_component_sbom import update_sboms
-from sbom.sbomlib import Component, Image, IndexImage, Snapshot
+from sbom.sbomlib import Component, Image, IndexImage, Snapshot, get_purl_digest
 
 TESTDATA_PATH = Path(__file__).parent.joinpath("testdata")
 
@@ -140,3 +144,151 @@ class TestSPDXVersion23:
                 ]
                 * num_components
             )
+
+
+class TestCycloneDX:
+    @staticmethod
+    def verify_purl(purl: PackageURL, kflx_component: Component) -> None:
+        """
+        Verify that the PURL in a CDX component matches the expected PURL based
+        on the Konflux component.
+        """
+        assert purl.qualifiers is not None
+        assert (
+            purl.qualifiers.get("repository_url") == kflx_component.repository  # type: ignore
+        )
+        assert purl.name == kflx_component.repository.split("/")[-1]
+
+    @staticmethod
+    def verify_tags(kflx_component: Component, cdx_component: dict) -> None:
+        """
+        Verify that all tags are present in PURLs in the evidence.identity field
+        if there are more than one.
+        """
+        if len(kflx_component.tags) == 1:
+            # in this case, we don't populate the evidence.identity field so
+            # let's make sure we add the tag to the component.purl field
+            purl = PackageURL.from_string(cdx_component["purl"])
+            assert purl.qualifiers is not None
+            assert purl.qualifiers.get("tag") == kflx_component.tags[0]  # type: ignore
+            return
+
+        tags = set(kflx_component.tags)
+
+        try:
+            identity = cdx_component["evidence"]["identity"]
+        except KeyError:
+            raise AssertionError("CDX component is missing evidence.identity field.")
+
+        for id_item in identity:
+            if id_item.get("field") != "purl":
+                continue
+            purl = PackageURL.from_string(id_item["concludedValue"])
+            TestCycloneDX.verify_purl(purl, kflx_component)
+
+            purl_tag = purl.qualifiers.get("tag")  # type: ignore
+            assert isinstance(purl_tag, str), f"Missing tag in identity purl {purl}."
+            tags.remove(purl_tag)
+
+        assert len(tags) == 0, f"Not all tags present in identity purls, missing {tags}."
+
+    @staticmethod
+    def find_matching_konflux_component(
+        snapshot: Snapshot, digest: str
+    ) -> Optional[Component]:
+        for component in snapshot.components:
+            if component.image.digest == digest:
+                return component
+
+        return None
+
+    @staticmethod
+    def verify_component_updated(
+        snapshot: Snapshot,
+        cdx_component: dict,
+        verify_tags: bool,
+    ) -> None:
+        """
+        Verify that CDX component with a matching Konflux component is updated.
+        """
+        if (purl_str := cdx_component.get("purl")) is None:
+            return
+
+        digest = get_purl_digest(purl_str)
+        kflx_component = TestCycloneDX.find_matching_konflux_component(snapshot, digest)
+        if kflx_component is None:
+            return
+
+        TestCycloneDX.verify_purl(PackageURL.from_string(purl_str), kflx_component)
+
+        if verify_tags:
+            TestCycloneDX.verify_tags(kflx_component, cdx_component)
+
+    @staticmethod
+    def verify_components_updated(snapshot: Snapshot, sbom: dict) -> None:
+        """
+        Verify that all CycloneDX container components that have a matching
+        Konflux component in the release are updated.
+        """
+        TestCycloneDX.verify_component_updated(
+            snapshot, sbom["metadata"]["component"], verify_tags=False
+        )
+
+        for component in sbom.get("components", []):
+            TestCycloneDX.verify_component_updated(snapshot, component, verify_tags=True)
+
+    @pytest.mark.asyncio
+    @patch("sbom.update_component_sbom.write_sbom")
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            pytest.param(CDXSpec.v1_4, id="cdx-1.4"),
+            pytest.param(CDXSpec.v1_5, id="cdx-1.5"),
+            pytest.param(CDXSpec.v1_6, id="cdx-1.6"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "tags",
+        [
+            pytest.param(["1.0"], id="single-tag"),
+            pytest.param(["1.0", "latest"], id="multiple-tags"),
+        ],
+    )
+    async def test_single_component_single_arch(
+        self, mock_write_sbom: AsyncMock, spec: CDXSpec, tags: list[str]
+    ) -> None:
+        data_path = TESTDATA_PATH.joinpath("single-component-single-arch/cdx")
+
+        async def fake_load_sbom(reference: str, _) -> tuple[dict, str]:
+            with open(data_path.joinpath("build_sbom.json")) as f:
+                build_sbom = json.load(f)
+                # we can do this because our build sbom should not contain any
+                # version-specific structure
+                build_sbom["specVersion"] = spec.value
+                return build_sbom, ""
+
+        snapshot = Snapshot(
+            components=[
+                Component(
+                    repository="registry.redhat.io/org/tenant/test",
+                    image=Image("sha256:deadbeef"),
+                    tags=tags,
+                )
+            ],
+        )
+
+        with patch("sbom.update_component_sbom.load_sbom", side_effect=fake_load_sbom):
+            await update_sboms(snapshot, Path("dummy"))
+
+            # get the SBOM that was written
+            sbom, _ = mock_write_sbom.call_args[0]
+
+            try:
+                TestCycloneDX.verify_components_updated(snapshot, sbom)
+            except Exception as err:
+                with tempfile.NamedTemporaryFile("w", delete=False) as tmpf:
+                    json.dump(sbom, tmpf)
+                    raise AssertionError(
+                        f"Failed verification of SBOM: {err}."
+                        " Writing generated SBOM to {tmpf.name}"
+                    ) from err

--- a/sbom/testdata/single-component-single-arch/cdx/build_sbom.json
+++ b/sbom/testdata/single-component-single-arch/cdx/build_sbom.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.6",
+    "serialNumber": "urn:uuid:91ab804b-b7e5-4c63-bcf9-aac30d9aa681",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2025-03-17T08:30:51Z",
+        "tools": {
+            "components": [
+                {
+                    "type": "application",
+                    "author": "anchore",
+                    "name": "syft",
+                    "version": "1.18.1"
+                }
+            ]
+        },
+        "component": {
+            "type": "container",
+            "name": "test-component",
+            "purl": "pkg:oci/demo@sha256:deadbeef?arch=amd64&repository_url=quay.io/redhat-user-workloads/demo",
+            "version": "7f1b956828d6acb13b9675f3a4b76252bb69b26d",
+            "hashes": [
+                {
+                    "alg": "SHA-256",
+                    "content": "deadbeef"
+                }
+            ]
+        }
+    },
+    "components": [
+        {
+            "type": "container",
+            "name": "test-component",
+            "purl": "pkg:oci/demo@sha256:deadbeef?arch=amd64&repository_url=quay.io/redhat-user-workloads/demo",
+            "version": "7f1b956828d6acb13b9675f3a4b76252bb69b26d",
+            "hashes": [
+                {
+                    "alg": "SHA-256",
+                    "content": "deadbeef"
+                }
+            ]
+        }
+    ]
+}

--- a/sbom/update_component_sbom.py
+++ b/sbom/update_component_sbom.py
@@ -83,7 +83,6 @@ def update_sbom_in_situ(
         image (IndexImage | Image): Object representing an image or an index
                                     image being released.
         sbom (dict): SBOM parsed as dictionary.
-
     """
     if SPDXVersion2.supports(sbom):
         SPDXVersion2().update_sbom(component, image, sbom)

--- a/sbom/update_component_sbom.py
+++ b/sbom/update_component_sbom.py
@@ -88,7 +88,9 @@ def update_sbom_in_situ(
         SPDXVersion2().update_sbom(component, image, sbom)
         return True
 
-    if CycloneDXVersion1.supports(sbom):
+    # The CDX handler does not support updating SBOMs for index images, as those
+    # are generated only as SPDX in Konflux.
+    if CycloneDXVersion1.supports(sbom) and isinstance(image, Image):
         CycloneDXVersion1().update_sbom(component, image, sbom)
         return True
 

--- a/sbom/update_component_sbom.py
+++ b/sbom/update_component_sbom.py
@@ -89,8 +89,8 @@ def update_sbom_in_situ(
         SPDXVersion2().update_sbom(component, image, sbom)
         return True
 
-    if CycloneDXVersion1.supports(sbom) and "specVersion" in sbom:
-        CycloneDXVersion1(sbom["specVersion"]).update_sbom(component, image, sbom)
+    if CycloneDXVersion1.supports(sbom):
+        CycloneDXVersion1().update_sbom(component, image, sbom)
         return True
 
     return False


### PR DESCRIPTION
This PR rewrites the CycloneDX SBOM update logic using the new API from sbomlib. We bump the version of all SBOMs to 1.6, so the `evidence.identity` field supports our tag use case (CycloneDX 1.X is forward-compatible).

**CycloneDX index image SBOMs are not supported**, because Konflux only generates index image SBOMs in the SPDX format.