### PR TITLE
fix: remove file filtering in tekton config file

### DIFF
--- a/.tekton/release-service-utils-pull-request.yaml
+++ b/.tekton/release-service-utils-pull-request.yaml
@@ -7,9 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "./***".pathChanged() || ".tekton/release-service-utils-pull-request.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" 
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-service


### PR DESCRIPTION
Since "./***".pathChanged()" can't work well  and  the task "check-if-e2e-irrelevant" was added to e2e pipeline, the PR is to remove file filering in tekton config file.

failed example: https://github.com/konflux-ci/release-service-utils/pull/493#issuecomment-3188562147