### PR TITLE
Increase internal-request timeout to match

### DIFF
--- a/utils/internal-request
+++ b/utils/internal-request
@@ -32,7 +32,7 @@
 #                       InternalRequest resource. The value of the parameter must be a string. Optional.
 #   -s                  Sync: a flag that indicates whether the script has to finish to complete
 #                       the tasks or exit immediately after creating the resource. Default is true.
-#   -t                  Timeout: Defaults to 600 seconds.
+#   -t                  Timeout: Defaults to 3600 seconds.
 #   --service-account   The name of the service account to be used in the pipelineRun execution. Optional.
 #   --pipeline-timeout  The total timeout for the invoked pipelineRun. Defaults to 60mins
 #   --task-timeout      The timeout for the tasks invoked in the pipelineRun. Defaults to 55mins
@@ -51,9 +51,9 @@
 set -e
 
 # Set defaults
-TIMEOUT=600
 SYNC=true
 PARAMS=""
+TIMEOUT=3600
 PIPELINE_TIMEOUT=1h0m0s
 TASK_TIMEOUT=0h55m0s
 FINALLY_TIMEOUT=0h5m0s
@@ -71,7 +71,7 @@ function usage {
     echo "                      InternalRequest resource. Optional."
     echo "  -s                  Sync: a flag that indicates whether the script has to finish to complete the tasks or"
     echo "                      exit immediately after creating the resource. Default is true."
-    echo "  -t                  Timeout: Defaults to 600 seconds."
+    echo "  -t                  Timeout: Defaults to 3600 seconds."
     echo "  --service-account   The name of the service account to be used in the pipelineRun execution. Optional."
     echo "  --pipeline-timeout  The total timeout for the invoked pipelineRun. Defaults to 60mins."
     echo "  --task-timeout      The timeout for the tasks invoked in the pipelineRun. Defaults to 55mins."


### PR DESCRIPTION
The TIMEOUT value here is the time that the parent release pipeline will wait for the internal request to finish, and the other timeouts are the timeouts applied to the child internalrequest pipeline.

If these are unequal, things don't make sense. We had a case today where an internalrequest pipeline took 20m. It succeeded in the end, but only after the parent release pipeline had given up on it. This can cause a thundering herd problem in the downstream cluster where internal requests pipelines execute, when parent pipelines retry and stack up more downstream internalrequests that end up going unused.