### PR TITLE
chore(KFLUXMIG-294): add rpm-build to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     python3-pip \
     python3-requests \
     python3-rpm \
+    rpm-build \
     skopeo \
     krb5-libs \
     krb5-devel \


### PR DESCRIPTION
Working on the [packaging](https://github.com/konflux-ci/release-service-catalog/pull/1460) of out-of-tree signed kernel modules. rpm-build is not shipped with the base image