### PR TITLE
fix: re-add public field for issues

### DIFF
--- a/templates/advisory.yaml.jinja
+++ b/templates/advisory.yaml.jinja
@@ -20,6 +20,9 @@ spec:
       {%- for issue in advisory.spec.issues.fixed %}
       - id: {{ issue.id }}
         source: {{ issue.source }}
+        {%- if 'public' in issue %}
+        public: {{ issue.public }}
+        {%- endif %}
       {%- endfor %}
 {%- endif %}
   content:

--- a/utils/test_apply_template.py
+++ b/utils/test_apply_template.py
@@ -99,11 +99,13 @@ def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
                                     "id": "KONFLUX-1",
                                     "source": "issues.redhat.com",
                                     "summary": "issue 1",
+                                    "public": "true",
                                 },
                                 {
                                     "id": "KONFLUX-2",
                                     "source": "issues.redhat.com",
                                     "summary": "issue 2",
+                                    "public": "false",
                                 },
                             ]
                         },
@@ -125,7 +127,7 @@ def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
         assert result["spec"]["topic"] == topic
         assert result["spec"]["synopsis"] == "Enhancement synopsis"
         for issue in result["spec"]["issues"]["fixed"]:
-            assert len(issue.keys()) == 2
+            assert len(issue.keys()) == 3
     finally:
         os.remove(filename)
 


### PR DESCRIPTION
- a recent change removed all other fields except id and source
- the public field is added by the pipeline and is needed for rendering later in customer portal