### PR TITLE
feat(templates): change 'synopsis' to be multiline

### DIFF
--- a/templates/advisory.yaml.jinja
+++ b/templates/advisory.yaml.jinja
@@ -24,7 +24,8 @@ spec:
 {%- endif %}
   content:
     {{ advisory.spec.content | to_nice_yaml(indent=2) | indent(4) | trim }}
-  synopsis: {{ advisory.spec.synopsis }}
+  synopsis: >-
+    {{ advisory.spec.synopsis | indent(4) }}
   topic: >-
     {{ advisory.spec.topic | indent(4) }}
   description: >-

--- a/utils/test_apply_template.py
+++ b/utils/test_apply_template.py
@@ -71,7 +71,7 @@ def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
         "expect-that-something-is-going-to-linewrap-it-at-some-point.-so-long."
     )
     # Confirm contributed partial templates are rendered
-    synopsis = "{%- if advisory.spec.type == 'RHEA' %} Enhancement{%- endif %} synopsis"
+    synopsis = "{% if advisory.spec.type == 'RHEA' %} Enhancement{%- endif %} synopsis"
     try:
         args = MagicMock()
         args.template = "templates/advisory.yaml.jinja"


### PR DESCRIPTION
This PR aims to change the `synopsis` field from a single line to a multiple lines.