### PR TITLE
feat(RELEASE-2209): add executor for catalog e2e test suite

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,120 @@
+# release-service-utils integration tests (catalog integration-test orchestration)
+
+**`utils-e2e-catalog-pipeline.yaml`** runs one `PipelineRun` that:
+
+1. **`extract-snapshot`** — reads **SNAPSHOT** for the utils container image and git URL/revision.
+
+2. **`find-affected-tasks`** — from the utils repo diff (vs `main`), decides which catalog integration suites are implicated and writes task results `pipelineTestSuite` / `pipelineUsed` (space-separated tokens when several suites apply).
+
+3. **`match-affected-suite`** — sets **`runCatalogE2e`** to `yes` only if find-affected produced a non-empty **`pipelineUsed`** (task result) and this scenario’s **`PIPELINE_TEST_SUITE`** param value appears among the suite tokens in **`pipelineTestSuite`**. Otherwise later work is skipped (success without fork or catalog child run).
+
+4. **`git-clone-catalog-patch-git-push`** — clones catalog, patches utils image refs, pushes a temporary GitHub fork (only when the `when:` clauses pass: non-empty **`pipelineUsed`** and **`runCatalogE2e`** is `yes`).
+
+5. **`run-catalog-e2e`** — creates a child `PipelineRun` for catalog’s integration-test pipeline (`integration-tests/pipelines/e2e-tests-staging-pipeline.yaml` in **release-service-catalog**), using pipeline params **`PIPELINE_TEST_SUITE`** / **`PIPELINE_USED`** (same names as the catalog IntegrationTestScenario; not the raw find-affected strings), then waits for success.
+
+Callers that target one catalog suite per check pass different **`PIPELINE_TEST_SUITE`** / **`PIPELINE_USED`** pairs while reusing this pipeline file.
+
+**When steps are skipped:** `find-affected-tasks` writes empty **`pipelineTestSuite`** / **`pipelineUsed`** (nothing to test for this diff), **`find-affected-tasks`** fails (for example when merge-base against `main` cannot be computed), or **`match-affected-suite`** sets **`runCatalogE2e`** to `no` because **`pipelineUsed`** is empty or this scenario’s **`PIPELINE_TEST_SUITE`** is not among the suite tokens in **`pipelineTestSuite`**.
+
+**`finally`** always runs: it tries to delete the per-run temp GitHub fork and may warn if the catalog branch moved since the run started.
+
+**Task results:** `find-affected-tasks` exposes `pipelineTestSuite` and `pipelineUsed` for gating; **`match-affected-suite`** sets **`runCatalogE2e`**.
+
+Implementation details are in `utils-e2e-catalog-pipeline.yaml` and `lib/find_catalog_suite_from_utils_diff.py`.
+
+---
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `pipelines/utils-e2e-catalog-pipeline.yaml` | Params mirror catalog ITS (`PIPELINE_TEST_SUITE`, `PIPELINE_USED`, secret names, …); optional params and defaults are in the YAML; tasks above. |
+| `run-test.sh` | Submits a `PipelineRun` with the same param names as catalog ITS (`PIPELINE_TEST_SUITE`, `PIPELINE_USED`, …); optional `--wait` (`./run-test.sh --help`). |
+| `lib/find_catalog_suite_from_utils_diff.py` | Maps a utils diff to affected suites; `--print-all-pairs` for tooling. |
+| `lib/catalog_clone_patch_push.sh` | Clone catalog, patch image refs, temp repo, push. |
+| `lib/run_single_catalog_e2e_suite.py` | Creates the child catalog `PipelineRun` and waits. |
+| `lib/catalog_cleanup.py` | Optional standalone cleanup (same idea as the pipeline `finally` task: delete temp fork, catalog drift warning). |
+
+Files under `integration-tests/lib/` are copied into the utils image at `/home/integration-tests/lib/`.
+
+---
+
+## Prerequisites (Konflux / cluster)
+
+- GitHub access for the temp fork: token with `repo` and `delete_repo`, and permissions to create repos under the org used by **`destRepoPrefix`** (see pipeline param).
+
+- **`VAULT_PASSWORD_SECRET_NAME`**, **`GITHUB_TOKEN_SECRET_NAME`**, **`KUBECONFIG_SECRET_NAME`**: pipeline parameters (same names as catalog ITS); values are **Kubernetes Secret names** passed through to the **child** catalog **`e2e-tests-staging-pipeline`** (keys `password`, `token`, `kubeconfig`).
+
+  Those Secrets must exist in **`rhtap-release-2-tenant`** where the child `PipelineRun` runs. The parent **`run-catalog-e2e`** step does **not** mount a kubeconfig Secret; it uses **in-cluster** `kubectl` like any other Tekton task.
+
+- **`PIPELINE_TEST_SUITE`** / **`PIPELINE_USED`**: must match a real `integration-tests/<dir>/` and RPA `pipelines/managed/<name>/` pairing, as for catalog’s own integration tests.
+
+- **`e2eWaitTimeout`**, **`catalogE2eRunnerImage`**: optional pipeline params; defaults are in `utils-e2e-catalog-pipeline.yaml` (same pattern as other optional Tekton params).
+
+- Child catalog `PipelineRun` is created in **`rhtap-release-2-tenant`** on the **same cluster** as the parent PLR (in-cluster `kubectl`), alongside catalog **`simple-e2e-test`** and e2e ExternalSecrets.
+
+---
+
+## How this runs
+
+**Production:** Konflux **IntegrationTestScenario** on **release-service-utils** with `pathInRepo: integration-tests/pipelines/utils-e2e-catalog-pipeline.yaml`, supplying the same param names as catalog ITS (**`PIPELINE_TEST_SUITE`**, **`PIPELINE_USED`**, **`VAULT_PASSWORD_SECRET_NAME`**, …), plus **`SNAPSHOT`**. Omit optional params to use pipeline defaults.
+
+### Run locally (`run-test.sh`)
+
+1. **Cluster**
+
+   `kubectl` context targets the right cluster. **`NAMESPACE`** must exist (default `rhtap-release-2-tenant`). In that namespace, ensure the GitHub token Secret named by **`GITHUB_TOKEN_SECRET_NAME`** (default `e2e-test-github-token`) exists for clone/push/`finally`.
+
+   In **`rhtap-release-2-tenant`**, ensure the three e2e Secrets exist (defaults `e2e-test-vault-password`, `e2e-test-github-token`, `e2e-test-service-account-kubeconfig`) for the **child** catalog run, or override the corresponding env vars when invoking **`run-test.sh`**.
+
+2. **Catalog fork/branch for this pipeline** (clone for find-affected + patch/push)
+
+   Defaults are **`CATALOG_REPO`**=`konflux-ci/release-service-catalog`, **`CATALOG_REF`**=`development`.
+
+   For a fork, e.g. `export CATALOG_REPO=my-org/release-service-catalog` and `export CATALOG_REF=my-feature-branch`.
+
+3. **Snapshot JSON (`SNAPSHOT_FILE`)**
+
+   Same *kind* of payload as Konflux’s **`SNAPSHOT`** pipeline parameter (a JSON string), but it does **not** have to be a complete or “real” snapshot.
+
+   **`run-test.sh` and `extract-snapshot` only `jq` three paths** — `components[0].containerImage`, `components[0].source.git.url`, and `components[0].source.git.revision`. You do **not** need `apiVersion`/`kind`, `metadata`, `application`, or any other field a **Snapshot** custom resource might carry on the cluster; extra keys from a full Konflux snapshot are harmless and ignored.
+
+   For **`components[0]`** you must supply:
+
+   - **`containerImage`** — digest of the **release-service-utils** image to exercise (e.g. `quay.io/.../release-service-utils@sha256:...`).
+   - **`source.git.url`** and **`source.git.revision`** — repo URL and commit the pipeline should treat as the utils source (used for diffing against `main` and for catalog patch metadata).
+
+   Create **`snapshot.json`** by hand from your pushed **release-service-utils** image digest and the matching git URL and commit (e.g. `git rev-parse HEAD`). The following is **complete** for this pipeline (no `application`, no CR envelope):
+
+   ```json
+   {
+     "components": [
+       {
+         "containerImage": "quay.io/your-org/release-service-utils@sha256:...",
+         "source": {
+           "git": {
+             "url": "https://github.com/your-org/release-service-utils.git",
+             "revision": "full40charcommitsha..."
+           }
+         }
+       }
+     ]
+   }
+   ```
+
+4. **Required env** before `./run-test.sh`
+
+   **`SNAPSHOT_FILE`** (path to that JSON), **`PIPELINE_TEST_SUITE`** (e.g. `e2e`), **`PIPELINE_USED`** (e.g. `fbc-release`).
+
+   See `./run-test.sh --help` for optional env vars. Unset optionals are omitted from the submitted `PipelineRun` so Tekton uses defaults from `utils-e2e-catalog-pipeline.yaml`. With **`--wait`**, **`E2E_WAIT_TIMEOUT`** is required (for `kubectl wait`); if you also want that value as pipeline **`e2eWaitTimeout`**, export it before invoking the script (same env var).
+
+5. **Commands** (from `integration-tests/`)
+
+   ```bash
+   export SNAPSHOT_FILE=/path/to/snapshot.json
+   export PIPELINE_TEST_SUITE=e2e
+   export PIPELINE_USED=fbc-release
+   ./run-test.sh                      # add --wait to block; with --wait the PipelineRun is deleted when done
+   ```
+
+   The child catalog e2e step uses the git resolver in **`lib/run_single_catalog_e2e_suite.py`** (upstream catalog `development` today); overriding that for a fork requires changing that script.

