### PR TITLE
Revert "fix(RELEASE-2369): quote fields to prevent YAML float truncat…

### DIFF
--- a/templates/advisory.yaml.jinja
+++ b/templates/advisory.yaml.jinja
@@ -4,10 +4,10 @@ metadata:
   name: {{ advisory_name }}
   ship_date: "{{ advisory_ship_date }}"
 spec:
-  product_id: "{{ advisory.spec.product_id }}"
-  product_name: "{{ advisory.spec.product_name }}"
-  product_version: "{{ advisory.spec.product_version }}"
-  product_stream: "{{ advisory.spec.product_stream }}"
+  product_id: {{ advisory.spec.product_id }}
+  product_name: {{ advisory.spec.product_name }}
+  product_version: {{ advisory.spec.product_version }}
+  product_stream: {{ advisory.spec.product_stream }}
   cpe: {{ advisory.spec.cpe }}
   type: {{ advisory.spec.type }}
 {%- if 'severity' in advisory.spec %}

--- a/utils/tests/test_apply_template.py
+++ b/utils/tests/test_apply_template.py
@@ -174,7 +174,7 @@ def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
                     "spec": {
                         "product_id": 1,
                         "product_name": "name",
-                        "product_version": "4.20",
+                        "product_version": "version",
                         "product_stream": "stream",
                         "cpe": "cpe:/id",
                         "type": "RHEA",
@@ -215,9 +215,6 @@ def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
         with open(filename, "r") as f:
             result = json.load(f)
 
-        assert result["spec"]["product_id"] == "1"
-        assert result["spec"]["product_version"] == "4.20"
-        assert result["spec"]["product_stream"] == "stream"
         assert result["spec"]["solution"] == solution
         assert result["spec"]["topic"] == topic
         assert result["spec"]["synopsis"] == "Enhancement synopsis"


### PR DESCRIPTION
This reverts commit 017d3ad4f36fe88e7cf6e22e5b0b7f428210e9d8.

This is due to the Advisory Schema not allowing product_id to be of type "string".

PR #706