### PR TITLE
feat(RELEASE-2387): update promote-overlay script

### DIFF
--- a/ci/promote-overlay/README.md
+++ b/ci/promote-overlay/README.md
@@ -10,7 +10,7 @@ There are 3 overlays:
 - staging
 - production
 
-Currently, when a PR is merged in the release-service repo, a PR in the infra-deployments repo is created by a RHTAP release pipeline which updates the **development** overlay. 
+Currently, when a PR is merged in the release-service repo, a PR in the infra-deployments repo is created by a RHTAP release pipeline which updates the **development** overlay.
 
 Promotion from a lower environment to higher environment is done manually by updating the target overlay.
 
@@ -40,10 +40,21 @@ For typical promotion batches of 20-50 commits, this is approximately 40-60x fas
   * **target-overlay**: Name of the overlay to target for promotion
   * **fork-owner**: Name of the owner of your infra-deployments fork in Github
 
+* Optional flags
+  * **--commit-to COMMIT_SHA**: Promote up to a specific commit.
+  * **--no-grafana**: Skip promoting the Grafana Dashboard overlay.
+  * **--no-release**: Skip promoting the Release Service overlay.
+
 ## Running the script
 
+Promote the full source overlay:
 ```
 % ./ci/promote-overlay/promote-overlay.sh --source-overlay development  --target-overlay staging --fork-owner scoheb
+```
+
+Promote up to a specific commit:
+```
+% ./ci/promote-overlay/promote-overlay.sh --source-overlay development  --target-overlay staging --fork-owner scoheb --commit-to 0ec7f0833cc251378f1e4efbc0a9506122cf4b73
 ```
 
 ## Example output

--- a/ci/promote-overlay/promote-overlay.sh
+++ b/ci/promote-overlay/promote-overlay.sh
@@ -10,11 +10,14 @@ make_json_safe() {
 
 print_help(){
     echo -e "$0 --source-overlay SOURCE_OVERLAY --target-overlay TARGET_OVERLAY --fork-owner FORK_OWNER \
-            [ --skip-cleanup ]\n"
+            [ --commit-to COMMIT_SHA ] [ --skip-cleanup ] [ --no-grafana ] [ --no-release ]\n"
     echo -e "\t--source-overlay SOURCE_OVERLAY\tName of the source overlay to promote to target"
     echo -e "\t--target-overlay TARGET_OVERLAY\tName of the overlay to target for promotion"
     echo -e "\t--fork-owner FORK_OWNER\tName of the owner of your infra-deployments fork in Github"
+    echo -e "\t--commit-to COMMIT_SHA\tPromote up to this specific commit"
     echo -e "\t--skip-cleanup\tDisable cleanup after test. Useful for debugging"
+    echo -e "\t--no-grafana\tSkip promoting the Grafana Dashboard overlay"
+    echo -e "\t--no-release\tSkip promoting the Release Service overlay"
 }
 
 require_arg() {
@@ -29,13 +32,25 @@ require_arg() {
     fi
 }
 
-OPTIONS=$(getopt -l "skip-cleanup,source-overlay:,target-overlay:,fork-owner:,help" -o "sc,src:,tgt:,fo:,h" -a -- "$@")
+OPTIONS=$(getopt -l "skip-cleanup,no-grafana,no-release,commit-to:,source-overlay:,target-overlay:,fork-owner:,help" -o "sc,ng,nr,ct:,src:,tgt:,fo:,h" -a -- "$@")
 eval set -- "$OPTIONS"
 while true; do
     case "$1" in
         -sc|--skip-cleanup)
             CLEANUP="true"
             shift
+            ;;
+        -ng|--no-grafana)
+            NO_GRAFANA="true"
+            shift
+            ;;
+        -nr|--no-release)
+            NO_RELEASE="true"
+            shift
+            ;;
+        -ct|--commit-to)
+            COMMIT_TO="$2"
+            shift 2
             ;;
         -src|--source-overlay)
             SOURCE_OVERLAY="$2"
@@ -66,6 +81,11 @@ require_arg "TARGET_OVERLAY" "${TARGET_OVERLAY}" "target-overlay"
 require_arg "FORK_OWNER" "${FORK_OWNER}" "fork-owner"
 require_arg "GITHUB_TOKEN" "${GITHUB_TOKEN}" "GITHUB_TOKEN environment variable"
 
