### PR TITLE
feat: determine name for product SBOM in-script

### DIFF
--- a/sbom/create_product_sbom.py
+++ b/sbom/create_product_sbom.py
@@ -180,7 +180,8 @@ def parse_release_notes(raw_json: str) -> ReleaseNotes:
 
 
 def get_filename(release_notes: ReleaseNotes) -> str:
-    return f"{release_notes.product_name} {release_notes.product_version}.json"
+    normalized_name = "-".join(release_notes.product_name.split())
+    return f"{normalized_name}-{release_notes.product_version}.json"
 
 
 def main() -> None:  # pragma: nocover
@@ -190,8 +191,8 @@ def main() -> None:  # pragma: nocover
     parser = argparse.ArgumentParser(
         prog="create-product-sbom",
         description="Create product-level SBOM from merged data file"
-        " and mapped snapshot spec. Names the SBOM file according to the SBOM"
-        " contents and prints the name to stdout.",
+        " and mapped snapshot spec. The SBOM file is named according to the SBOM"
+        " contents and is printed to stdout.",
     )
     parser.add_argument(
         "--data-path",
@@ -223,9 +224,9 @@ def main() -> None:  # pragma: nocover
             sbom = create_sbom(release_notes, snapshot)
 
         fname = get_filename(release_notes)
-        output = str(args.output_path.joinpath(fname))
-        write_file(document=sbom, file_name=output, validate=True)
-        print(output)
+        output_path = str(args.output_path.joinpath(fname))
+        write_file(document=sbom, file_name=output_path, validate=True)
+        print(f"SBOM file: {output_path}")
     except Exception:  # pylint: disable=broad-except
         logger.exception("Creation of the product-level SBOM failed.")
         raise

--- a/sbom/logging.py
+++ b/sbom/logging.py
@@ -6,14 +6,14 @@ logconfig = {
     "disable_existing_loggers": False,
     "formatters": {"simple": {"format": "%(asctime)s - %(levelname)s - %(message)s"}},
     "handlers": {
-        "stdout": {
+        "stderr": {
             "class": "logging.StreamHandler",
             "formatter": "simple",
-            "stream": "ext://sys.stdout",
+            "stream": "ext://sys.stderr",
         }
     },
     "loggers": {"sbom": {"level": "DEBUG"}},
-    "root": {"level": "WARNING", "handlers": ["stdout"]},
+    "root": {"level": "WARNING", "handlers": ["stderr"]},
 }
 
 

--- a/sbom/test_create_product_sbom.py
+++ b/sbom/test_create_product_sbom.py
@@ -7,7 +7,12 @@ import pytest
 from packageurl import PackageURL
 from spdx_tools.spdx.writer.json.json_writer import write_document_to_stream
 
-from sbom.create_product_sbom import ReleaseNotes, create_sbom, parse_release_notes
+from sbom.create_product_sbom import (
+    ReleaseNotes,
+    create_sbom,
+    get_filename,
+    parse_release_notes,
+)
 from sbom.sbomlib import Component, Image, IndexImage, Snapshot
 
 Digests = namedtuple("Digests", ["single_arch", "multi_arch"])
@@ -260,3 +265,8 @@ def test_create_sbom(snapshot: Snapshot, purls: List[str], cpe: Union[str, List[
     verify_package_licenses(sbom_dict)
 
     assert sbom_dict["dataLicense"] == "CC0-1.0"
+
+
+def test_get_filename() -> None:
+    notes = ReleaseNotes(product_name="Amazing Red Hat Product", product_version="1.0", cpe="")
+    assert get_filename(notes) == "Amazing-Red-Hat-Product-1.0.json"


### PR DESCRIPTION
By naming the file according to its contents in this script, we can simplify the Tekton task that uses it.

With the move to Atlas V2, the name is no longer used as an ID, so we can use a more human-readable name.