### PR TITLE
Put file locking around writes to sbom files

### DIFF
--- a/sbom/test_update_component_sbom.py
+++ b/sbom/test_update_component_sbom.py
@@ -7,8 +7,8 @@ import pytest
 from pathlib import Path
 
 from sbom.handlers.cyclonedx1 import CDXSpec
-from sbom.update_component_sbom import update_sboms
-from sbom.sbomlib import Component, Image, IndexImage, Snapshot, get_purl_digest
+from sbom.update_component_sbom import update_sboms, fetch_sbom, load_sbom
+from sbom.sbomlib import Component, Image, IndexImage, Snapshot, get_purl_digest, SBOMError
 
 TESTDATA_PATH = Path(__file__).parent.joinpath("testdata")
 
@@ -19,7 +19,7 @@ class TestSPDXVersion23:
     async def test_single_component_single_arch(self, mock_write_sbom: AsyncMock) -> None:
         data_path = TESTDATA_PATH.joinpath("single-component-single-arch/spdx")
 
-        async def fake_load_sbom(reference: str, _) -> tuple[dict, str]:
+        async def fake_load_sbom(reference: str, _, component_name: str = None) -> tuple[dict, str]:
             with open(data_path.joinpath("build_sbom.json")) as f:
                 return json.load(f), ""
 
@@ -54,7 +54,7 @@ class TestSPDXVersion23:
             "sha256:84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921"
         )
 
-        async def fake_load_sbom(reference: str, _) -> tuple[dict, str]:
+        async def fake_load_sbom(reference: str, _, component_name: str = None) -> tuple[dict, str]:
             if index_digest in reference:
                 with open(data_path.joinpath("build_index_sbom.json")) as f:
                     return json.load(f), ""
@@ -107,7 +107,7 @@ class TestSPDXVersion23:
 
         num_components = 250
 
-        async def fake_load_sbom(reference: str, _) -> tuple[dict, str]:
+        async def fake_load_sbom(reference: str, _, component_name: str = None) -> tuple[dict, str]:
             if index_digest in reference:
                 with open(data_path.joinpath("build_index_sbom.json")) as f:
                     return json.load(f), ""
@@ -255,7 +255,7 @@ class TestCycloneDX:
     ) -> None:
         data_path = TESTDATA_PATH.joinpath("single-component-single-arch/cdx")
 
-        async def fake_load_sbom(reference: str, _) -> tuple[dict, str]:
+        async def fake_load_sbom(reference: str, _, component_name: str = None) -> tuple[dict, str]:
             with open(data_path.joinpath("build_sbom.json")) as f:
                 build_sbom = json.load(f)
                 # we can do this, because our build sbom should not contain any
@@ -290,3 +290,43 @@ class TestCycloneDX:
                         f"Failed verification of SBOM: {err}."
                         " Writing generated SBOM to {tmpf.name}"
                     ) from err
+
+
+class TestErrorHandling:
+    """Test component-specific file paths to prevent data mixing."""
+    
+    @pytest.mark.asyncio
+    async def test_component_specific_file_paths(self):
+        """Test that component names are properly included in file paths."""
+        with patch('sbom.update_component_sbom.sbomlib.make_oci_auth_file') as mock_auth, \
+             patch('sbom.update_component_sbom.sbomlib.run_async_subprocess') as mock_run, \
+             patch('aiofiles.open') as mock_open, \
+             patch('sbom.update_component_sbom.lock') as mock_lock:
+            
+            # Mock the auth file context manager
+            mock_auth.return_value.__enter__.return_value = "/tmp/auth.json"
+            mock_auth.return_value.__exit__.return_value = None
+            
+            # Mock cosign returning valid JSON content
+            mock_run.return_value = (0, b'{"test": "data"}', b"")
+            
+            # Mock file operations
+            mock_file = AsyncMock()
+            mock_open.return_value.__aenter__.return_value = mock_file
+            
+            # Mock lock context manager
+            mock_lock.return_value.__aenter__ = AsyncMock()
+            mock_lock.return_value.__aexit__ = AsyncMock()
+            
+            # Test with component name
+            result = await fetch_sbom(Path("/tmp"), "test-registry/test-image@sha256:abc123", "test-component")
+            
+            # Verify the path includes the component name
+            assert "test-component-sha256:abc123" in str(result)
+            
+            # Test without component name (backward compatibility)
+            result = await fetch_sbom(Path("/tmp"), "test-registry/test-image@sha256:abc123")
+            
+            # Verify the path doesn't include component name
+            assert "test-component" not in str(result)
+            assert "sha256:abc123" in str(result)

--- a/sbom/test_update_component_sbom.py
+++ b/sbom/test_update_component_sbom.py
@@ -7,8 +7,8 @@ import pytest
 from pathlib import Path
 
 from sbom.handlers.cyclonedx1 import CDXSpec
-from sbom.update_component_sbom import update_sboms, fetch_sbom, load_sbom
-from sbom.sbomlib import Component, Image, IndexImage, Snapshot, get_purl_digest, SBOMError
+from sbom.update_component_sbom import update_sboms, fetch_sbom
+from sbom.sbomlib import Component, Image, IndexImage, Snapshot, get_purl_digest
 
 TESTDATA_PATH = Path(__file__).parent.joinpath("testdata")
 
@@ -19,7 +19,9 @@ class TestSPDXVersion23:
     async def test_single_component_single_arch(self, mock_write_sbom: AsyncMock) -> None:
         data_path = TESTDATA_PATH.joinpath("single-component-single-arch/spdx")
 
