### PR TITLE
fix(RELEASE-1828): address CVEs in syft, cosign, glab, and opm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM quay.io/konflux-ci/oras:latest@sha256:e52de03c78ea65bf806cebee6892f054e2ae7b554d302e4a83ef28ec5010b2ee as oras
-FROM registry.redhat.io/rhtas/cosign-rhel9:1.0.2-1719417920 as cosign
+FROM registry.redhat.io/rhtas/cosign-rhel9:1.1.1-1736785731 as cosign
 FROM registry.access.redhat.com/ubi9/ubi:9.6-1755678605
 
-ARG COSIGN_VERSION=2.4.0
 ARG KUBECTL_VERSION=1.27.2
-ARG OPM_VERSION=v1.38.0
+ARG OPM_VERSION=v1.50.0
 ARG PUBTOOLS_CGW_VERSION=0.5.4
 ARG PUBTOOLS_PULP_VERSION=1.33.2
 ARG PUBTOOLS_EXODUS_VERSION=1.5.2
@@ -12,9 +11,9 @@ ARG PUBTOOLS_MARKETPLACESVM_VERSION=1.7.0
 ARG PUBTOOLS_SIGN_VERSION=0.0.14
 ARG PUBTOOLS_PYXIS_VERSION=1.3.7
 ARG YQ_VERSION=4.34.1
-ARG GLAB_VERSION=1.48.0
+ARG GLAB_VERSION=1.51.0
 ARG GH_VERSION=2.32.1
-ARG SYFT_VERSION=1.12.2
+ARG SYFT_VERSION=1.19.0
 
 RUN curl -L https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 -o /usr/bin/yq &&\
     curl -L https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/bin/kubectl &&\


### PR DESCRIPTION
fix(RELEASE-1828): address CVEs in syft, cosign, glab, and opm

These updates address vulnerabilities that have been flagged by AppSRE SLO.
Clair Scan [JSON](https://privatebin.corp.redhat.com/?2a104bb7b1ea085a#2AHuwcsQNcKHtABQmmZYj1yDAVKeQrAKaHGbRpbn8LKm) 

CVE-2024-45337

* Syft > v1.18.1*
- https://github.com/anchore/syft/pull/3523
- https://github.com/anchore/syft/releases/tag/v1.18.1

* Cosign > 1.1.1-1736785731
- https://catalog.redhat.com/software/containers/rhtas/cosign-rhel9/65f1eed5b8a552c8d7ee4c53?image=67ab2b6bda9916974f54f515&architecture=amd64&container-tabs=overview

* Gitlab > v1.51.0
- https://gitlab.com/gitlab-org/cli/-/releases/v1.51.0
- https://gitlab.com/gitlab-org/cli/-/raw/v1.51.0/go.mod

CVE-2024-41110

* Cosign > 1.1.1-1736785731
- https://catalog.redhat.com/software/containers/rhtas/cosign-rhel9/65f1eed5b8a552c8d7ee4c53?image=67ab2b6bda9916974f54f515&architecture=amd64&container-tabs=overview

* Opm > v1.43.1*
- https://github.com/operator-framework/operator-registry/releases/tag/v1.43.1
- https://github.com/operator-framework/operator-registry/blob/dff7915e80b476bf817e25e8101455716e6352be/go.mod#L86

CVE-2025-21613

* Opm > v1.50.0
- https://github.com/operator-framework/operator-registry/releases/tag/v1.50.0
- https://github.com/operator-framework/operator-registry/blob/ed8d23bef591f894839f9f85f82c000f1a9c231a/go.mod#L104

* Syft > v1.19.0
- https://github.com/anchore/syft/releases/tag/v1.19.0
- https://github.com/anchore/syft/blob/222e6548a96f8c80015c1d24f01dea3052a04893/go.mod#L39
