### PR TITLE
feat(RELEASE-2382): use exponential backoff in retry script

### DIFF
--- a/utils/retry
+++ b/utils/retry
@@ -11,7 +11,8 @@
 # Behavior:
 # - Runs the given command up to <max_attempts> times.
 # - Stops immediately if the command succeeds (exit status 0).
-# - Waits (5 × attempt_number) seconds before each retry (5s before 2nd attempt, 10s before 3rd, etc.).
+# - Uses exponential backoff: waits 5×2^(attempt-1) seconds before each retry
+#   (5s, 10s, 20s, 40s, ...).
 # - Exits with 0 if the command eventually succeeds, otherwise with the last command’s exit code.
 
 max_attempts="$1"
@@ -24,7 +25,7 @@ until "$@"; do
         echo "Attempt $attempt failed and there are no more retries left!" >&2
         exit 1
     fi
-    sleep_time=$(( 5 * attempt ))
+    sleep_time=$(( 5 * (2 ** (attempt - 1)) ))
     echo "Attempt $attempt failed! Trying again in $sleep_time seconds..." >&2
     sleep "$sleep_time"
     (( attempt++ ))


### PR DESCRIPTION
Replace linear backoff (5×attempt) with exponential backoff (10×2^(attempt-1)) to give stressed services progressively more recovery time between retries.

For 5 retries, total wait increases from 50s to 75s (5s, 10s, 20s, 40s vs old 5s, 10s, 15s, 20s).

Assisted-by: Cursor