### PR TITLE
refactor: convert check-embargoed-cves to python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,8 +154,10 @@ ENV PATH="$PATH:/home/pubtools-pulp-wrapper"
 ENV PATH="$PATH:/home/pubtools-marketplacesvm-wrapper"
 ENV PATH="$PATH:/home/developer-portal-wrapper"
 ENV PATH="$PATH:/home/publish-to-cgw-wrapper"
-# Need to set PYTHONPATH to be able to run sbom scripts as modules
-ENV PYTHONPATH="$PYTHONPATH:/home"
+# Flat imports: helpers and task scripts must be importable.
+# Tests use the same layout via pyproject [tool.pytest.ini_options] pythonpath.
+# Keep /home for other modules (e.g. pyxis, sbom) that expect it.
+ENV PYTHONPATH="/home:/home/scripts/python/helpers:/home/scripts/python/tasks/internal"
 
 # uv installs newer requests and certifi which don't use the system CA like the one installed via
 # dnf. So we need to point requests to the system CA bundle explicitly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = "Konflux Release Service Utils"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "requests",
+    "requests-kerberos",
     "jinja2",
     "check-jsonschema",
     "jinja2-ansible-filters",
@@ -25,7 +27,11 @@ dependencies = [
 line-length = 95
 
 [tool.pytest.ini_options]
-pythonpath = ["integration-tests/lib"]
+pythonpath = [
+  "integration-tests/lib",
+  "scripts/python/helpers",
+  "scripts/python/tasks/internal",
+]
 
 [dependency-groups]
 dev = [
@@ -40,7 +46,7 @@ omit = [
     "**/tests/*",
     ".github/*",
     "ci/*",
-    "scripts/*",
+    "scripts/bash/*",
     "templates/*",
     "data/*",
 ]

--- a/scripts/python/helpers/__init__.py
+++ b/scripts/python/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable Python helpers for release task scripts."""

--- a/scripts/python/helpers/authentication.py
+++ b/scripts/python/helpers/authentication.py
@@ -1,0 +1,125 @@
+"""Authentication oriented helpers for task scripts.
+
+Store reusable, task-agnostic pieces here: krb5 configuration for container
+runs, ``kinit`` with keytabs from the filesystem, and reading typical mounted
+service-account / secret file layouts.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+import retry
+
+
+def read_mounted_text(mount: Path, filename: str) -> str:
+    """
+    Read a UTF-8 file (``mount / filename``) and return the text with leading
+    and trailing whitespace removed. Use for one-line secret values (API base URL,
+    principal name) when a pod mounts a volume as a directory of small files.
+    """
+    return (mount / filename).read_text(encoding="utf-8").strip()
+
+
+def load_keytab_from_mount(
+    mount: Path,
+    *,
+    principal_file: str,
+    keytab_b64_file: str,
+) -> tuple[str, bytes]:
+    """
+    Load a Kerberos principal and raw keytab from files under *mount*.
+
+    *principal_file* is a one-line text file (principal). *keytab_b64_file*
+    is the same for a base64-encoded keytab. Returns the principal string and
+    the decoded keytab bytes.
+    """
+    princ = read_mounted_text(mount, principal_file)
+    b64 = read_mounted_text(mount, keytab_b64_file).encode("ascii")
+    return princ, base64.b64decode(b64)
+
+
+def load_service_account(
+    mount: Path,
+    text_files: Sequence[str] = (),
+    *,
+    principal_file: str,
+    keytab_b64_file: str,
+) -> tuple[str, bytes, dict[str, str]]:
+    """
+    Load a mounted Kubernetes-style service account: principal, keytab, and extra
+    one-value string files (API base URL, usernames, etc.).
+
+    *principal_file* and *keytab_b64_file* are passed through to
+    ``load_keytab_from_mount``. It then reads each additional filename in
+    ``text_files`` and returns a
+    dict mapping that filename to stripped text (for example an API base URL
+    in one file). You can list several files; each name becomes a key in the
+    returned dict.
+    """
+    princ, keytab = load_keytab_from_mount(
+        mount, principal_file=principal_file, keytab_b64_file=keytab_b64_file
+    )
+    extra: dict[str, str] = {name: read_mounted_text(mount, name) for name in text_files}
+    return princ, keytab, extra
+
+
+def patch_krb5_config(source: str) -> str:
+    """
+    Return ``source`` with one line added immediately after ``[libdefaults]``.
+
+    Inserts ``dns_canonicalize_hostname = false`` to avoid
+    "Invalid UID in persistent keyring name" / hostname canonicalization
+    issues when some environments use a temporary KRB5_CONFIG derived from the
+    system ``/etc/krb5.conf`` template.
+
+    **source** is the full file text. If a ``[libdefaults]`` line is present, one
+    setting line is inserted immediately after it; if that section is missing,
+    the returned string matches **source** unchanged.
+    """
+    out: list[str] = []
+    for line in source.splitlines(keepends=True):
+        out.append(line)
+        if line.strip() == "[libdefaults]":
+            out.append("    dns_canonicalize_hostname = false\n")
+    return "".join(out)
+
+
+def kinit_with_retry(
+    princ: str, keytab: Path, extra_env: dict[str, str], *, max_attempts: int = 5
+) -> None:
+    """
+    Run ``kinit`` with a keytab, retrying a few times on non-zero exit.
+
+    Merges ``os.environ`` with ``extra_env`` for the ``kinit`` child only.
+    If every attempt fails, the last ``CalledProcessError`` is raised. **princ** is
+    the principal; **keytab** is the keytab path; **extra_env** is merged in (for
+    example ``KRB5CCNAME`` and ``KRB5_CONFIG``). For verbose libkrb5 trace, set
+    ``KRB5_TRACE=/dev/stderr`` in the process environment (or in **extra_env**)
+    on the parent before calling. **max_attempts** is how many times to run
+    ``kinit`` before giving up, with exponential backoff (5s, 10s, 20s...).
+    """
+
+    def _run_once() -> None:
+        p = subprocess.run(
+            ["kinit", princ, "-k", "-t", str(keytab)],
+            check=False,
+            env={**os.environ, **extra_env},
+        )
+        if p.returncode == 0:
+            return
+        raise subprocess.CalledProcessError(
+            p.returncode,
+            f"kinit {princ} -k -t {keytab!s}",
+        )
+
+    retry.retry_with_exponential_backoff(
+        _run_once,
+        max_attempts=max_attempts,
+        retry_on=subprocess.CalledProcessError,
+        base_sleep_seconds=5,
+    )

--- a/scripts/python/helpers/file.py
+++ b/scripts/python/helpers/file.py
@@ -1,0 +1,56 @@
+"""File, path, and temporary-file helpers for task scripts."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def path_from_env_variable(
+    name: str,
+    default: str | Path,
+) -> Path:
+    """
+    Return a filesystem path from the string value of an environment variable, or
+    a default.
+
+    The value of name in ``os.environ`` (if set and not blank after
+    ``str.strip``) is interpreted as a path; it is not a path to a file whose
+    contents you read, and this function does not open or stat paths.
+
+    If the variable is missing or only whitespace, default is returned (a str
+    or an existing ``Path``).
+
+    Typical use: a Tekton or pod env var that holds a mount directory path, with
+    tests setting the same variable to a temp directory. Existence of the path
+    is not checked.
+    """
+    raw = os.environ.get(name)
+    if raw is not None and str(raw).strip() != "":
+        return Path(str(raw).strip())
+    return default if isinstance(default, Path) else Path(default)
+
+
+def make_tempfile_path(
+    prefix: str,
+    data: bytes | None = None,
+) -> Path:
+    """
+    Create a secure private temp file and return a pathlib.Path to it.
+
+    Uses the standard library ``tempfile.mkstemp``, which creates a new file and
+    returns a file handle (a safe pattern). We never use the old ``mktemp`` API
+    (unsafe under concurrency; deprecated in Python 3.12). If ``data`` is given,
+    those bytes are written into the new file; otherwise the file is empty. The
+    file is closed before returning; the caller is responsible for deleting the
+    path when done. ``prefix`` is the filename prefix in the system temp
+    directory, same as the ``prefix`` argument to ``mkstemp``.
+    """
+    fd, name = tempfile.mkstemp(prefix=prefix)
+    try:
+        if data is not None:
+            os.write(fd, data)
+    finally:
+        os.close(fd)
+    return Path(name)

--- a/scripts/python/helpers/http_client.py
+++ b/scripts/python/helpers/http_client.py
@@ -1,0 +1,103 @@
+"""HTTP helpers for task code using the third-party ``requests`` library.
+
+The catalog often shows shell with ``curl --retry 3`` and Kerberos or bearer
+auth. The equivalent here is ``get_text`` (GET with retries on the session) plus
+either ``HTTPKerberosAuth`` from the ``requests_kerberos`` package (after
+``kinit``) or regular headers, using urllib3's retry support on a ``Session``.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import time
+from collections.abc import Mapping
+from typing import Any
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
+
+MAX_429_ATTEMPTS = 5
+MAX_404_ATTEMPTS = 3
+BASE_SLEEP_TIME_SECONDS = 1
+
+
+def _retries() -> Retry:
+    """Transients similar to common ``curl --retry 3`` (connection + some HTTP)."""
+    return Retry(
+        total=3,
+        connect=3,
+        read=3,
+        status=2,
+        backoff_factor=0.4,
+        status_forcelist=(500, 502, 503, 504),
+        allowed_methods=frozenset({"GET"}),
+        raise_on_status=False,
+    )
+
+
+def get_session() -> requests.Session:
+    """
+    Build a ``requests.Session`` with the shared retry policy on http and https.
+    ``get_text`` uses this. Tests can patch this function to supply a custom session.
+    """
+    s = requests.Session()
+    a = HTTPAdapter(max_retries=_retries())
+    s.mount("https://", a)
+    s.mount("http://", a)
+    return s
+
+
+def get_text(
+    url: str,
+    *,
+    auth: Any = None,
+    headers: Mapping[str, str] | None = None,
+    timeout: float = 60.0,
+) -> str:
+    """
+    Perform an HTTP(S) GET for the given URL and return the body as a string.
+
+    Non-2xx responses become ``requests.HTTPError`` (similar to ``curl
+    --fail``). You may pass optional ``auth`` (for example
+    ``HTTPKerberosAuth``) and request ``headers`` (bearer token, content type,
+    etc.). ``timeout`` is seconds for the call.
+
+    HTTP 429 is retried with exponential backoff plus 0-2s jitter up to
+    ``MAX_429_ATTEMPTS`` total attempts. HTTP 404 is retried similarly only if
+    ``CURL_WITH_RETRY_RETRY_404`` is set to a non-empty value.
+    """
+    session = get_session()
+    retries_429 = 0
+    retries_404 = 0
+    should_retry_404 = bool(os.environ.get("CURL_WITH_RETRY_RETRY_404"))
+
+    while True:
+        r = session.get(
+            url,
+            auth=auth,
+            headers=dict(headers) if headers is not None else None,
+            timeout=timeout,
+        )
+        if 200 <= r.status_code < 300:
+            return r.text
+
+        if r.status_code == 429:
+            retries_429 += 1
+            if retries_429 < MAX_429_ATTEMPTS:
+                delay = BASE_SLEEP_TIME_SECONDS * (2 ** (retries_429 - 1))
+                delay += random.randint(0, 2)
+                time.sleep(delay)
+                continue
+
+        if r.status_code == 404 and should_retry_404:
+            retries_404 += 1
+            if retries_404 < MAX_404_ATTEMPTS:
+                delay = BASE_SLEEP_TIME_SECONDS * (2 ** (retries_404 - 1))
+                delay += random.randint(0, 2)
+                time.sleep(delay)
+                continue
+
+        r.raise_for_status()
+        return r.text

--- a/scripts/python/helpers/osidb.py
+++ b/scripts/python/helpers/osidb.py
@@ -1,0 +1,45 @@
+"""OSIDB (Open Security Issue Database) client helpers for task scripts.
+
+The usual flow is: load a service-account style mount (files such as
+``name``, ``base64_keytab``, and ``osidb_url``) using
+``authentication.load_service_account`` (pass ``principal_file`` and
+``keytab_b64_file`` for the mount, plus e.g. ``"osidb_url"`` in ``text_files``), then run
+``kinit`` using helpers in
+``authentication``, then call ``get_access_token`` so later calls can use a
+bearer token. ``get_access_token`` fetches a token with the ``requests``
+library, Kerberos negotiate auth from ``requests_kerberos``, and an HTTP GET
+helper from the ``http_client`` module.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import http_client
+from requests_kerberos import HTTPKerberosAuth, OPTIONAL
+
+
+def get_access_token(osidb_url: str) -> str:
+    """
+    Get a short-lived bearer string from the OSIDB ``/auth/token`` URL using
+    GSS/SPNEGO. You need a working Kerberos cache (for example from
+    ``kinit`` / ``kinit_with_retry`` in ``authentication``). The response is
+    JSON; this function returns the value of the top ``"access"`` string for
+    use as ``Authorization: Bearer ...`` on later API calls. Raises
+    ``ValueError`` if the body is empty or the token is missing.
+    """
+    base = osidb_url.rstrip("/")
+    body = http_client.get_text(
+        f"{base}/auth/token",
+        auth=HTTPKerberosAuth(mutual_authentication=OPTIONAL),
+    )
+    if not body.strip():
+        err = f"empty token response from {base}/auth/token"
+        raise ValueError(err)
+    data: dict[str, Any] = json.loads(body)
+    t = data.get("access")
+    if t is None or t == "":
+        err = f"no .access in token response: {data!r}"
+        raise ValueError(err)
+    return t if isinstance(t, str) else str(t)

--- a/scripts/python/helpers/retry.py
+++ b/scripts/python/helpers/retry.py
@@ -1,0 +1,40 @@
+"""Retry helpers with exponential backoff."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def retry_with_exponential_backoff(
+    operation: Callable[[], T],
+    *,
+    max_attempts: int,
+    retry_on: type[BaseException] | tuple[type[BaseException], ...] = Exception,
+    base_sleep_seconds: int = 5,
+    sleep_fn: Callable[[float], None] | None = None,
+) -> T:
+    """
+    Run ``operation`` up to ``max_attempts`` times, retrying selected failures.
+
+    On each retry, waits ``base_sleep_seconds * 2 ** (attempt - 1)`` seconds (5,
+    10, 20, 40, ... by default). If a failure is not in ``retry_on``, it is
+    raised immediately. If retries are exhausted, the last matching exception is
+    raised.
+    """
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be >= 1")
+    sleeper = time.sleep if sleep_fn is None else sleep_fn
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return operation()
+        except retry_on:
+            if attempt >= max_attempts:
+                raise
+            sleeper(base_sleep_seconds * (2 ** (attempt - 1)))
+
+    raise RuntimeError("unreachable")

--- a/scripts/python/helpers/tekton.py
+++ b/scripts/python/helpers/tekton.py
@@ -1,0 +1,117 @@
+"""Shared helpers for Tekton ``result``-file and step-error conventions in task scripts.
+
+The catalog passes result file locations via environment variables
+(``env.value: $(results.foo.path)`` on the task step). Tasks that require those
+paths should fail fast in the same way: print to stderr and exit 1, since
+downstream can only interpret ``result`` bodies when the step was intended to
+write them.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import TextIO
+
+
+class CheckStepError(Exception):
+    """
+    Pairs a short *human* description of what the task was doing (the first
+    argument) with the real exception, for the Tekton one-line result file.
+    The standard library and ``requests`` only know about the underlying failure
+    (HTTP, I/O, exit code) — not which high-level action was running; attach
+    that at each ``raise`` site.
+    """
+
+    def __init__(self, action: str, cause: BaseException) -> None:
+        self.action = action
+        self.cause = cause
+        super().__init__(f"{action}: {cause}")
+
+
+def result_text_from_exception(exc: BaseException, *, max_len: int = 500) -> str:
+    """
+    ``str(exc)`` in a form suitable for a Tekton ``result`` value.
+
+    Reuses each exception’s normal string (no custom wording per type).
+    Newlines are flattened and the text is cut at *max_len* so the value
+    is not unbounded.
+    """
+    t = str(exc).replace("\n", " ").strip()
+    if len(t) > max_len:
+        t = t[: max_len - 3] + "..."
+    return t
+
+
+def result_text_for_check_step_error(program_name: str, e: CheckStepError) -> str:
+    """
+    Text to put in a Tekton ``result`` when a task step failed with
+    ``CheckStepError`` — the *action* from the error plus
+    ``result_text_from_exception`` on the underlying *cause*.
+
+    *program_name* is usually the basename of ``sys.argv[0]`` for messages that
+    look like a log line prefix.
+    """
+    why = result_text_from_exception(e.cause)
+    return f"{program_name}: Failed while {e.action}: {why}."
+
+
+def subprocess_cmd_preview_for_tekton_result(
+    cmd: str | list[str] | tuple[object, ...] | object,
+    *,
+    max_len: int = 200,
+) -> str:
+    """
+    One-line description of a subprocess *cmd* for Tekton ``result`` files.
+
+    ``CalledProcessError`` (and some APIs) expose *cmd* as a string, a list of
+    argv pieces, or another object. Result lines stay short, so the joined or
+    string form is cut to *max_len* characters.
+    """
+    if isinstance(cmd, (list, tuple)) and cmd:
+        t = " ".join(str(x) for x in cmd)
+    else:
+        t = str(cmd)
+    return t[:max_len]
+
+
+def _join_var_names(names: list[str]) -> str:
+    """
+    Build a small English list for a one-line error message, for example
+    "A and B" or "A, B, and C".
+    """
+    if len(names) == 1:
+        return names[0]
+    if len(names) == 2:
+        return f"{names[0]} and {names[1]}"
+    return f"{', '.join(names[:-1])}, and {names[-1]}"
+
+
+def result_paths(*env_var_names: str, file: TextIO = sys.stderr) -> tuple[Path, ...]:
+    """
+    Return pathlib Paths for the given environment variable names, in order.
+
+    In Tekton, each result file is often wired as an env var whose value is the
+    path the step must write. For every name you pass, the value in ``os.environ``
+    must be non-empty. If any are missing or empty, a single error line is
+    printed to ``file`` and ``SystemExit(1)`` is raised, so the step can stop
+    before it tries to write to unknown locations.
+
+    Example names: ``"RESULT_RESULT"``, ``"RESULT_EMBARGOED_CVES"``.
+    """
+    if not env_var_names:
+        raise ValueError("at least one environment variable name is required")
+    out: list[Path] = []
+    missing: list[str] = []
+    for n in env_var_names:
+        v = os.environ.get(n)
+        if v is None or not str(v).strip():
+            missing.append(n)
+        else:
+            out.append(Path(v))
+    if missing:
+        label = _join_var_names(missing)
+        print(f"{label} must be set", file=file)
+        raise SystemExit(1)
+    return tuple(out)

--- a/scripts/python/helpers/test_authentication.py
+++ b/scripts/python/helpers/test_authentication.py
@@ -1,0 +1,134 @@
+"""Tests for the ``authentication`` helper module."""
+
+from __future__ import annotations
+
+import base64
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import authentication
+
+
+def test_read_mounted_text_strips_whitespace(tmp_path: Path) -> None:
+    """Stripped file contents are returned without surrounding whitespace."""
+    f = tmp_path / "f"
+    f.write_text("  a\nb  ", encoding="utf-8")
+    assert authentication.read_mounted_text(tmp_path, "f") == "a\nb"
+
+
+def test_load_keytab_from_mount_resolves_princ_and_keytab(tmp_path: Path) -> None:
+    """Principal and decoded keytab bytes come from the paths given by the keyword args."""
+    d = tmp_path
+    (d / "name").write_text("p@REALM", encoding="utf-8")
+    (d / "base64_keytab").write_text(
+        base64.b64encode(b"ktab").decode("ascii"), encoding="utf-8"
+    )
+    princ, raw = authentication.load_keytab_from_mount(
+        d, principal_file="name", keytab_b64_file="base64_keytab"
+    )
+    assert princ == "p@REALM" and raw == b"ktab"
+
+
+def test_load_keytab_from_mount_renamed_files(tmp_path: Path) -> None:
+    """
+    Any filenames passed as *principal_file* and *keytab_b64_file* are read
+    under the mount.
+    """
+    d = tmp_path
+    (d / "x").write_text("other", encoding="utf-8")
+    (d / "y").write_text(base64.b64encode(b"A").decode("ascii"), encoding="utf-8")
+    princ, raw = authentication.load_keytab_from_mount(
+        d, principal_file="x", keytab_b64_file="y"
+    )
+    assert princ == "other" and raw == b"A"
+
+
+def test_load_service_account_includes_text_files_in_dict(tmp_path: Path) -> None:
+    """*text_files* entries are the third return value, keyed by filename."""
+    d = tmp_path
+    (d / "name").write_text("u1", encoding="utf-8")
+    (d / "base64_keytab").write_text(base64.b64encode(b"ab").decode("ascii"), encoding="utf-8")
+    (d / "api_url").write_text("https://ex/a", encoding="utf-8")
+    n, raw, files = authentication.load_service_account(
+        d, ("api_url",), principal_file="name", keytab_b64_file="base64_keytab"
+    )
+    assert n == "u1" and raw == b"ab" and files == {"api_url": "https://ex/a"}
+
+
+def test_load_service_account_multiple_text_files(tmp_path: Path) -> None:
+    """*text_files* can name several strip-read files; values map by filename."""
+    d = tmp_path
+    (d / "name").write_text("p", encoding="utf-8")
+    (d / "base64_keytab").write_text(base64.b64encode(b"x").decode("ascii"), encoding="utf-8")
+    (d / "errata_api").write_text("https://errata/", encoding="utf-8")
+    (d / "other").write_text("o", encoding="utf-8")
+    _, _, files = authentication.load_service_account(
+        d, ("errata_api", "other"), principal_file="name", keytab_b64_file="base64_keytab"
+    )
+    assert files == {"errata_api": "https://errata/", "other": "o"}
+
+
+def test_patch_krb5_inserts_after_libdefaults() -> None:
+    """A line is inserted right after the ``[libdefaults]`` section header."""
+    src = "[libdefaults]\n# c\n[realms]\n"
+    out = authentication.patch_krb5_config(src)
+    assert "dns_canonicalize_hostname = false" in out
+    assert out.index("[libdefaults]") < out.index("dns_canonicalize_hostname")
+
+
+def test_kinit_succeeds_first_try(tmp_path: Path) -> None:
+    """A successful kinit is not retried; environment keys are passed through."""
+    kt = tmp_path / "t.kt"
+    kt.write_bytes(b"x")
+    cc = tmp_path / "cc"
+    cfg = tmp_path / "c.conf"
+    cc.write_text("x", encoding="utf-8")
+    cfg.write_text("x", encoding="utf-8")
+    calls: list = []
+
+    def _fake_run(
+        cmd: list[str] | str,
+        check: object,
+        env: dict,  # noqa: ARG001
+    ) -> object:  # type: ignore[no-untyped-def]
+        del check
+        calls.append((list(cmd) if isinstance(cmd, list) else [cmd], env.get("KRB5CCNAME")))
+        r = mock.MagicMock()
+        r.returncode = 0
+        return r
+
+    with mock.patch("authentication.subprocess.run", side_effect=_fake_run):
+        authentication.kinit_with_retry(
+            "p", kt, {"KRB5CCNAME": str(cc), "KRB5_CONFIG": str(cfg)}
+        )
+    assert len(calls) == 1
+    assert calls[0][0][0:4] == ["kinit", "p", "-k", "-t"]
+
+
+def test_kinit_fails_five_times(tmp_path: Path) -> None:
+    """After ``max_attempts`` failures, the last ``CalledProcessError`` is raised."""
+    kt = tmp_path / "t.kt"
+    kt.write_bytes(b"x")
+    cc = tmp_path / "cc"
+    cfg = tmp_path / "c.conf"
+    cc.write_text("x", encoding="utf-8")
+    cfg.write_text("x", encoding="utf-8")
+
+    def _fail(*args, **kwargs) -> object:  # type: ignore[no-untyped-def]
+        del args, kwargs
+        r = mock.MagicMock()
+        r.returncode = 1
+        return r
+
+    with (
+        mock.patch("authentication.subprocess.run", side_effect=_fail),
+        mock.patch("authentication.retry.time.sleep") as sleep_mock,
+    ):
+        with pytest.raises(subprocess.CalledProcessError):
+            authentication.kinit_with_retry(
+                "p", kt, {"KRB5CCNAME": str(cc), "KRB5_CONFIG": str(cfg)}
+            )
+    sleep_mock.assert_has_calls([mock.call(5), mock.call(10), mock.call(20), mock.call(40)])

--- a/scripts/python/helpers/test_file.py
+++ b/scripts/python/helpers/test_file.py
@@ -1,0 +1,64 @@
+"""Tests for the ``file`` helper module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import file
+import pytest
+
+
+def test_path_from_env_variable_uses_set_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-empty env value (after trim) is returned as a ``Path``."""
+    p = tmp_path / "m"
+    monkeypatch.setenv("MOUNT", str(p))
+    assert file.path_from_env_variable("MOUNT", "/d/e/f") == p
+
+
+def test_path_from_env_variable_strips_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Surrounding whitespace on the env value is removed before path construction."""
+    p = tmp_path / "m"
+    monkeypatch.setenv("MOUNT", f"  {p}  ")
+    assert file.path_from_env_variable("MOUNT", "/d") == p
+
+
+def test_path_from_env_variable_uses_default_when_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unset or all-whitespace *name* yields *default* (``Path`` or str)."""
+    default = str(tmp_path / "default")
+    monkeypatch.delenv("MOUNT", raising=False)
+    assert file.path_from_env_variable("MOUNT", default) == tmp_path / "default"
+    monkeypatch.setenv("MOUNT", "   ")
+    assert file.path_from_env_variable("MOUNT", default) == tmp_path / "default"
+
+
+def test_path_from_env_variable_path_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """*default* may be a ``Path`` object, returned unchanged when the env is unset."""
+    d = tmp_path / "d"
+    monkeypatch.delenv("MOUNTX", raising=False)
+    assert file.path_from_env_variable("MOUNTX", d) == d
+
+
+def test_make_tempfile_path_empty_file() -> None:
+    """A ``None`` payload leaves the created file with zero length."""
+    p = file.make_tempfile_path("t-", None)
+    try:
+        assert p.read_bytes() == b""
+    finally:
+        p.unlink(missing_ok=True)
+
+
+def test_make_tempfile_path_with_bytes() -> None:
+    """If ``data`` is set, the file on disk has exactly those bytes."""
+    p = file.make_tempfile_path("t-", b"hello")
+    try:
+        assert p.read_bytes() == b"hello"
+    finally:
+        p.unlink(missing_ok=True)

--- a/scripts/python/helpers/test_http_client.py
+++ b/scripts/python/helpers/test_http_client.py
@@ -1,0 +1,135 @@
+"""Tests for the ``http_client`` helper module."""
+
+from __future__ import annotations
+
+import unittest.mock as mock
+
+import pytest
+import requests
+from requests.adapters import HTTPAdapter
+
+import http_client
+
+
+def test_retries_policy_defaults() -> None:
+    """The shared retry config matches the module defaults."""
+    r = http_client._retries()
+    assert r.total == 3
+    assert r.connect == 3
+    assert r.read == 3
+    assert r.status == 2
+    assert r.backoff_factor == 0.4
+    assert r.raise_on_status is False
+    assert set(r.status_forcelist) == {500, 502, 503, 504}
+    assert set(r.allowed_methods) == {"GET"}
+
+
+def test_get_session_mounts_retry_adapter() -> None:
+    """`get_session` mounts an `HTTPAdapter` for both HTTP schemes."""
+    s = http_client.get_session()
+    https_adapter = s.adapters["https://"]
+    http_adapter = s.adapters["http://"]
+    assert isinstance(https_adapter, HTTPAdapter)
+    assert isinstance(http_adapter, HTTPAdapter)
+    assert https_adapter.max_retries.total == 3
+    assert http_adapter.max_retries.total == 3
+
+
+def test_get_text_uses_session_and_headers() -> None:
+    """``get_text`` passes *headers* through to ``get_session``’s ``.get`` call."""
+    session = mock.MagicMock()
+    r = mock.MagicMock()
+    r.status_code = 200
+    r.text = "body"
+    r.raise_for_status = mock.MagicMock()
+    session.get.return_value = r
+    with mock.patch("http_client.get_session", return_value=session):
+        out = http_client.get_text("https://e/x", headers={"A": "b", "C": "d"})
+
+    assert out == "body"
+    assert session.get.call_count == 1
+    cargs, ckw = session.get.call_args
+    assert cargs[0] == "https://e/x"
+    assert ckw["headers"] == {"A": "b", "C": "d"}
+    assert ckw["auth"] is None
+    r.raise_for_status.assert_not_called()
+
+
+def test_get_text_auth_passed() -> None:
+    """*auth* is passed through (e.g. for SPNEGO)."""
+    session = mock.MagicMock()
+    r = mock.MagicMock()
+    r.status_code = 200
+    r.text = "t"
+    session.get.return_value = r
+    ra = object()
+    with mock.patch("http_client.get_session", return_value=session):
+        assert http_client.get_text("https://u", auth=ra) == "t"
+    assert session.get.call_args[1]["auth"] is ra
+
+
+def test_get_text_http_error() -> None:
+    """A failed HTTP status raises ``requests.HTTPError`` (like ``curl --fail``)."""
+    session = mock.MagicMock()
+    r = mock.MagicMock()
+    r.status_code = 500
+    r.raise_for_status.side_effect = requests.HTTPError("nope", response=mock.MagicMock())
+    session.get.return_value = r
+    with mock.patch("http_client.get_session", return_value=session):
+        with pytest.raises(requests.HTTPError):
+            http_client.get_text("https://u/")
+
+
+def test_get_text_retries_429_then_succeeds() -> None:
+    """HTTP 429 is retried with backoff; a later 2xx response returns body text."""
+    session = mock.MagicMock()
+
+    r1 = mock.MagicMock()
+    r1.status_code = 429
+    r1.text = "rate-limited-1"
+    r1.raise_for_status.side_effect = requests.HTTPError("429", response=mock.MagicMock())
+    r2 = mock.MagicMock()
+    r2.status_code = 429
+    r2.text = "rate-limited-2"
+    r2.raise_for_status.side_effect = requests.HTTPError("429", response=mock.MagicMock())
+    r3 = mock.MagicMock()
+    r3.status_code = 200
+    r3.text = "ok"
+    r3.raise_for_status = mock.MagicMock()
+    session.get.side_effect = [r1, r2, r3]
+
+    with (
+        mock.patch("http_client.get_session", return_value=session),
+        mock.patch("http_client.random.randint", return_value=0),
+        mock.patch("http_client.time.sleep") as sleep_mock,
+    ):
+        assert http_client.get_text("https://u") == "ok"
+
+    assert session.get.call_count == 3
+    sleep_mock.assert_has_calls([mock.call(1), mock.call(2)])
+
+
+def test_get_text_retries_404_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTP 404 retries happen only when `CURL_WITH_RETRY_RETRY_404` is set."""
+    monkeypatch.setenv("CURL_WITH_RETRY_RETRY_404", "1")
+    session = mock.MagicMock()
+
+    r1 = mock.MagicMock()
+    r1.status_code = 404
+    r1.text = "not-found"
+    r1.raise_for_status.side_effect = requests.HTTPError("404", response=mock.MagicMock())
+    r2 = mock.MagicMock()
+    r2.status_code = 200
+    r2.text = "ok"
+    r2.raise_for_status = mock.MagicMock()
+    session.get.side_effect = [r1, r2]
+
+    with (
+        mock.patch("http_client.get_session", return_value=session),
+        mock.patch("http_client.random.randint", return_value=0),
+        mock.patch("http_client.time.sleep") as sleep_mock,
+    ):
+        assert http_client.get_text("https://u") == "ok"
+
+    assert session.get.call_count == 2
+    sleep_mock.assert_called_once_with(1)

--- a/scripts/python/helpers/test_osidb.py
+++ b/scripts/python/helpers/test_osidb.py
@@ -1,0 +1,43 @@
+"""Tests for the ``osidb`` helper module."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+import requests_kerberos
+
+import osidb
+
+
+def test_get_access_token_returns_access_string() -> None:
+    """
+    A JSON body with a non-empty string ``access`` is returned, and the token URL
+    is ``{base}/auth/token`` (trailing slash on the base is stripped before join).
+    """
+    with mock.patch("http_client.get_text", return_value='{"access": "tok-abc"}') as m:
+        out = osidb.get_access_token("https://osidb.example.com/")
+    assert out == "tok-abc"
+    m.assert_called_once()
+    cargs, ckwargs = m.call_args
+    assert cargs[0] == "https://osidb.example.com/auth/token"
+    assert "auth" in ckwargs
+    assert isinstance(ckwargs["auth"], requests_kerberos.HTTPKerberosAuth)
+
+
+def test_get_access_token_rejects_empty_body() -> None:
+    """A blank HTTP body raises with a message about the token request."""
+    with mock.patch("http_client.get_text", return_value=""):
+        with pytest.raises(ValueError) as e:
+            osidb.get_access_token("https://u")
+    assert e.value
+    assert "empty" in str(e.value) or "token" in str(e.value)
+
+
+@pytest.mark.parametrize("body", ['{"x": 1}', '{"access": ""}'])
+def test_get_access_token_rejects_invalid_access(body: str) -> None:
+    """``ValueError`` when JSON has no non-empty string ``access`` (missing or empty)."""
+    with mock.patch("http_client.get_text", return_value=body):
+        with pytest.raises(ValueError) as e:
+            osidb.get_access_token("https://u")
+    assert "access" in str(e.value) or e.value

--- a/scripts/python/helpers/test_retry.py
+++ b/scripts/python/helpers/test_retry.py
@@ -1,0 +1,70 @@
+"""Tests for the ``retry`` helper module."""
+
+from __future__ import annotations
+
+import pytest
+import retry
+
+
+def test_retry_with_exponential_backoff_succeeds_after_retries() -> None:
+    """Matching failures sleep with exponential delays until success."""
+    calls = {"n": 0}
+    sleeps: list[float] = []
+
+    def _op() -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ValueError("retry me")
+        return "ok"
+
+    out = retry.retry_with_exponential_backoff(
+        _op,
+        max_attempts=5,
+        retry_on=ValueError,
+        base_sleep_seconds=5,
+        sleep_fn=sleeps.append,
+    )
+    assert out == "ok"
+    assert calls["n"] == 3
+    assert sleeps == [5, 10]
+
+
+def test_retry_with_exponential_backoff_raises_after_last_attempt() -> None:
+    """When all attempts fail with a retryable error, the last error is raised."""
+    sleeps: list[float] = []
+
+    def _op() -> None:
+        raise ValueError("still failing")
+
+    with pytest.raises(ValueError, match="still failing"):
+        retry.retry_with_exponential_backoff(
+            _op,
+            max_attempts=3,
+            retry_on=ValueError,
+            base_sleep_seconds=5,
+            sleep_fn=sleeps.append,
+        )
+    assert sleeps == [5, 10]
+
+
+def test_retry_with_exponential_backoff_does_not_retry_other_exceptions() -> None:
+    """Exceptions outside ``retry_on`` are raised immediately without sleeping."""
+    sleeps: list[float] = []
+
+    def _op() -> None:
+        raise TypeError("no retry")
+
+    with pytest.raises(TypeError, match="no retry"):
+        retry.retry_with_exponential_backoff(
+            _op,
+            max_attempts=5,
+            retry_on=ValueError,
+            sleep_fn=sleeps.append,
+        )
+    assert sleeps == []
+
+
+def test_retry_with_exponential_backoff_rejects_zero_attempts() -> None:
+    """``max_attempts`` must be at least 1."""
+    with pytest.raises(ValueError, match=">= 1"):
+        retry.retry_with_exponential_backoff(lambda: None, max_attempts=0)

--- a/scripts/python/helpers/test_tekton.py
+++ b/scripts/python/helpers/test_tekton.py
@@ -1,0 +1,97 @@
+"""Tests for the ``tekton`` helper module."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+import tekton
+
+
+def test_check_step_error() -> None:
+    """``CheckStepError`` stores the human *action* and the underlying *cause*."""
+    inner = KeyError("k")
+    err = tekton.CheckStepError("step", inner)
+    assert err.action == "step" and err.cause is inner
+
+
+def test_result_text_from_exception_truncates() -> None:
+    """Long exception text is cut to *max_len* and ends with an ellipsis."""
+    e = KeyError("e" * 1000)
+    s = tekton.result_text_from_exception(e, max_len=40)
+    assert s.endswith("...")
+    assert len(s) == 40
+
+
+def test_result_text_for_check_step_error_includes_action_and_cause() -> None:
+    """Result text includes the user-facing *action* and the cause string."""
+    inner = ValueError("token request failed")
+    s = tekton.result_text_for_check_step_error(
+        "check_embargoed_cves.py",
+        tekton.CheckStepError("getting an OSIDB access token (HTTP request)", inner),
+    )
+    assert "OSIDB access token" in s
+    assert "token request failed" in s
+    assert "Failed while" in s
+
+
+def test_subprocess_cmd_preview_for_tekton_result() -> None:
+    """A list *cmd* is space-joined, then trimmed to *max_len* for result lines."""
+    long = "x" * 300
+    s = tekton.subprocess_cmd_preview_for_tekton_result(
+        ["kinit", "p@R", "-k", "-t", long], max_len=30
+    )
+    assert len(s) == 30
+    assert s.startswith("kinit p@R -k -t ")
+
+
+def test_subprocess_cmd_preview_for_string_cmd() -> None:
+    """A non-list command uses its plain string form before trimming."""
+    s = tekton.subprocess_cmd_preview_for_tekton_result("echo hi", max_len=20)
+    assert s == "echo hi"
+
+
+def test_result_paths_returns_in_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each set env var yields a ``Path`` in the same order as the arguments."""
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.write_text("x", encoding="utf-8")
+    b.write_text("y", encoding="utf-8")
+    monkeypatch.setenv("RESULT_RESULT", str(a))
+    monkeypatch.setenv("RESULT_EMBARGOED_CVES", str(b))
+    one, two = tekton.result_paths("RESULT_RESULT", "RESULT_EMBARGOED_CVES")
+    assert (one, two) == (a, b)
+
+
+def test_result_paths_missing_exits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset or empty env values print which names are missing and exit with code 1."""
+    p = tmp_path / "a"
+    p.write_text("x", encoding="utf-8")
+    buf = io.StringIO()
+    monkeypatch.setenv("A_ONLY", str(p))
+    with pytest.raises(SystemExit) as ex:
+        tekton.result_paths("A_ONLY", "B_MISSING", file=buf)
+    assert ex.value.code == 1
+    s = buf.getvalue()
+    assert "B_MISSING" in s
+    assert "must be set" in s
+
+
+def test_result_paths_three_missing_names_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Three missing names are joined in the error with an Oxford-comma style list."""
+    buf = io.StringIO()
+    for name in ("A", "B", "C"):
+        monkeypatch.delenv(name, raising=False)
+    with pytest.raises(SystemExit) as ex:
+        tekton.result_paths("A", "B", "C", file=buf)
+    assert ex.value.code == 1
+    assert buf.getvalue().strip() == "A, B, and C must be set"
+
+
+def test_result_paths_no_names() -> None:
+    """Calling ``result_paths`` with no var names is a programming error."""
+    with pytest.raises(ValueError, match="at least one"):
+        tekton.result_paths()

--- a/scripts/python/tasks/internal/check_embargoed_cves.py
+++ b/scripts/python/tasks/internal/check_embargoed_cves.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Check whether CVEs are embargoed using the OSIDB API.
+
+* Reads service account data from ``/mnt/osidb-service-account/`` (or
+  ``OSIDB_SERVICE_ACCOUNT_MOUNT``): ``name``, ``base64_keytab``, ``osidb_url``.
+* Authenticate with kinit (retried), then for each CVE obtain a token and GET
+  ``/osidb/api/v2/flaws`` with the requested fields.
+* Writes result paths from ``RESULT_RESULT`` and ``RESULT_EMBARGOED_CVES`` (set by
+  the runner, e.g. a Tekton task).
+* After a valid invocation with those env vars, always exits with status ``0``;
+  success or failure is in the result files, including a short message that names
+  the step that failed (e.g. ``kinit_with_retry``, ``get_access_token``) or that
+  listed CVEs are not clearly public in OSIDB. Bad or missing/empty
+  ``--cves`` exits before result handling (our checks use 1; argparse uses 2 for
+  malformed argv).
+
+``OSIDB_SERVICE_ACCOUNT_MOUNT`` can be overridden in tests to use a temp
+directory with the same file layout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Sequence
+
+import requests
+import urllib.parse
+
+import authentication
+import file
+import http_client
+import osidb
+import tekton
+
+PROG = "check_embargoed_cves.py"
+
+
+def parse_cve_list(value: str) -> list[str]:
+    """Split a string into non-empty CVE tokens on whitespace (strip first)."""
+    return [c for c in re.split(r"\s+", value.strip()) if c]
+
+
+def is_embargoed_flaw_response(data: dict[str, Any]) -> bool:
+    """
+    Return True if the first flaw in the list response is not clearly not embargoed.
+
+    Only ``results[0].embargoed`` with JSON value ``false`` is treated as
+    not embargoed. Empty ``results``, a missing first row, a non-dict first row,
+    a missing key, or ``null``/``true`` is treated as embargoed or not visible.
+    """
+    results = data.get("results")
+    if not isinstance(results, list) or not results:
+        return True
+    first = results[0]
+    if not isinstance(first, dict):
+        return True
+    em = first.get("embargoed", None)
+    if em is False:
+        return False
+    return True
+
+
+def _embargo_finding_result_text(program_name: str) -> str:
+    """
+    Text to write to ``RESULT_RESULT`` when the run finished without a Python
+    exception but the OSIDB API indicates at least one listed CVE is embargoed
+    or not clearly public.
+
+    CVE ids are written to ``RESULT_EMBARGOED_CVES``; this string in
+    ``RESULT_RESULT`` points readers there.
+    """
+    return (
+        f"{program_name}: check failed: at least one CVE is embargoed or not "
+        f"clearly public in OSIDB; see the embargoed_cves result for ids"
+    )
+
+
+def fetch_flaw_state(osidb_url: str, token: str, cve_id: str) -> dict[str, Any]:
+    """
+    GET the v2 flaw list for one CVE, asking only for ``cve_id`` and
+    ``embargoed`` fields, using the bearer token.
+
+    Returns a parsed JSON object, or an empty dict if the response body is
+    empty (treated as no visible flaw for embargo decisions).
+    """
+    q = urllib.parse.urlencode([("cve_id", cve_id), ("include_fields", "cve_id,embargoed")])
+    u = f"{osidb_url.rstrip('/')}/osidb/api/v2/flaws?{q}"
+    body = http_client.get_text(
+        u,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    if not body.strip():
+        return {}
+    return json.loads(body)
+
+
+def _usage_text() -> str:
+    """Return the short usage summary printed to stderr on bad CLI usage."""
+    return (
+        f"usage: {PROG} [--cves 'CVE-1 CVE-2']\n"
+        f"  --cves  The CVEs to check (space-separated, quote if you pass several)\n"
+    )
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """
+    Parse CLI arguments: ``--cves`` (required) and ``-h`` / ``--help``.
+
+    The Tekton task uses a fixed argv shape; this uses strict parsing (extra
+    arguments are rejected by ``argparse`` with exit 2). Help, or missing/blank
+    ``--cves``, print our usage to stderr and exit 1. Returns a namespace
+    with a ``cves`` string.
+    """
+    p = argparse.ArgumentParser(prog=PROG, add_help=False, usage=argparse.SUPPRESS)
+    p.add_argument("-h", "--help", action="store_true")
+    p.add_argument("--cves", metavar="CVES")
+    ns = p.parse_args(argv or [])
+    if ns.help:
+        print(_usage_text(), file=sys.stderr, end="")
+        raise SystemExit(1)
+    if not ns.cves or not str(ns.cves).strip():
+        print(_usage_text(), file=sys.stderr, end="")
+        raise SystemExit(1)
+    return ns
+
+
+def run_check(
+    cve_ids: Sequence[str],
+    mount: Path,
+    *,
+    kinit: Any = authentication.kinit_with_retry,
+    get_token: Any = osidb.get_access_token,
+    get_flaw: Any = fetch_flaw_state,
+    krb5_template: Path = Path("/etc/krb5.conf"),
+) -> tuple[list[str], int]:
+    """
+    Core check: kinit, then for each CVE fetch token + flaw JSON and test embargo.
+
+    Writes the keytab and a patched KRB5_CONFIG to temp files, runs ``kinit``,
+    then for each id obtains a token and queries flaws. Injected callables
+    (``kinit``, ``get_token``, ``get_flaw``) default to the real implementation
+    and are only replaced in tests.
+
+    Return value: ``(affected_cve_ids, 0 or 1)`` — the second is ``1`` if
+    at least one CVE is embargoed or not clearly public, and ``0`` if all
+    are clear. Raises ``ValueError`` if ``cve_ids`` is empty. On operational
+    failures, raises ``CheckStepError`` from the ``tekton`` helper, which
+    carries a short English *action* and the original exception.
+    """
+    if not cve_ids:
+        raise ValueError("no CVEs")
+    # Read principal, keytab, and base URL from the same layout as the Tekton secret mount.
+    try:
+        princ, keytab_bytes, text = authentication.load_service_account(
+            mount,
+            ("osidb_url",),
+            principal_file="name",
+            keytab_b64_file="base64_keytab",
+        )
+    except (OSError, ValueError) as e:
+        raise tekton.CheckStepError("reading the mounted OSIDB service account", e) from e
+    osidb_url = text["osidb_url"]
+
+    # Ephemeral keytab and credential cache: never leave secret material in fixed paths.
+    kpath = file.make_tempfile_path("keytab-", keytab_bytes)
+    cca_fd, cca_name = tempfile.mkstemp()
+    os.close(cca_fd)
+    ccache_path = Path(cca_name)
+
+    # krb5.conf: patch a temp copy (dns_canonicalize_hostname) so kinit works in the container.
+    try:
+        ksrc = krb5_template.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        raise tekton.CheckStepError("reading the Kerberos configuration", e) from e
+    kcfg = file.make_tempfile_path(
+        "krb5-", authentication.patch_krb5_config(ksrc).encode("utf-8")
+    )
+
+    try:
+        kenv = {
+            "KRB5CCNAME": str(ccache_path),
+            "KRB5_CONFIG": str(kcfg),
+        }
+        try:
+            kinit(princ, kpath, kenv, max_attempts=5)
+        except subprocess.CalledProcessError as e:
+            raise tekton.CheckStepError("logging in with Kerberos (kinit)", e) from e
+        # kinit’s env is only for the child; GSS/HTTP in this process needs
+        # the same ccache in ``os.environ``.
+        os.environ.update(kenv)
+
+        # Short-lived token per CVE, matching the shell task (avoids an expired
+        # token mid-loop).
+        found: list[str] = []
+        for cve in cve_ids:
+            print(f"Checking CVE {cve}", flush=True)
+            try:
+                tok = get_token(osidb_url)
+            except (OSError, requests.RequestException, ValueError) as e:
+                raise tekton.CheckStepError(
+                    "getting an OSIDB access token (HTTP request)", e
+                ) from e
+            try:
+                data = get_flaw(osidb_url, tok, cve)
+            except (
+                OSError,
+                requests.RequestException,
+                TypeError,
+                json.JSONDecodeError,
+                ValueError,
+            ) as e:
+                raise tekton.CheckStepError(
+                    "querying the OSIDB flaws API (HTTP request)", e
+                ) from e
+            if is_embargoed_flaw_response(data):
+                print(f"CVE {cve} is embargoed", flush=True)
+                found.append(cve)
+
+        # Return code 0/1 is logical outcome only; main() maps it to the Tekton result files.
+        return (found, 0 if not found else 1)
+    finally:
+        # kpath, ccache, kcfg: remove all temp files even when kinit or a later step raises.
+        for p in (kpath, ccache_path, kcfg):
+            p.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """
+    CLI entry: bad args return 1; a normal run writes result files and returns 0.
+
+    Normal runs (with ``RESULT_RESULT`` and ``RESULT_EMBARGOED_CVES``) always
+    exit 0 at the process level; logical success is ``Success`` in the first
+    result, logical failure is an error-line style message and optional CVE
+    list in the second. If required result env vars are missing, the process
+    raises ``SystemExit`` with code 1.
+    """
+    a = sys.argv[1:] if argv is None else argv[1:]
+    try:
+        args = parse_args(a)
+    except SystemExit as e:
+        # argparse / parse_args use exit(1) for help or bad input; that path
+        # cannot write results.
+        code = e.code
+        if isinstance(code, int):
+            return code
+        return 1
+    cve_list = parse_cve_list(args.cves)
+    if not cve_list:
+        return 1
+
+    rpath, epath = tekton.result_paths("RESULT_RESULT", "RESULT_EMBARGOED_CVES")
+    # Clear both files up front: if run_check throws, the embargoed list
+    # stays empty and we still fill result.
+    epath.write_text("", encoding="utf-8")
+    # Use argv[0] base name in messages (how users see the process in task
+    # logs, not __file__).
+    name = str(Path((argv or sys.argv)[0]).name)
+    mount = file.path_from_env_variable(
+        "OSIDB_SERVICE_ACCOUNT_MOUNT", "/mnt/osidb-service-account"
+    )
+    problem: list[str] = []
+    out_rc: int = 0
+    step_err: tekton.CheckStepError | None = None
+    try:
+        problem, out_rc = run_check(cve_list, mount=mount)
+    except tekton.CheckStepError as e:
+        # CheckStepError carries a plain-English action plus the cause.
+        out_rc, problem = 1, []
+        step_err = e
+    except Exception as e:
+        # Any bug or unexpected error still produces a result line; never drop
+        # Tekton with no "result" body.
+        out_rc, problem = 1, []
+        step_err = tekton.CheckStepError("running the check", e)
+
+    epath.write_text("".join(f"{c} " for c in problem), encoding="utf-8")
+    if not out_rc:
+        rpath.write_text("Success", encoding="utf-8")
+    elif problem:
+        # The API ran, but at least one CVE is not clearly public; not a step exception.
+        rpath.write_text(_embargo_finding_result_text(name), encoding="utf-8")
+    elif step_err is not None:
+        # Exception on the way: which step and the original error; process
+        # still exits 0 below.
+        rpath.write_text(
+            tekton.result_text_for_check_step_error(name, step_err), encoding="utf-8"
+        )
+    # Task step must exit 0 or Tekton may not publish results; the catalog documents this.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/internal/test_check_embargoed_cves.py
+++ b/scripts/python/tasks/internal/test_check_embargoed_cves.py
@@ -1,0 +1,445 @@
+"""Tests for ``check_embargoed_cves``."""
+
+from __future__ import annotations
+
+import base64
+import runpy
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import check_embargoed_cves
+import file
+import pytest
+import tekton
+
+
+def _write_service_account(
+    d: Path, *, name: str = "myname", keytab: bytes = b"kb", url: str = "myurl"
+) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "name").write_text(name, encoding="utf-8")
+    (d / "base64_keytab").write_text(
+        base64.b64encode(keytab).decode("ascii"), encoding="utf-8"
+    )
+    (d / "osidb_url").write_text(url, encoding="utf-8")
+
+
+def _minimal_krb5(path: Path) -> Path:
+    path.write_text(
+        "# t\n[libdefaults]\n    default_realm = FOO\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _no_kinit(
+    *args: object,
+    **kwargs: object,
+) -> None:
+    del args, kwargs
+
+
+def _setup_tekton_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mount: Path
+) -> tuple[Path, Path]:
+    rpath = tmp_path / "r"
+    epath = tmp_path / "e"
+    monkeypatch.setenv("RESULT_RESULT", str(rpath))
+    monkeypatch.setenv("RESULT_EMBARGOED_CVES", str(epath))
+    monkeypatch.setenv("OSIDB_SERVICE_ACCOUNT_MOUNT", str(mount))
+    return rpath, epath
+
+
+def _is_expected_embargo_outcome(s: str) -> bool:
+    return "embargoed" in s or "not clearly public" in s
+
+
+def test_parse_cve_list() -> None:
+    """Whitespace around tokens is stripped; multiple CVEs split on whitespace."""
+    assert check_embargoed_cves.parse_cve_list("  CVE-1  CVE-2  ") == ["CVE-1", "CVE-2"]
+
+
+@pytest.mark.parametrize(
+    ("payload", "exp"),
+    [
+        ({}, True),
+        ({"results": []}, True),
+        ({"results": None}, True),
+        ({"results": ["not-a-dict"]}, True),
+        ({"results": [{}]}, True),
+        ({"results": [{"embargoed": None}]}, True),
+        ({"results": [{"embargoed": True}]}, True),
+        ({"results": [{"embargoed": False}]}, False),
+    ],
+)
+def test_is_embargoed_flaw_response(payload: dict, exp: bool) -> None:
+    """Only ``results[0].embargoed == false`` means not embargoed; all other shapes do."""
+    assert check_embargoed_cves.is_embargoed_flaw_response(payload) is exp
+
+
+def test_fetch_flaw_state_empty_bodies() -> None:
+    """An empty body from the flaws request is an empty result dict."""
+    with mock.patch("http_client.get_text", return_value="") as m:
+        d = check_embargoed_cves.fetch_flaw_state("https://u", "t", "CVE-1")
+        m.assert_called()
+    assert d == {}
+
+
+def test_fetch_flaw_state_parses_json_body() -> None:
+    """A non-empty flaws body is parsed with `json.loads` and returned as a dict."""
+    body = '{"results": [{"cve_id": "CVE-1", "embargoed": false}]}'
+    with mock.patch("http_client.get_text", return_value=body):
+        out = check_embargoed_cves.fetch_flaw_state("https://u", "tok", "CVE-1")
+    assert out == {"results": [{"cve_id": "CVE-1", "embargoed": False}]}
+
+
+def test_parse_args_help() -> None:
+    """``-h`` / ``--help`` prints usage to stderr and exits with code 1."""
+    with pytest.raises(SystemExit) as e:
+        check_embargoed_cves.parse_args(["-h"])
+    assert e.value.code == 1
+
+
+def test_parse_args_missing_cves() -> None:
+    """Missing or blank ``--cves`` prints usage and exits with code 1."""
+    with pytest.raises(SystemExit) as e:
+        check_embargoed_cves.parse_args(["--cves", "  "])
+    assert e.value.code == 1
+
+
+def test_parse_args_rejects_trailing_junk() -> None:
+    """argparse fails extra argv tokens (e.g. stray positionals) with exit 2."""
+    with pytest.raises(SystemExit) as e:
+        check_embargoed_cves.parse_args(["--cves", "CVE-1", "extra"])
+    assert e.value.code == 2
+
+
+def test_parse_args_ok() -> None:
+    """Valid ``--cves`` yields a namespace with the raw string (including for multi-CVE)."""
+    a = check_embargoed_cves.parse_args(["--cves", "CVE-1"])
+    assert a.cves == "CVE-1"
+
+
+def test_main_passes_service_account_mount_resolved_by_environ(
+    sa_mount: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    The mount directory passed to ``run_check`` is
+    ``path_from_env_variable("OSIDB_SERVICE_ACCOUNT_MOUNT", ...)`` (set vs default).
+    """
+    _setup_tekton_env(tmp_path, monkeypatch, sa_mount)
+    seen: list[Path] = []
+
+    def _fake_run_check(_cve: list[str], mount: Path, **_k: object) -> tuple[list[str], int]:
+        seen.append(mount)
+        return ([], 0)
+
+    with mock.patch.object(check_embargoed_cves, "run_check", side_effect=_fake_run_check):
+        check_embargoed_cves.main(["check_embargoed_cves.py", "--cves", "CVE-1"])
+    assert seen[0] == sa_mount
+    assert seen[0] == file.path_from_env_variable(
+        "OSIDB_SERVICE_ACCOUNT_MOUNT", "/mnt/osidb-service-account"
+    )
+    seen.clear()
+    monkeypatch.delenv("OSIDB_SERVICE_ACCOUNT_MOUNT", raising=False)
+    with mock.patch.object(check_embargoed_cves, "run_check", side_effect=_fake_run_check):
+        check_embargoed_cves.main(["check_embargoed_cves.py", "--cves", "CVE-1"])
+    assert seen[0] == Path("/mnt/osidb-service-account")
+    assert seen[0] == file.path_from_env_variable(
+        "OSIDB_SERVICE_ACCOUNT_MOUNT", "/mnt/osidb-service-account"
+    )
+
+
+@pytest.fixture
+def sa_mount(tmp_path: Path) -> Path:
+    p = tmp_path / "m"
+    _write_service_account(p)
+    return p
+
+
+def test_run_check_all_flaws_not_embargoed(sa_mount: Path, tmp_path: Path) -> None:
+    """When every flaw response shows not embargoed, the affected list is empty and rc is 0."""
+    krb5 = _minimal_krb5(tmp_path / "k5.conf")
+
+    def gtok(_: str) -> str:
+        return "dummy-token"
+
+    def gflav(_u: str, _t: str, _c: str) -> dict:  # noqa: ARG001
+        return {"results": [{"embargoed": False}]}
+
+    p, r = check_embargoed_cves.run_check(
+        ["CVE-123", "CVE-456"],
+        sa_mount,
+        kinit=_no_kinit,
+        get_token=gtok,
+        get_flaw=gflav,
+        krb5_template=krb5,
+    )
+    assert p == [] and r == 0
+
+
+def test_run_check_rejects_empty_cve_list(sa_mount: Path) -> None:
+    """`run_check` with no CVE ids raises `ValueError` before any API or kinit work."""
+    with pytest.raises(ValueError, match="no CVEs"):
+        check_embargoed_cves.run_check([], sa_mount)
+
+
+def test_run_check_wraps_service_account_read_errors(tmp_path: Path) -> None:
+    """Errors while reading the mounted service account are wrapped as `CheckStepError`."""
+    with pytest.raises(tekton.CheckStepError) as e:
+        check_embargoed_cves.run_check(["CVE-1"], tmp_path / "missing-mount")
+    assert "reading the mounted OSIDB service account" in str(e.value)
+
+
+def test_run_check_wraps_krb5_read_errors(sa_mount: Path, tmp_path: Path) -> None:
+    """If the Kerberos template cannot be read, `run_check` raises `CheckStepError`."""
+    with pytest.raises(tekton.CheckStepError) as e:
+        check_embargoed_cves.run_check(
+            ["CVE-1"],
+            sa_mount,
+            kinit=_no_kinit,
+            get_token=lambda _: "dummy-token",
+            get_flaw=lambda _u, _t, _c: {"results": [{"embargoed": False}]},
+            krb5_template=tmp_path / "missing-krb5.conf",
+        )
+    assert "reading the Kerberos configuration" in str(e.value)
+
+
+def test_run_check_wraps_kinit_called_process_error(sa_mount: Path, tmp_path: Path) -> None:
+    """`CalledProcessError` from the injected `kinit` is wrapped with a kinit action."""
+    krb5 = _minimal_krb5(tmp_path / "k5.conf")
+
+    def _kfail(*_a: object, **_k: object) -> None:
+        raise subprocess.CalledProcessError(1, "kinit")
+
+    with pytest.raises(tekton.CheckStepError) as e:
+        check_embargoed_cves.run_check(
+            ["CVE-1"],
+            sa_mount,
+            kinit=_kfail,
+            get_token=lambda _: "dummy-token",
+            get_flaw=lambda _u, _t, _c: {"results": [{"embargoed": False}]},
+            krb5_template=krb5,
+        )
+    assert "logging in with Kerberos (kinit)" in str(e.value)
+
+
+def test_run_check_wraps_get_token_errors(sa_mount: Path, tmp_path: Path) -> None:
+    """Token acquisition failures are wrapped as a `CheckStepError` with token context."""
+    krb5 = _minimal_krb5(tmp_path / "k5.conf")
+
+    def _gtok_fail(_u: str) -> str:
+        raise ValueError("bad token response")
+
+    with pytest.raises(tekton.CheckStepError) as e:
+        check_embargoed_cves.run_check(
+            ["CVE-1"],
+            sa_mount,
+            kinit=_no_kinit,
+            get_token=_gtok_fail,
+            get_flaw=lambda _u, _t, _c: {"results": [{"embargoed": False}]},
+            krb5_template=krb5,
+        )
+    assert "getting an OSIDB access token" in str(e.value)
+
+
+def test_run_check_wraps_get_flaw_errors(sa_mount: Path, tmp_path: Path) -> None:
+    """Flaw API parse/request failures are wrapped as a `CheckStepError`."""
+    krb5 = _minimal_krb5(tmp_path / "k5.conf")
+
+    def _gflaw_fail(_u: str, _t: str, _c: str) -> dict:
+        raise ValueError("malformed flaws json")
+
+    with pytest.raises(tekton.CheckStepError) as e:
+        check_embargoed_cves.run_check(
+            ["CVE-1"],
+            sa_mount,
+            kinit=_no_kinit,
+            get_token=lambda _: "dummy-token",
+            get_flaw=_gflaw_fail,
+            krb5_template=krb5,
+        )
+    assert "querying the OSIDB flaws API" in str(e.value)
+
+
+def test_run_check_empty_body_treated_as_embargoed(sa_mount: Path, tmp_path: Path) -> None:
+    """An empty flaws dict has no clear ``embargoed: false``; CVE is reported."""
+    krb5 = _minimal_krb5(tmp_path / "k5.conf")
+
+    def gtok(_: str) -> str:
+        return "dummy-token"
+
+    def gflav(_u: str, _t: str, cve: str) -> dict:  # noqa: ARG001
+        if cve == "CVE-noaccess":
+            return {}
+        return {"results": [{"embargoed": False}]}
+
+    p, r = check_embargoed_cves.run_check(
+        ["CVE-noaccess"],
+        sa_mount,
+        kinit=_no_kinit,
+        get_token=gtok,
+        get_flaw=gflav,
+        krb5_template=krb5,
+    )
+    assert p == ["CVE-noaccess"] and r == 1
+
+
+def test_run_check_mixed_list_reports_embargoed_cve(sa_mount: Path, tmp_path: Path) -> None:
+    """Only CVEs with embargoed (or not clearly public) flaw data are returned."""
+    krb5 = _minimal_krb5(tmp_path / "k5.conf")
+
+    def gtok(_: str) -> str:
+        return "dummy-token"
+
+    def gflav(_u: str, _t: str, cve: str) -> dict:  # noqa: ARG001
+        if cve == "CVE-embargo":
+            return {"results": [{"embargoed": True}]}
+        return {"results": [{"embargoed": False}]}
+
+    p, r = check_embargoed_cves.run_check(
+        ["CVE-123", "CVE-embargo"],
+        sa_mount,
+        kinit=_no_kinit,
+        get_token=gtok,
+        get_flaw=gflav,
+        krb5_template=krb5,
+    )
+    assert p == ["CVE-embargo"] and r == 1
+
+
+def test_main_all_clear(
+    sa_mount: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    ``Success`` in ``RESULT_RESULT`` and an empty embargo list when
+    ``run_check`` finds no issues.
+    """
+    rpath, epath = _setup_tekton_env(tmp_path, monkeypatch, sa_mount)
+    with mock.patch.object(
+        check_embargoed_cves,
+        "run_check",
+        return_value=([], 0),
+    ) as run_mock:
+        out = check_embargoed_cves.main(
+            ["check_embargoed_cves.py", "--cves", "CVE-123 CVE-456"]
+        )
+    run_mock.assert_called()
+    assert out == 0
+    assert rpath.read_text() == "Success"
+    assert epath.read_text() == ""
+
+
+def test_main_cve_treated_inaccessible(
+    sa_mount: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With affected CVEs from ``run_check``, the main result file gets the embargo summary."""
+    rpath, epath = _setup_tekton_env(tmp_path, monkeypatch, sa_mount)
+    with mock.patch.object(
+        check_embargoed_cves,
+        "run_check",
+        return_value=(["CVE-noaccess"], 1),
+    ):
+        out = check_embargoed_cves.main(["check_embargoed_cves.py", "--cves", "CVE-noaccess"])
+    assert out == 0
+    assert _is_expected_embargo_outcome(rpath.read_text())
+    assert epath.read_text() == "CVE-noaccess "
+
+
+def test_main_mixed_cves_one_reported_embargoed(
+    sa_mount: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Single affected id is written to the embargo result, summary in the
+    other.
+    """
+    rpath, epath = _setup_tekton_env(tmp_path, monkeypatch, sa_mount)
+    with mock.patch.object(
+        check_embargoed_cves,
+        "run_check",
+        return_value=(["CVE-embargo"], 1),
+    ):
+        out = check_embargoed_cves.main(
+            ["check_embargoed_cves.py", "--cves", "CVE-123 CVE-embargo"]
+        )
+    assert out == 0
+    assert _is_expected_embargo_outcome(rpath.read_text())
+    assert epath.read_text() == "CVE-embargo "
+
+
+def test_main_kinit_failure_writes_subprocess_error(
+    sa_mount: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``CheckStepError`` from ``run_check`` becomes a formatted one-line result message."""
+    rpath, epath = _setup_tekton_env(tmp_path, monkeypatch, sa_mount)
+    e = subprocess.CalledProcessError(1, "kinit")
+    with mock.patch.object(
+        check_embargoed_cves,
+        "run_check",
+        side_effect=tekton.CheckStepError("logging in with Kerberos (kinit)", e),
+    ):
+        out = check_embargoed_cves.main(["c", "--cves", "CVE-1"])
+    assert out == 0
+    t = rpath.read_text()
+    assert "logging in with Kerberos" in t
+    assert "kinit" in t.lower()
+    assert "Failed while" in t
+    assert t.startswith("c:")  # program basename from argv[0]
+    assert epath.read_text() == ""
+
+
+def test_main_arg_parse_returns_one() -> None:
+    """
+    ``main`` returns the same exit code as ``parse_args``/argparse (1 for
+    help, missing ``--cves``).
+    """
+    assert check_embargoed_cves.main(["p"]) == 1
+    assert check_embargoed_cves.main(["p", "-h"]) == 1
+
+
+def test_main_parse_args_non_int_exit_code_returns_one() -> None:
+    """A non-int `SystemExit.code` from parsing maps to return code 1 in `main`."""
+    with mock.patch.object(check_embargoed_cves, "parse_args", side_effect=SystemExit("x")):
+        assert check_embargoed_cves.main(["p", "--cves", "CVE-1"]) == 1
+
+
+def test_main_returns_one_when_cve_list_is_empty_after_parsing() -> None:
+    """An empty parsed CVE list returns 1 before touching Tekton result paths."""
+    ns = mock.MagicMock(cves="   ")
+    with mock.patch.object(check_embargoed_cves, "parse_args", return_value=ns):
+        assert check_embargoed_cves.main(["p", "--cves", "ignored"]) == 1
+
+
+def test_main_missing_tekton_env() -> None:
+    """Without ``RESULT_*`` env vars, ``result_paths`` raises ``SystemExit(1)``."""
+    with mock.patch.object(
+        check_embargoed_cves, "parse_args", return_value=mock.MagicMock(cves="CVE-1")
+    ):
+        with pytest.raises(SystemExit) as e:
+            check_embargoed_cves.main(["p", "--cves", "CVE-1"])
+    assert e.value.code == 1
+
+
+def test_main_wraps_unexpected_exceptions_in_running_check_action(
+    sa_mount: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unexpected exceptions from `run_check` are wrapped as `running the check`."""
+    rpath, epath = _setup_tekton_env(tmp_path, monkeypatch, sa_mount)
+    with mock.patch.object(
+        check_embargoed_cves, "run_check", side_effect=RuntimeError("boom")
+    ):
+        out = check_embargoed_cves.main(["check_embargoed_cves.py", "--cves", "CVE-1"])
+    assert out == 0
+    text = rpath.read_text()
+    assert "running the check" in text
+    assert "boom" in text
+    assert epath.read_text() == ""
+
+
+def test_module_main_guard_raises_system_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Executing the file as `__main__` triggers the bottom `raise SystemExit(main())`."""
+    monkeypatch.setattr("sys.argv", ["check_embargoed_cves.py"])
+    with pytest.raises(SystemExit) as e:
+        runpy.run_path(str(Path(check_embargoed_cves.__file__)), run_name="__main__")
+    assert e.value.code == 1


### PR DESCRIPTION
This commit refactors the check-embargoed-cves bash script into python. It also adds some helper modules that other tasks will use as they are converted.

Assisted-By: Cursor