### PR TITLE
feat(RELEASE-1570): stop populating updated_date in advisories

### DIFF
--- a/templates/advisory.yaml.jinja
+++ b/templates/advisory.yaml.jinja
@@ -3,7 +3,6 @@ kind: Advisory
 metadata:
   name: {{ advisory_name }}
   ship_date: "{{ advisory_ship_date }}"
-  updated_date: "{{ advisory_ship_date }}"
 spec:
   product_id: {{ advisory.spec.product_id }}
   product_name: {{ advisory.spec.product_name }}


### PR DESCRIPTION
We are removing the field from the advisory yaml files. Instead, this field will be injected in the Gitlab CI pipeline before the UMB message is sent. This is already implemented in both staging and production advisory repos.