### PR TITLE
fix(KONFLUX-7227): escape fields in advisory jinja template

### DIFF
--- a/templates/advisory.yaml.jinja
+++ b/templates/advisory.yaml.jinja
@@ -27,13 +27,9 @@ spec:
 {%- endif %}
   content:
     {{ advisory.spec.content | to_nice_yaml(indent=2) | indent(4) | trim }}
-  synopsis: >-
-    {{ advisory.spec.synopsis | indent(4) }}
-  topic: >-
-    {{ advisory.spec.topic | indent(4) }}
-  description: >-
-    {{ advisory.spec.description | indent(4) }}
-  solution: >-
-    {{ advisory.spec.solution | indent(4) }}
+  synopsis: {{ advisory.spec.synopsis | to_json }}
+  topic: {{ advisory.spec.topic | to_json }}
+  description: {{ advisory.spec.description | to_json }}
+  solution: {{ advisory.spec.solution | to_json }}
   references:
     {{ advisory.spec.references | to_nice_yaml | indent(4) }}

--- a/utils/tests/test_apply_template.py
+++ b/utils/tests/test_apply_template.py
@@ -70,8 +70,9 @@ def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
         "on-and-on-and-on-and-on-and-on,-it's-so-long-that-you-would-"
         "expect-that-something-is-going-to-linewrap-it-at-some-point.-so-long."
     )
+    description = 'Important: colon with a whitespace after should render correctly; "test"'
     # Confirm contributed partial templates are rendered
-    synopsis = "{% if advisory.spec.type == 'RHEA' %} Enhancement{%- endif %} synopsis"
+    synopsis = "{% if advisory.spec.type == 'RHEA' %}Enhancement{%- endif %} synopsis"
     try:
         args = MagicMock()
         args.template = "templates/advisory.yaml.jinja"
@@ -88,7 +89,7 @@ def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
                         "cpe": "cpe:/id",
                         "type": "RHEA",
                         "topic": topic,
-                        "description": "description",
+                        "description": description,
                         "solution": solution,
                         "synopsis": synopsis,
                         "references": ["testing"],
@@ -125,6 +126,7 @@ def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
 
         assert result["spec"]["solution"] == solution
         assert result["spec"]["topic"] == topic
+        assert result["spec"]["description"] == description
         assert result["spec"]["synopsis"] == "Enhancement synopsis"
         for issue in result["spec"]["issues"]["fixed"]:
             assert len(issue.keys()) == 3


### PR DESCRIPTION
The advisory.yaml.jinja template was causing YAML parsing errors due to unescaped strings in several fields.
This commit fixes the issue by applying the `to_json` filter to properly escape the strings.