### PR TITLE
fix: successful http codes in curl-with-retry

### DIFF
--- a/utils/curl-with-retry
+++ b/utils/curl-with-retry
@@ -25,7 +25,7 @@ TMPFILE=$(mktemp)  # Create a temporary file for output
 for ((i=1; i<=MAX_RETRIES; i++)); do
     RESPONSE=$(curl -s -o "$TMPFILE" -w "%{http_code}" "$@")
 
-    if [ "$RESPONSE" -eq 200 ]; then
+    if [[ "$RESPONSE" -ge 200 && "$RESPONSE" -lt 300 ]]; then
         cat "$TMPFILE"  # Print the output
         exit 0
     elif [ "$RESPONSE" -eq 429 ]; then # Rate limited


### PR DESCRIPTION
We got a report from a user showing that Jira
will return code 201 when closing an issue
and our script would consider it a failure.

Anything >= 200 and < 300 is a success.

Another potential issue could be 3xx codes,
but we don't expect those now and normally
you'd want to use -L to follow those
anyway. So we shouldn't have to worry about
that.

Slack thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1748510448369709