+if [ "$NO_RELEASE" == "true" ] && [ "$NO_GRAFANA" == "true" ]; then
+  echo "Error: --no-release and --no-grafana cannot both be set"
+  exit 1
+fi
+
 # GitHub repository details
 owner="redhat-appstudio"
 repo="infra-deployments"
@@ -75,7 +95,6 @@ token="${GITHUB_TOKEN}"
 
 # Branch and commit details
 new_branch="release-service-${TARGET_OVERLAY}-update-"$(date '+%Y_%m_%d__%H_%M_%S')
-commit_message="Promote release-service from ${SOURCE_OVERLAY} to ${TARGET_OVERLAY}"
 
 # Fork repository and branch parameters
 fork_repo="infra-deployments"  # Change this to your fork's repository
@@ -121,19 +140,67 @@ git fetch --all --tags --prune
 git reset --hard HEAD
 git checkout -b "$new_branch" origin/"$base_branch"
 
-RS_SOURCE_OVERLAY_COMMIT=$(yq '.images[0].newTag' < components/release/${SOURCE_OVERLAY}/kustomization.yaml)
-RS_TARGET_OVERLAY_COMMIT=$(yq '.images[0].newTag' < components/release/${TARGET_OVERLAY}/kustomization.yaml)
+if [ "${NO_RELEASE}" != "true" ]; then
+  RS_SOURCE_OVERLAY_COMMIT=$(yq '.images[0].newTag' < components/release/${SOURCE_OVERLAY}/kustomization.yaml)
+  RS_TARGET_OVERLAY_COMMIT=$(yq '.images[0].newTag' < components/release/${TARGET_OVERLAY}/kustomization.yaml)
 
-echo ""
-echo 'release-service source overlay commit -> '"$RS_SOURCE_OVERLAY_COMMIT"
-echo 'release-service target overlay commit -> '"$RS_TARGET_OVERLAY_COMMIT"
-echo ""
+  if [ -n "$COMMIT_TO" ]; then
+    RS_SOURCE_OVERLAY_COMMIT="$COMMIT_TO"
+  fi
+
+  echo ""
+  echo 'release-service source overlay commit -> '"$RS_SOURCE_OVERLAY_COMMIT"
+  echo 'release-service target overlay commit -> '"$RS_TARGET_OVERLAY_COMMIT"
+  echo ""
+fi
+
+if [ "${NO_GRAFANA}" != "true" ]; then
+  GRAFANA_SOURCE_COMMIT=$(grep -oE '[0-9a-f]{40}' components/monitoring/grafana/${SOURCE_OVERLAY}/dashboards/release/kustomization.yaml)
+  GRAFANA_TARGET_COMMIT=$(grep -oE '[0-9a-f]{40}' components/monitoring/grafana/${TARGET_OVERLAY}/dashboards/release/kustomization.yaml)
+
+  if [ -n "$COMMIT_TO" ]; then
+    GRAFANA_SOURCE_COMMIT="$COMMIT_TO"
+  fi
+
+  echo 'grafana-dashboard source ref -> '"$GRAFANA_SOURCE_COMMIT"
+  echo 'grafana-dashboard target ref -> '"$GRAFANA_TARGET_COMMIT"
+  echo ""
+fi
+
+if [ "${NO_RELEASE}" == "true" ]; then
+  commit_message="Promote release grafana-dashboard from ${SOURCE_OVERLAY} to ${TARGET_OVERLAY}"
+elif [ "${NO_GRAFANA}" == "true" ]; then
+  commit_message="Promote release-service from ${SOURCE_OVERLAY} to ${TARGET_OVERLAY}"
+else
+  commit_message="Promote release-service and grafana-dashboard from ${SOURCE_OVERLAY} to ${TARGET_OVERLAY}"
+fi
 
 cd  ${releaseServiceDir}
 git fetch --all --tags --prune
-RS_COMMITS=($(git rev-list --first-parent --ancestry-path "$RS_TARGET_OVERLAY_COMMIT"'...'"$RS_SOURCE_OVERLAY_COMMIT"))
 
