### PR TITLE
fix(RELEASE-1767): keep newlines in advisory fields

### DIFF
--- a/templates/advisory.yaml.jinja
+++ b/templates/advisory.yaml.jinja
@@ -27,13 +27,13 @@ spec:
   skip_customer_notifications: {{ advisory.spec.skip_customer_notifications | default(False) }}
   content:
     {{ advisory.spec.content | to_nice_yaml(indent=2) | indent(4) | trim }}
-  synopsis: >-
+  synopsis: |-
     {{ advisory.spec.synopsis | indent(4) }}
-  topic: >-
+  topic: |-
     {{ advisory.spec.topic | indent(4) }}
-  description: >-
+  description: |-
     {{ advisory.spec.description | indent(4) }}
-  solution: >-
+  solution: |-
     {{ advisory.spec.solution | indent(4) }}
   references:
     {{ advisory.spec.references | to_nice_yaml | indent(4) }}


### PR DESCRIPTION
Until now, we used `>-` for multiline strings for some of the fields in the advisory jinja template. That means that we were removing most newlines from the input string. We shouldn't do that. We should pass the string that the user provided on input unmodified.

With `|-`, all newlines will be preserved.