### PR TITLE
chore: add skopeo image check to promote-overlay

### DIFF
--- a/ci/promote-overlay/promote-overlay.sh
+++ b/ci/promote-overlay/promote-overlay.sh
@@ -189,6 +189,17 @@ if [[ -n "$COMMIT_TO" && "$NO_GRAFANA" != "true" ]] && ! git merge-base --is-anc
   exit 1
 fi
 
+# Validate that the release-service image is available
+if [ "${NO_RELEASE}" != "true" ]; then
+  RS_IMAGE="quay.io/konflux-ci/release-service:${RS_SOURCE_OVERLAY_COMMIT}"
+  echo "Checking image is available: ${RS_IMAGE}"
+  if ! skopeo inspect --raw "docker://${RS_IMAGE}" > /dev/null; then
+    echo "Error: image ${RS_IMAGE} is not available"
+    exit 1
+  fi
+  echo "Image ${RS_IMAGE} is available"
+fi
+
 # Determine commit range for PR listing
 if [ "${NO_RELEASE}" != "true" ]; then
   RANGE_FROM="$RS_TARGET_OVERLAY_COMMIT"


### PR DESCRIPTION
Validate that the release-service container image exists before promoting. This helps catch the issue where a release is skipped for a newer snapshot.