### PR TITLE
chore: identify helm chart artifacts

### DIFF
--- a/utils/get-image-architectures
+++ b/utils/get-image-architectures
@@ -45,7 +45,8 @@ fi
 RAW_OUTPUT=$(skopeo inspect "${SKOPEO_RETRIES[@]}" --no-tags --raw docker://${IMAGE})
 
 ARTIFACT_TYPE=$(jq -r '.artifactType' <<< $RAW_OUTPUT)
-if [ "$ARTIFACT_TYPE" != "null" ] ; then
+CONFIG_MEDIA_TYPE=$(jq -r '.config.mediaType' <<< $RAW_OUTPUT)
+if [ "$ARTIFACT_TYPE" != "null" ] || [ "$CONFIG_MEDIA_TYPE" == "application/vnd.cncf.helm.config.v1+json" ] ; then
     # OCI artifact (not a normal image)
     digest=$(echo $IMAGE | awk -F '@' '{print $2}')
     if [[ ! "$digest" =~ ^sha256: ]] ; then


### PR DESCRIPTION
Not all non-image OCI artifacts have .artifactType != null.
For example, Helm artifacts don't include that field at all.

Extending the check for recognizing generic artifacts to also include
Helm charts.