### PR TITLE
fix(RELEASE-2158): allow non-root user to append to system CA bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,6 +142,8 @@ RUN groupadd -g 1001 group1 && \
     # Ensure group permissions are inherited by new subdirectories
     find /var/workdir /home /tekton -type d -exec chmod g+s {} +
 
+RUN chmod -R a+w /etc/pki/
+
 # Switch to a non-root user
 USER 1001
 


### PR DESCRIPTION
Grant group write permission to /etc/pki/ before switching to USER 1001 so the release tasks can append custom CA certificates to the system trust bundle at runtime, enabling TLS connections to self-hosted Quay registries with custom CAs.

Assisted-by: Cursor