--- a/integration-tests/lib/catalog_clone_patch_push.sh
+++ b/integration-tests/lib/catalog_clone_patch_push.sh
@@ -5,7 +5,7 @@
 #
 # Required env: GITHUB_TOKEN, UTILS_IMAGE
 # Optional: CATALOG_REPO (default konflux-ci/release-service-catalog), CATALOG_REF (development),
-#           DEST_REPO_PREFIX (default hacbs-release-tests/catalog-e2e), PIPELINE_UID
+#           DEST_REPO_PREFIX (default hacbs-release-tests/utils-e2e), PIPELINE_UID
 set -euo pipefail
 
 : "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"

--- a/integration-tests/pipelines/utils-e2e-catalog-pipeline.yaml
+++ b/integration-tests/pipelines/utils-e2e-catalog-pipeline.yaml
@@ -1,0 +1,489 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: utils-e2e-catalog-pipeline
+spec:
+  description: >-
+    Clone release-service-catalog, patch it to use the utils image from SNAPSHOT, push to a temporary
+    GitHub fork, then optionally start a child PipelineRun for catalog integration tests (the path in
+    catalog is integration-tests/pipelines/e2e-tests-staging-pipeline.yaml today; change the ref if that
+    moves). find-affected-tasks maps the utils diff to affected catalog integration suite directory
+    names; match-affected-suite decides whether PIPELINE_TEST_SUITE is in that set. If not, patch
+    and downstream catalog test tasks are skipped (no-op success). Pipeline params use the same names
+    as the catalog IntegrationTestScenario (PIPELINE_TEST_SUITE, PIPELINE_USED, secret *_NAME params).
+  params:
+    - name: SNAPSHOT
+      type: string
+      description: Konflux Snapshot JSON (utils component build).
+    - name: catalogE2eRunnerImage
+      type: string
+      default: "quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-catalog:latest"
+      description: >-
+        release-service-catalog image with /home/e2e/tests (SNAPSHOT.components[0].containerImage in
+        the child catalog test PipelineRun). Optional; omit to use the default.
+    - name: PIPELINE_TEST_SUITE
+      type: string
+      description: >-
+        Name of the catalog integration-tests/<name>/ directory to exercise (e.g. e2e). Same param as
+        catalog e2e; compared to find-affected-tasks’ affected suite list.
+    - name: PIPELINE_USED
+      type: string
+      description: >-
+        Basename under catalog pipelines/managed/<name>/ for the catalog test run (same param as catalog
+        e2e; must pair with PIPELINE_TEST_SUITE the same way as in catalog RPAs).
+    - name: catalogRepo
+      type: string
+      default: konflux-ci/release-service-catalog
+    - name: catalogRef
+      type: string
+      default: development
+    - name: destRepoPrefix
+      type: string
+      default: hacbs-release-tests/catalog-utils-e2e
+      description: >-
+        Prefix for the temporary GitHub repo; each run uses <destRepoPrefix>-<pipelineRun.uid>.
+    - name: VAULT_PASSWORD_SECRET_NAME
+      type: string
+      default: e2e-test-vault-password
+    - name: GITHUB_TOKEN_SECRET_NAME
+      type: string
+      default: e2e-test-github-token
+    - name: KUBECONFIG_SECRET_NAME
+      type: string
+      default: e2e-test-service-account-kubeconfig
+      description: >-
+        Secret name (key kubeconfig) for the child catalog e2e-tests-staging-pipeline (same param name
+        as catalog ITS). Use the kubeconfig that reaches the stage/test cluster where catalog integration
+        steps run.
+    - name: orchestrationKubeconfigSecretName
+      type: string
+      default: e2e-test-konflux-api-kubeconfig
+      description: >-
+        Secret name (key kubeconfig) used only by run-catalog-e2e to run kubectl against the Konflux
+        cluster where this PipelineRun exists.
+    - name: e2eWaitTimeout
+      type: string
+      default: "14400"
+      description: >-
+        Max time in seconds to wait for the child catalog e2e PipelineRun (default 14400 = 4h).
+        Passed through as env E2E_WAIT_TIMEOUT to run_single_catalog_e2e_suite.py.
+  tasks:
+    - name: extract-snapshot
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+        results:
+          - name: utilsImage
+            type: string
+          - name: utilsSourceUrl
+            type: string
+          - name: utilsSourceRevision
+            type: string
+        steps:
+          - name: extract
+            image: quay.io/konflux-ci/release-service-utils@sha256:e852a62497c4537059bb1f4c3ddf5c1a813b2b22bd9f4bb826cffb36af7d5f65
+            env:
+              - name: "SNAPSHOT_JSON"
+                value: "$(params.SNAPSHOT)"
+            script: |
+              #!/bin/bash
+              set -euo pipefail
+              jq -e . <<< "${SNAPSHOT_JSON}" >/dev/null
+              utils_image=$(jq -r '.components[0].containerImage // empty' <<< "${SNAPSHOT_JSON}")
+              utils_git_url=$(jq -r '.components[0].source.git.url // empty' <<< "${SNAPSHOT_JSON}")
+              utils_git_revision=$(jq -r '.components[0].source.git.revision // empty' <<< "${SNAPSHOT_JSON}")
+              if [[ -z "${utils_image}" ]]; then
+                echo "ERROR: SNAPSHOT has no components[0].containerImage" >&2
+                exit 1
+              fi
+              if [[ -z "${utils_git_url}" || -z "${utils_git_revision}" ]]; then
+                echo "ERROR: SNAPSHOT missing source.git url/revision" >&2
+                exit 1
+              fi
+              echo -n "${utils_image}" > "$(results.utilsImage.path)"
+              echo -n "${utils_git_url}" > "$(results.utilsSourceUrl.path)"
+              echo -n "${utils_git_revision}" > "$(results.utilsSourceRevision.path)"
+            securityContext:
+              runAsUser: 1001
+
+    - name: find-affected-tasks
+      runAfter:
+        - extract-snapshot
+      params:
+        - name: catalogRepo
+          value: $(params.catalogRepo)
+        - name: catalogRef
+          value: $(params.catalogRef)
+        - name: utilsSourceUrl
+          value: $(tasks.extract-snapshot.results.utilsSourceUrl)
+        - name: utilsSourceRevision
+          value: $(tasks.extract-snapshot.results.utilsSourceRevision)
+      taskSpec:
+        params:
+          - name: catalogRepo
+          - name: catalogRef
+          - name: utilsSourceUrl
+          - name: utilsSourceRevision
+        results:
+          - name: pipelineTestSuite
+            type: string
+          - name: pipelineUsed
+            type: string
+        steps:
+          - name: detect-changes
+            image: $(tasks.extract-snapshot.results.utilsImage)
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              write_results() {
+                echo -n "$1" > "$(results.pipelineTestSuite.path)"
+                echo -n "$2" > "$(results.pipelineUsed.path)"
+              }
+
+              utils_git_url="$(params.utilsSourceUrl)"
+              utils_git_revision="$(params.utilsSourceRevision)"
+
+              scratch_dir="$(mktemp -d)"
+              git clone -q "${utils_git_url}" "${scratch_dir}/repo"
+              cd "${scratch_dir}/repo"
+              git fetch -q origin main:refs/remotes/origin/main
+              git checkout -q "${utils_git_revision}"
+
+              merge_base=$(git merge-base HEAD origin/main 2>/dev/null || true)
+              if [[ -z "${merge_base}" ]]; then
+                echo "ERROR: find-affected: could not compute merge-base between HEAD and origin/main." >&2
+                echo "  This usually means origin/main is missing (fetch failed?), or HEAD shares no" >&2
+                echo "  common history with main (unrelated histories). Fix the clone/fetch or branch." >&2
+                exit 1
+              fi
+
+              # Full diff vs merge-base; find_catalog_suite_from_utils_diff + Dockerfile map paths to
+              # search tokens—paths outside COPY→/home trees yield no suite match (no pipeline list).
+              changed=$(
+                git diff --name-only "${merge_base}..HEAD" 2>/dev/null || true
+              )
+              if [[ -z "${changed}" ]]; then
+                echo "find-affected: no relevant changes vs merge-base; skipping patch and catalog tests" >&2
+                write_results "" ""
+                exit 0
+              fi
+
+              echo "find-affected: relevant paths changed:" >&2
+              echo "${changed}" >&2
+
+              catalog_clone="${scratch_dir}/catalog"
+              git clone -q --depth 1 --branch "$(params.catalogRef)" \
+                "https://github.com/$(params.catalogRepo).git" "${catalog_clone}"
+              json_result=$(
+                printf '%s\n' "${changed}" | python3 integration-tests/lib/find_catalog_suite_from_utils_diff.py \
+                  --catalog "${catalog_clone}"
+              )
+              # JSON null → empty string so match-affected-suite skips when nothing resolves.
+              suite=$(jq -r '.pipelineTestSuite // ""' <<< "${json_result}")
+              pipelineUsed=$(jq -r '.pipelineUsed // ""' <<< "${json_result}")
+              echo "find-affected: pipelineTestSuite=${suite} pipelineUsed=${pipelineUsed}" >&2
+              write_results "${suite}" "${pipelineUsed}"
+            securityContext:
+              runAsUser: 1001
+
+    - name: match-affected-suite
+      runAfter:
+        - find-affected-tasks
+      params:
+        - name: utilImage
+          value: $(tasks.extract-snapshot.results.utilsImage)
+        - name: affectedSuites
+          value: $(tasks.find-affected-tasks.results.pipelineTestSuite)
+        - name: affectedPipelineUsed
+          value: $(tasks.find-affected-tasks.results.pipelineUsed)
+        - name: PIPELINE_TEST_SUITE
+          value: $(params.PIPELINE_TEST_SUITE)
+      taskSpec:
+        params:
+          - name: utilImage
+          - name: affectedSuites
+          - name: affectedPipelineUsed
+          - name: PIPELINE_TEST_SUITE
+        results:
+          - name: runCatalogE2e
+            type: string
+        steps:
+          - name: decide
+            image: $(params.utilImage)
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              # runCatalogE2e: "yes" = run fork + catalog e2e for this scenario; "no" = skip (success).
+              # Each IntegrationTestScenario sets PIPELINE_TEST_SUITE; we only run heavy work when
+              # that suite is in the PR's affected set AND find-affected found something to test.
+
+              # No affected pipelines → nothing to gate; downstream when: blocks also skip on empty pipelineUsed.
+              if [[ -z "$(params.affectedPipelineUsed)" ]]; then
+                echo "match-affected-suite: pipelineUsed empty -> runCatalogE2e=no (skip fork / catalog e2e)" >&2
+                echo -n no > "$(results.runCatalogE2e.path)"
+                exit 0
+              fi
+
+              # affectedSuites is whitespace-separated integration-tests/<dir>/ names from the utils diff.
+              # If this scenario's dir is among them, we run catalog tests for this check.
+              configured="$(params.PIPELINE_TEST_SUITE)"
+              affected="$(params.affectedSuites)"
+              pipeline_used="$(params.affectedPipelineUsed)"
+              {
+                echo "=== match-affected-suite ==="
+                echo "scenario PIPELINE_TEST_SUITE: ${configured}"
+                echo ""
+                echo "find-affected pipelineTestSuite tokens:"
+                for w in ${affected}; do echo "  ${w}"; done
+                echo ""
+                echo "find-affected pipelineUsed tokens:"
+                for w in ${pipeline_used}; do echo "  ${w}"; done
+                echo ""
+              } >&2
+              python3 -c "
+              import sys
+              configured, aff = sys.argv[1], sys.argv[2]
+              tokens = {w for w in aff.split() if w}
+              print('yes' if configured in tokens else 'no', end='')
+              " "${configured}" "${affected}" | tee "$(results.runCatalogE2e.path)"
+              # Newline on stdout only so logs do not glue tee output to the next line.
+              echo
+              decision=$(tr -d '\n' < "$(results.runCatalogE2e.path)")
+              echo "task result runCatalogE2e: ${decision}" >&2
+            securityContext:
+              runAsUser: 1001
+
+    - name: git-clone-catalog-patch-git-push
+      runAfter:
+        - extract-snapshot
+        - find-affected-tasks
+        - match-affected-suite
+      when:
+        - input: $(tasks.find-affected-tasks.results.pipelineUsed)
+          operator: notin
+          values: [""]
+        - input: $(tasks.match-affected-suite.results.runCatalogE2e)
+          operator: in
+          values: ["yes"]
+      params:
+        - name: utilImage
+          value: $(tasks.extract-snapshot.results.utilsImage)
+        - name: utilsSourceUrl
+          value: $(tasks.extract-snapshot.results.utilsSourceUrl)
+        - name: utilsSourceRevision
+          value: $(tasks.extract-snapshot.results.utilsSourceRevision)
+        - name: catalogRepo
+          value: $(params.catalogRepo)
+        - name: catalogRef
+          value: $(params.catalogRef)
+        - name: destRepoPrefix
+          value: $(params.destRepoPrefix)
+        - name: pipelineUid
+          value: $(context.pipelineRun.uid)
+        - name: GITHUB_TOKEN_SECRET_NAME
+          value: $(params.GITHUB_TOKEN_SECRET_NAME)
+      taskSpec:
+        params:
+          - name: utilImage
+          - name: utilsSourceUrl
+          - name: utilsSourceRevision
+          - name: catalogRepo
+          - name: catalogRef
+          - name: destRepoPrefix
+          - name: pipelineUid
+          - name: GITHUB_TOKEN_SECRET_NAME
+        results:
+          - name: catalogBaseSha
+            type: string
+          - name: catalogGitUrl
+            type: string
+          - name: catalogGitRevision
+            type: string
+          - name: tempRepoName
+            type: string
+        steps:
+          - name: clone-patch-push
+            image: $(params.utilImage)
+            env:
+              - name: GITHUB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.GITHUB_TOKEN_SECRET_NAME)
+                    key: token
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              export GITHUB_TOKEN
+              export UTILS_IMAGE="$(params.utilImage)"
+              export CATALOG_REPO="$(params.catalogRepo)"
+              export CATALOG_REF="$(params.catalogRef)"
+              export DEST_REPO_PREFIX="$(params.destRepoPrefix)"
+              export PIPELINE_UID="$(params.pipelineUid)"
+              UTILS_WORK_DIR="$(mktemp -d)"
+              cd "${UTILS_WORK_DIR}"
+              git init -q
+              git remote add origin "$(params.utilsSourceUrl)"
+              git fetch -q --depth 1 origin "$(params.utilsSourceRevision)"
+              git checkout -q FETCH_HEAD
+              bash "${UTILS_WORK_DIR}/integration-tests/lib/catalog_clone_patch_push.sh" \
+                "$(results.catalogBaseSha.path)" \
+                "$(results.catalogGitUrl.path)" \
+                "$(results.catalogGitRevision.path)" \
+                "$(results.tempRepoName.path)"
+            securityContext:
+              runAsUser: 1001
+
+    - name: run-catalog-e2e
+      runAfter:
+        - git-clone-catalog-patch-git-push
+      when:
+        - input: $(tasks.find-affected-tasks.results.pipelineUsed)
+          operator: notin
+          values: [""]
+        - input: $(tasks.match-affected-suite.results.runCatalogE2e)
+          operator: in
+          values: ["yes"]
+      params:
+        - name: utilImage
+          value: $(tasks.extract-snapshot.results.utilsImage)
+        - name: catalogE2eRunnerImage
+          value: $(params.catalogE2eRunnerImage)
+        - name: catalogGitUrl
+          value: $(tasks.git-clone-catalog-patch-git-push.results.catalogGitUrl)
+        - name: catalogGitRevision
+          value: $(tasks.git-clone-catalog-patch-git-push.results.catalogGitRevision)
+        - name: PIPELINE_TEST_SUITE
+          value: $(params.PIPELINE_TEST_SUITE)
+        - name: PIPELINE_USED
+          value: $(params.PIPELINE_USED)
+        - name: VAULT_PASSWORD_SECRET_NAME
+          value: $(params.VAULT_PASSWORD_SECRET_NAME)
+        - name: GITHUB_TOKEN_SECRET_NAME
+          value: $(params.GITHUB_TOKEN_SECRET_NAME)
+        - name: KUBECONFIG_SECRET_NAME
+          value: $(params.KUBECONFIG_SECRET_NAME)
+        - name: orchestrationKubeconfigSecretName
+          value: $(params.orchestrationKubeconfigSecretName)
+        - name: e2eWaitTimeout
+          value: $(params.e2eWaitTimeout)
+        - name: parentPipelineRun
+          value: $(context.pipelineRun.name)
+      taskSpec:
+        params:
+          - name: utilImage
+          - name: catalogE2eRunnerImage
+          - name: catalogGitUrl
+          - name: catalogGitRevision
+          - name: PIPELINE_TEST_SUITE
+          - name: PIPELINE_USED
+          - name: VAULT_PASSWORD_SECRET_NAME
+          - name: GITHUB_TOKEN_SECRET_NAME
+          - name: KUBECONFIG_SECRET_NAME
+          - name: orchestrationKubeconfigSecretName
+          - name: e2eWaitTimeout
+          - name: parentPipelineRun
+        steps:
+          - name: run-catalog-e2e
+            image: $(params.utilImage)
+            env:
+              - name: ORCHESTRATOR_PIPELINE_RUN_UID
+                value: $(context.pipelineRun.uid)
+              - name: KUBECONFIG_SECRET_CONTENT
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.orchestrationKubeconfigSecretName)
+                    key: kubeconfig
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              kubeconfig_path=$(mktemp)
+              echo "${KUBECONFIG_SECRET_CONTENT:?}" > "${kubeconfig_path}"
+              export KUBECONFIG="${kubeconfig_path}"
+              export CATALOG_E2E_RUNNER_IMAGE="$(params.catalogE2eRunnerImage)"
+              export CATALOG_GIT_URL="$(params.catalogGitUrl)"
+              export CATALOG_GIT_REVISION="$(params.catalogGitRevision)"
+              export PIPELINE_TEST_SUITE="$(params.PIPELINE_TEST_SUITE)"
+              export PIPELINE_USED="$(params.PIPELINE_USED)"
+              export VAULT_PASSWORD_SECRET_NAME="$(params.VAULT_PASSWORD_SECRET_NAME)"
+              export GITHUB_TOKEN_SECRET_NAME="$(params.GITHUB_TOKEN_SECRET_NAME)"
+              export KUBECONFIG_SECRET_NAME="$(params.KUBECONFIG_SECRET_NAME)"
+              export PARENT_PIPELINE_RUN="$(params.parentPipelineRun)"
+              export E2E_WAIT_TIMEOUT="$(params.e2eWaitTimeout)"
+              exec python3 /home/integration-tests/lib/run_single_catalog_e2e_suite.py
+            securityContext:
+              runAsUser: 1001
+
+  finally:
+    - name: cleanup-temp-repo
+      params:
+        - name: destRepoPrefix
+          value: $(params.destRepoPrefix)
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: catalogRepo
+          value: $(params.catalogRepo)
+        - name: catalogRef
+          value: $(params.catalogRef)
+        - name: GITHUB_TOKEN_SECRET_NAME
+          value: $(params.GITHUB_TOKEN_SECRET_NAME)
+        - name: utilImage
+          value: $(tasks.extract-snapshot.results.utilsImage)
+      taskSpec:
+        params:
+          - name: destRepoPrefix
+          - name: pipelineRunUid
+          - name: catalogRepo
+          - name: catalogRef
+          - name: GITHUB_TOKEN_SECRET_NAME
+          - name: utilImage
+        steps:
+          - name: cleanup
+            image: $(params.utilImage)
+            env:
+              - name: GITHUB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.GITHUB_TOKEN_SECRET_NAME)
+                    key: token
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              export GITHUB_TOKEN
+              temp_fork_repo="$(params.destRepoPrefix)-$(params.pipelineRunUid)"
+              temp_fork_clone_dir="$(mktemp -d)"
+              if git clone --depth 1 "https://${GITHUB_TOKEN}@github.com/${temp_fork_repo}.git" \
+                  "${temp_fork_clone_dir}/repo" 2>/dev/null; then
+                cd "${temp_fork_clone_dir}/repo"
+                if [[ -f .catalog-clone-base-sha ]]; then
+                  catalog_sha_at_patch="$(tr -d '[:space:]' < .catalog-clone-base-sha)"
+                  catalog_sha_now="$(
+                    git ls-remote "https://github.com/$(params.catalogRepo).git" \
+                      "refs/heads/$(params.catalogRef)" 2>/dev/null \
+                      | awk '{print $1}' | head -1
+                  )"
+                  if [[ -n "${catalog_sha_at_patch}" && -n "${catalog_sha_now}" \
+                      && "${catalog_sha_now}" != "${catalog_sha_at_patch}" ]]; then
+                    echo ""
+                    echo "================================================================================"
+                    echo "  WARNING: $(params.catalogRepo) branch $(params.catalogRef) changed since this test started."
+                    echo "    SHA at catalog clone: ${catalog_sha_at_patch}"
+                    echo "    SHA now:              ${catalog_sha_now}"
+                    echo "  E2E ran against an older catalog snapshot. Consider re-running."
+                    echo "================================================================================"
+                    echo ""
+                  fi
+                fi
+              fi
+              catalog_clone_dir="$(mktemp -d)"
+              git clone --depth 1 --branch "$(params.catalogRef)" \
+                "https://${GITHUB_TOKEN}@github.com/$(params.catalogRepo).git" "${catalog_clone_dir}/catalog"
+              echo "Deleting temporary repo ${temp_fork_repo} (ignore errors if create failed)..."
+              bash "${catalog_clone_dir}/catalog/integration-tests/scripts/delete-repository.sh" \
+                "${temp_fork_repo}" || true
+            securityContext:
+              runAsUser: 1001

