### PR TITLE
feat(RELEASE-2209): add helper scripts to create catalog fork

### DIFF
--- a/integration-tests/lib/catalog_cleanup.py
+++ b/integration-tests/lib/catalog_cleanup.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Compare catalog branch head to CATALOG_BASE_SHA; warn if it moved. Delete temp GitHub repo.
+
+Uses release-service-catalog's ``delete-repository.sh`` (same API as catalog e2e).
+
+Required env:
+  GITHUB_TOKEN
+  TEMP_REPO_NAME  (full org/repo of the temporary fork, e.g.
+  hacbs-release-tests/catalog-utils-e2e-<uid>)
+
+Optional env:
+  CATALOG_BASE_SHA
+  CATALOG_REPO     (default: konflux-ci/release-service-catalog)
+  CATALOG_REF      (default: development)
+  INTEGRATION_TESTS_SCRIPTS_DIR  If set and contains delete-repository.sh,
+  skip cloning catalog.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from catalog_e2e_helpers import require_env
+
+
+def _ls_remote_head(*, catalog_repo: str, catalog_ref: str) -> str:
+    """SHA of refs/heads/<ref> from GitHub (no auth; public konflux-ci catalog)."""
+    url = f"https://github.com/{catalog_repo}.git"
+    proc = subprocess.run(
+        ["git", "ls-remote", url, f"refs/heads/{catalog_ref}"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return ""
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    if not lines:
+        return ""
+    return lines[0].split()[0]
+
+
+def _warn_catalog_drift(*, catalog_repo: str, catalog_ref: str, catalog_base_sha: str) -> None:
+    current = _ls_remote_head(catalog_repo=catalog_repo, catalog_ref=catalog_ref)
+    if current and current != catalog_base_sha:
+        print()
+        print("=" * 80)
+        print(f"  WARNING: release-service-catalog branch '{catalog_ref}' has new commits")
+        print("  since this test started.")
+        print(f"    SHA at clone: {catalog_base_sha}")
+        print(f"    SHA now:      {current}")
+        print(
+            "  E2E ran against the older catalog snapshot. Re-run if you need latest catalog."
+        )
+        print()
+
+
+def _acquire_delete_repository_script_dir(
+    *, catalog_repo: str, catalog_ref: str
+) -> tuple[Path, Path | None]:
+    """Fetch directory with ``delete-repository.sh``; optional temp clone root to remove."""
+    override = os.environ.get("INTEGRATION_TESTS_SCRIPTS_DIR", "").strip()
+    if override:
+        d = Path(override)
+        if (d / "delete-repository.sh").is_file():
+            return d, None
+
+    td = Path(tempfile.mkdtemp(prefix="catalog_cleanup-"))
+    clone_dest = td / "catalog"
+    url = f"https://github.com/{catalog_repo}.git"
+    try:
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                catalog_ref,
+                url,
+                str(clone_dest),
+            ],
+            check=True,
+            timeout=600,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        shutil.rmtree(td, ignore_errors=True)
+        print(f"ERROR: git clone failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    scripts = clone_dest / "integration-tests" / "scripts"
+    if not (scripts / "delete-repository.sh").is_file():
+        shutil.rmtree(td, ignore_errors=True)
+        missing = scripts / "delete-repository.sh"
+        print(f"ERROR: delete-repository.sh missing after clone: {missing}", file=sys.stderr)
+        sys.exit(1)
+    return scripts, td
+
+
+def main() -> None:
+    # delete-repository.sh uses this from the environment; do not embed it in clone URLs.
+    require_env("GITHUB_TOKEN")
+    temp_repo_name = require_env("TEMP_REPO_NAME")
+    catalog_repo = os.environ.get("CATALOG_REPO", "konflux-ci/release-service-catalog").strip()
+    catalog_ref = os.environ.get("CATALOG_REF", "development").strip()
+    base_sha = os.environ.get("CATALOG_BASE_SHA", "").strip()
+
+    if base_sha:
+        _warn_catalog_drift(
+            catalog_repo=catalog_repo,
+            catalog_ref=catalog_ref,
+            catalog_base_sha=base_sha,
+        )
+
+    scripts_dir, clone_root = _acquire_delete_repository_script_dir(
+        catalog_repo=catalog_repo,
+        catalog_ref=catalog_ref,
+    )
+    delete_script = scripts_dir / "delete-repository.sh"
+
+    try:
+        print(f"Deleting temporary repo {temp_repo_name}...")
+        subprocess.run(
+            ["bash", str(delete_script), temp_repo_name],
+            check=True,
+            env=os.environ.copy(),
+            timeout=300,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: delete-repository.sh exited {e.returncode}", file=sys.stderr)
+        sys.exit(e.returncode)
+    except subprocess.TimeoutExpired as e:
+        print(
+            f"ERROR: delete-repository.sh timed out after {e.timeout}s",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    finally:
+        if clone_root is not None:
+            shutil.rmtree(clone_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/integration-tests/lib/catalog_clone_patch_push.sh
+++ b/integration-tests/lib/catalog_clone_patch_push.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Clone release-service-catalog, replace konflux-ci release-service-utils image refs with UTILS_IMAGE,
+# push to a new GitHub repo.
+# Outputs results for Tekton (stdout markers + optional result files).
+#
+# Required env: GITHUB_TOKEN, UTILS_IMAGE
+# Optional: CATALOG_REPO (default konflux-ci/release-service-catalog), CATALOG_REF (development),
+#           DEST_REPO_PREFIX (default hacbs-release-tests/catalog-e2e), PIPELINE_UID
+set -euo pipefail
+
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+: "${UTILS_IMAGE:?UTILS_IMAGE is required}"
+
+CATALOG_REPO="${CATALOG_REPO:-konflux-ci/release-service-catalog}"
+CATALOG_REF="${CATALOG_REF:-development}"
+DEST_REPO="${DEST_REPO_PREFIX:-hacbs-release-tests/utils-e2e}-${PIPELINE_UID:-$(date +%s)}"
+BRANCH_NAME="${BRANCH_NAME:-patched-catalog}"
+
+CATALOG_CLONE_DIR="$(mktemp -d)"
+trap 'rm -rf "${CATALOG_CLONE_DIR}"' EXIT
+
+echo "Cloning ${CATALOG_REPO}@${CATALOG_REF} into ${CATALOG_CLONE_DIR}..."
+git clone --depth 1 --branch "${CATALOG_REF}" \
+  "https://${GITHUB_TOKEN}@github.com/${CATALOG_REPO}.git" "${CATALOG_CLONE_DIR}"
+cd "${CATALOG_CLONE_DIR}"
+# Shallow clone + push to an empty repo often yields "did not receive expected object" / index-pack
+# on the remote; need a complete object graph for git push to pack correctly.
+if [[ -f "$(git rev-parse --git-dir)/shallow" ]]; then
+  echo "Fetching full history (git fetch --unshallow) for a reliable push..."
+  git fetch --unshallow
+fi
+
+CATALOG_BASE_SHA="$(git rev-parse HEAD)"
+echo "Recorded CATALOG_BASE_SHA=${CATALOG_BASE_SHA}"
+
+# GitHub rejects PAT pushes that touch workflow YAML without `workflow` scope. We push HEAD~1 to
+# `development` for find_release_pipelines_from_pr; that ref must not contain workflow files, so
+# remove workflows in their own commit *before* the image patch (HEAD~1 is then pushable).
+if [[ -d .github/workflows ]]; then
+  echo "Removing .github/workflows before image patch (required for PAT push of development ref)."
+  rm -rf .github/workflows
+  git config user.email "catalog-e2e@konflux-ci"
+  git config user.name "konflux-release-team"
+  git add -A
+  git commit -m "chore(e2e): drop workflows for GitHub PAT push"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "${SCRIPT_DIR}/catalog_e2e_helpers.py"
+
+echo "${CATALOG_BASE_SHA}" > .catalog-clone-base-sha
+
+git config user.email "konflux-release-team@redhat.com"
+git config user.name "konflux-release-team"
+git add -A
+git commit -m "chore(e2e): use release-service-utils PR image for integration tests"
+
+INTEGRATION_SCRIPTS_DIR="${CATALOG_CLONE_DIR}/integration-tests/scripts"
+if [[ ! -f "${INTEGRATION_SCRIPTS_DIR}/create-github-repo.sh" ]]; then
+  echo "ERROR: create-github-repo.sh not found at ${INTEGRATION_SCRIPTS_DIR}" >&2
+  exit 1
+fi
+
+echo "Creating GitHub repo ${DEST_REPO}..."
+bash "${INTEGRATION_SCRIPTS_DIR}/create-github-repo.sh" "${DEST_REPO}" \
+  "Temporary catalog fork for release-service-utils e2e (auto-deleted)" false
+
+git remote add dest "https://${GITHUB_TOKEN}@github.com/${DEST_REPO}.git"
+# HEAD~1 is the workflow-free commit (when .github/workflows existed); find_release_pipelines_from_pr
+# uses origin/development...HEAD (image patch only when two commits; else HEAD~1 is upstream).
+git push dest "HEAD~1:refs/heads/development"
+git checkout -b "${BRANCH_NAME}"
+git push -u dest "${BRANCH_NAME}"
+
+CATALOG_GIT_URL="https://github.com/${DEST_REPO}"
+echo "Pushed development (catalog base) and ${BRANCH_NAME} (patched) to ${CATALOG_GIT_URL}"
+
+# Optional Tekton result paths: $1 $2 $3 $4 = CATALOG_BASE_SHA, CATALOG_GIT_URL, CATALOG_GIT_REVISION, TEMP_REPO_NAME
+if [[ -n "${1:-}" ]]; then echo -n "${CATALOG_BASE_SHA}" > "$1"; fi
+if [[ -n "${2:-}" ]]; then echo -n "${CATALOG_GIT_URL}" > "$2"; fi
+if [[ -n "${3:-}" ]]; then echo -n "${BRANCH_NAME}" > "$3"; fi
+if [[ -n "${4:-}" ]]; then echo -n "${DEST_REPO}" > "$4"; fi

--- a/integration-tests/lib/catalog_e2e_helpers.py
+++ b/integration-tests/lib/catalog_e2e_helpers.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Functions used for orchestrating catalog e2e."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def require_env(name: str) -> str:
+    v = os.environ.get(name, "").strip()
+    if not v:
+        print(f"ERROR: {name} is required", file=sys.stderr)
+        sys.exit(1)
+    return v
+
+
+# Any registry/repo path ending in /release-service-utils with :tag or @digest.
+_UTILS_IMAGE_REF = re.compile(
+    r"(?:[\w.-]+/)+release-service-utils(?::[^\s\n\"'#]+|@[^\s\n\"'#]+)"
+)
+_MULTILINE_UTILS_REF = re.compile(
+    r"(image:\s*\n\s*)(?:[\w.-]+/)+release-service-utils(?::[^\s\n\"'#]+|@[^\s\n\"'#]+)",
+    re.MULTILINE,
+)
+
+
+def patch_catalog_utils_image_refs(root: Path, utils_image: str) -> int:
+    """Replace release-service-utils container image refs under ``root``.
+
+    Skips ``tasks/**/tests/*.yaml`` (Tekton unit-test fixtures). Returns the
+    number of YAML files modified.
+    """
+    root = root.resolve()
+    tasks_root = root / "tasks"
+
+    def _under_task_tests(p: Path) -> bool:
+        try:
+            rel = p.relative_to(tasks_root)
+        except ValueError:
+            return False
+        return "tests" in rel.parts
+
+    modified = 0
+    for path in root.rglob("*.yaml"):
+        if tasks_root.is_dir() and _under_task_tests(path):
+            continue
+        text = path.read_text(encoding="utf-8")
+        new = _UTILS_IMAGE_REF.sub(utils_image, text)
+        new = _MULTILINE_UTILS_REF.sub(r"\1" + utils_image, new)
+        if new != text:
+            path.write_text(new, encoding="utf-8")
+            modified += 1
+    return modified
+
+
+if __name__ == "__main__":
+    utils_image = require_env("UTILS_IMAGE")
+    n = patch_catalog_utils_image_refs(Path.cwd(), utils_image)
+    if n == 0:
+        print(
+            "ERROR: No YAML changes after patching release-service-utils image refs.",
+            file=sys.stderr,
+        )
+        print(
+            "       Check that catalog tasks still reference "
+            "quay.io/konflux-ci/release-service-utils@",
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/integration-tests/lib/tests/test_catalog_cleanup.py
+++ b/integration-tests/lib/tests/test_catalog_cleanup.py
@@ -1,0 +1,334 @@
+"""Unit tests for ``catalog_cleanup``."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import catalog_cleanup as uc
+
+
+def test_ls_remote_head_parses_first_sha(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parse the first token of the first non-empty ls-remote line."""
+    proc = subprocess.CompletedProcess(
+        ["git", "ls-remote"],
+        0,
+        "abc123def456\trefs/heads/development\n",
+        "",
+    )
+    monkeypatch.setattr(uc.subprocess, "run", MagicMock(return_value=proc))
+    sha = uc._ls_remote_head(
+        catalog_repo="konflux-ci/release-service-catalog",
+        catalog_ref="development",
+    )
+    assert sha == "abc123def456"
+
+
+def test_ls_remote_head_returns_empty_on_git_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Return empty string when git ls-remote exits non-zero."""
+    proc = subprocess.CompletedProcess(["git", "ls-remote"], 1, "", "err")
+    monkeypatch.setattr(uc.subprocess, "run", MagicMock(return_value=proc))
+    assert uc._ls_remote_head(catalog_repo="org/repo", catalog_ref="main") == ""
+
+
+def test_ls_remote_head_returns_empty_when_no_output_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Return empty string when stdout has no non-empty lines."""
+    proc = subprocess.CompletedProcess(["git", "ls-remote"], 0, "\n\n", "")
+    monkeypatch.setattr(uc.subprocess, "run", MagicMock(return_value=proc))
+    assert uc._ls_remote_head(catalog_repo="org/repo", catalog_ref="main") == ""
+
+
+def test_warn_catalog_drift_prints_when_head_differs(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Print a warning block when remote head differs from the base SHA."""
+    monkeypatch.setattr(
+        uc,
+        "_ls_remote_head",
+        lambda **_: "newsha",
+    )
+    uc._warn_catalog_drift(
+        catalog_repo="org/repo",
+        catalog_ref="dev",
+        catalog_base_sha="oldsha",
+    )
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "oldsha" in out and "newsha" in out
+
+
+def test_warn_catalog_drift_silent_when_head_matches(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Print nothing when remote head equals the base SHA."""
+    monkeypatch.setattr(uc, "_ls_remote_head", lambda **_: "same")
+    uc._warn_catalog_drift(
+        catalog_repo="org/repo",
+        catalog_ref="dev",
+        catalog_base_sha="same",
+    )
+    assert capsys.readouterr().out == ""
+
+
+def test_warn_catalog_drift_silent_when_ls_remote_empty(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Print nothing when ls-remote yields no current SHA."""
+    monkeypatch.setattr(uc, "_ls_remote_head", lambda **_: "")
+    uc._warn_catalog_drift(
+        catalog_repo="org/repo",
+        catalog_ref="dev",
+        catalog_base_sha="any",
+    )
+    assert capsys.readouterr().out == ""
+
+
+def test_acquire_delete_repository_script_dir_uses_integration_tests_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Use INTEGRATION_TESTS_SCRIPTS_DIR when delete-repository.sh exists there."""
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "delete-repository.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+    monkeypatch.setenv("INTEGRATION_TESTS_SCRIPTS_DIR", str(scripts))
+    d, clone_root = uc._acquire_delete_repository_script_dir(
+        catalog_repo="org/repo",
+        catalog_ref="main",
+    )
+    assert d == scripts
+    assert clone_root is None
+
+
+def test_acquire_delete_repository_script_dir_clone_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Clone catalog layout and return scripts dir plus temp root to remove."""
+    td = tmp_path / "clone-root"
+    td.mkdir()
+    clone_dest = td / "catalog"
+
+    def fake_run(cmd: list, check: bool = False, timeout: object = None, **kwargs):
+        if cmd[:2] == ["git", "clone"]:
+            clone_dest.mkdir(parents=True)
+            dr = clone_dest / "integration-tests" / "scripts" / "delete-repository.sh"
+            dr.parent.mkdir(parents=True)
+            dr.write_text("#!/bin/bash\n", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    monkeypatch.delenv("INTEGRATION_TESTS_SCRIPTS_DIR", raising=False)
+    monkeypatch.setattr(uc.tempfile, "mkdtemp", lambda **kw: str(td))
+    monkeypatch.setattr(uc.subprocess, "run", fake_run)
+
+    scripts_dir, clone_root = uc._acquire_delete_repository_script_dir(
+        catalog_repo="org/repo",
+        catalog_ref="main",
+    )
+    assert scripts_dir == clone_dest / "integration-tests" / "scripts"
+    assert clone_root == td
+
+
+def test_acquire_delete_repository_script_dir_clone_failure_exits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """On git clone failure, remove temp dir and exit with code 1."""
+    td = tmp_path / "fail-root"
+    td.mkdir()
+
+    def fake_run(cmd: list, check: bool = False, timeout: object = None, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.delenv("INTEGRATION_TESTS_SCRIPTS_DIR", raising=False)
+    monkeypatch.setattr(uc.tempfile, "mkdtemp", lambda **kw: str(td))
+    monkeypatch.setattr(uc.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as ei:
+        uc._acquire_delete_repository_script_dir(
+            catalog_repo="org/repo",
+            catalog_ref="main",
+        )
+    assert ei.value.code == 1
+    assert "git clone failed" in capsys.readouterr().err
+
+
+def test_acquire_delete_repository_script_dir_missing_delete_script_after_clone_exits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Exit 1 if clone succeeds but delete-repository.sh is absent."""
+    td = tmp_path / "bad-clone"
+    td.mkdir()
+
+    def fake_run(cmd: list, check: bool = False, timeout: object = None, **kwargs):
+        if cmd[:2] == ["git", "clone"]:
+            (td / "catalog").mkdir()
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    monkeypatch.delenv("INTEGRATION_TESTS_SCRIPTS_DIR", raising=False)
+    monkeypatch.setattr(uc.tempfile, "mkdtemp", lambda **kw: str(td))
+    monkeypatch.setattr(uc.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as ei:
+        uc._acquire_delete_repository_script_dir(
+            catalog_repo="org/repo",
+            catalog_ref="main",
+        )
+    assert ei.value.code == 1
+    assert "delete-repository.sh missing" in capsys.readouterr().err
+
+
+def test_main_runs_delete_and_removes_clone_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Run delete-repository.sh then rmtree the clone temp directory in finally."""
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "delete-repository.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+    clone_td = tmp_path / "td"
+    clone_td.mkdir()
+
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("TEMP_REPO_NAME", "org/temp-repo")
+    monkeypatch.delenv("CATALOG_BASE_SHA", raising=False)
+    monkeypatch.setattr(
+        uc,
+        "_acquire_delete_repository_script_dir",
+        lambda **_: (scripts, clone_td),
+    )
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list, check: bool = False, env: dict | None = None, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(uc.subprocess, "run", fake_run)
+
+    uc.main()
+
+    assert any(c[:2] == ["bash", str(scripts / "delete-repository.sh")] for c in calls)
+    assert "org/temp-repo" in calls[-1]
+    assert "Deleting temporary repo" in capsys.readouterr().out
+    assert not clone_td.exists()
+
+
+def test_main_skips_drift_when_no_base_sha(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Do not call drift warning when CATALOG_BASE_SHA is unset."""
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "delete-repository.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("TEMP_REPO_NAME", "org/r")
+    monkeypatch.delenv("CATALOG_BASE_SHA", raising=False)
+    monkeypatch.setattr(
+        uc,
+        "_acquire_delete_repository_script_dir",
+        lambda **_: (scripts, None),
+    )
+
+    with patch.object(uc, "_warn_catalog_drift") as mock_warn:
+        monkeypatch.setattr(
+            uc.subprocess,
+            "run",
+            MagicMock(return_value=subprocess.CompletedProcess([], 0, "", "")),
+        )
+        uc.main()
+
+    mock_warn.assert_not_called()
+
+
+def test_main_calls_warn_when_catalog_base_sha_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Call drift warning when CATALOG_BASE_SHA is set."""
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "delete-repository.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("TEMP_REPO_NAME", "org/r")
+    monkeypatch.setenv("CATALOG_BASE_SHA", "abc")
+    monkeypatch.setenv("CATALOG_REPO", "org/catalog")
+    monkeypatch.setenv("CATALOG_REF", "dev")
+    monkeypatch.setattr(
+        uc,
+        "_acquire_delete_repository_script_dir",
+        lambda **_: (scripts, None),
+    )
+
+    with patch.object(uc, "_warn_catalog_drift") as mock_warn:
+        monkeypatch.setattr(
+            uc.subprocess,
+            "run",
+            MagicMock(return_value=subprocess.CompletedProcess([], 0, "", "")),
+        )
+        uc.main()
+
+    mock_warn.assert_called_once_with(
+        catalog_repo="org/catalog",
+        catalog_ref="dev",
+        catalog_base_sha="abc",
+    )
+
+
+def test_main_delete_failure_exits_with_return_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Propagate delete-repository.sh non-zero exit as process exit code."""
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "delete-repository.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("TEMP_REPO_NAME", "org/r")
+    monkeypatch.setattr(
+        uc,
+        "_acquire_delete_repository_script_dir",
+        lambda **_: (scripts, None),
+    )
+
+    def fake_run(cmd: list, check: bool = False, **kwargs):
+        raise subprocess.CalledProcessError(7, cmd)
+
+    monkeypatch.setattr(uc.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as ei:
+        uc.main()
+    assert ei.value.code == 7
+
+
+def test_main_delete_timeout_exits_1(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Exit 1 when delete-repository.sh exceeds subprocess timeout."""
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "delete-repository.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("TEMP_REPO_NAME", "org/r")
+    monkeypatch.setattr(
+        uc,
+        "_acquire_delete_repository_script_dir",
+        lambda **_: (scripts, None),
+    )
+
+    def fake_run(cmd: list, check: bool = False, timeout: object = None, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, timeout)
+
+    monkeypatch.setattr(uc.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as ei:
+        uc.main()
+    assert ei.value.code == 1
+    assert "timed out" in capsys.readouterr().err

--- a/integration-tests/lib/tests/test_catalog_e2e_helpers.py
+++ b/integration-tests/lib/tests/test_catalog_e2e_helpers.py
@@ -1,0 +1,116 @@
+"""Unit tests for ``catalog_e2e_helpers``."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import catalog_e2e_helpers as ceh
+
+HELPER_PY = Path(__file__).resolve().parent.parent / "catalog_e2e_helpers.py"
+
+
+def test_require_env_returns_stripped_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return the env value when it is set and non-empty after strip."""
+    monkeypatch.setenv("FOO_VAR", "  bar  ")
+    assert ceh.require_env("FOO_VAR") == "bar"
+
+
+def test_require_env_missing_exits(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Exit with code 1 when the variable is unset or blank."""
+    monkeypatch.delenv("MISSING_XYZ", raising=False)
+    with pytest.raises(SystemExit) as ei:
+        ceh.require_env("MISSING_XYZ")
+    assert ei.value.code == 1
+    assert "MISSING_XYZ" in capsys.readouterr().err
+
+
+def test_patch_catalog_utils_image_refs_replaces_inline_image(tmp_path: Path) -> None:
+    """Single-line image refs ending in release-service-utils are rewritten."""
+    y = tmp_path / "task.yaml"
+    y.write_text(
+        "image: quay.io/konflux-ci/release-service-utils@sha256:abc\n",
+        encoding="utf-8",
+    )
+    assert ceh.patch_catalog_utils_image_refs(tmp_path, "registry.example/ns/img:v9") == 1
+    assert "registry.example/ns/img:v9" in y.read_text(encoding="utf-8")
+    assert "release-service-utils" not in y.read_text(encoding="utf-8")
+
+
+def test_patch_catalog_utils_image_refs_skips_task_tests_fixtures(tmp_path: Path) -> None:
+    """Do not patch YAML under tasks/**/tests/."""
+    tasks = tmp_path / "tasks" / "managed" / "t"
+    fixture = tasks / "tests" / "data.yaml"
+    fixture.parent.mkdir(parents=True, exist_ok=True)
+    fixture.write_text(
+        "image: quay.io/konflux-ci/release-service-utils@sha256:abc\n",
+        encoding="utf-8",
+    )
+    assert ceh.patch_catalog_utils_image_refs(tmp_path, "other:img") == 0
+    assert "release-service-utils" in fixture.read_text(encoding="utf-8")
+
+
+def test_patch_catalog_utils_image_refs_multiline_image(tmp_path: Path) -> None:
+    """Match image: newline continuation style used in some Task YAML."""
+    y = tmp_path / "t.yaml"
+    y.write_text(
+        "steps:\n"
+        "- name: s\n"
+        "  image:\n"
+        "    quay.io/konflux-ci/release-service-utils@sha256:beef\n",
+        encoding="utf-8",
+    )
+    assert (
+        ceh.patch_catalog_utils_image_refs(tmp_path, "x/y/release-service-utils-custom:v1")
+        == 1
+    )
+    text = y.read_text(encoding="utf-8")
+    assert "release-service-utils-custom:v1" in text
+    assert "quay.io/konflux-ci/release-service-utils@" not in text
+
+
+def test_patch_catalog_utils_image_refs_returns_zero_when_no_matching_refs(
+    tmp_path: Path,
+) -> None:
+    """Return 0 when YAML exists but has no release-service-utils image refs."""
+    (tmp_path / "other.yaml").write_text("image: other:img\n", encoding="utf-8")
+    assert ceh.patch_catalog_utils_image_refs(tmp_path, "replacement:img") == 0
+
+
+def test_run_as_script_patches_from_cwd(tmp_path: Path) -> None:
+    """``python3 catalog_e2e_helpers.py`` patches when run from catalog root."""
+    (tmp_path / "a.yaml").write_text(
+        "image: quay.io/konflux-ci/release-service-utils:v1\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [sys.executable, str(HELPER_PY)],
+        cwd=tmp_path,
+        env={**os.environ, "UTILS_IMAGE": "replacement:img"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert "replacement:img" in (tmp_path / "a.yaml").read_text(encoding="utf-8")
+
+
+def test_run_as_script_exits_1_when_nothing_patched(tmp_path: Path) -> None:
+    """``python3 catalog_e2e_helpers.py`` exits 1 if no refs match."""
+    (tmp_path / "b.yaml").write_text("image: other:img\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(HELPER_PY)],
+        cwd=tmp_path,
+        env={**os.environ, "UTILS_IMAGE": "replacement:img"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 1
+    assert "No YAML changes" in proc.stderr


### PR DESCRIPTION
This commit is part of a multi commit effort to enable running the catalog pipeline e2e test suites for PRs to this repo. This commit adds a bash script that will push a fork of the catalog repo with the utils imageRefs updated to one built from the PR. It also includes a python file (with unit tests) to cleanup the created fork once testing is complete.

We can then use this catalog fork via git resolver in the e2e test suites to test with our new image.

Assisted-By: Cursor