-echo "Fetching PR information for ${#RS_COMMITS[@]} commits..."
+# Validate that --commit-to is not behind either target overlay
+if [[ -n "$COMMIT_TO" && "$NO_RELEASE" != "true" ]] && ! git merge-base --is-ancestor "$RS_TARGET_OVERLAY_COMMIT" "$COMMIT_TO"; then
+  echo "Error: --commit-to (${COMMIT_TO:0:12}) is behind the ${TARGET_OVERLAY} release overlay (${RS_TARGET_OVERLAY_COMMIT:0:12})"
+  exit 1
+fi
+
+if [[ -n "$COMMIT_TO" && "$NO_GRAFANA" != "true" ]] && ! git merge-base --is-ancestor "$GRAFANA_TARGET_COMMIT" "$COMMIT_TO"; then
+  echo "Error: --commit-to (${COMMIT_TO:0:12}) is behind the ${TARGET_OVERLAY} grafana overlay (${GRAFANA_TARGET_COMMIT:0:12})"
+  exit 1
+fi
+
+# Determine commit range for PR listing
+if [ "${NO_RELEASE}" != "true" ]; then
+  RANGE_FROM="$RS_TARGET_OVERLAY_COMMIT"
+  RANGE_TO="$RS_SOURCE_OVERLAY_COMMIT"
+else
+  RANGE_FROM="$GRAFANA_TARGET_COMMIT"
+  RANGE_TO="$GRAFANA_SOURCE_COMMIT"
+fi
+
+COMMITS=($(git rev-list --first-parent --ancestry-path "$RANGE_FROM"'...'"$RANGE_TO"))
+
+echo "Fetching PR information for ${#COMMITS[@]} commits..."
 
 graphql_request() {
   local query="$1"
@@ -162,20 +229,20 @@ graphql_request() {
 }
 
 # Process commits in batches of 50
-if [ ${#RS_COMMITS[@]} -eq 0 ]; then
+if [ ${#COMMITS[@]} -eq 0 ]; then
   echo "No commits to process"
 else
   batch_size=50
 
-  for ((i=0; i<${#RS_COMMITS[@]}; i+=batch_size)); do
+  for ((i=0; i<${#COMMITS[@]}; i+=batch_size)); do
     # Build GraphQL query for this batch
     query="query {"
     batch_end=$((i + batch_size))
-    [ $batch_end -gt ${#RS_COMMITS[@]} ] && batch_end=${#RS_COMMITS[@]}
+    [ $batch_end -gt ${#COMMITS[@]} ] && batch_end=${#COMMITS[@]}
 
     for ((j=i; j<batch_end; j++)); do
       query="$query
-      c$j: search(query: \"repo:konflux-ci/release-service is:pr sha:${RS_COMMITS[$j]}\", type: ISSUE, first: 1) {
+      c$j: search(query: \"repo:konflux-ci/release-service is:pr sha:${COMMITS[$j]}\", type: ISSUE, first: 1) {
         edges {
           node {
             ... on PullRequest {
@@ -213,13 +280,26 @@ else
     done
   done
 
-  echo "Successfully processed ${#RS_COMMITS[@]} commits"
+  echo "Successfully processed ${#COMMITS[@]} commits"
 fi
 
 cd ${infraDeploymentDir}
-sed -i "s/$RS_TARGET_OVERLAY_COMMIT/$RS_SOURCE_OVERLAY_COMMIT/g" components/release/${TARGET_OVERLAY}/kustomization.yaml
 
-git add components/release/${TARGET_OVERLAY}/kustomization.yaml
+if [ "${NO_RELEASE}" != "true" ]; then
+  sed -i "s/$RS_TARGET_OVERLAY_COMMIT/$RS_SOURCE_OVERLAY_COMMIT/g" components/release/${TARGET_OVERLAY}/kustomization.yaml
+  git add components/release/${TARGET_OVERLAY}/kustomization.yaml
+fi
+
+if [ "${NO_GRAFANA}" != "true" ]; then
+  sed -i "s/$GRAFANA_TARGET_COMMIT/$GRAFANA_SOURCE_COMMIT/g" components/monitoring/grafana/${TARGET_OVERLAY}/dashboards/release/kustomization.yaml
+  git add components/monitoring/grafana/${TARGET_OVERLAY}/dashboards/release/kustomization.yaml
+fi
+
+if git diff --cached --quiet; then
+  echo "Nothing to commit overlays are already up to date."
+  exit 0
+fi
+
 git commit -m "$commit_message"
 
 git push origin "$new_branch"


### PR DESCRIPTION
Since the grafana dashboard moved to per env overlays we now need to promote the dashboard ref the same way we promote release-service. This updates the script to handle both together.

* Add grafana dashboard promotion
* Add --no-grafana and --no-release to skip either one
* Add --commit-to to promote up to a specific commit

Assisted-by: Claude