### PR TITLE
feat(RELEASE-2209): imported functions trigger tests

### DIFF
--- a/integration-tests/lib/find_catalog_suite_from_utils_diff.py
+++ b/integration-tests/lib/find_catalog_suite_from_utils_diff.py
@@ -15,6 +15,9 @@ Map a release-service-utils diff to catalog ``PIPELINE_TEST_SUITE`` /
    any ``*.md`` file), or changes to the repo-root ``Dockerfile``, force all catalog
    RPA suites—plumbing and image layout are not reliably reflected in Task YAML
    substring search alone.
+5. Changes under ``scripts/python/helpers/*.py`` also add repo paths for task
+   scripts that import those modules (see `helper_task_import_graph`) so
+   catalog Tasks that invoke ``tasks/…/*.py`` still match when only helpers move.
 
 **Stdin** (one changed path per line): print one JSON object
 ``{"pipelineTestSuite": <string|null>, "pipelineUsed": <string|null>}``.
@@ -40,6 +43,7 @@ import sys
 from pathlib import Path
 
 import find_search_tokens_from_dockerfile as fts
+import helper_task_import_graph as htig
 
 _MANAGED_PIPELINE_PATH = re.compile(r"pipelines/managed/([^/]+)/")
 
@@ -265,6 +269,9 @@ def resolve(catalog: Path, changed_lines: list[str]) -> dict[str, str | None]:
     changed = [c.strip() for c in changed_lines if c.strip()]
     if not changed:
         return {"pipelineTestSuite": None, "pipelineUsed": None}
+
+    repo_root = Path.cwd().resolve()
+    changed = htig.expand_changed_paths_for_helper_deps(repo_root, changed)
 
     suites: set[str] = set()
 

--- a/integration-tests/lib/helper_task_import_graph.py
+++ b/integration-tests/lib/helper_task_import_graph.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Map ``scripts/python/helpers/*.py`` to task scripts that import them.
+
+Task scripts live under ``scripts/python/tasks/**/*.py``. Imports are resolved with
+the ``ast`` module: bare imports like ``import file`` match ``helpers/file.py``;
+``from helpers.foo import ...`` is also recognized when present.
+
+Used by `find_catalog_suite_from_utils_diff` so a helper-only diff still
+propagates to dependent ``tasks/`` paths for Dockerfile token generation.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _helper_stems(helpers_root: Path) -> frozenset[str]:
+    """Stem names for each ``*.py`` directly under ``helpers_root``."""
+    # Only top-level modules (``helpers/foo.py``). Nested packages are out of scope
+    # for this lightweight scanner.
+    if not helpers_root.is_dir():
+        return frozenset()
+    return frozenset(p.stem for p in helpers_root.glob("*.py") if p.is_file())
+
+
+def _is_task_script(path: Path) -> bool:
+    """Skip unit tests next to tasks and anything under a ``tests`` directory."""
+    # Task YAML references runnable entrypoints, not pytest modules or fixtures.
+    if path.name.startswith("test_"):
+        return False
+    if "tests" in path.parts:
+        return False
+    return path.suffix == ".py"
+
+
+def _collect_imported_helper_names(tree: ast.AST, helper_stems: frozenset[str]) -> set[str]:
+    """Return helper module stems referenced by *tree* that exist under helpers."""
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            # ``import foo`` / ``import foo.bar`` — first segment must match a helper stem.
+            for alias in node.names:
+                stem = alias.name.split(".", 1)[0]
+                if stem in helper_stems:
+                    found.add(stem)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is None:
+                continue
+            parts = node.module.split(".")
+            # ``from helpers.foo import ...`` → ``foo.py`` under helpers/.
+            if parts[0] == "helpers" and len(parts) >= 2:
+                inner = parts[1]
+                if inner in helper_stems:
+                    found.add(inner)
+            elif parts[0] in helper_stems:
+                # Rare: ``from file import ...`` with ``file`` as the package prefix.
+                found.add(parts[0])
+    return found
+
+
+def build_helper_to_task_paths(repo_root: Path) -> dict[str, set[str]]:
+    """Build reverse map: helper stem -> repo-relative paths of importing tasks."""
+    helpers_root = repo_root / "scripts" / "python" / "helpers"
+    tasks_root = repo_root / "scripts" / "python" / "tasks"
+    stems = _helper_stems(helpers_root)
+    if not stems or not tasks_root.is_dir():
+        return {}
+
+    reverse: dict[str, set[str]] = {s: set() for s in stems}
+    for py in tasks_root.rglob("*.py"):
+        if not _is_task_script(py):
+            continue
+        try:
+            text = py.read_text(encoding="utf-8", errors="replace")
+            tree = ast.parse(text, filename=str(py))
+        except (OSError, SyntaxError):
+            # Broken files cannot be analyzed; omit rather than failing the pipeline.
+            continue
+        rel = py.relative_to(repo_root).as_posix()
+        for stem in _collect_imported_helper_names(tree, stems):
+            reverse[stem].add(rel)
+    return reverse
+
+
+def expand_changed_paths_for_helper_deps(
+    repo_root: Path,
+    changed_paths: list[str],
+    *,
+    _reverse: dict[str, set[str]] | None = None,
+) -> list[str]:
+    """Append task paths that import changed helpers; preserve order, dedupe.
+
+    Paths under ``scripts/python/helpers/*.py`` add any task files that import that
+    helper module. Other paths pass through unchanged.
+    """
+    reverse = _reverse if _reverse is not None else build_helper_to_task_paths(repo_root)
+    if not reverse:
+        return list(changed_paths)
+
+    helper_prefix = "scripts/python/helpers/"
+    seen: set[str] = set()
+    out: list[str] = []
+
+    def add(p: str) -> None:
+        """Normalize repo-relative paths once and dedupe."""
+        norm = p.strip().strip("./")
+        if not norm or norm in seen:
+            return
+        seen.add(norm)
+        out.append(norm)
+
+    for raw in changed_paths:
+        s = raw.strip().strip("./")
+        if not s:
+            continue
+        add(s)
+        if not s.startswith(helper_prefix) or not s.endswith(".py"):
+            continue
+        stem = Path(s).stem
+        if stem == "__init__":
+            # We only index plain modules; package ``__init__`` has no stem mapping.
+            continue
+        # Stable order so repeated runs diffs are deterministic.
+        for task_rel in sorted(reverse.get(stem, ())):
+            add(task_rel)
+
+    return out

