### PR TITLE
feat(RELEASE-186): breaking change as label

### DIFF
--- a/ci/promote-overlay/promote-overlay.sh
+++ b/ci/promote-overlay/promote-overlay.sh
@@ -140,7 +140,11 @@ RS_COMMITS=($(git rev-list --first-parent --ancestry-path "$RS_TARGET_OVERLAY_CO
 ## now loop through the above array
 for RS_COMMIT in "${RS_COMMITS[@]}"
 do
-  PR_URL=$(curl -s   -H 'Authorization: token  '"$token"  'https://api.github.com/search/issues?q=sha:'"$RS_COMMIT" | jq -r '.items[0].pull_request.html_url')
+  PR_INFO="$(curl -s   -H 'Authorization: token  '"$token"  'https://api.github.com/search/issues?q=is:pr+sha:'"$RS_COMMIT")"
+  echo -n "$(jq -r '.items[0].pull_request.html_url' <<< "$PR_INFO")"
+  LABEL="$(jq -r '.items[0].labels[].name | select(. | contains("breaking-change"))' <<< "$PR_INFO")"
+  [[ -z "$LABEL" ]] || echo -n " ($LABEL)"
+  echo
    # or do whatever with individual element of the array
   description="$description"' - '"$PR_URL"'\r\n'
 done


### PR DESCRIPTION
`ci/promote_overlay/promote_overlay.sh` now fetches label `breaking-change` on PRs - this will make it more clear when a breaking change is being promoted.