### PR TITLE
feat(PVSEC-12961): add rh-model-signing to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     git \
     git-lfs \
     jq \
-    python3-devel \
+    python3.10-devel \
     diffutils \
     python3-pip \
     python3-requests \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "release-service-utils"
 version = "0.1.0"
 description = "Konflux Release Service Utils"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "jinja2",
     "check-jsonschema",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "jinja2-ansible-filters",
     "packaging",
     "packageurl-python",
+    "rh-model-signing>=0.1.0",
     "pubtools-content-gateway==0.5.4",
     "pubtools-pulp==1.33.2",
     "pubtools-exodus==1.5.2",


### PR DESCRIPTION
I am currently creating a Konflux task for AI model signing in the [release-service-catalog](https://github.com/konflux-ci/release-service-catalog/tree/development) repo. The preferred way to do this is with the new [Red Hat model-signing tool](https://pypi.org/project/rh-model-signing/0.1.0/#description), which I propose we add to this image.

JIRA link: [PVSEC-12961](https://issues.redhat.com/browse/PVSEC-12961)