--- a/integration-tests/lib/tests/test_find_catalog_suite_from_utils_diff.py
+++ b/integration-tests/lib/tests/test_find_catalog_suite_from_utils_diff.py
@@ -244,6 +244,34 @@ def test_suites_from_catalog_script_splits_stdout_tokens(tmp_path: Path) -> None
 
 
 @pytest.mark.usefixtures("utils_repo_root")
+def test_resolve_expands_helper_import_to_dependent_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Helper-only diffs also consider ``tasks/*.py`` files that import that helper."""
+    root = Path.cwd()
+    (root / "scripts" / "python" / "helpers").mkdir(parents=True)
+    (root / "scripts" / "python" / "tasks" / "internal").mkdir(parents=True)
+    (root / "scripts" / "python" / "helpers" / "file.py").write_text("#\n", encoding="utf-8")
+    (root / "scripts" / "python" / "tasks" / "internal" / "consumer.py").write_text(
+        "import file\n",
+        encoding="utf-8",
+    )
+    captured: list[list[str]] = []
+    orig_collect = fc._collect_task_search_tokens
+
+    def spy(changed_paths: list[str]):
+        captured.append(list(changed_paths))
+        return orig_collect(changed_paths)
+
+    monkeypatch.setattr(fc, "_collect_task_search_tokens", spy)
+    _write_rpa(tmp_path, "e2e", "p: pipelines/managed/e2e/")
+    with patch.object(fc, "_suites_from_catalog_script", return_value={"e2e"}):
+        fc.resolve(tmp_path, ["scripts/python/helpers/file.py"])
+    assert len(captured) == 1
+    assert "scripts/python/tasks/internal/consumer.py" in captured[0]
+
+
+@pytest.mark.usefixtures("utils_repo_root")
 def test_collect_task_search_tokens_maps_paths_via_dockerfile(tmp_path: Path) -> None:
     """Maps paths using cwd ``Dockerfile`` (same as ``search_tokens_for_changed_paths``)."""
     tokens = fc._collect_task_search_tokens(["pyxis/foo.py"])

--- a/integration-tests/lib/tests/test_helper_task_import_graph.py
+++ b/integration-tests/lib/tests/test_helper_task_import_graph.py
@@ -1,0 +1,181 @@
+"""Tests for ``helper_task_import_graph``."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import patch
+
+import helper_task_import_graph as ht
+
+
+def _minimal_repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    (root / "scripts" / "python" / "helpers").mkdir(parents=True)
+    (root / "scripts" / "python" / "tasks" / "internal").mkdir(parents=True)
+    return root
+
+
+def test_is_task_script_requires_py_suffix() -> None:
+    """Runnable tasks are ``*.py``; other suffixes are ignored."""
+    assert ht._is_task_script(Path("scripts/python/tasks/internal/run.py")) is True
+    assert ht._is_task_script(Path("scripts/python/tasks/internal/run.sh")) is False
+    assert ht._is_task_script(Path("scripts/python/tasks/managed/test_run.py")) is False
+    assert ht._is_task_script(Path("scripts/python/tasks/managed/tests/run.py")) is False
+
+
+def test_collect_import_from_helpers_pkg_form() -> None:
+    """``from helpers.foo import …`` maps to stem ``foo`` when it exists under helpers."""
+    tree = ast.parse("from helpers.bar import thing\n")
+    stems = frozenset({"bar"})
+    assert ht._collect_imported_helper_names(tree, stems) == {"bar"}
+
+
+def test_collect_import_from_top_level_pkg_prefix() -> None:
+    """``from file import …`` counts when ``file`` is a helper module stem."""
+    tree = ast.parse("from file import read_all\n")
+    stems = frozenset({"file"})
+    assert ht._collect_imported_helper_names(tree, stems) == {"file"}
+
+
+def test_collect_import_from_relative_skipped() -> None:
+    """``from . import …`` has ``module is None`` and does not match helpers."""
+    tree = ast.parse("from . import sibling\n")
+    stems = frozenset({"sibling"})
+    assert ht._collect_imported_helper_names(tree, stems) == set()
+
+
+def test_build_helper_to_task_paths_bare_import(tmp_path: Path) -> None:
+    """``import foo`` maps helper stem ``foo`` to the task path."""
+    root = _minimal_repo(tmp_path)
+    (root / "scripts" / "python" / "helpers" / "foo.py").write_text("# x\n", encoding="utf-8")
+    task = root / "scripts" / "python" / "tasks" / "internal" / "runner.py"
+    task.write_text("import foo\n", encoding="utf-8")
+
+    rev = ht.build_helper_to_task_paths(root)
+    assert rev.get("foo") == {"scripts/python/tasks/internal/runner.py"}
+
+
+def test_build_helper_to_task_paths_skips_test_modules(tmp_path: Path) -> None:
+    """Skip ``test_*.py`` next to tasks."""
+    root = _minimal_repo(tmp_path)
+    (root / "scripts" / "python" / "helpers" / "foo.py").write_text("#\n", encoding="utf-8")
+    (root / "scripts" / "python" / "tasks" / "internal" / "test_runner.py").write_text(
+        "import foo\n", encoding="utf-8"
+    )
+
+    rev = ht.build_helper_to_task_paths(root)
+    assert rev.get("foo") == set()
+
+
+def test_build_helper_to_task_paths_skips_syntax_error(tmp_path: Path) -> None:
+    """Invalid Python in a task file is skipped without failing (SyntaxError path)."""
+    root = _minimal_repo(tmp_path)
+    (root / "scripts" / "python" / "helpers" / "foo.py").write_text("#\n", encoding="utf-8")
+    bad = root / "scripts" / "python" / "tasks" / "internal" / "broken.py"
+    bad.write_text("def not_closed(\n", encoding="utf-8")
+    good = root / "scripts" / "python" / "tasks" / "internal" / "ok.py"
+    good.write_text("import foo\n", encoding="utf-8")
+
+    rev = ht.build_helper_to_task_paths(root)
+    assert rev.get("foo") == {"scripts/python/tasks/internal/ok.py"}
+
+
+def test_build_helper_to_task_paths_skips_oserror_on_read(tmp_path: Path) -> None:
+    """Unreadable task files are omitted (OSError path)."""
+    root = _minimal_repo(tmp_path)
+    (root / "scripts" / "python" / "helpers" / "foo.py").write_text("#\n", encoding="utf-8")
+    task = root / "scripts" / "python" / "tasks" / "internal" / "blocked.py"
+    task.write_text("import foo\n", encoding="utf-8")
+
+    real_read = Path.read_text
+
+    def read_text_wrapper(self: Path, *a, **kw):
+        if self.name == "blocked.py":
+            raise OSError("permission denied")
+        return real_read(self, *a, **kw)
+
+    with patch.object(Path, "read_text", read_text_wrapper):
+        rev = ht.build_helper_to_task_paths(root)
+    assert rev.get("foo") == set()
+
+
+def test_expand_changed_paths_for_helper_deps_appends_tasks(tmp_path: Path) -> None:
+    """Changing a helper path pulls in importing task paths."""
+    root = _minimal_repo(tmp_path)
+    (root / "scripts" / "python" / "helpers" / "file.py").write_text("#\n", encoding="utf-8")
+    task = root / "scripts" / "python" / "tasks" / "internal" / "step.py"
+    task.write_text("import file\n", encoding="utf-8")
+
+    reverse = ht.build_helper_to_task_paths(root)
+    out = ht.expand_changed_paths_for_helper_deps(
+        root,
+        ["scripts/python/helpers/file.py"],
+        _reverse=reverse,
+    )
+    assert out == [
+        "scripts/python/helpers/file.py",
+        "scripts/python/tasks/internal/step.py",
+    ]
+
+
+def test_expand_changed_paths_for_helper_deps_preserves_order_dedupes(
+    tmp_path: Path,
+) -> None:
+    """Dedupe paths and keep first occurrence order."""
+    root = _minimal_repo(tmp_path)
+    (root / "scripts" / "python" / "helpers" / "a.py").write_text("#\n", encoding="utf-8")
+    t1 = root / "scripts" / "python" / "tasks" / "internal" / "t1.py"
+    t2 = root / "scripts" / "python" / "tasks" / "internal" / "t2.py"
+    t1.write_text("import a\n", encoding="utf-8")
+    t2.write_text("import a\n", encoding="utf-8")
+
+    reverse = ht.build_helper_to_task_paths(root)
+    out = ht.expand_changed_paths_for_helper_deps(
+        root,
+        ["scripts/python/helpers/a.py", "scripts/python/tasks/internal/t1.py"],
+        _reverse=reverse,
+    )
+    assert out[0] == "scripts/python/helpers/a.py"
+    assert out[1] == "scripts/python/tasks/internal/t1.py"
+    assert out[2] == "scripts/python/tasks/internal/t2.py"
+
+
+def test_expand_changed_paths_for_helper_deps_no_helpers_dir(tmp_path: Path) -> None:
+    """Missing helpers tree leaves paths unchanged."""
+    root = tmp_path / "empty"
+    root.mkdir()
+    out = ht.expand_changed_paths_for_helper_deps(root, ["README.md"])
+    assert out == ["README.md"]
+
+
+def test_expand_skips_blank_changed_lines(tmp_path: Path) -> None:
+    """Empty stdin lines are ignored."""
+    root = _minimal_repo(tmp_path)
+    (root / "scripts" / "python" / "helpers" / "a.py").write_text("#\n", encoding="utf-8")
+    reverse = ht.build_helper_to_task_paths(root)
+    out = ht.expand_changed_paths_for_helper_deps(
+        root,
+        ["", "   ", "\t"],
+        _reverse=reverse,
+    )
+    assert out == []
+
+
+def test_expand_skips_helpers_init_py(tmp_path: Path) -> None:
+    """``helpers/__init__.py`` does not map to helper stems; no extra task paths."""
+    root = _minimal_repo(tmp_path)
+    (root / "scripts" / "python" / "helpers" / "__init__.py").write_text(
+        "#\n", encoding="utf-8"
+    )
+    (root / "scripts" / "python" / "helpers" / "mod.py").write_text("#\n", encoding="utf-8")
+    task = root / "scripts" / "python" / "tasks" / "internal" / "t.py"
+    task.write_text("import mod\n", encoding="utf-8")
+
+    reverse = ht.build_helper_to_task_paths(root)
+    out = ht.expand_changed_paths_for_helper_deps(
+        root,
+        ["scripts/python/helpers/__init__.py"],
+        _reverse=reverse,
+    )
+    assert out == ["scripts/python/helpers/__init__.py"]


### PR DESCRIPTION
This commit updates the new utils e2e tests to prepare for the addition of python task scripts to this repo. We will have helper modules that multiple tasks can import. If a task script uses a function from a helper module, we need to be sure that the e2e tests relevant to that task are still triggered. This commit adds that piece. So, for example, if you have a function in scripts/tasks/helpers/file.py and it is used in scripts/tasks/internal/check_embargoed_cves.py, any update to the function in file.py should be treated like an update in the embargoed script too.

Assisted-By: Cursor