### PR TITLE
feat(ISV-5783): differentiate repositories

### DIFF
--- a/sbom/create_product_sbom.py
+++ b/sbom/create_product_sbom.py
@@ -101,7 +101,7 @@ def get_component_packages(components: List[Component]) -> List[Package]:
         checksum = component.image.digest.split(":", 1)[1]
 
         purls = [
-            construct_purl(component.repository, component.image.digest, tag=tag)
+            construct_purl(component.release_repository, component.image.digest, tag=tag)
             for tag in component.tags
         ]
 

--- a/sbom/handlers/spdx2.py
+++ b/sbom/handlers/spdx2.py
@@ -205,7 +205,7 @@ class SPDXVersion2(SBOMHandler):  # pylint: disable=too-few-public-methods
         """
         Update the SBOM of an index image in a repository.
         """
-        sbom["name"] = make_reference(component.repository, index.digest)
+        sbom["name"] = make_reference(component.release_repository, index.digest)
 
         index_package = cls._find_image_package(sbom, index.digest)
         if not index_package:
@@ -213,7 +213,7 @@ class SPDXVersion2(SBOMHandler):  # pylint: disable=too-few-public-methods
 
         index_package.update_external_refs(
             index.digest,
-            component.repository,
+            component.release_repository,
             component.tags,
         )
 
@@ -236,7 +236,7 @@ class SPDXVersion2(SBOMHandler):  # pylint: disable=too-few-public-methods
             arch = get_purl_arch(original_purl)
             package.update_external_refs(
                 image.digest,
-                component.repository,
+                component.release_repository,
                 component.tags,
                 arch=arch,
             )
@@ -246,7 +246,7 @@ class SPDXVersion2(SBOMHandler):  # pylint: disable=too-few-public-methods
         """
         Update the SBOM of single-arch image in a repository.
         """
-        sbom["name"] = make_reference(component.repository, image.digest)
+        sbom["name"] = make_reference(component.release_repository, image.digest)
 
         image_package = cls._find_image_package(sbom, image.digest)
         if not image_package:
@@ -254,7 +254,7 @@ class SPDXVersion2(SBOMHandler):  # pylint: disable=too-few-public-methods
 
         image_package.update_external_refs(
             image.digest,
-            component.repository,
+            component.release_repository,
             component.tags,
         )
 

--- a/sbom/test_create_product_sbom.py
+++ b/sbom/test_create_product_sbom.py
@@ -168,9 +168,10 @@ def verify_package_licenses(sbom) -> None:
                 components=[
                     Component(
                         name="component",
-                        repository="quay.io/repo",
+                        release_repository="quay.io/repo",
                         image=Image(digest=DIGESTS.single_arch),
                         tags=["1.0", "latest"],
+                        repository="quay.io/repo",
                     )
                 ]
             ),
@@ -185,7 +186,7 @@ def verify_package_licenses(sbom) -> None:
                 components=[
                     Component(
                         name="component",
-                        repository="quay.io/repo",
+                        release_repository="quay.io/repo",
                         image=IndexImage(
                             digest=DIGESTS.multi_arch,
                             children=[
@@ -194,6 +195,7 @@ def verify_package_licenses(sbom) -> None:
                             ],
                         ),
                         tags=["1.0", "latest"],
+                        repository="quay.io/repo",
                     )
                 ]
             ),
@@ -208,7 +210,7 @@ def verify_package_licenses(sbom) -> None:
                 components=[
                     Component(
                         name="multiarch-component",
-                        repository="quay.io/repo",
+                        release_repository="quay.io/repo",
                         image=IndexImage(
                             digest=DIGESTS.multi_arch,
                             children=[
@@ -217,12 +219,14 @@ def verify_package_licenses(sbom) -> None:
                             ],
                         ),
                         tags=["1.0", "latest"],
+                        repository="quay.io/repo",
                     ),
                     Component(
                         name="singlearch-component",
-                        repository="quay.io/another-repo",
+                        release_repository="quay.io/another-repo",
                         image=Image(digest=DIGESTS.single_arch),
                         tags=["2.0", "production"],
+                        repository="quay.io/repo",
                     ),
                 ]
             ),