-        async def fake_load_sbom(reference: str, _, component_name: str = None) -> tuple[dict, str]:
+        async def fake_load_sbom(
+            reference: str, _, component_name: str = None
+        ) -> tuple[dict, str]:
             with open(data_path.joinpath("build_sbom.json")) as f:
                 return json.load(f), ""
 
@@ -54,7 +56,9 @@ class TestSPDXVersion23:
             "sha256:84fb3b3c3cef7283a9c5172f25cf00c53274eea4972a9366e24e483ef2507921"
         )
 
-        async def fake_load_sbom(reference: str, _, component_name: str = None) -> tuple[dict, str]:
+        async def fake_load_sbom(
+            reference: str, _, component_name: str = None
+        ) -> tuple[dict, str]:
             if index_digest in reference:
                 with open(data_path.joinpath("build_index_sbom.json")) as f:
                     return json.load(f), ""
@@ -107,7 +111,9 @@ class TestSPDXVersion23:
 
         num_components = 250
 
-        async def fake_load_sbom(reference: str, _, component_name: str = None) -> tuple[dict, str]:
+        async def fake_load_sbom(
+            reference: str, _, component_name: str = None
+        ) -> tuple[dict, str]:
             if index_digest in reference:
                 with open(data_path.joinpath("build_index_sbom.json")) as f:
                     return json.load(f), ""
@@ -255,7 +261,9 @@ class TestCycloneDX:
     ) -> None:
         data_path = TESTDATA_PATH.joinpath("single-component-single-arch/cdx")
 
-        async def fake_load_sbom(reference: str, _, component_name: str = None) -> tuple[dict, str]:
+        async def fake_load_sbom(
+            reference: str, _, component_name: str = None
+        ) -> tuple[dict, str]:
             with open(data_path.joinpath("build_sbom.json")) as f:
                 build_sbom = json.load(f)
                 # we can do this, because our build sbom should not contain any
@@ -294,39 +302,46 @@ class TestCycloneDX:
 
 class TestErrorHandling:
     """Test component-specific file paths to prevent data mixing."""
-    
+
     @pytest.mark.asyncio
     async def test_component_specific_file_paths(self):
         """Test that component names are properly included in file paths."""
-        with patch('sbom.update_component_sbom.sbomlib.make_oci_auth_file') as mock_auth, \
-             patch('sbom.update_component_sbom.sbomlib.run_async_subprocess') as mock_run, \
-             patch('aiofiles.open') as mock_open, \
-             patch('sbom.update_component_sbom.lock') as mock_lock:
-            
+        with patch(
+            "sbom.update_component_sbom.sbomlib.make_oci_auth_file"
+        ) as mock_auth, patch(
+            "sbom.update_component_sbom.sbomlib.run_async_subprocess"
+        ) as mock_run, patch(
+            "aiofiles.open"
+        ) as mock_open, patch(
+            "sbom.update_component_sbom.lock"
+        ) as mock_lock:
+
             # Mock the auth file context manager
             mock_auth.return_value.__enter__.return_value = "/tmp/auth.json"
             mock_auth.return_value.__exit__.return_value = None
-            
+
             # Mock cosign returning valid JSON content
             mock_run.return_value = (0, b'{"test": "data"}', b"")
-            
+
             # Mock file operations
             mock_file = AsyncMock()
             mock_open.return_value.__aenter__.return_value = mock_file
-            
+
             # Mock lock context manager
             mock_lock.return_value.__aenter__ = AsyncMock()
             mock_lock.return_value.__aexit__ = AsyncMock()
-            
+
             # Test with component name
-            result = await fetch_sbom(Path("/tmp"), "test-registry/test-image@sha256:abc123", "test-component")
-            
+            result = await fetch_sbom(
+                Path("/tmp"), "test-registry/test-image@sha256:abc123", "test-component"
+            )
+
             # Verify the path includes the component name
             assert "test-component-sha256:abc123" in str(result)
-            
+
             # Test without component name (backward compatibility)
             result = await fetch_sbom(Path("/tmp"), "test-registry/test-image@sha256:abc123")
-            
+
             # Verify the path doesn't include component name
             assert "test-component" not in str(result)
             assert "sha256:abc123" in str(result)

--- a/sbom/update_component_sbom.py
+++ b/sbom/update_component_sbom.py
@@ -45,7 +45,9 @@ async def lock(key: Path):
         yield
 
 
-async def fetch_sbom(destination_dir: Path, reference: str, component_name: str = None) -> Path:
+async def fetch_sbom(
+    destination_dir: Path, reference: str, component_name: str = None
+) -> Path:
     """
     Download an SBOM for an image reference to a destination directory.
     """
@@ -67,7 +69,7 @@ async def fetch_sbom(destination_dir: Path, reference: str, component_name: str 
         path = destination_dir.joinpath(f"{safe_component_name}-{digest}")
     else:
         path = destination_dir.joinpath(digest)
-    
+
     async with lock(path):
         async with aiofiles.open(path, "wb") as file:
             await file.write(stdout)
@@ -75,7 +77,9 @@ async def fetch_sbom(destination_dir: Path, reference: str, component_name: str 
     return path
 
 
-async def load_sbom(reference: str, destination: Path, component_name: str = None) -> tuple[dict, Path]:
+async def load_sbom(
+    reference: str, destination: Path, component_name: str = None
+) -> tuple[dict, Path]:
     """
     Download the sbom for the image reference, save it to a directory and parse
     it into a dictionary.


### PR DESCRIPTION
If we do this in parallel and if a pullspec is listed in a snapshot twice, then the two routines collide, one fetching and the other writing the augmented sbom - resulting in malformed json.