### PR TITLE
fix(ISV-5990): fix SBOM update failing silently

### DIFF
--- a/sbom/handlers/cyclonedx1.py
+++ b/sbom/handlers/cyclonedx1.py
@@ -121,9 +121,10 @@ class CycloneDXVersion1(SBOMHandler):
     def _update_container_component(
         self, kflx_component: Component, cdx_component: dict, update_tags: bool
     ) -> None:
-        if cdx_component.get("type") != "container":
+        if (comp_type := cdx_component.get("type")) != "container":
             logger.warning(
-                'Called update method on CDX package with type %s instead of "container".'
+                'Called update method on CDX package with type %s instead of "container".',
+                comp_type,
             )
             return
 

--- a/sbom/sbomlib.py
+++ b/sbom/sbomlib.py
@@ -113,7 +113,10 @@ class SBOMHandler(Protocol):
     """
 
     def update_sbom(
-        self, component: Component, image: Union[IndexImage, Image], sbom: dict[str, Any]
+        self,
+        component: Component,
+        image: Union[IndexImage, Image],
+        sbom: dict[str, Any],
     ) -> None:
         """
         Update the specified SBOM in-place based on the provided component information.
@@ -157,7 +160,11 @@ async def construct_image(repository: str, image_digest: str) -> Union[Image, In
 
 
 async def make_component(
-    name: str, release_repository: str, image_digest: str, tags: list[str], repository: str
+    name: str,
+    release_repository: str,
+    image_digest: str,
+    tags: list[str],
+    repository: str,
 ) -> Component:
     """
     Creates a component object from input data.
@@ -338,6 +345,8 @@ def make_oci_auth_file(
     if auth is None:
         auth = Path(os.path.expanduser("~/.docker/config.json"))
 
+    logger.debug("Creating OCI auth file for %s from %s.", reference, auth)
+
     if not auth.is_file():
         raise ValueError(f"No docker config file at {auth}")
 
@@ -355,29 +364,39 @@ def make_oci_auth_file(
     with open(auth, mode="r", encoding="utf-8") as f:
         config = json.load(f)
     auths = config.get("auths", {})
+    logger.debug("OCI auth in %s available for repositories: %s", auth, list(auths.keys()))
 
     current_ref = ref
 
+    tempdir = None
+    config_fp = None
     try:
-        tmpfile = tempfile.NamedTemporaryFile(mode="w", delete=False)
+        tempdir = tempfile.TemporaryDirectory()
+        config_path = Path(tempdir.name).joinpath("config.json")
+        config_fp = open(config_path, "w")
+
         while True:
             token = auths.get(current_ref)
             if token is not None:
-                json.dump({"auths": {registry: token}}, tmpfile)
-                tmpfile.close()
-                yield tmpfile.name
+                json.dump({"auths": {registry: token}}, config_fp)
+                config_fp.close()
+                yield str(config_path)
                 return
 
             if "/" not in current_ref:
                 break
             current_ref = current_ref.rsplit("/", 1)[0]
 
-        json.dump({"auths": {}}, tmpfile)
-        tmpfile.close()
-        yield tmpfile.name
+        logger.warning("No authentication for %s found!", reference)
+        json.dump({"auths": {}}, config_fp)
+        config_fp.close()
+        yield str(config_path)
     finally:
-        # this also deletes the file
-        tmpfile.close()
+        if config_fp is not None:
+            config_fp.close()
+
+        if tempdir is not None:
+            tempdir.cleanup()
 
 
 def without_sha_header(digest: str) -> str:

--- a/sbom/test_sbomlib.py
+++ b/sbom/test_sbomlib.py
@@ -37,7 +37,7 @@ def test_get_oci_auth_file(auths, reference, expected_auths):
         json.dump(test_config, config)
         config.flush()
 
-        with sbomlib.make_oci_auth_file(reference, auth=Path(config.name)) as authfile:
+        with sbomlib.make_oci_auth_file(reference, authfile=Path(config.name)) as authfile:
             with open(authfile, "r") as fp:
                 data = json.loads(fp.read())
                 assert data["auths"] == expected_auths

--- a/sbom/update_component_sbom.py
+++ b/sbom/update_component_sbom.py
@@ -113,9 +113,8 @@ async def update_sbom(
         destination (Path): Path to the directory to save the SBOMs to.
     """
 
-    reference = None
+    reference = f"{component.repository}@{image.digest}"
     try:
-        reference = f"{component.repository}@{image.digest}"
         sbom, sbom_path = await load_sbom(reference, destination)
 
         if not update_sbom_in_situ(component, image, sbom):

--- a/sbom/update_component_sbom.py
+++ b/sbom/update_component_sbom.py
@@ -7,6 +7,7 @@ directory and updates them with release time data.
 Example usage:
 $ update_component_sbom --snapshot-path snapshot_spec.json --output-path sboms/
 """
+
 import argparse
 import asyncio
 import json
@@ -112,6 +113,7 @@ async def update_sbom(
         destination (Path): Path to the directory to save the SBOMs to.
     """
 
+    reference = None
     try:
         reference = f"{component.repository}@{image.digest}"
         sbom, sbom_path = await load_sbom(reference, destination)
@@ -123,6 +125,7 @@ async def update_sbom(
         logger.info("Successfully enriched SBOM for image %s", reference)
     except (SBOMError, ValueError):
         logger.exception("Failed to enrich SBOM for image %s.", reference)
+        raise
 
 
 async def update_component_sboms(component: Component, destination: Path) -> None:


### PR DESCRIPTION
The update_component_sboms script was silently failing on a cosign authorization issue. This PR fixes the cause of the silent failures and the auth issue itself.

Cosign was failing because the authentication file was not named "config.json" as expected.