### PR TITLE
fix(RELEASE-2367): make push-disk-image pipeline idempotent

### DIFF
--- a/developer-portal-wrapper/developer_portal_wrapper.py
+++ b/developer-portal-wrapper/developer_portal_wrapper.py
@@ -1,20 +1,16 @@
 #!/usr/bin/env python3
-"""
-Run push-cgw-metadata command to push metadata to CGW:
-1. Extract all components under contentGateway key from dataPath
-2. Find all the files in contentDir that starts with the component name
-4. Generate necessary metadata for each file
-5. Dump the metadata to a YAML file
-6. Run push-cgw-metadata to push the metadata
-"""
+"""Publish content to CGW using idempotent create/update behavior."""
 
 import os
 import sys
 import yaml
 import hashlib
-import subprocess
 import argparse
 import logging
+
+import requests
+from requests.auth import HTTPBasicAuth
+from utils import cgw_idempotency
 
 LOG = logging.getLogger("developer-portal-wrapper")
 DEFAULT_LOG_FMT = "%(asctime)s [%(levelname)-8s] %(message)s"
@@ -26,7 +22,6 @@ CGW_ENV_VARS_STRICT = (
 
 WORKSPACE_DIR = "/tmp"
 METADATA_FILE_PATH = f"{WORKSPACE_DIR}/cgw_metadata.yaml"
-RESULT_FILE_JSON_PATH = f"{WORKSPACE_DIR}/results.json"
 
 os.makedirs(WORKSPACE_DIR, exist_ok=True)
 
@@ -53,44 +48,40 @@ def generate_metadata(
     content_list that starts with the component name
     """
     metadata = []
-
     short_url_prefix = f"/cgw/{product_code}/{product_version_name}"
-    for file in content_list:
-        matching_component = file.startswith(file_prefix)
 
-        if matching_component:
-            LOG.info("processing file: %s", file)
-            component_item = {
-                "productName": product_name,
-                "productCode": product_code,
-                "productVersionName": product_version_name,
-                "downloadURL": generate_download_url(content_dir, file),
+    for order, file in enumerate(content_list, start=1):
+        if not file.startswith(file_prefix):
+            LOG.warning(
+                "Skipping file: %s as it does not start with the expected prefix", file
+            )
+            continue
+
+        LOG.info("Processing file: %s", file)
+        metadata.append(
+            {
                 "shortURL": f"{short_url_prefix}/{file}",
+                "downloadURL": generate_download_url(content_dir, file),
                 "label": file,
                 "type": "FILE",
                 "hidden": False,
                 "invisible": False,
+                "order": order,
             }
-            metadata.append(
-                {
-                    "type": "file",
-                    "action": "create",
-                    "metadata": component_item,
-                }
-            )
-        else:
-            LOG.warning(f"Skipping file: {file} as it does not start with any component name")
+        )
 
     return metadata
 
 
 def validate_env_vars():
+    """Assert that all required CGW environment variables are set."""
     assert all(
         [os.getenv(item) for item in CGW_ENV_VARS_STRICT]
     ), f"Provide all required CGW environment variables: {', '.join(CGW_ENV_VARS_STRICT)}"
 
 
 def parse_args():
+    """Parse and return command line arguments."""
     parser = argparse.ArgumentParser(
         prog="developer_portal_wrapper",
         description="Add binaries to Developer Portal.",
@@ -122,7 +113,10 @@ def parse_args():
     )
     parser.add_argument(
         "--cgw-hostname",
-        help="Content Gateway Hostname in Developer Portal",
+        help=(
+            "Content Gateway base URL in Developer Portal, "
+            "for example: https://developers.qa.redhat.com/content-gateway/rest/admin"
+        ),
         required=True,
     )
     parser.add_argument(
@@ -139,7 +133,73 @@ def parse_args():
     return parser.parse_args()
 
 
+def publish_metadata(
+    *,
+    cgw_hostname,
+    product_name,
+    product_code,
+    product_version_name,
+    metadata,
+    dry_run=False,
+):
+    """Idempotently publish file metadata to the Content Gateway.
+
+    Looks up the product and version by name, then creates, updates, or skips
+    each file entry depending on whether it already exists with matching content.
+    In dry-run mode no API calls are made; placeholder IDs are used instead.
+    """
+    username = os.getenv("CGW_USERNAME")
+    password = os.getenv("CGW_PASSWORD")
+
+    session = requests.Session()
+    session.auth = HTTPBasicAuth(username, password)
+    session.headers.update(
+        {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+    )
+
+    if dry_run:
+        product_id = 999999
+        product_version_id = 999999
+        created_ids = [999999 for _ in metadata]
+        updated_ids = []
+        skipped_ids = []
+    else:
+        product_id = cgw_idempotency.get_product_id(
+            host=cgw_hostname,
+            session=session,
+            product_name=product_name,
+            product_code=product_code,
+        )
+        product_version_id = cgw_idempotency.get_version_id(
+            host=cgw_hostname,
+            session=session,
+            product_id=product_id,
+            version_name=product_version_name,
+        )
+        for item in metadata:
+            item["productVersionId"] = product_version_id
+
+        created_ids, updated_ids, skipped_ids = cgw_idempotency.create_files(
+            host=cgw_hostname,
+            session=session,
+            product_id=product_id,
+            version_id=product_version_id,
+            metadata=metadata,
+        )
+
+    LOG.info(
+        "CGW publish summary: created=%s updated=%s skipped=%s",
+        len(created_ids),
+        len(updated_ids),
+        len(skipped_ids),
+    )
+
+
 def main():
+    """Entry point: parse arguments, generate metadata, and publish to CGW."""
     args = parse_args()
 
     loglevel = logging.DEBUG if args.debug else logging.INFO
@@ -181,27 +241,34 @@ def main():
         yaml.dump(metadata, file, default_flow_style=False, sort_keys=False)
 
     LOG.info(f"YAML content dumped to {METADATA_FILE_PATH}")
-    cgw_username = os.getenv("CGW_USERNAME")
-    main_command = "push-cgw-metadata"
-    common_args = [
-        "--CGW_filepath",
-        METADATA_FILE_PATH,
-        "--CGW_hostname",
-        cgw_hostname,
-    ]
-    cred_args = ["--CGW_username", cgw_username]
-    command = [main_command] + common_args
-    cmd_str = " ".join(command)
-    command += cred_args
-
     if args.dry_run:
-        LOG.info("Would have run: %s", cmd_str)
+        LOG.info(
+            "Would idempotently publish %s file(s) to CGW host %s for product %s/%s",
+            len(metadata),
+            cgw_hostname,
+            product_code,
+            product_version_name,
+        )
+        publish_metadata(
+            cgw_hostname=cgw_hostname,
+            product_name=product_name,
+            product_code=product_code,
+            product_version_name=product_version_name,
+            metadata=metadata,
+            dry_run=True,
+        )
     else:
         try:
-            LOG.info("Running %s", cmd_str)
-            subprocess.run(command, check=True)
-        except subprocess.CalledProcessError:
-            LOG.exception("Command %s failed, check exception for details", cmd_str)
+            LOG.info("Publishing metadata to CGW using idempotent API flow")
+            publish_metadata(
+                cgw_hostname=cgw_hostname,
+                product_name=product_name,
+                product_code=product_code,
+                product_version_name=product_version_name,
+                metadata=metadata,
+            )
+        except RuntimeError:
+            LOG.exception("CGW publish failed")
             raise
         except Exception as exc:
             LOG.exception("Unknown error occurred")

--- a/developer-portal-wrapper/test_developer_portal_wrapper.py
+++ b/developer-portal-wrapper/test_developer_portal_wrapper.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 import tempfile
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -62,9 +62,79 @@ def test_dry_run(caplog, mock_gw_env_vars):
             assert "This is a dry-run!" in caplog.messages
             assert "2 files will be published to CGW" in caplog.messages
             assert (
-                "Would have run: push-cgw-metadata "
-                "--CGW_filepath /tmp/cgw_metadata.yaml "
-                "--CGW_hostname localhost"
+                "Would idempotently publish 2 file(s) to CGW host "
+                "localhost for product 2/TEST NAME"
             ) in caplog.messages
+            assert "CGW publish summary: created=2 updated=0 skipped=0" in caplog.messages
+
+    temp_dir.cleanup()
+
+
+@patch("developer_portal_wrapper.cgw_idempotency.create_files")
+@patch("developer_portal_wrapper.cgw_idempotency.get_version_id")
+@patch("developer_portal_wrapper.cgw_idempotency.get_product_id")
+def test_disk_image_style_publish_is_idempotent(
+    mock_get_product, mock_get_version, mock_create_files, mock_gw_env_vars
+):
+    """Validate disk-image style flow uses idempotent CGW publish."""
+    mock_get_product.return_value = 101
+    mock_get_version.return_value = 202
+    mock_create_files.return_value = ([1001], [1002], [1003])
+
+    temp_dir = tempfile.TemporaryDirectory()
+    matching_files = [
+        "amd-1.3-x86_64-kvm.qcow2",
+        "amd-1.3-x86_64-boot.iso.gz",
+    ]
+    non_matching_files = ["sha256sum.txt", "sha256sum.txt.sig", "notes.txt"]
+
+    for file_name in matching_files + non_matching_files:
+        with open(f"{temp_dir.name}/{file_name}", "w") as file:
+            file.write("dummy content")
+
+    args = [
+        "",
+        "--product-name",
+        "Disk Image for Linux",
+        "--product-code",
+        "DISK",
+        "--product-version-name",
+        "1.3-staging",
+        "--cgw-hostname",
+        "https://content-gateway.example.com",
+        "--content-directory",
+        temp_dir.name,
+        "--file-prefix",
+        "amd-1.3",
+    ]
+
+    with patch.object(sys, "argv", args):
+        developer_portal_wrapper.main()
+
+    mock_get_product.assert_called_once_with(
+        host="https://content-gateway.example.com",
+        session=ANY,
+        product_name="Disk Image for Linux",
+        product_code="DISK",
+    )
+    mock_get_version.assert_called_once_with(
+        host="https://content-gateway.example.com",
+        session=ANY,
+        product_id=101,
+        version_name="1.3-staging",
+    )
+
+    create_kwargs = mock_create_files.call_args.kwargs
+    assert create_kwargs["host"] == "https://content-gateway.example.com"
+    assert create_kwargs["product_id"] == 101
+    assert create_kwargs["version_id"] == 202
+
+    metadata = create_kwargs["metadata"]
+    labels = {item["label"] for item in metadata}
+    assert labels == set(matching_files)
+    for item in metadata:
+        assert item["productVersionId"] == 202
+        assert item["shortURL"].startswith("/cgw/DISK/1.3-staging/")
+        assert "/content/origin/files/sha256/" in item["downloadURL"]
 
     temp_dir.cleanup()

--- a/publish-to-cgw-wrapper/publish_to_cgw_wrapper.py
+++ b/publish-to-cgw-wrapper/publish_to_cgw_wrapper.py
@@ -27,6 +27,7 @@ import hashlib
 import logging
 import requests
 from requests.auth import HTTPBasicAuth
+from utils import cgw_idempotency
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
@@ -118,50 +119,6 @@ def validate_components(data):
         f"{len(components) - len(valid_components)} skipped components"
     )
     return valid_components
-
-
-def call_cgw_api(*, host, method, endpoint, session, data=None):
-    """Make an API call to the Content Gateway service."""
-    try:
-        response = session.request(
-            method=method.upper(),
-            url=f"{host}{endpoint}",
-            json=data,
-        )
-
-        if not response.ok:
-            error_message = (
-                response.text.strip() or f"HTTP {response.status_code}:{response.reason}"
-            )
-            raise RuntimeError(f"API call failed: {error_message}")
-
-        return response
-    except requests.RequestException as e:
-        raise RuntimeError(f"API call failed: {e}")
-
-
-def get_product_id(*, host, session, product_name, product_code):
-    """Retrieve the product ID by name and product code."""
-    products = call_cgw_api(host=host, method="GET", endpoint="/products", session=session)
-    products = products.json()
-    for product in products:
-        if product.get("name") == product_name and product.get("productCode") == product_code:
-            logging.info(f"Found product: {product_name} with ID {product.get('id')}")
-            return product.get("id")
-    raise ValueError(f"Product {product_name} not found with product code {product_code}")
-
-
-def get_version_id(*, host, session, product_id, version_name):
-    """Retrieve the version ID for a specific product."""
-    versions = call_cgw_api(
-        host=host, method="GET", endpoint=f"/products/{product_id}/versions", session=session
-    )
-    versions = versions.json()
-    for version in versions:
-        if version.get("versionName") == version_name:
-            logging.info(f"Found version: {version_name} with ID {version.get('id')}")
-            return version.get("id")
-    raise ValueError(f"Version not found: {version_name}")
 
 
 def generate_download_url(content_dir, file_name):
@@ -259,118 +216,6 @@ def generate_metadata(
     return metadata
 
 
-def find_existing_file(existing_files, new_file):
-    """Find a file with matching shortURL, regardless of downloadURL"""
-    for file in existing_files:
-        if file.get("shortURL") == new_file.get("shortURL"):
-            return file
-    return None
-
-
-def update_file(*, host, session, product_id, version_id, file_id, file_metadata):
-    """Update an existing file using POST with ID in body"""
-    # Add the file ID to the metadata for update
-    update_data = {**file_metadata, "id": file_id}
-
-    response = call_cgw_api(
-        host=host,
-        method="POST",
-        endpoint=f"/products/{product_id}/versions/{version_id}/files",
-        session=session,
-        data=update_data,
-    )
-    return response
-
-
-def rollback_files(*, host, session, product_id, version_id, created_file_ids):
-    """Rollback created files by listing and deleting them."""
-    if created_file_ids:
-        logging.warning(
-            f"Rolling back created files due to failure "
-            f"(productId: {product_id}, productVersionId: {version_id})"
-        )
-
-    for file_id in created_file_ids:
-        try:
-            call_cgw_api(
-                host=host,
-                method="DELETE",
-                endpoint=f"/products/{product_id}/versions/{version_id}/files/{file_id}",
-                session=session,
-            )
-        except Exception as e:
-            raise RuntimeError(f"Failed to rollback file: {e}")
-
-
-def create_files(*, host, session, product_id, version_id, metadata):
-    """Create files using the metadata created and rollback on failure."""
-    created_file_ids = []
-    updated_file_ids = []
-    skipped_files_ids = []
-    try:
-        existing_files = call_cgw_api(
-            host=host,
-            method="GET",
-            endpoint=f"/products/{product_id}/versions/{version_id}/files",
-            session=session,
-        )
-        existing_files = existing_files.json()
-
-        for file_metadata in metadata:
-            existing_file = find_existing_file(existing_files, file_metadata)
-
-            if existing_file:
-                # Check if downloadURL is different (needs update)
-                if existing_file.get("downloadURL") != file_metadata.get("downloadURL"):
-                    logging.info(
-                        f"Updating file: {file_metadata['label']} "
-                        f"(ID: {existing_file['id']}) with new downloadURL"
-                    )
-                    update_file(
-                        host=host,
-                        session=session,
-                        product_id=product_id,
-                        version_id=version_id,
-                        file_id=existing_file["id"],
-                        file_metadata=file_metadata,
-                    )
-                    updated_file_ids.append(existing_file["id"])
-                    logging.info(f"Successfully updated file ID: {existing_file['id']}")
-                else:
-                    # File exists with same downloadURL - skip
-                    skipped_files_ids.append(existing_file.get("id"))
-                    logging.info(
-                        f"Skipping: File {existing_file['label']} already exists "
-                        f"with same content (ID: {existing_file['id']})"
-                    )
-            else:
-                # File doesn't exist - create new
-                logging.info(
-                    f"Creating file: {file_metadata['label']} "
-                    f"with ShortURL {file_metadata['shortURL']}"
-                )
-                created_file_id = call_cgw_api(
-                    host=host,
-                    method="POST",
-                    endpoint=f"/products/{product_id}/versions/{version_id}/files",
-                    session=session,
-                    data=file_metadata,
-                )
-                created_file_id = created_file_id.json()
-                logging.info(f"Successfully created file with ID: {created_file_id}")
-                created_file_ids.append(created_file_id)
-        return created_file_ids, updated_file_ids, skipped_files_ids
-    except Exception as e:
-        rollback_files(
-            host=host,
-            session=session,
-            product_id=product_id,
-            version_id=version_id,
-            created_file_ids=created_file_ids,
-        )
-        raise RuntimeError(f"Failed to create file: {e}")
-
-
 def process_component(*, host, session, component, dry_run=False, component_index):
     """
     Process a component retrieve product/version ID,
@@ -389,14 +234,14 @@ def process_component(*, host, session, component, dry_run=False, component_inde
         product_id = 999999
         product_version_id = 999999
     else:
-        product_id = get_product_id(
+        product_id = cgw_idempotency.get_product_id(
             host=host,
             session=session,
             product_name=productName,
             product_code=productCode,
         )
 
-        product_version_id = get_version_id(
+        product_version_id = cgw_idempotency.get_version_id(
             host=host,
             session=session,
             product_id=product_id,
@@ -419,7 +264,7 @@ def process_component(*, host, session, component, dry_run=False, component_inde
         updated = []
         skipped = []
     else:
-        created, updated, skipped = create_files(
+        created, updated, skipped = cgw_idempotency.create_files(
             host=host,
             session=session,
             product_id=product_id,
@@ -501,7 +346,7 @@ def main():
                 if all_results:
                     logging.warning("Rolling back all created files due to error.")
                     for result in all_results:
-                        rollback_files(
+                        cgw_idempotency.rollback_files(
                             host=args.cgw_host,
                             session=session,
                             product_id=result["product_id"],

--- a/publish-to-cgw-wrapper/test_publish_to_cgw_integration.py
+++ b/publish-to-cgw-wrapper/test_publish_to_cgw_integration.py
@@ -153,7 +153,7 @@ def metadata():
     ]
 
 
-@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
 @patch.dict(os.environ, {"CGW_USERNAME": "username", "CGW_PASSWORD": "password"})
 @patch("sys.argv", new_callable=lambda: ["publish_to_cgw_wrapper.py"])
 def test_main_creates_files(
@@ -214,7 +214,7 @@ def test_main_creates_files(
     assert results_json[1]["no_of_files_skipped"] == 0
 
 
-@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
 @patch.dict(os.environ, {"CGW_USERNAME": "user", "CGW_PASSWORD": "password"})
 @patch("sys.argv", new_callable=lambda: ["publish_to_cgw_wrapper.py"])
 def test_main_skips_3_creates_2(mock_sys_argv, mock_call, data_json, metadata):
@@ -273,7 +273,7 @@ def test_main_skips_3_creates_2(mock_sys_argv, mock_call, data_json, metadata):
     assert results_json[1]["no_of_files_skipped"] == 0
 
 
-@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
 @patch.dict(os.environ, {"CGW_USERNAME": "user", "CGW_PASSWORD": "password"})
 @patch("sys.argv", new_callable=lambda: ["publish_to_cgw_wrapper.py"])
 def test_main_partial_skip_fail_rollback(mock_sys_argv, mock_call, data_json):

--- a/publish-to-cgw-wrapper/test_publish_to_cgw_wrapper.py
+++ b/publish-to-cgw-wrapper/test_publish_to_cgw_wrapper.py
@@ -2,7 +2,7 @@ import hashlib
 import pytest
 import requests
 import json
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import ANY, MagicMock, call, patch
 import publish_to_cgw_wrapper as cgw_wrapper
 
 
@@ -274,7 +274,7 @@ def test_call_cgw_api_success(mock_request, session):
     mock_response.json.return_value = {"result": "success"}
     mock_request.return_value = mock_response
 
-    response = cgw_wrapper.call_cgw_api(
+    response = cgw_wrapper.cgw_idempotency.call_cgw_api(
         host="https://cgw.com/cgw/rest/admin",
         method="GET",
         endpoint="/endpoint",
@@ -294,7 +294,7 @@ def test_call_cgw_api_failure(mock_request, session):
     mock_response.text = "Unauthorized"
     mock_request.return_value = mock_response
     with pytest.raises(RuntimeError, match="API call failed: Unauthorized"):
-        cgw_wrapper.call_cgw_api(
+        cgw_wrapper.cgw_idempotency.call_cgw_api(
             host="https://cgw.com/cgw/rest/admin",
             method="GET",
             endpoint="/endpoint",
@@ -307,7 +307,7 @@ def test_call_cgw_api_exception(mock_request, session):
     """Test API call failure when an exception is raised."""
     mock_request.side_effect = requests.exceptions.RequestException("Connection error")
     with pytest.raises(RuntimeError, match="API call failed: Connection error"):
-        cgw_wrapper.call_cgw_api(
+        cgw_wrapper.cgw_idempotency.call_cgw_api(
             host="https://cgw.com/cgw/rest/admin",
             method="GET",
             endpoint="/endpoint",
@@ -315,14 +315,14 @@ def test_call_cgw_api_exception(mock_request, session):
         )
 
 
-@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
 def test_get_product_id(mock_call):
     """Test getting product ID."""
     mock_call.return_value.json.return_value = [
         {"name": "product_name_1", "productCode": "code1", "id": 5468},
         {"name": "product_name_2", "productCode": "code2", "id": 6789},
     ]
-    product_id = cgw_wrapper.get_product_id(
+    product_id = cgw_wrapper.cgw_idempotency.get_product_id(
         host="https://cgw.com/cgw/rest/admin",
         session=None,
         product_name="product_name_1",
@@ -334,7 +334,7 @@ def test_get_product_id(mock_call):
     assert product_id == 5468
 
 
-@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
 def test_get_product_id_not_found(mock_call):
     """Test getting product ID when product is not found."""
     mock_call.return_value.json.return_value = [
@@ -344,7 +344,7 @@ def test_get_product_id_not_found(mock_call):
     with pytest.raises(
         ValueError, match="Product product_name_3 not found with product code code3"
     ):
-        cgw_wrapper.get_product_id(
+        cgw_wrapper.cgw_idempotency.get_product_id(
             host="https://cgw.com/cgw/rest/admin",
             session=None,
             product_name="product_name_3",
@@ -355,14 +355,14 @@ def test_get_product_id_not_found(mock_call):
     )
 
 
-@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
 def test_get_version_id(mock_call):
     """Test getting version ID."""
     mock_call.return_value.json.return_value = [
         {"id": 4156067, "versionName": "1.1"},
         {"id": 4156068, "versionName": "1.2"},
     ]
-    version_id = cgw_wrapper.get_version_id(
+    version_id = cgw_wrapper.cgw_idempotency.get_version_id(
         host="https://cgw.com/cgw/rest/admin",
         session=None,
         product_id="4010426",
@@ -377,7 +377,7 @@ def test_get_version_id(mock_call):
     assert version_id == 4156068
 
 
-@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
 def test_get_version_id_not_found(mock_call):
     """Test getting version ID when version is not found."""
     mock_call.return_value.json.return_value = [
@@ -385,7 +385,7 @@ def test_get_version_id_not_found(mock_call):
         {"id": 4156068, "versionName": "1.2"},
     ]
     with pytest.raises(ValueError, match="Version not found: 1.3"):
-        cgw_wrapper.get_version_id(
+        cgw_wrapper.cgw_idempotency.get_version_id(
             host="https://cgw.com/cgw/rest/admin",
             session=None,
             product_id="4010426",
@@ -519,7 +519,7 @@ def test_generate_metadata_multi_component_ordering(data_json):
 def test_file_already_exists(metadata):
     """Test checking if a file already exists."""
     new_file = metadata[0]
-    assert cgw_wrapper.find_existing_file(metadata, new_file) is metadata[0]
+    assert cgw_wrapper.cgw_idempotency.find_existing_file(metadata, new_file) is metadata[0]
 
 
 def test_file_does_not_exist(metadata):
@@ -528,13 +528,38 @@ def test_file_does_not_exist(metadata):
     new_file["label"] = "nonexistent-file.gz"
     new_file["shortURL"] = "/pub/cgw/product_name_1/1.2/nonexistent-file.gz"
     new_file["downloadURL"] = "/content/origin/files/sha256/0d/somehash/nonexistent-file.gz"
-    assert cgw_wrapper.find_existing_file(metadata, new_file) is None
+    assert cgw_wrapper.cgw_idempotency.find_existing_file(metadata, new_file) is None
 
 
-@patch("publish_to_cgw_wrapper.call_cgw_api")
+def test_find_existing_file_matches_timestamped_shorturl():
+    existing_files = [
+        {
+            "id": 111,
+            "shortURL": (
+                "/cgw/RelengTestProduct/1.8.5/"
+                "releng-test-product-1.7-1777488203-x86_64-boot.iso.gz"
+            ),
+            "downloadURL": "/content/origin/files/sha256/aa/old/old.iso.gz",
+        }
+    ]
+    new_file = {
+        "shortURL": (
+            "/cgw/RelengTestProduct/1.8.5/"
+            "releng-test-product-1.7-1777494747-x86_64-boot.iso.gz"
+        ),
+        "downloadURL": "/content/origin/files/sha256/bb/new/new.iso.gz",
+    }
+
+    assert (
+        cgw_wrapper.cgw_idempotency.find_existing_file(existing_files, new_file)
+        == existing_files[0]
+    )
+
+
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
 def test_rollback_files(mock_call):
     """Test rolling back created files."""
-    response = cgw_wrapper.rollback_files(
+    response = cgw_wrapper.cgw_idempotency.rollback_files(
         host="https://cgw.com/cgw/rest/admin",
         session=None,
         product_id="101",
@@ -561,13 +586,13 @@ def test_rollback_files(mock_call):
     assert response is None
 
 
-@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
 def test_rollback_files_exception(mock_call):
     """Test rolling back created files when an exception is raised."""
     mock_call.side_effect = [None, RuntimeError("File can not be deleted")]
 
     with pytest.raises(RuntimeError, match="File can not be deleted"):
-        cgw_wrapper.rollback_files(
+        cgw_wrapper.cgw_idempotency.rollback_files(
             host="https://cgw.com/cgw/rest/admin",
             session=None,
             product_id="101",
@@ -593,7 +618,7 @@ def test_rollback_files_exception(mock_call):
     assert mock_call.call_count == 2
 
 
-@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
 def test_create_files_success(mock_call, metadata):
     """Test successful file creation with no existing files."""
     mock_call.side_effect = [
@@ -603,7 +628,7 @@ def test_create_files_success(mock_call, metadata):
     ]
     metadata = metadata[:2]
 
-    created, updated, skipped = cgw_wrapper.create_files(
+    created, updated, skipped = cgw_wrapper.cgw_idempotency.create_files(
         host="https://cgw.com/cgw/rest/admin",
         session=None,
         product_id="101",
@@ -642,7 +667,7 @@ def test_create_files_success(mock_call, metadata):
     assert skipped == []
 
 
-@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
 def test_create_files_with_existing(mock_call, metadata):
     """Test file creation when some files already exist."""
     existing_files = [
@@ -658,7 +683,7 @@ def test_create_files_with_existing(mock_call, metadata):
         MagicMock(json=lambda: 4571),  # cosign-darwin-amd64.gz (created)
     ]
 
-    created, updated, skipped = cgw_wrapper.create_files(
+    created, updated, skipped = cgw_wrapper.cgw_idempotency.create_files(
         host="https://cgw.com/cgw/rest/admin",
         session=None,
         product_id="101",
@@ -710,7 +735,7 @@ def test_create_files_with_existing(mock_call, metadata):
     assert skipped == [4566, 4567]
 
 
-@patch("publish_to_cgw_wrapper.call_cgw_api")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
 def test_create_files_exception(mock_call, metadata):
     """Test file creation when an exception is raised and check rollback is successful."""
     mock_call.side_effect = [
@@ -721,7 +746,7 @@ def test_create_files_exception(mock_call, metadata):
     ]
 
     with pytest.raises(RuntimeError, match="File can not be created"):
-        cgw_wrapper.create_files(
+        cgw_wrapper.cgw_idempotency.create_files(
             host="https://cgw.com/cgw/rest/admin",
             session=None,
             product_id="101",
@@ -762,10 +787,88 @@ def test_create_files_exception(mock_call, metadata):
     assert mock_call.call_count == 4
 
 
-@patch("publish_to_cgw_wrapper.create_files")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.call_cgw_api")
+def test_create_files_removes_duplicate_timestamped_entries_and_updates(mock_call):
+    existing_files = [
+        {
+            "id": 1001,
+            "shortURL": (
+                "/cgw/RelengTestProduct/1.8.5/"
+                "releng-test-product-1.7-1777488203-x86_64-boot.iso.gz"
+            ),
+            "downloadURL": "/content/origin/files/sha256/aa/old.iso.gz",
+            "label": "releng-test-product-1.7-1777488203-x86_64-boot.iso.gz",
+        },
+        {
+            "id": 1002,
+            "shortURL": (
+                "/cgw/RelengTestProduct/1.8.5/"
+                "releng-test-product-1.7-1777493915-x86_64-boot.iso.gz"
+            ),
+            "downloadURL": "/content/origin/files/sha256/aa/older.iso.gz",
+            "label": "releng-test-product-1.7-1777493915-x86_64-boot.iso.gz",
+        },
+    ]
+    new_metadata = [
+        {
+            "shortURL": (
+                "/cgw/RelengTestProduct/1.8.5/"
+                "releng-test-product-1.7-1777494747-x86_64-boot.iso.gz"
+            ),
+            "downloadURL": "/content/origin/files/sha256/bb/new.iso.gz",
+            "label": "releng-test-product-1.7-1777494747-x86_64-boot.iso.gz",
+            "productVersionId": 4156460,
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "order": 1,
+        }
+    ]
+    mock_call.side_effect = [
+        MagicMock(json=lambda: existing_files),
+        MagicMock(),  # delete duplicate id 1002
+        MagicMock(json=lambda: {"id": 1001}),  # update existing id 1001
+    ]
+
+    created, updated, skipped = cgw_wrapper.cgw_idempotency.create_files(
+        host="https://cgw.com/cgw/rest/admin",
+        session=None,
+        product_id="101",
+        version_id="201",
+        metadata=new_metadata,
+    )
+
+    expected_calls = [
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="GET",
+            endpoint="/products/101/versions/201/files",
+            session=None,
+        ),
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="DELETE",
+            endpoint="/products/101/versions/201/files/1002",
+            session=None,
+        ),
+        call(
+            host="https://cgw.com/cgw/rest/admin",
+            method="POST",
+            endpoint="/products/101/versions/201/files",
+            session=None,
+            data={**new_metadata[0], "id": 1001},
+        ),
+    ]
+    mock_call.assert_has_calls(expected_calls, any_order=False)
+    assert created == []
+    assert updated == [1001]
+    assert skipped == []
+
+
+@patch("publish_to_cgw_wrapper.cgw_idempotency.create_files")
 @patch("publish_to_cgw_wrapper.generate_metadata")
-@patch("publish_to_cgw_wrapper.get_version_id")
-@patch("publish_to_cgw_wrapper.get_product_id")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.get_version_id")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.get_product_id")
 def test_process_component_success(
     mock_get_product,
     mock_get_version,
@@ -831,3 +934,80 @@ def test_process_component_success(
     assert result["no_of_files_updated"] == 2
     assert result["no_of_files_skipped"] == 2
     assert result["metadata"] == metadata
+
+
+@patch("publish_to_cgw_wrapper.cgw_idempotency.create_files")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.get_version_id")
+@patch("publish_to_cgw_wrapper.cgw_idempotency.get_product_id")
+def test_push_artifacts_style_main_with_files_array_uses_idempotent_flow(
+    mock_get_product, mock_get_version, mock_create_files, tmp_path
+):
+    """Validate push-artifacts style flow preserves create/update/skip behavior."""
+    mock_get_product.return_value = 1234
+    mock_get_version.return_value = 5678
+    mock_create_files.return_value = ([1], [2], [3])
+
+    content_dir = tmp_path / "content"
+    content_dir.mkdir()
+    for name in [
+        "releng-test-product-iso-amd64.tar.gz",
+        "releng-test-product-qcow2-amd64.tar.gz",
+        "sha256sum.txt",
+        "sha256sum.txt.sig",
+        "sha256sum.txt.gpg",
+    ]:
+        (content_dir / name).write_text("dummy")
+
+    data_json = {
+        "components": [
+            {
+                "name": "releng-test-product-binaries",
+                "files": [
+                    {"source": "/releases/releng-test-product-iso-amd64.tar.gz"},
+                    {"source": "/releases/releng-test-product-qcow2-amd64.tar.gz"},
+                ],
+                "contentGateway": {
+                    "productName": "Releng Test Product",
+                    "productCode": "RelengTestProduct",
+                    "productVersionName": "1.8.5",
+                    "mirrorOpenshiftPush": True,
+                    "contentDir": str(content_dir),
+                },
+            }
+        ]
+    }
+
+    argv = [
+        "publish_to_cgw_wrapper.py",
+        "--cgw_host",
+        "https://content-gateway.example.com",
+        "--data_json",
+        json.dumps(data_json),
+    ]
+
+    with patch.dict("os.environ", {"CGW_USERNAME": "user", "CGW_PASSWORD": "token"}):
+        with patch("sys.argv", argv):
+            results = cgw_wrapper.main()
+
+    assert len(results) == 1
+    assert results[0]["no_of_files_created"] == 1
+    assert results[0]["no_of_files_updated"] == 1
+    assert results[0]["no_of_files_skipped"] == 1
+
+    mock_get_product.assert_called_once_with(
+        host="https://content-gateway.example.com",
+        session=ANY,
+        product_name="Releng Test Product",
+        product_code="RelengTestProduct",
+    )
+    mock_get_version.assert_called_once_with(
+        host="https://content-gateway.example.com",
+        session=ANY,
+        product_id=1234,
+        version_name="1.8.5",
+    )
+    create_kwargs = mock_create_files.call_args.kwargs
+    assert create_kwargs["host"] == "https://content-gateway.example.com"
+    assert create_kwargs["product_id"] == 1234
+    assert create_kwargs["version_id"] == 5678
+    assert len(create_kwargs["metadata"]) >= 2

--- a/pubtools-pulp-wrapper/pulp_push_wrapper.py
+++ b/pubtools-pulp-wrapper/pulp_push_wrapper.py
@@ -28,16 +28,23 @@ UD cache flush credentials:
 """
 
 import argparse
+import json
 import logging
 import os
 import re
+import ssl
 import subprocess
 import sys
+import time
+from urllib import parse, request
 
 LOG = logging.getLogger("pubtools-pulp-wrapper")
 DEFAULT_LOG_FMT = "%(asctime)s [%(levelname)-8s] %(message)s"
 DEFAULT_DATE_FMT = "%Y-%m-%d %H:%M:%S %z"
 COMMAND = "pubtools-pulp-push"
+TIMESTAMP_TOKEN_RE = re.compile(r"^\d{8,14}$")
+POLL_INTERVAL_SECONDS = 2
+POLL_TIMEOUT_SECONDS = 120
 EXODUS_ENV_VARS_STRICT = (
     "EXODUS_PULP_HOOK_ENABLED",
     "EXODUS_GW_CERT",
@@ -104,6 +111,15 @@ def parse_args():
         default="",
     )
 
+    publish = parser.add_argument_group("Publish options")
+    publish.add_argument(
+        "--no-clean",
+        action="store_true",
+        help="Disable cleaning remote content not in the staged source. By default, "
+        "remote content not present in the current push will be removed.",
+        default=False,
+    )
+
     return parser.parse_args()
 
 
@@ -113,6 +129,184 @@ def get_source_url(stagedirs):
             raise ValueError("Not a valid staging directory: %s" % item)
 
     return f"staged:{','.join(stagedirs)}"
+
+
+def get_source_dirs(source_url):
+    if not source_url.startswith("staged:"):
+        return []
+    return [item for item in source_url.removeprefix("staged:").split(",") if item]
+
+
+def normalize_timestamped_name(filename):
+    tokens = filename.split("-")
+    for idx, token in enumerate(tokens):
+        # Remove a timestamp-like token between stable filename parts.
+        if TIMESTAMP_TOKEN_RE.match(token) and 0 < idx < (len(tokens) - 1):
+            return "-".join(tokens[:idx] + tokens[idx + 1 :])
+    return filename
+
+
+def build_timestamp_search_patterns(filename):
+    tokens = filename.split("-")
+    patterns = set()
+
+    # Always match the exact filename variant being pushed.
+    patterns.add(f"^{re.escape(filename)}$")
+
+    has_timestamp = any(TIMESTAMP_TOKEN_RE.match(token) for token in tokens)
+    if has_timestamp:
+        # Match other timestamp variants in the same filename position.
+        pattern_tokens = [
+            r"\d{8,14}" if TIMESTAMP_TOKEN_RE.match(token) else re.escape(token)
+            for token in tokens
+        ]
+        patterns.add("^" + "-".join(pattern_tokens) + "$")
+
+        # Also match the equivalent non-timestamped name if present.
+        normalized = normalize_timestamped_name(filename)
+        patterns.add(f"^{re.escape(normalized)}$")
+
+    return sorted(patterns)
+
+
+def build_repo_file_map(stagedirs):
+    repo_to_files = {}
+    for stagedir in stagedirs:
+        if not os.path.isdir(stagedir):
+            LOG.warning("Skipping non-directory staged source: %s", stagedir)
+            continue
+        for repo_name in os.listdir(stagedir):
+            files_dir = os.path.join(stagedir, repo_name, "FILES")
+            if not os.path.isdir(files_dir):
+                continue
+            files = {
+                filename
+                for filename in os.listdir(files_dir)
+                if os.path.isfile(os.path.join(files_dir, filename))
+            }
+            if not files:
+                continue
+            repo_to_files.setdefault(repo_name, set()).update(files)
+    return repo_to_files
+
+
+def make_ssl_context(cert_file=None, key_file=None):
+    ctx = ssl.create_default_context()
+    if cert_file and key_file:
+        ctx.load_cert_chain(certfile=cert_file, keyfile=key_file)
+    elif cert_file:
+        ctx.load_cert_chain(certfile=cert_file)
+    return ctx
+
+
+def pulp_request(url, context, payload=None):
+    data = None
+    headers = {}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = request.Request(url, data=data, headers=headers)
+    with request.urlopen(req, context=context) as response:
+        body = response.read()
+    if not body:
+        return None
+    return json.loads(body.decode("utf-8"))
+
+
+def wait_for_task(task_href, context):
+    task_url = task_href
+    deadline = time.time() + POLL_TIMEOUT_SECONDS
+    while time.time() < deadline:
+        task = pulp_request(task_url, context=context)
+        if task is None:
+            raise RuntimeError(f"Empty response while polling Pulp task status: {task_url}")
+        state = task.get("state")
+        if state == "finished":
+            if task.get("error") or task.get("exception") or task.get("traceback"):
+                raise RuntimeError(f"Pulp task failed: {task_url}: {task}")
+            return
+        if state == "skipped":
+            return
+        if state in ("error", "canceled"):
+            raise RuntimeError(f"Pulp task {state}: {task_url}: {task}")
+        time.sleep(POLL_INTERVAL_SECONDS)
+    raise TimeoutError(f"Timed out waiting for Pulp task: {task_url}")
+
+
+def prune_matching_content_before_push(parsed):
+    if parsed.no_clean:
+        return
+
+    stagedirs = get_source_dirs(parsed.source)
+    repo_to_files = build_repo_file_map(stagedirs)
+    if not repo_to_files:
+        LOG.info("No staged FILES content found for pre-push cleanup.")
+        return
+
+    if not parsed.pulp_cert:
+        LOG.warning("Skipping pre-push cleanup: --pulp-cert is required for mTLS Pulp calls.")
+        return
+
+    pulp_base = parsed.pulp_url.rstrip("/")
+    context = make_ssl_context(cert_file=parsed.pulp_cert, key_file=parsed.pulp_key)
+
+    for repo_name, files in sorted(repo_to_files.items()):
+        matched_existing = set()
+        repo_path = parse.quote(repo_name, safe="")
+        search_url = f"{pulp_base}/pulp/api/v2/repositories/{repo_path}/search/units/"
+
+        for file_name in sorted(files):
+            for pattern in build_timestamp_search_patterns(file_name):
+                payload = {
+                    "criteria": {
+                        "filters": {
+                            "unit": {
+                                "name": {
+                                    "$regex": pattern,
+                                }
+                            }
+                        }
+                    },
+                    "include_repos": True,
+                }
+                response = pulp_request(search_url, context=context, payload=payload) or []
+                for unit in response:
+                    name = unit.get("metadata", {}).get("name")
+                    if name:
+                        matched_existing.add(name)
+
+        # Remove all matched units first so re-push is deterministic.
+        names_to_remove = sorted(matched_existing)
+        if not names_to_remove:
+            LOG.info("No existing matching units to remove in repo %s.", repo_name)
+            continue
+
+        LOG.info(
+            "Removing %d existing matching unit(s) from repo %s before re-push.",
+            len(names_to_remove),
+            repo_name,
+        )
+        unassociate_url = (
+            f"{pulp_base}/pulp/api/v2/repositories/{repo_path}/actions/unassociate/"
+        )
+        unassociate_payload = {
+            "criteria": {
+                "filters": {
+                    "unit": {
+                        "name": {
+                            "$in": names_to_remove,
+                        }
+                    }
+                }
+            }
+        }
+        response = (
+            pulp_request(unassociate_url, context=context, payload=unassociate_payload) or {}
+        )
+        for task in response.get("spawned_tasks", []):
+            href = task.get("_href")
+            if href:
+                wait_for_task(parse.urljoin(pulp_base, href), context=context)
 
 
 def settings_to_args(parsed):
@@ -132,6 +326,9 @@ def settings_to_args(parsed):
 
     for _ in range(parsed.debug):
         out.append("--debug")
+
+    if not parsed.no_clean:
+        out.append("--clean")
 
     return out
 
@@ -180,6 +377,7 @@ def main():
         LOG.info("Would have run: %s", cmd_str)
     else:
         try:
+            prune_matching_content_before_push(args)
             LOG.info("Running %s", cmd_str)
             subprocess.run(command, check=True)
         except subprocess.CalledProcessError:

--- a/pubtools-pulp-wrapper/test_pulp_push_wrapper.py
+++ b/pubtools-pulp-wrapper/test_pulp_push_wrapper.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -43,7 +43,7 @@ def test_dry_run(caplog, mock_gw_env_vars):
             assert "This is a dry-run!" in caplog.messages
             assert (
                 "Would have run: pubtools-pulp-push --pulp-url https://pulp-test.dev"
-                " --source staged:/test/1,/test/2"
+                " --source staged:/test/1,/test/2 --clean"
             ) in caplog.messages
 
 
@@ -65,7 +65,7 @@ def test_basic_command(mock_run, caplog, mock_gw_env_vars):
             assert "This is a dry-run!" not in caplog.messages
             assert (
                 "Running pubtools-pulp-push --pulp-url https://pulp-test.dev"
-                " --source staged:/test/1,/test/2"
+                " --source staged:/test/1,/test/2 --clean"
             ) in caplog.messages
 
     mock_run.assert_called_once_with(
@@ -75,6 +75,269 @@ def test_basic_command(mock_run, caplog, mock_gw_env_vars):
             "https://pulp-test.dev",
             "--source",
             "staged:/test/1,/test/2",
+            "--clean",
         ],
         check=True,
     )
+
+
+@patch("subprocess.run")
+def test_no_clean_flag(mock_run, caplog, mock_gw_env_vars):
+    args = [
+        "",
+        "--source",
+        "/test/1",
+        "--pulp-url",
+        "https://pulp-test.dev",
+        "--no-clean",
+    ]
+
+    with patch.object(sys, "argv", args):
+        with caplog.at_level(logging.INFO):
+            pulp_push_wrapper.main()
+            assert (
+                "Running pubtools-pulp-push --pulp-url https://pulp-test.dev"
+                " --source staged:/test/1"
+            ) in caplog.messages
+
+    mock_run.assert_called_once_with(
+        [
+            "pubtools-pulp-push",
+            "--pulp-url",
+            "https://pulp-test.dev",
+            "--source",
+            "staged:/test/1",
+        ],
+        check=True,
+    )
+
+
+def test_build_timestamp_search_patterns():
+    patterns = pulp_push_wrapper.build_timestamp_search_patterns(
+        "releng-test-product-1.7-1777068929-x86_64-boot.iso.gz"
+    )
+    assert r"^releng\-test\-product\-1\.7\-1777068929\-x86_64\-boot\.iso\.gz$" in patterns
+    assert r"^releng-test-product-1\.7-\d{8,14}-x86_64-boot\.iso\.gz$" in patterns
+    assert r"^releng\-test\-product\-1\.7\-x86_64\-boot\.iso\.gz$" in patterns
+
+
+def test_get_source_dirs():
+    assert pulp_push_wrapper.get_source_dirs("staged:/tmp/a,/tmp/b") == ["/tmp/a", "/tmp/b"]
+    assert pulp_push_wrapper.get_source_dirs("docker://foo/bar") == []
+
+
+def test_normalize_timestamped_name():
+    assert (
+        pulp_push_wrapper.normalize_timestamped_name(
+            "releng-test-product-1.7-1777068929-x86_64-boot.iso.gz"
+        )
+        == "releng-test-product-1.7-x86_64-boot.iso.gz"
+    )
+    assert (
+        pulp_push_wrapper.normalize_timestamped_name(
+            "releng-test-product-binaries-linux-amd64-1.7.0.tar.gz"
+        )
+        == "releng-test-product-binaries-linux-amd64-1.7.0.tar.gz"
+    )
+
+
+def test_build_repo_file_map(tmp_path):
+    repo = tmp_path / "repo-a" / "FILES"
+    repo.mkdir(parents=True)
+    (repo / "a.txt").write_text("a")
+    (repo / "b.txt").write_text("b")
+    (tmp_path / "repo-empty" / "FILES").mkdir(parents=True)
+
+    result = pulp_push_wrapper.build_repo_file_map([str(tmp_path), "/does/not/exist"])
+    assert result == {"repo-a": {"a.txt", "b.txt"}}
+
+
+@patch("pulp_push_wrapper.ssl.create_default_context")
+def test_make_ssl_context(mock_create_context):
+    mock_ctx = MagicMock()
+    mock_create_context.return_value = mock_ctx
+
+    ctx = pulp_push_wrapper.make_ssl_context("/tmp/cert", "/tmp/key")
+    assert ctx is mock_ctx
+    mock_ctx.load_cert_chain.assert_called_once_with(certfile="/tmp/cert", keyfile="/tmp/key")
+
+
+@patch("pulp_push_wrapper.request.urlopen")
+def test_pulp_request_with_payload(mock_urlopen):
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'{"ok": true}'
+    mock_urlopen.return_value.__enter__.return_value = mock_response
+
+    result = pulp_push_wrapper.pulp_request(
+        "https://example.com", context="ctx", payload={"a": 1}
+    )
+    assert result == {"ok": True}
+
+
+@patch("pulp_push_wrapper.request.urlopen")
+def test_pulp_request_empty_body(mock_urlopen):
+    mock_response = MagicMock()
+    mock_response.read.return_value = b""
+    mock_urlopen.return_value.__enter__.return_value = mock_response
+
+    result = pulp_push_wrapper.pulp_request("https://example.com", context="ctx")
+    assert result is None
+
+
+@patch("pulp_push_wrapper.time.sleep")
+@patch("pulp_push_wrapper.time.time")
+@patch("pulp_push_wrapper.pulp_request")
+def test_wait_for_task_success(mock_pulp_request, mock_time, _mock_sleep):
+    mock_time.side_effect = [0, 1, 2]
+    mock_pulp_request.side_effect = [{"state": "running"}, {"state": "finished"}]
+
+    pulp_push_wrapper.wait_for_task("https://example.com/task", context="ctx")
+    assert mock_pulp_request.call_count == 2
+
+
+@patch("pulp_push_wrapper.time.sleep")
+@patch("pulp_push_wrapper.time.time")
+@patch("pulp_push_wrapper.pulp_request")
+def test_wait_for_task_timeout(mock_pulp_request, mock_time, _mock_sleep):
+    mock_time.side_effect = [0, 200]
+    mock_pulp_request.return_value = {"state": "running"}
+
+    with pytest.raises(TimeoutError):
+        pulp_push_wrapper.wait_for_task("https://example.com/task", context="ctx")
+
+
+@patch("pulp_push_wrapper.time.sleep")
+@patch("pulp_push_wrapper.time.time")
+@patch("pulp_push_wrapper.pulp_request")
+def test_wait_for_task_empty_response(mock_pulp_request, mock_time, _mock_sleep):
+    mock_time.side_effect = [0, 1]
+    mock_pulp_request.return_value = None
+
+    with pytest.raises(RuntimeError, match="Empty response while polling Pulp task"):
+        pulp_push_wrapper.wait_for_task("https://example.com/task", context="ctx")
+
+
+@patch("pulp_push_wrapper.time.sleep")
+@patch("pulp_push_wrapper.time.time")
+@patch("pulp_push_wrapper.pulp_request")
+@pytest.mark.parametrize(
+    "terminal_state",
+    ["error", "canceled"],
+)
+def test_wait_for_task_terminal_failure_state(
+    mock_pulp_request, mock_time, _mock_sleep, terminal_state
+):
+    mock_time.side_effect = [0, 1]
+    mock_pulp_request.return_value = {
+        "state": terminal_state,
+        "error": {"code": "PLP0001", "description": "task failed"},
+    }
+
+    with pytest.raises(RuntimeError, match=f"Pulp task {terminal_state}"):
+        pulp_push_wrapper.wait_for_task("https://example.com/task", context="ctx")
+
+    assert mock_pulp_request.call_count == 1
+
+
+@patch("pulp_push_wrapper.time.sleep")
+@patch("pulp_push_wrapper.time.time")
+@patch("pulp_push_wrapper.pulp_request")
+def test_wait_for_task_finished_with_error_details(mock_pulp_request, mock_time, _mock_sleep):
+    mock_time.side_effect = [0, 1]
+    mock_pulp_request.return_value = {
+        "state": "finished",
+        "error": {"code": "PLP0001", "description": "partial failure"},
+    }
+
+    with pytest.raises(RuntimeError, match="Pulp task failed"):
+        pulp_push_wrapper.wait_for_task("https://example.com/task", context="ctx")
+
+
+@patch("pulp_push_wrapper.time.sleep")
+@patch("pulp_push_wrapper.time.time")
+@patch("pulp_push_wrapper.pulp_request")
+def test_wait_for_task_skipped(mock_pulp_request, mock_time, _mock_sleep):
+    mock_time.side_effect = [0, 1]
+    mock_pulp_request.return_value = {"state": "skipped"}
+
+    pulp_push_wrapper.wait_for_task("https://example.com/task", context="ctx")
+    assert mock_pulp_request.call_count == 1
+
+
+@patch("subprocess.run")
+@patch("pulp_push_wrapper.wait_for_task")
+@patch("pulp_push_wrapper.make_ssl_context", return_value="ctx")
+@patch("pulp_push_wrapper.pulp_request")
+def test_prune_matching_content_before_push(
+    mock_pulp_request,
+    _mock_ctx,
+    _mock_wait,
+    mock_run,
+    tmp_path,
+    mock_gw_env_vars,
+):
+    repo = "konflux-release-e2e-1_DOT_0-for-rhel-10-x86_64-files"
+    files_dir = tmp_path / repo / "FILES"
+    files_dir.mkdir(parents=True)
+    (files_dir / "releng-test-product-1.7-1777068929-x86_64-boot.iso.gz").write_text("boot")
+    (files_dir / "releng-test-product-1.7-1777068929-x86_64-kvm.qcow2").write_text("kvm")
+
+    mock_pulp_request.side_effect = [
+        [
+            {"metadata": {"name": "releng-test-product-1.7-1777068929-x86_64-boot.iso.gz"}},
+            {"metadata": {"name": "releng-test-product-1.7-1777067342-x86_64-boot.iso.gz"}},
+        ],
+        [],
+        [],
+        [
+            {"metadata": {"name": "releng-test-product-1.7-1777068929-x86_64-kvm.qcow2"}},
+            {"metadata": {"name": "releng-test-product-1.7-1777067342-x86_64-kvm.qcow2"}},
+        ],
+        [],
+        [],
+        {"spawned_tasks": []},
+    ]
+
+    args = [
+        "",
+        "--source",
+        str(tmp_path),
+        "--pulp-url",
+        "https://pulp-test.dev",
+        "--pulp-cert",
+        "/tmp/test.crt",
+        "--pulp-key",
+        "/tmp/test.key",
+    ]
+
+    with patch.object(sys, "argv", args):
+        pulp_push_wrapper.main()
+
+    unassociate_call = next(
+        call
+        for call in mock_pulp_request.call_args_list
+        if "$in"
+        in call.kwargs.get("payload", {})
+        .get("criteria", {})
+        .get("filters", {})
+        .get("unit", {})
+        .get("name", {})
+    )
+    payload = unassociate_call.kwargs["payload"]
+    names = payload["criteria"]["filters"]["unit"]["name"]["$in"]
+    assert set(names) == {
+        "releng-test-product-1.7-1777068929-x86_64-boot.iso.gz",
+        "releng-test-product-1.7-1777067342-x86_64-boot.iso.gz",
+        "releng-test-product-1.7-1777068929-x86_64-kvm.qcow2",
+        "releng-test-product-1.7-1777067342-x86_64-kvm.qcow2",
+    }
+
+    mock_run.assert_called_once()
+
+
+@patch("pulp_push_wrapper.pulp_request")
+def test_prune_matching_content_before_push_skips_on_no_clean(mock_pulp_request):
+    args = MagicMock()
+    args.no_clean = True
+    pulp_push_wrapper.prune_matching_content_before_push(args)
+    mock_pulp_request.assert_not_called()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ line-length = 95
 
 [tool.pytest.ini_options]
 pythonpath = [
+  ".",
   "integration-tests/lib",
   "scripts/python/helpers",
   "scripts/python/tasks/internal",

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Shared helper utilities for release-service-utils wrappers.

--- a/utils/cgw_idempotency.py
+++ b/utils/cgw_idempotency.py
@@ -1,0 +1,230 @@
+import logging
+import re
+from urllib.parse import urlsplit, urlunsplit
+
+import requests
+
+TIMESTAMP_TOKEN_RE = re.compile(r"-(\d{10})(?=-)")
+
+
+def call_cgw_api(*, host, method, endpoint, session, data=None):
+    """Make an API call to the Content Gateway service."""
+    try:
+        response = session.request(
+            method=method.upper(),
+            url=f"{host}{endpoint}",
+            json=data,
+        )
+
+        if not response.ok:
+            error_message = (
+                response.text.strip() or f"HTTP {response.status_code}:{response.reason}"
+            )
+            raise RuntimeError(f"API call failed: {error_message}")
+
+        return response
+    except requests.RequestException as e:
+        raise RuntimeError(f"API call failed: {e}")
+
+
+def get_product_id(*, host, session, product_name, product_code):
+    """Retrieve the product ID by name and product code."""
+    products = call_cgw_api(
+        host=host, method="GET", endpoint="/products", session=session
+    ).json()
+    for product in products:
+        if product.get("name") == product_name and product.get("productCode") == product_code:
+            logging.info("Found product: %s with ID %s", product_name, product.get("id"))
+            return product.get("id")
+    raise ValueError(f"Product {product_name} not found with product code {product_code}")
+
+
+def get_version_id(*, host, session, product_id, version_name):
+    """Retrieve the version ID for a specific product."""
+    versions = call_cgw_api(
+        host=host,
+        method="GET",
+        endpoint=f"/products/{product_id}/versions",
+        session=session,
+    ).json()
+    for version in versions:
+        if version.get("versionName") == version_name:
+            logging.info("Found version: %s with ID %s", version_name, version.get("id"))
+            return version.get("id")
+    raise ValueError(f"Version not found: {version_name}")
+
+
+def find_existing_file(existing_files, new_file):
+    """Find a file with matching logical shortURL, regardless of downloadURL."""
+    new_shorturl = normalize_shorturl_for_matching(new_file.get("shortURL", ""))
+    for file in existing_files:
+        if normalize_shorturl_for_matching(file.get("shortURL", "")) == new_shorturl:
+            return file
+    return None
+
+
+def normalize_shorturl_for_matching(shorturl):
+    """
+    Normalize shortURL for idempotent matching.
+
+    For timestamped filenames such as
+    `...-1777494747-x86_64-boot.iso.gz`, strip the epoch token so
+    subsequent runs with a new timestamp still match the same logical file.
+    """
+    if not shorturl:
+        return shorturl
+
+    parts = urlsplit(shorturl)
+    segments = parts.path.split("/")
+    if segments:
+        segments[-1] = TIMESTAMP_TOKEN_RE.sub("", segments[-1])
+    normalized_path = "/".join(segments)
+    return urlunsplit(
+        (parts.scheme, parts.netloc, normalized_path, parts.query, parts.fragment)
+    )
+
+
+def remove_duplicate_entries(*, host, session, product_id, version_id, duplicates):
+    """Delete duplicate CGW file entries and keep one canonical entry."""
+    if not duplicates:
+        return
+
+    for dup in duplicates:
+        call_cgw_api(
+            host=host,
+            method="DELETE",
+            endpoint=f"/products/{product_id}/versions/{version_id}/files/{dup['id']}",
+            session=session,
+        )
+        logging.info("Removed duplicate CGW file ID: %s (%s)", dup["id"], dup.get("shortURL"))
+
+
+def update_file(*, host, session, product_id, version_id, file_id, file_metadata):
+    """Update an existing file using POST with ID in body."""
+    update_data = {**file_metadata, "id": file_id}
+    return call_cgw_api(
+        host=host,
+        method="POST",
+        endpoint=f"/products/{product_id}/versions/{version_id}/files",
+        session=session,
+        data=update_data,
+    )
+
+
+def rollback_files(*, host, session, product_id, version_id, created_file_ids):
+    """Rollback created files by listing and deleting them."""
+    if created_file_ids:
+        logging.warning(
+            "Rolling back created files due to failure (productId: %s, productVersionId: %s)",
+            product_id,
+            version_id,
+        )
+
+    for file_id in created_file_ids:
+        try:
+            call_cgw_api(
+                host=host,
+                method="DELETE",
+                endpoint=f"/products/{product_id}/versions/{version_id}/files/{file_id}",
+                session=session,
+            )
+        except Exception as e:
+            raise RuntimeError(f"Failed to rollback file: {e}")
+
+
+def create_files(*, host, session, product_id, version_id, metadata):
+    """
+    Create or update files idempotently.
+
+    Existing files are matched by shortURL:
+    - same shortURL + same downloadURL -> skip
+    - same shortURL + different downloadURL -> update
+    - no match -> create
+    """
+    created_file_ids = []
+    updated_file_ids = []
+    skipped_files_ids = []
+
+    try:
+        existing_files = call_cgw_api(
+            host=host,
+            method="GET",
+            endpoint=f"/products/{product_id}/versions/{version_id}/files",
+            session=session,
+        ).json()
+
+        for file_metadata in metadata:
+            matching_files = [
+                file
+                for file in existing_files
+                if normalize_shorturl_for_matching(file.get("shortURL", ""))
+                == normalize_shorturl_for_matching(file_metadata.get("shortURL", ""))
+            ]
+            existing_file = matching_files[0] if matching_files else None
+
+            if len(matching_files) > 1:
+                remove_duplicate_entries(
+                    host=host,
+                    session=session,
+                    product_id=product_id,
+                    version_id=version_id,
+                    duplicates=matching_files[1:],
+                )
+                existing_files = [
+                    f
+                    for f in existing_files
+                    if f.get("id") not in {d["id"] for d in matching_files[1:]}
+                ]
+
+            if existing_file:
+                if existing_file.get("downloadURL") != file_metadata.get(
+                    "downloadURL"
+                ) or existing_file.get("shortURL") != file_metadata.get("shortURL"):
+                    logging.info(
+                        "Updating file: %s (ID: %s) to latest metadata",
+                        file_metadata["label"],
+                        existing_file["id"],
+                    )
+                    update_file(
+                        host=host,
+                        session=session,
+                        product_id=product_id,
+                        version_id=version_id,
+                        file_id=existing_file["id"],
+                        file_metadata=file_metadata,
+                    )
+                    updated_file_ids.append(existing_file["id"])
+                    logging.info("Successfully updated file ID: %s", existing_file["id"])
+                else:
+                    skipped_files_ids.append(existing_file.get("id"))
+                    logging.info(
+                        "Skipping: File %s already exists with same content (ID: %s)",
+                        existing_file["label"],
+                        existing_file["id"],
+                    )
+            else:
+                logging.info(
+                    "Creating file: %s with ShortURL %s",
+                    file_metadata["label"],
+                    file_metadata["shortURL"],
+                )
+                created_file_id = call_cgw_api(
+                    host=host,
+                    method="POST",
+                    endpoint=f"/products/{product_id}/versions/{version_id}/files",
+                    session=session,
+                    data=file_metadata,
+                ).json()
+                logging.info("Successfully created file with ID: %s", created_file_id)
+                created_file_ids.append(created_file_id)
+
+        return created_file_ids, updated_file_ids, skipped_files_ids
+    except Exception as e:
+        rollback_files(
+            host=host,
+            session=session,
+            product_id=product_id,
+            version_id=version_id,
+            created_file_ids=created_file_ids,
+        )
+        raise RuntimeError(f"Failed to create file: {e}")

--- a/utils/tests/test_apply_template.py
+++ b/utils/tests/test_apply_template.py
@@ -8,7 +8,7 @@ import pytest
 
 from unittest.mock import patch, MagicMock
 
-from apply_template import setup_argparser, main
+from utils.apply_template import setup_argparser, main
 
 
 @patch(
@@ -49,8 +49,8 @@ def test_setup_argparser_improper_args():
 
 
 @patch("builtins.open")
-@patch("apply_template.Template.render")
-@patch("apply_template.setup_argparser")
+@patch("utils.apply_template.Template.render")
+@patch("utils.apply_template.setup_argparser")
 def test_apply_template_advisory_template(
     mock_argparser: MagicMock, mock_render: MagicMock, mock_open: MagicMock
 ):
@@ -76,7 +76,7 @@ def test_apply_template_advisory_template(
     assert json.loads(written) == {"foo": "bar"}
 
 
-@patch("apply_template.setup_argparser")
+@patch("utils.apply_template.setup_argparser")
 def test_apply_template_with_data_file(mock_argparser: MagicMock):
     _, data_filename = tempfile.mkstemp(suffix=".json")
     _, output_filename = tempfile.mkstemp()
@@ -145,7 +145,7 @@ def test_apply_template_with_data_file(mock_argparser: MagicMock):
         os.remove(output_filename)
 
 
-@patch("apply_template.setup_argparser")
+@patch("utils.apply_template.setup_argparser")
 def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
     _, filename = tempfile.mkstemp()
 
@@ -228,7 +228,7 @@ def test_apply_template_advisory_template_in_full(mock_argparser: MagicMock):
         os.remove(filename)
 
 
-@patch("apply_template.setup_argparser")
+@patch("utils.apply_template.setup_argparser")
 def test_apply_template_advisory_template_fail_syntax_error(mock_argparser: MagicMock):
     _, filename = tempfile.mkstemp()
 

--- a/utils/tests/test_find_matching_purl.py
+++ b/utils/tests/test_find_matching_purl.py
@@ -1,4 +1,4 @@
-from find_matching_purl import find_matching_purl
+from utils.find_matching_purl import find_matching_purl
 
 
 def test_find_matching_purl_success():

--- a/utils/tests/test_get_cgw_download_urls.py
+++ b/utils/tests/test_get_cgw_download_urls.py
@@ -1,7 +1,7 @@
 import pytest
 import requests
 from unittest.mock import Mock
-from get_cgw_download_urls import list_download_urls, call_cgw_api, get_version_id
+from utils.get_cgw_download_urls import list_download_urls, call_cgw_api, get_version_id
 
 
 @pytest.fixture
@@ -44,7 +44,7 @@ def test_list_download_urls(monkeypatch, capsys, mock_file_data):
     def mock_api(*args, **kwargs):
         return mock_file_data
 
-    monkeypatch.setattr("get_cgw_download_urls.call_cgw_api", mock_api)
+    monkeypatch.setattr("utils.get_cgw_download_urls.call_cgw_api", mock_api)
     list_download_urls("http://mock", None, 1, 1)
     output = capsys.readouterr().out.strip().split("\n")
     assert len(output) == 3
@@ -82,12 +82,12 @@ def test_get_version_id_success(monkeypatch):
         assert endpoint == "/products/123/versions"
         return mock_versions
 
-    monkeypatch.setattr("get_cgw_download_urls.call_cgw_api", mock_call_cgw_api)
+    monkeypatch.setattr("utils.get_cgw_download_urls.call_cgw_api", mock_call_cgw_api)
     version_id = get_version_id("http://mock", None, 123, "3.15.4")
     assert version_id == 101
 
 
 def test_get_version_id_not_found(monkeypatch):
-    monkeypatch.setattr("get_cgw_download_urls.call_cgw_api", lambda *a, **kw: [])
+    monkeypatch.setattr("utils.get_cgw_download_urls.call_cgw_api", lambda *a, **kw: [])
     with pytest.raises(ValueError, match="Version '3.15.9' not found"):
         get_version_id("http://mock", None, 123, "3.15.9")

--- a/utils/tests/test_get_resource.py
+++ b/utils/tests/test_get_resource.py
@@ -10,7 +10,7 @@ import os
 import pytest
 from unittest.mock import patch
 
-from get_resource import (
+from utils.get_resource import (
     main,
     extract_jsonpath,
     format_jsonpath_result,
@@ -128,7 +128,7 @@ def test_ensure_ka_config_already_exists(tmp_path):
         ensure_ka_config()
 
 
-@patch("get_resource._run")
+@patch("utils.get_resource._run")
 def test_ensure_ka_config_configmap_not_found(mock_run, tmp_path):
     config_file = tmp_path / "ka-config"
     mock_run.return_value = (1, "", "not found")
@@ -137,7 +137,7 @@ def test_ensure_ka_config_configmap_not_found(mock_run, tmp_path):
             ensure_ka_config()
 
 
-@patch("get_resource._run")
+@patch("utils.get_resource._run")
 def test_ensure_ka_config_creation_succeeds(mock_run, tmp_path):
     config_file = tmp_path / "ka-config"
 
@@ -154,7 +154,7 @@ def test_ensure_ka_config_creation_succeeds(mock_run, tmp_path):
         ensure_ka_config()
 
 
-@patch("get_resource._run")
+@patch("utils.get_resource._run")
 def test_ensure_ka_config_set_host_fails(mock_run, tmp_path):
     config_file = tmp_path / "ka-config"
     mock_run.side_effect = [
@@ -166,7 +166,7 @@ def test_ensure_ka_config_set_host_fails(mock_run, tmp_path):
             ensure_ka_config()
 
 
-@patch("get_resource._run")
+@patch("utils.get_resource._run")
 def test_ensure_ka_config_set_ca_fails(mock_run, tmp_path):
     config_file = tmp_path / "ka-config"
     mock_run.side_effect = [
@@ -185,7 +185,7 @@ def test_ensure_ka_config_set_ca_fails(mock_run, tmp_path):
             ensure_ka_config()
 
 
-@patch("get_resource._run")
+@patch("utils.get_resource._run")
 def test_ensure_ka_config_ssl_cert_file_used(mock_run, tmp_path):
     config_file = tmp_path / "ka-config"
 
@@ -215,14 +215,14 @@ def test_ensure_ka_config_ssl_cert_file_used(mock_run, tmp_path):
     assert "/path/to/cert.pem" in ca_calls[0]
 
 
-@patch("get_resource.ensure_ka_config", side_effect=RuntimeError("config unavailable"))
+@patch("utils.get_resource.ensure_ka_config", side_effect=RuntimeError("config unavailable"))
 def test_get_from_ka_config_unavailable(_):
     with pytest.raises(RuntimeError, match="config unavailable"):
         get_from_ka("snapshot", "ns1", "snap1")
 
 
-@patch("get_resource.ensure_ka_config")
-@patch("get_resource._run")
+@patch("utils.get_resource.ensure_ka_config")
+@patch("utils.get_resource._run")
 def test_get_from_ka_named_get_success(mock_run, _):
     ka_response = {
         "items": [
@@ -243,8 +243,8 @@ def test_get_from_ka_named_get_success(mock_run, _):
     assert data["metadata"]["name"] == "snap1"
 
 
-@patch("get_resource.ensure_ka_config")
-@patch("get_resource._run")
+@patch("utils.get_resource.ensure_ka_config")
+@patch("utils.get_resource._run")
 def test_get_from_ka_list_fallback_filters_by_name(mock_run, _):
     list_response = {
         "items": [
@@ -277,8 +277,8 @@ def test_get_from_ka_list_fallback_filters_by_name(mock_run, _):
     assert "wrong" not in data.get("spec", {})
 
 
-@patch("get_resource.ensure_ka_config")
-@patch("get_resource._run")
+@patch("utils.get_resource.ensure_ka_config")
+@patch("utils.get_resource._run")
 def test_get_from_ka_list_fallback_picks_highest_version(mock_run, _):
     list_response = {
         "items": [
@@ -317,8 +317,8 @@ def test_get_from_ka_list_fallback_picks_highest_version(mock_run, _):
     assert data["spec"]["version"] == "newest"
 
 
-@patch("get_resource.ensure_ka_config")
-@patch("get_resource._run")
+@patch("utils.get_resource.ensure_ka_config")
+@patch("utils.get_resource._run")
 def test_get_from_ka_no_matching_items(mock_run, _):
     list_response = {
         "items": [
@@ -339,8 +339,8 @@ def test_get_from_ka_no_matching_items(mock_run, _):
         get_from_ka("snapshot", "ns1", "snap1")
 
 
-@patch("get_resource.ensure_ka_config")
-@patch("get_resource._run")
+@patch("utils.get_resource.ensure_ka_config")
+@patch("utils.get_resource._run")
 def test_get_from_ka_both_get_and_list_fail(mock_run, _):
     mock_run.side_effect = [
         (1, "", ""),
@@ -374,7 +374,7 @@ def test_main_invalid_namespaced_name(capsys):
     assert "expected namespace/name" in capsys.readouterr().err
 
 
-@patch("get_resource._run")
+@patch("utils.get_resource._run")
 def test_main_kubectl_success_json(mock_run, capsys):
     resource_json = json.dumps(
         {
@@ -391,7 +391,7 @@ def test_main_kubectl_success_json(mock_run, capsys):
     assert json.loads(out)["kind"] == "Snapshot"
 
 
-@patch("get_resource._run")
+@patch("utils.get_resource._run")
 def test_main_kubectl_success_jsonpath(mock_run, capsys):
     mock_run.return_value = (0, "snap1", "")
     with patch(
@@ -404,7 +404,7 @@ def test_main_kubectl_success_jsonpath(mock_run, capsys):
     assert capsys.readouterr().out == "snap1"
 
 
-@patch("get_resource._run")
+@patch("utils.get_resource._run")
 def test_main_non_ka_type_no_jsonpath_exits_with_error(mock_run, capsys):
     mock_run.return_value = (
         1,
@@ -418,7 +418,7 @@ def test_main_non_ka_type_no_jsonpath_exits_with_error(mock_run, capsys):
     assert "NotFound" in capsys.readouterr().err
 
 
-@patch("get_resource._run")
+@patch("utils.get_resource._run")
 def test_main_non_ka_type_jsonpath_returns_empty_object(mock_run, capsys):
     mock_run.return_value = (1, "", "not found")
     with patch(
@@ -429,8 +429,8 @@ def test_main_non_ka_type_jsonpath_returns_empty_object(mock_run, capsys):
     assert capsys.readouterr().out.strip() == "{}"
 
 
-@patch("get_resource.get_from_ka")
-@patch("get_resource._run")
+@patch("utils.get_resource.get_from_ka")
+@patch("utils.get_resource._run")
 def test_main_ka_fallback_success(mock_run, mock_ka, capsys):
     mock_run.return_value = (1, "", "not found")
     ka_result = {
@@ -452,8 +452,8 @@ def test_main_ka_fallback_success(mock_run, mock_ka, capsys):
     assert out["metadata"]["name"] == "snap1"
 
 
-@patch("get_resource.get_from_ka")
-@patch("get_resource._run")
+@patch("utils.get_resource.get_from_ka")
+@patch("utils.get_resource._run")
 def test_main_ka_fallback_with_jsonpath(mock_run, mock_ka, capsys):
     mock_run.return_value = (1, "", "not found")
     ka_result = {
@@ -476,8 +476,8 @@ def test_main_ka_fallback_with_jsonpath(mock_run, mock_ka, capsys):
     assert capsys.readouterr().out.strip() == "myapp"
 
 
-@patch("get_resource.get_from_ka", side_effect=RuntimeError("KA failed"))
-@patch("get_resource._run")
+@patch("utils.get_resource.get_from_ka", side_effect=RuntimeError("KA failed"))
+@patch("utils.get_resource._run")
 def test_main_ka_fails_jsonpath_returns_empty(mock_run, mock_ka, capsys):
     mock_run.return_value = (1, "", "")
 
@@ -489,8 +489,8 @@ def test_main_ka_fails_jsonpath_returns_empty(mock_run, mock_ka, capsys):
     assert capsys.readouterr().out.strip() == "{}"
 
 
-@patch("get_resource.get_from_ka", side_effect=RuntimeError("KA failed"))
-@patch("get_resource._run")
+@patch("utils.get_resource.get_from_ka", side_effect=RuntimeError("KA failed"))
+@patch("utils.get_resource._run")
 def test_main_ka_fails_no_jsonpath_exits_nonzero(mock_run, mock_ka, capsys):
     mock_run.return_value = (1, "", "resource not found")
 
@@ -500,8 +500,8 @@ def test_main_ka_fails_no_jsonpath_exits_nonzero(mock_run, mock_ka, capsys):
         assert exc_info.value.code == 1
 
 
-@patch("get_resource.get_from_ka")
-@patch("get_resource._run")
+@patch("utils.get_resource.get_from_ka")
+@patch("utils.get_resource._run")
 def test_main_ka_fallback_wildcard_jsonpath(mock_run, mock_ka, capsys):
     mock_run.return_value = (1, "", "")
     ka_result = {
@@ -536,8 +536,8 @@ def test_main_ka_fallback_wildcard_jsonpath(mock_run, mock_ka, capsys):
     assert "comp-b" in out
 
 
-@patch("get_resource.get_from_ka", side_effect=RuntimeError("KA unavailable"))
-@patch("get_resource._run")
+@patch("utils.get_resource.get_from_ka", side_effect=RuntimeError("KA unavailable"))
+@patch("utils.get_resource._run")
 def test_main_ka_not_available_exits_nonzero(mock_run, mock_ka, capsys):
     mock_run.return_value = (1, "", "")
 
@@ -547,8 +547,8 @@ def test_main_ka_not_available_exits_nonzero(mock_run, mock_ka, capsys):
         assert exc_info.value.code == 1
 
 
-@patch("get_resource.get_from_ka")
-@patch("get_resource._run")
+@patch("utils.get_resource.get_from_ka")
+@patch("utils.get_resource._run")
 def test_main_snapshot_uses_ka(mock_run, mock_ka, capsys):
     mock_run.return_value = (1, "", "")
     ka_data = {"metadata": {"name": "s", "namespace": "n", "resourceVersion": "1"}}
@@ -561,8 +561,8 @@ def test_main_snapshot_uses_ka(mock_run, mock_ka, capsys):
     mock_ka.assert_called_once()
 
 
-@patch("get_resource.get_from_ka")
-@patch("get_resource._run")
+@patch("utils.get_resource.get_from_ka")
+@patch("utils.get_resource._run")
 def test_main_snapshots_uses_ka(mock_run, mock_ka, capsys):
     mock_run.return_value = (1, "", "")
     ka_data = {"metadata": {"name": "s", "namespace": "n", "resourceVersion": "1"}}
@@ -575,8 +575,8 @@ def test_main_snapshots_uses_ka(mock_run, mock_ka, capsys):
     mock_ka.assert_called_once()
 
 
-@patch("get_resource.get_from_ka")
-@patch("get_resource._run")
+@patch("utils.get_resource.get_from_ka")
+@patch("utils.get_resource._run")
 def test_main_deployment_no_ka(mock_run, mock_ka, capsys):
     mock_run.return_value = (1, "", "not found")
 
@@ -587,8 +587,8 @@ def test_main_deployment_no_ka(mock_run, mock_ka, capsys):
     mock_ka.assert_not_called()
 
 
-@patch("get_resource.get_from_ka")
-@patch("get_resource._run")
+@patch("utils.get_resource.get_from_ka")
+@patch("utils.get_resource._run")
 def test_main_pod_no_ka(mock_run, mock_ka, capsys):
     mock_run.return_value = (1, "", "not found")
 


### PR DESCRIPTION
This PR delivers two related idempotency changes for the push-disk-image pipeline.

Pulp idempotency prune (RELEASE-2367)
pulp_push_wrapper now queries the target Pulp repo and unassociates older timestamped variants of matching staged files before running pubtools-pulp-push. This prevents duplicate timestamped content from accumulating and keeps only the latest relevant artifacts associated. Unit tests were added for timestamp matching and prune selection behavior.

Shared CGW idempotency logic
Common Content Gateway create/update/skip/rollback behavior was extracted into utils/cgw_idempotency.py and reused by both developer_portal_wrapper and publish_to_cgw_wrapper. This removes duplicated logic and keeps both publish paths behaviorally aligned. Regression tests cover both flows:

disk-image style (filePrefix-based)
push-artifacts style (files[]-based)
