### PR TITLE
chore(RELEASE-2209): update e2e pipeline default param

### DIFF
--- a/integration-tests/pipelines/utils-e2e-catalog-pipeline.yaml
+++ b/integration-tests/pipelines/utils-e2e-catalog-pipeline.yaml
@@ -58,7 +58,7 @@ spec:
         steps run.
     - name: orchestrationKubeconfigSecretName
       type: string
-      default: e2e-test-konflux-api-kubeconfig
+      default: e2e-test-service-account-kubeconfig
       description: >-
         Secret name (key kubeconfig) used only by run-catalog-e2e to run kubectl against the Konflux
         cluster where this PipelineRun exists.


### PR DESCRIPTION
This commit updates the orchestration kubeconfig secret default used in the e2e pipeline to be the same as the other kubeconfig secret. Because they are used on the same cluster, we can use the same secret for both.