--- a/sbom/test_sbomlib.py
+++ b/sbom/test_sbomlib.py
@@ -63,12 +63,14 @@ async def test_make_snapshot(index_manifest: dict[str, str]) -> None:
                     "containerImage": "quay.io/repo1@sha256:deadbeef",
                     "rh-registry-repo": "registry.redhat.io/repo1",
                     "tags": ["1.0"],
+                    "repository": "quay.io/repo1",
                 },
                 {
                     "name": "comp-2",
                     "containerImage": "quay.io/repo2@sha256:ffffffff",
                     "rh-registry-repo": "registry.redhat.io/repo2",
                     "tags": ["2.0", "latest"],
+                    "repository": "quay.io/repo2",
                 },
             ]
         }
@@ -78,21 +80,23 @@ async def test_make_snapshot(index_manifest: dict[str, str]) -> None:
         components=[
             Component(
                 name="comp-1",
-                repository="registry.redhat.io/repo1",
+                release_repository="registry.redhat.io/repo1",
                 image=IndexImage("sha256:deadbeef", children=[Image("sha256:aaaaffff")]),
                 tags=["1.0"],
+                repository="quay.io/repo1",
             ),
             Component(
                 name="comp-2",
-                repository="registry.redhat.io/repo2",
+                release_repository="registry.redhat.io/repo2",
                 image=IndexImage("sha256:ffffffff", children=[Image("sha256:bbbbffff")]),
                 tags=["2.0", "latest"],
+                repository="quay.io/repo2",
             ),
         ],
     )
 
     def fake_get_image_manifest(repository: str, _: str) -> dict[str, Any]:
-        if repository == "registry.redhat.io/repo1":
+        if repository == "quay.io/repo1":
             child_digest = "sha256:aaaaffff"
 
             return {

--- a/sbom/test_update_component_sbom.py
+++ b/sbom/test_update_component_sbom.py
@@ -27,9 +27,10 @@ class TestSPDXVersion23:
             components=[
                 Component(
                     name="component",
-                    repository="registry.redhat.io/org/tenant/test",
+                    release_repository="registry.redhat.io/org/tenant/test",
                     image=Image("sha256:deadbeef"),
                     tags=["1.0", "latest"],
+                    repository="quay.io/repo",
                 )
             ],
         )
@@ -65,12 +66,13 @@ class TestSPDXVersion23:
             components=[
                 Component(
                     name="component",
-                    repository="registry.redhat.io/org/tenant/test",
+                    release_repository="registry.redhat.io/org/tenant/test",
                     image=IndexImage(
                         index_digest,
                         children=[Image(child_digest)],
                     ),
                     tags=["1.0", "latest"],
+                    repository="quay.io/repo",
                 )
             ],
         )
@@ -117,12 +119,13 @@ class TestSPDXVersion23:
             components=[
                 Component(
                     name="component",
-                    repository="registry.redhat.io/org/tenant/test",
+                    release_repository="registry.redhat.io/org/tenant/test",
                     image=IndexImage(
                         index_digest,
                         children=[Image(child_digest)],
                     ),
                     tags=["1.0", "latest"],
+                    repository="quay.io/repo",
                 )
             ]
             * num_components,
@@ -264,9 +267,10 @@ class TestCycloneDX:
             components=[
                 Component(
                     name="component",
-                    repository="registry.redhat.io/org/tenant/test",
+                    release_repository="registry.redhat.io/org/tenant/test",
                     image=Image("sha256:deadbeef"),
                     tags=tags,
+                    repository="quay.io/repo",
                 )
             ],
         )

--- a/sbom/update_component_sbom.py
+++ b/sbom/update_component_sbom.py
@@ -37,7 +37,7 @@ async def fetch_sbom(destination_dir: Path, reference: str) -> Path:
     with sbomlib.make_oci_auth_file(reference) as authfile:
         code, stdout, stderr = await sbomlib.run_async_subprocess(
             ["cosign", "download", "sbom", reference],
-            env={"DOCKER_CONFIG": authfile},
+            env={"DOCKER_CONFIG": str(Path(authfile).parent)},
             retry_times=3,
         )
 


### PR DESCRIPTION
The component gets a new field "release_repository", which contains the public-facing repository (such as registry.redhat.io). This field is used to update the SBOMs.

The "repository" field is used for the internal quay repository.