### PR TITLE
feat(RELEASE-1569): allow other jira fields

### DIFF
--- a/templates/advisory.yaml.jinja
+++ b/templates/advisory.yaml.jinja
@@ -16,7 +16,11 @@ spec:
 {%- endif %}
 {%- if 'issues' in advisory.spec %}
   issues:
-    {{ advisory.spec.issues | to_nice_yaml(indent=2) | indent(4) | trim }}
+    fixed:
+      {%- for issue in advisory.spec.issues.fixed %}
+      - id: {{ issue.id }}
+        source: {{ issue.source }}
+      {%- endfor %}
 {%- endif %}
   content:
     {{ advisory.spec.content | to_nice_yaml(indent=2) | indent(4) | trim }}

--- a/utils/test_apply_template.py
+++ b/utils/test_apply_template.py
@@ -93,6 +93,20 @@ def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
                         "synopsis": synopsis,
                         "references": ["testing"],
                         "content": {},
+                        "issues": {
+                            "fixed": [
+                                {
+                                    "id": "KONFLUX-1",
+                                    "source": "issues.redhat.com",
+                                    "summary": "issue 1",
+                                },
+                                {
+                                    "id": "KONFLUX-2",
+                                    "source": "issues.redhat.com",
+                                    "summary": "issue 2",
+                                },
+                            ]
+                        },
                     }
                 },
             }
@@ -110,6 +124,8 @@ def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
         assert result["spec"]["solution"] == solution
         assert result["spec"]["topic"] == topic
         assert result["spec"]["synopsis"] == "Enhancement synopsis"
+        for issue in result["spec"]["issues"]["fixed"]:
+            assert len(issue.keys()) == 2
     finally:
         os.remove(filename)
 


### PR DESCRIPTION
- ensure additional jira field in data model for issues does not alter the advisory rendered format of issues.
- the goal is to allow other advisory keys makes use of additional jira fields like summary.