### PR TITLE
fix: prevent null values in advisory YAML when issues.fixed is empty

### DIFF
--- a/templates/advisory.yaml.jinja
+++ b/templates/advisory.yaml.jinja
@@ -14,7 +14,7 @@ spec:
 {%- if 'severity' in advisory.spec %}
   severity: {{ advisory.spec.severity }}
 {%- endif %}
-{%- if 'issues' in advisory.spec %}
+{%- if 'issues' in advisory.spec and advisory.spec.issues.fixed %}
   issues:
     fixed:
       {%- for issue in advisory.spec.issues.fixed %}


### PR DESCRIPTION
When the Jira collector returns no issues, it creates an empty array [] for issues.fixed. The advisory template was rendering this as:

  issues:
    fixed:

This creates a null value for 'fixed' in YAML, causing schema validation to fail with "None is not of type 'array'".

Fix the template condition to only render the issues section when issues.fixed contains actual data, not just when the field exists.