### PR TITLE
feat(RELEASE-1843): add skip_customer_notifications field in advisories

### DIFF
--- a/templates/advisory.yaml.jinja
+++ b/templates/advisory.yaml.jinja
@@ -24,6 +24,7 @@ spec:
         {%- endif %}
       {%- endfor %}
 {%- endif %}
+  skip_customer_notifications: {{ advisory.spec.skip_customer_notifications | default(False) }}
   content:
     {{ advisory.spec.content | to_nice_yaml(indent=2) | indent(4) | trim }}
   synopsis: >-


### PR DESCRIPTION
This will be an optional in the releaseNotes, but we want it to be set in the resulting advisory yaml always, defaulting to false.