--- a/integration-tests/run-test.sh
+++ b/integration-tests/run-test.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+#
+# run-test.sh - Submit a Tekton PipelineRun for utils-e2e-catalog-pipeline
+#
+# Overview:
+#   Thin wrapper that passes the same parameters an IntegrationTestScenario would use for
+#   integration-tests/pipelines/utils-e2e-catalog-pipeline.yaml in release-service-utils. It
+#   kubectl-creates a PipelineRun in your cluster (requires kubectl and jq).
+#
+# Required environment variables:
+#   SNAPSHOT_FILE
+#     Path to a Konflux Snapshot JSON file (same shape as the SNAPSHOT pipeline parameter). It
+#     must describe the utils build under components[0] (containerImage and source.git url and
+#     revision), which the pipeline uses to clone the utils repo and diff against main.
+#
+#   PIPELINE_TEST_SUITE
+#     Name of the catalog integration-tests/<name>/ directory to exercise (e.g. e2e). Same pipeline
+#     parameter name as the catalog IntegrationTestScenario (PIPELINE_TEST_SUITE).
+#
+#   PIPELINE_USED
+#     Basename of the managed pipeline under catalog pipelines/managed/<name>/ (e.g. fbc-release).
+#     Same pipeline parameter name as the catalog IntegrationTestScenario (PIPELINE_USED).
+#
+# Optional (omit env vars to use Tekton defaults from the resolved pipeline YAML):
+#   NAMESPACE (default rhtap-release-2-tenant only for kubectl; not a pipeline param).
+#   CATALOG_REPO, CATALOG_REF, DEST_REPO_PREFIX, CATALOG_E2E_RUNNER_IMAGE, VAULT_PASSWORD_SECRET_NAME,
+#   GITHUB_TOKEN_SECRET_NAME, KUBECONFIG_SECRET_NAME, E2E_WAIT_TIMEOUT (pipeline param e2eWaitTimeout).
+#   With --wait, E2E_WAIT_TIMEOUT is required (kubectl wait --timeout); pick a duration that fits your run
+#   (the pipeline default for e2eWaitTimeout is in utils-e2e-catalog-pipeline.yaml).
+#   RUN_TEST_KEEP_PIPELINERUN=1  With --wait, skip deleting the PipelineRun when finished (debugging).
+#
+# Local kubeconfig (required for real runs, not --dry-run):
+#   Before creating the PipelineRun, the script uploads your local kubeconfig (first path in $KUBECONFIG,
+#   else ~/.kube/config) into a temporary Secret in NAMESPACE (key kubeconfig), sets pipeline param
+#   orchestrationKubeconfigSecretName to that name, then patches the Secret with an ownerReference to the
+#   PipelineRun so the Secret is garbage-collected when the PipelineRun is deleted (--wait deletes the PLR
+#   when finished). If PipelineRun creation fails before the patch, the script deletes the Secret on exit.
+#
+# Options:
+#   --dry-run          kubectl create --dry-run=client -o yaml (no PipelineRun created)
+#   --wait             After create, block until the PipelineRun finishes (success or failure);
+#                      requires E2E_WAIT_TIMEOUT (kubectl wait --timeout). When the run finishes, deletes the PipelineRun so runs
+#                      do not accumulate; set RUN_TEST_KEEP_PIPELINERUN=1 to skip deletion.
+#   (default)          Prints how to watch logs / status; does not wait (PipelineRun remains).
+#
+set -euo pipefail
+
+_resolve_local_kubeconfig_file() {
+  local first
+  if [[ -n "${KUBECONFIG:-}" ]]; then
+    first="${KUBECONFIG%%:*}"
+    if [[ -f "${first}" ]]; then
+      echo "${first}"
+      return 0
+    fi
+  fi
+  if [[ -f "${HOME}/.kube/config" ]]; then
+    echo "${HOME}/.kube/config"
+    return 0
+  fi
+  return 1
+}
+
+DRY=false
+WAIT=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) awk 'NR==1{next} /^set -euo pipefail$/{exit} {print}' "$0"; exit 0 ;;
+    --dry-run) DRY=true ;;
+    --wait) WAIT=true ;;
+    *) echo "run-test.sh: unknown arg: $1 (try --help)" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+command -v kubectl >/dev/null 2>&1 || { echo "run-test.sh: kubectl is required" >&2; exit 1; }
+
+: "${SNAPSHOT_FILE:?run-test.sh: SNAPSHOT_FILE is required (path to Konflux Snapshot JSON)}"
+: "${PIPELINE_TEST_SUITE:?run-test.sh: PIPELINE_TEST_SUITE is required (catalog integration-tests/<name>/)}"
+: "${PIPELINE_USED:?run-test.sh: PIPELINE_USED is required (catalog pipelines/managed/<name>/ basename)}"
+[[ -f "${SNAPSHOT_FILE}" ]] || { echo "run-test.sh: no such file: ${SNAPSHOT_FILE}" >&2; exit 1; }
+jq -e . "${SNAPSHOT_FILE}" >/dev/null || exit 1
+
+# Git resolver for this PipelineRun: snapshot components[0].source.git url/revision (jq // defaults).
+SNAP_GIT_URL=$(jq -r '.components[0].source.git.url // "https://github.com/konflux-ci/release-service-utils.git"' "${SNAPSHOT_FILE}")
+SNAP_GIT_REV=$(jq -r '.components[0].source.git.revision // "development"' "${SNAPSHOT_FILE}")
+if [[ "${SNAP_GIT_URL}" == git@github.com:* ]]; then
+  SNAP_GIT_URL="https://github.com/${SNAP_GIT_URL#git@github.com:}"
+fi
+if [[ "${SNAP_GIT_URL}" == https://github.com/* && "${SNAP_GIT_URL}" != *.git ]]; then
+  SNAP_GIT_URL="${SNAP_GIT_URL}.git"
+fi
+
+NAMESPACE="${NAMESPACE:-rhtap-release-2-tenant}"
+readonly _UTILS_PIPELINE_PATH_IN_REPO='integration-tests/pipelines/utils-e2e-catalog-pipeline.yaml'
+
+# Optional spec.params: omit unset env vars so Tekton uses pipeline defaults. A param set to the
+# empty string on the PipelineRun still overrides the default (Tekton treats it as an explicit value).
+
+# Append {name, value} to OPTIONAL_PLR_PARAMS when value is non-empty.
+optional_plr_param_add_if_set() {
+  local _param_name=$1
+  local _param_value=${2:-}
+  [[ -z "${_param_value}" ]] && return 0
+  OPTIONAL_PLR_PARAMS=$(jq -cn \
+    --argjson arr "${OPTIONAL_PLR_PARAMS}" \
+    --arg n "${_param_name}" \
+    --arg v "${_param_value}" \
+    '$arr + [{name: $n, value: $v}]')
+}
+
+ORCH_SECRET_NAME=""
+ORCH_SECRET_PATCHED=""
+cleanup_orch_secret_if_unpatched() {
+  if [[ -n "${ORCH_SECRET_NAME:-}" && -z "${ORCH_SECRET_PATCHED:-}" ]]; then
+    echo "run-test.sh: deleting orchestration Secret ${ORCH_SECRET_NAME} (PipelineRun was not linked)" >&2
+    kubectl delete secret "${ORCH_SECRET_NAME}" -n "${NAMESPACE}" --ignore-not-found >/dev/null 2>&1 || true
+  fi
+}
+
+if [[ "${DRY}" == true ]]; then
+  ORCHESTRATION_KUBECONFIG_SECRET_NAME="utils-e2e-orch-dry-run-placeholder"
+else
+  trap cleanup_orch_secret_if_unpatched EXIT
+  KCFG_LOCAL=$(_resolve_local_kubeconfig_file) || {
+    echo "run-test.sh: could not find a local kubeconfig (set KUBECONFIG to a file, or create ~/.kube/config)" >&2
+    exit 1
+  }
+  if command -v openssl >/dev/null 2>&1; then
+    ORCH_SECRET_NAME="utils-e2e-orch-$(openssl rand -hex 6)"
+  else
+    ORCH_SECRET_NAME="utils-e2e-orch-${RANDOM}${RANDOM}"
+  fi
+  echo "run-test.sh: creating orchestration Secret ${ORCH_SECRET_NAME} from ${KCFG_LOCAL}" >&2
+  kubectl create secret generic "${ORCH_SECRET_NAME}" -n "${NAMESPACE}" --from-file=kubeconfig="${KCFG_LOCAL}"
+  ORCHESTRATION_KUBECONFIG_SECRET_NAME="${ORCH_SECRET_NAME}"
+fi
+
+echo "run-test.sh: pipelineRef from git url=${SNAP_GIT_URL} revision=${SNAP_GIT_REV} path=${_UTILS_PIPELINE_PATH_IN_REPO}" >&2
+
+OPTIONAL_PLR_PARAMS='[]'
+optional_plr_param_add_if_set catalogRepo "${CATALOG_REPO:-}"
+optional_plr_param_add_if_set catalogRef "${CATALOG_REF:-}"
+optional_plr_param_add_if_set destRepoPrefix "${DEST_REPO_PREFIX:-}"
+optional_plr_param_add_if_set catalogE2eRunnerImage "${CATALOG_E2E_RUNNER_IMAGE:-}"
+optional_plr_param_add_if_set VAULT_PASSWORD_SECRET_NAME "${VAULT_PASSWORD_SECRET_NAME:-}"
+optional_plr_param_add_if_set GITHUB_TOKEN_SECRET_NAME "${GITHUB_TOKEN_SECRET_NAME:-}"
+optional_plr_param_add_if_set KUBECONFIG_SECRET_NAME "${KUBECONFIG_SECRET_NAME:-}"
+optional_plr_param_add_if_set e2eWaitTimeout "${E2E_WAIT_TIMEOUT:-}"
+
+PR_JSON=$(jq -n \
+  --arg ns "${NAMESPACE}" --rawfile snap "${SNAPSHOT_FILE}" \
+  --arg pts "${PIPELINE_TEST_SUITE}" --arg pu "${PIPELINE_USED}" \
+  --arg okc "${ORCHESTRATION_KUBECONFIG_SECRET_NAME}" \
+  --argjson optional_params "${OPTIONAL_PLR_PARAMS}" \
+  --arg pgu "${SNAP_GIT_URL}" --arg pgr "${SNAP_GIT_REV}" --arg pgp "${_UTILS_PIPELINE_PATH_IN_REPO}" \
+  '
+  {
+    apiVersion: "tekton.dev/v1",
+    kind: "PipelineRun",
+    metadata: {generateName: "utils-e2e-orchestrator-", namespace: $ns},
+    spec: {
+      pipelineRef: {
+        resolver: "git",
+        params: [
+          {name: "url", value: $pgu},
+          {name: "revision", value: $pgr},
+          {name: "pathInRepo", value: $pgp}
+        ]
+      },
+      params:
+        [
+          {name: "SNAPSHOT", value: $snap},
+          {name: "PIPELINE_TEST_SUITE", value: $pts},
+          {name: "PIPELINE_USED", value: $pu},
+          {name: "orchestrationKubeconfigSecretName", value: $okc}
+        ]
+        + $optional_params
+    }
+  }
+')
+
+if [[ "${DRY}" == true ]]; then
+  echo "${PR_JSON}" | kubectl create --dry-run=client -f - -o yaml
+  exit 0
+fi
+
+PR_NAME=$(echo "${PR_JSON}" | kubectl create -f - -o jsonpath='{.metadata.name}')
+echo "Created PipelineRun ${PR_NAME} in namespace ${NAMESPACE}"
+
+if [[ -n "${ORCH_SECRET_NAME}" ]]; then
+  PR_UID=$(kubectl get pipelinerun "${PR_NAME}" -n "${NAMESPACE}" -o jsonpath='{.metadata.uid}')
+  ORCH_PATCH_JSON=$(jq -n \
+    --arg name "${PR_NAME}" --arg uid "${PR_UID}" \
+    '{"metadata":{"ownerReferences":[{"apiVersion":"tekton.dev/v1","kind":"PipelineRun","name":$name,"uid":$uid,"blockOwnerDeletion":false}]}}')
+  kubectl patch secret "${ORCH_SECRET_NAME}" -n "${NAMESPACE}" --type=merge -p "${ORCH_PATCH_JSON}" >/dev/null
+  ORCH_SECRET_PATCHED=1
+  trap - EXIT
+fi
+
+delete_pipelinerun() {
+  [[ "${RUN_TEST_KEEP_PIPELINERUN:-}" == 1 ]] && return 0
+  local pr=$1
+  echo "run-test.sh: deleting pipelinerun ${pr} in ${NAMESPACE}" >&2
+  kubectl delete pipelinerun "${pr}" -n "${NAMESPACE}" --ignore-not-found >/dev/null 2>&1 || true
+}
+
+print_monitoring_hint() {
+  local pr=$1
+  cat <<EOF
+
+Monitor this run:
+  kubectl get pipelinerun "${pr}" -n "${NAMESPACE}" -w
+  kubectl describe pipelinerun "${pr}" -n "${NAMESPACE}"
+  (if tkn is installed)  tkn pipelinerun logs "${pr}" -n "${NAMESPACE}" -f
+
+EOF
+}
+
+print_monitoring_hint "${PR_NAME}"
+
+if [[ "${WAIT}" == true ]]; then
+  : "${E2E_WAIT_TIMEOUT:?run-test.sh: E2E_WAIT_TIMEOUT is required with --wait (seconds for kubectl wait --timeout)}"
+  echo "Waiting for completion (timeout ${E2E_WAIT_TIMEOUT}s)..."
+  if ! kubectl wait --for=jsonpath='{.status.completionTime}' "pipelinerun/${PR_NAME}" -n "${NAMESPACE}" \
+    --timeout="${E2E_WAIT_TIMEOUT}s"; then
+    echo "run-test.sh: wait failed or timed out" >&2
+    delete_pipelinerun "${PR_NAME}"
+    exit 1
+  fi
+  ok=$(kubectl get pipelinerun "${PR_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}')
+  if [[ "${ok}" != "True" ]]; then
+    echo "run-test.sh: PipelineRun ${PR_NAME} did not succeed (Succeeded=${ok:-empty})" >&2
+    delete_pipelinerun "${PR_NAME}"
+    exit 1
+  fi
+  echo "PipelineRun ${PR_NAME} succeeded."
+  delete_pipelinerun "${PR_NAME}"
+fi


### PR DESCRIPTION
This is the final commit in a multi commit effort to enable running the catalog pipeline e2e test suites for PRs to this repo. This commit adds the pipeline yaml that will be used in this repo's e2e to call the catalog e2e, documentation describing how it works, and a run-test.sh file to enable developers to run the testing locally (vs via the ITS during the PR process).

Assisted-By: Cursor