### PR TITLE
feat(RELEASE-2386): add optional 404 retry to curl-with-retry

### DIFF
--- a/utils/curl-with-retry
+++ b/utils/curl-with-retry
@@ -3,12 +3,12 @@
 # script:      curl-with-retry
 #
 # description: This script handles Jira API rate limiting by retrying requests with exponential backoff.
-#              It will retry up to 5 times, and will wait for a random amount of time between retries.
-#              There are a few caveats:
-#              - The script will only retry if the response code is 429 (rate limited).
-#              - You can still use --retry as needed to retry 5xx errors.
-#              - -o/--output should not be specified - the response will always be printed to stdout.
-#              - --fail should not be specified. The script will always fail if the request fails.
+#              429 responses are retried up to MAX_429_ATTEMPTS times (sleeps only before another attempt).
+#              If CURL_WITH_RETRY_RETRY_404 is set to any non-empty value, HTTP 404 is retried up to
+#              MAX_404_ATTEMPTS times (3 attempts total = 2 retries).
+#              You can still use --retry as needed to retry 5xx errors.
+#              -o/--output should not be specified - the response will always be printed to stdout.
+#              --fail should not be specified. The script will always fail if the request fails.
 #
 # example command:
 #              curl-with-retry
@@ -16,27 +16,53 @@
 
 set -eu
 
-#!/bin/bash
-
-MAX_RETRIES=5
+MAX_429_ATTEMPTS=5
+MAX_404_ATTEMPTS=3
 BASE_SLEEP_TIME=1  # Initial wait time in seconds
 TMPFILE=$(mktemp)  # Create a temporary file for output
 
-for ((i=1; i<=MAX_RETRIES; i++)); do
+COUNT_429=0
+COUNT_404=0
+
+while true; do
     RESPONSE=$(curl -s -o "$TMPFILE" -w "%{http_code}" "$@")
 
     if [[ "$RESPONSE" -ge 200 && "$RESPONSE" -lt 300 ]]; then
         cat "$TMPFILE"  # Print the output
         exit 0
     elif [ "$RESPONSE" -eq 429 ]; then # Rate limited
-        SLEEP_TIME=$((BASE_SLEEP_TIME * 2 ** (i-1)))  # Exponential growth
-        JITTER=$((RANDOM % 3))  # Random delay (0-2s)
-        TOTAL_SLEEP=$((SLEEP_TIME + JITTER))
+        COUNT_429=$((COUNT_429 + 1))
 
         cat "$TMPFILE" >&2 # Print the output
         echo >&2
 
-        echo "Rate limited. Retrying in $TOTAL_SLEEP seconds..." >&2
+        if [ "$COUNT_429" -ge "$MAX_429_ATTEMPTS" ]; then
+            echo "Request failed with status 429. Out of retries, exiting" >&2
+            exit 1
+        fi
+
+        SLEEP_TIME=$((BASE_SLEEP_TIME * 2 ** (COUNT_429 - 1)))  # Exponential growth
+        JITTER=$((RANDOM % 3))  # Random delay (0-2s)
+        TOTAL_SLEEP=$((SLEEP_TIME + JITTER))
+
+        echo "Received HTTP 429 (rate limited). Retrying in $TOTAL_SLEEP seconds..." >&2
+        sleep "$TOTAL_SLEEP"
+    elif [ "$RESPONSE" -eq 404 ] && [ -n "${CURL_WITH_RETRY_RETRY_404:-}" ]; then
+        COUNT_404=$((COUNT_404 + 1))
+
+        cat "$TMPFILE" >&2 # Print the output
+        echo >&2
+
+        if [ "$COUNT_404" -ge "$MAX_404_ATTEMPTS" ]; then
+            echo "Request failed with status 404. Out of retries, exiting" >&2
+            exit 1
+        fi
+
+        SLEEP_TIME=$((BASE_SLEEP_TIME * 2 ** (COUNT_404 - 1)))  # Exponential growth
+        JITTER=$((RANDOM % 3))
+        TOTAL_SLEEP=$((SLEEP_TIME + JITTER))
+
+        echo "Received HTTP 404 (CURL_WITH_RETRY_RETRY_404 is set). Retrying in $TOTAL_SLEEP seconds..." >&2
         sleep "$TOTAL_SLEEP"
     else
         cat "$TMPFILE" >&2 # Print the output
@@ -45,6 +71,3 @@ for ((i=1; i<=MAX_RETRIES; i++)); do
         exit 1
     fi
 done
-
-echo "Max retries reached, exiting." >&2
-exit 1


### PR DESCRIPTION
Jira issue GET can intermittently return 404 on Atlassian Cloud even when the issue exists and the token is valid. Add optional handling via CURL_WITH_RETRY_RETRY_404: up to three attempts (two retries) with exponential backoff. Keep 429 handling at five attempts. Refactor to a while loop with separate counters.