### PR TITLE
feat(RELEASE-1984): add check-fbc-opt-in python script

### DIFF
--- a/scripts/python/helpers/image_ref.py
+++ b/scripts/python/helpers/image_ref.py
@@ -1,0 +1,25 @@
+"""Helpers for parsing and normalizing container image references."""
+
+from __future__ import annotations
+
+
+def pyxis_url_for_pull_spec(pyxis_url: str, pull_spec: str) -> str:
+    """
+    Build the Pyxis repository/tag API URL for `pull_spec`.
+
+    `registry.redhat.io` is rewritten to `registry.access.redhat.com` to
+    match Pyxis lookups.
+    """
+    normalized = pull_spec.replace("registry.redhat.io", "registry.access.redhat.com", 1)
+    parts = normalized.split("/", 2)
+    if len(parts) < 3:
+        raise ValueError(f"invalid pull spec: {pull_spec!r}")
+    registry, repo, image_and_tag = parts
+    image, sep, tag = image_and_tag.partition(":")
+    base = (
+        f"{pyxis_url.rstrip('/')}/repositories/registry/{registry}/repository/"
+        f"{repo}/{image}"
+    )
+    if sep and tag:
+        return f"{base}/tag/{tag}"
+    return base

--- a/scripts/python/helpers/logger.py
+++ b/scripts/python/helpers/logger.py
@@ -1,0 +1,15 @@
+"""Configured logger for task scripts — writes to stderr."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("release")
+logger.setLevel(logging.DEBUG)
+
+# Clear any existing handlers first
+logger.handlers.clear()
+_handler = logging.StreamHandler()
+_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+logger.addHandler(_handler)
+logger.propagate = False

--- a/scripts/python/helpers/test_image_ref.py
+++ b/scripts/python/helpers/test_image_ref.py
@@ -1,0 +1,30 @@
+"""Tests for the `image_ref` helper module."""
+
+from __future__ import annotations
+
+import image_ref
+import pytest
+
+
+def test_pyxis_url_for_pull_spec_with_tag_and_registry_rewrite() -> None:
+    """Tagged refs map to `.../tag/<tag>` and rewrite registry.redhat.io host."""
+    out = image_ref.pyxis_url_for_pull_spec(
+        "https://pyxis.engineering.redhat.com/v1",
+        "registry.redhat.io/repo/image:1.2",
+    )
+    assert out.endswith(
+        "/repositories/registry/registry.access.redhat.com/repository/repo/image/tag/1.2"
+    )
+
+
+def test_pyxis_url_for_pull_spec_without_tag() -> None:
+    """Untyped pull specs omit the trailing `/tag` path segment."""
+    out = image_ref.pyxis_url_for_pull_spec("https://pyxis/v1", "r.io/repo/image")
+    assert out.endswith("/repositories/registry/r.io/repository/repo/image")
+    assert "/tag/" not in out
+
+
+def test_pyxis_url_for_pull_spec_invalid() -> None:
+    """Invalid pull specs raise `ValueError`."""
+    with pytest.raises(ValueError, match="invalid pull spec"):
+        image_ref.pyxis_url_for_pull_spec("https://pyxis/v1", "not/a-pullspec")

--- a/scripts/python/helpers/test_logger.py
+++ b/scripts/python/helpers/test_logger.py
@@ -1,0 +1,18 @@
+"""Tests for the task `logger` helper (stdlib `logging` setup)."""
+
+from __future__ import annotations
+
+import logging
+
+from logger import logger
+
+
+def test_handler_formatter_matches_task_format() -> None:
+    """Log lines use `LEVELNAME: message` on stderr."""
+    assert logger.handlers, "release logger should have a handler from import"
+    handler = logger.handlers[0]
+    assert isinstance(handler.formatter, logging.Formatter)
+    info_rec = logging.LogRecord("release", logging.INFO, __file__, 0, "hello", (), None)
+    assert handler.format(info_rec) == "INFO: hello"
+    warn_rec = logging.LogRecord("release", logging.WARNING, __file__, 0, "oops", (), None)
+    assert handler.format(warn_rec) == "WARNING: oops"

--- a/scripts/python/tasks/internal/check_fbc_opt_in.py
+++ b/scripts/python/tasks/internal/check_fbc_opt_in.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Check FBC opt-in status in Pyxis for container images."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import os
+import subprocess
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import requests
+from requests.auth import AuthBase
+from requests_kerberos import HTTPKerberosAuth, OPTIONAL
+
+import authentication
+import file
+import http_client
+import image_ref
+import tekton
+from logger import logger
+
+PROG = "check_fbc_opt_in.py"
+
+
+def parse_container_images(value: str) -> list[str]:
+    """Parse `value` as a JSON array of non-empty image strings."""
+    # Input is a JSON array string; keep validation strict so malformed input fails fast.
+    data = json.loads(value)
+    if not isinstance(data, list):
+        raise ValueError("container images must be a JSON array")
+    out: list[str] = []
+    for item in data:
+        if not isinstance(item, str):
+            raise ValueError("container images must be strings")
+        stripped = item.strip()
+        if not stripped:
+            raise ValueError("container images must be non-empty")
+        out.append(stripped)
+    return out
+
+
+def get_fbc_opt_in(
+    pyxis_url: str,
+    pull_spec: str,
+    auth: AuthBase | None,
+    *,
+    warn_on_query_failure: bool = True,
+) -> bool:
+    """
+    Return `True` only when the Pyxis JSON body sets `fbc_opt_in` to JSON boolean
+    true.
+
+    Query failures, non-JSON responses, and missing fields are treated as
+    opt-out (`False`).
+    """
+    try:
+        # Build the Pyxis endpoint for this image pull spec.
+        body = http_client.get_text(
+            image_ref.pyxis_url_for_pull_spec(pyxis_url, pull_spec),
+            auth=auth,
+        )
+        data: dict[str, Any] = json.loads(body)
+    except (
+        OSError,
+        ValueError,
+        TypeError,
+        json.JSONDecodeError,
+        requests.RequestException,
+    ):
+        # Fail closed: treat query/parsing errors as not opted in.
+        if warn_on_query_failure:
+            logger.warning(
+                f"Failed to query Pyxis for {pull_spec}, assuming opt-out",
+            )
+        return False
+    return data.get("fbc_opt_in") is True
+
+
+def run_check(
+    container_images: list[str],
+    pyxis_url: str,
+    service_account_mount: Path,
+    iib_services_config_mount: Path,
+    *,
+    kinit: Callable[..., None] = authentication.kinit_with_retry,
+    get_opt_in: Callable[[str, str, AuthBase | None], bool] = get_fbc_opt_in,
+) -> list[dict[str, Any]]:
+    """
+    Authenticate with Kerberos then query Pyxis FBC opt-in for each image.
+
+    Returns one result object per input image:
+    `{"containerImage": "...", "fbcOptIn": bool}`.
+    """
+    logger.info("Setting up Kerberos authentication for Pyxis...")
+    # Read mounted principal/keytab from the service-account secret volume.
+    try:
+        principal = authentication.read_mounted_text(service_account_mount, "principal")
+        keytab_b64 = authentication.read_mounted_text(service_account_mount, "keytab")
+        keytab_bytes = base64.b64decode(keytab_b64.encode("ascii"))
+    except (OSError, ValueError, binascii.Error) as e:
+        raise tekton.CheckStepError("reading the mounted IIB service account", e) from e
+
+    # Read krb5.conf from the iib-services-config mount.
+    try:
+        krb5_source = (iib_services_config_mount / "krb5.conf").read_text(
+            encoding="utf-8", errors="replace"
+        )
+    except OSError as e:
+        raise tekton.CheckStepError("reading the Kerberos configuration", e) from e
+
+    # Create ephemeral files for keytab and kerberos configuration.
+    keytab_path = file.make_tempfile_path("keytab-", keytab_bytes)
+    krb5_path = file.make_tempfile_path("krb5-", krb5_source.encode("utf-8"))
+    # Use a private credentials cache file per run instead of default user cache path.
+    ccache_fd, ccache_name = tempfile.mkstemp()
+    os.close(ccache_fd)
+    ccache_path = Path(ccache_name)
+
+    try:
+        # Kerberos env for config path, ccache path, and optional trace output.
+        kenv = {
+            "KRB5_CONFIG": str(krb5_path),
+            "KRB5CCNAME": str(ccache_path),
+            "KRB5_TRACE": "/dev/stderr",
+        }
+        try:
+            # Retry kinit with exponential backoff from the shared retry helper.
+            logger.info("Logging in with Kerberos (kinit)...")
+            kinit(principal, keytab_path, kenv, max_attempts=5)
+        except subprocess.CalledProcessError as e:
+            raise tekton.CheckStepError("logging in with Kerberos (kinit)", e) from e
+        # requests-kerberos reads Kerberos env from this process, not the kinit child.
+        os.environ.update(kenv)
+
+        # Reuse one Kerberos auth object while querying each image's Pyxis record.
+        auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL)
+        logger.info("Checking FBC opt-in status for provided container images...")
+        opt_in_rows: list[dict[str, Any]] = []
+        for image in container_images:
+            logger.info("Checking opt-in status for: %s with pyxis url: %s", image, pyxis_url)
+            opted_in = get_opt_in(pyxis_url, image, auth)
+            logger.info("Container %s opt-in status: %s", image, str(opted_in).lower())
+            opt_in_rows.append(
+                {
+                    "containerImage": image,
+                    "fbcOptIn": opted_in,
+                }
+            )
+        return opt_in_rows
+    finally:
+        # Always clean up secret-bearing temp files.
+        for p in (keytab_path, krb5_path, ccache_path):
+            p.unlink(missing_ok=True)
+
+
+def main() -> int:
+    """Write `RESULT_OPT_IN_RESULTS` and return exit code `0` on success."""
+    # `RESULT_OPT_IN_RESULTS` is the path of the JSON file this step writes.
+    rpath = tekton.result_paths("RESULT_OPT_IN_RESULTS")[0]
+    raw_images = os.environ.get("CONTAINER_IMAGES", "")
+
+    try:
+        pyxis_url = os.environ.get("PYXIS_URL", "").strip()
+        if not pyxis_url:
+            raise ValueError("PYXIS_URL must be set")
+        # Mount paths are overridable for tests but fixed in task runtime.
+        service_account_mount = file.path_from_env_variable(
+            "IIB_SERVICE_ACCOUNT_MOUNT", "/mnt/service-account-secret"
+        )
+        iib_services_config_mount = file.path_from_env_variable(
+            "IIB_SERVICES_CONFIG_MOUNT", "/mnt/iib-services-config"
+        )
+
+        images = parse_container_images(raw_images)
+        results = run_check(
+            images,
+            pyxis_url,
+            service_account_mount,
+            iib_services_config_mount,
+        )
+    except (ValueError, tekton.CheckStepError) as e:
+        # Surface validation and step failures as a clear one-line SystemExit message.
+        raise SystemExit(f"{PROG}: {e}") from e
+
+    logger.info("FBC opt-in check completed")
+    logger.info("Results:")
+    logger.info(json.dumps(results, indent=2))
+
+    # Downstream tasks consume a JSON array from this result file.
+    rpath.write_text(json.dumps(results), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/internal/test_check_fbc_opt_in.py
+++ b/scripts/python/tasks/internal/test_check_fbc_opt_in.py
@@ -1,0 +1,171 @@
+"""Tests for `check_fbc_opt_in`."""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import check_fbc_opt_in
+import pytest
+import requests
+import tekton
+
+
+def _write_service_account(
+    d: Path, principal: str = "user@REALM", keytab: bytes = b"kt"
+) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "principal").write_text(principal, encoding="utf-8")
+    (d / "keytab").write_text(base64.b64encode(keytab).decode("ascii"), encoding="utf-8")
+
+
+def _write_krb5(d: Path) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "krb5.conf").write_text("[libdefaults]\n default_realm = FOO\n", encoding="utf-8")
+
+
+def _no_kinit(*_a: object, **_k: object) -> None:
+    return None
+
+
+def test_parse_container_images_ok() -> None:
+    """A JSON list of non-empty strings is parsed in order."""
+    assert check_fbc_opt_in.parse_container_images('["a:b", "c:d"]') == ["a:b", "c:d"]
+
+
+@pytest.mark.parametrize("raw", ['{"x": 1}', '["ok", ""]', "[1]"])
+def test_parse_container_images_invalid(raw: str) -> None:
+    """Non-array or non-string/blank items raise `ValueError`."""
+    with pytest.raises(ValueError):
+        check_fbc_opt_in.parse_container_images(raw)
+
+
+def test_get_fbc_opt_in_true_false_and_missing() -> None:
+    """Only explicit `fbc_opt_in: true` maps to `True`."""
+    with mock.patch("http_client.get_text", return_value='{"fbc_opt_in": true}'):
+        assert check_fbc_opt_in.get_fbc_opt_in("https://p", "r.io/repo/i:1", None) is True
+    with mock.patch("http_client.get_text", return_value='{"fbc_opt_in": false}'):
+        assert check_fbc_opt_in.get_fbc_opt_in("https://p", "r.io/repo/i:1", None) is False
+    with mock.patch("http_client.get_text", return_value="{}"):
+        assert check_fbc_opt_in.get_fbc_opt_in("https://p", "r.io/repo/i:1", None) is False
+
+
+def test_get_fbc_opt_in_http_error_returns_false() -> None:
+    """HTTP exceptions are treated as opt-out."""
+    with mock.patch(
+        "http_client.get_text",
+        side_effect=requests.HTTPError("boom", response=mock.MagicMock()),
+    ):
+        assert check_fbc_opt_in.get_fbc_opt_in("https://p", "r.io/repo/i:1", None) is False
+
+
+def test_run_check_returns_results_for_each_input(tmp_path: Path) -> None:
+    """Each input image produces one output object with computed `fbcOptIn`."""
+    sa = tmp_path / "sa"
+    cfg = tmp_path / "cfg"
+    _write_service_account(sa)
+    _write_krb5(cfg)
+
+    def _opt(_u: str, image: str, _a: object) -> bool:
+        return image.endswith(":yes")
+
+    out = check_fbc_opt_in.run_check(
+        ["r/repo/i:yes", "r/repo/i:no"],
+        "https://pyxis/v1",
+        sa,
+        cfg,
+        kinit=_no_kinit,
+        get_opt_in=_opt,
+    )
+    assert out == [
+        {"containerImage": "r/repo/i:yes", "fbcOptIn": True},
+        {"containerImage": "r/repo/i:no", "fbcOptIn": False},
+    ]
+
+
+def test_run_check_wraps_service_account_errors(tmp_path: Path) -> None:
+    """Missing principal/keytab files become `CheckStepError` with mount context."""
+    cfg = tmp_path / "cfg"
+    _write_krb5(cfg)
+    with pytest.raises(tekton.CheckStepError, match="mounted IIB service account"):
+        check_fbc_opt_in.run_check(["r/repo/i:1"], "https://pyxis/v1", tmp_path / "sa", cfg)
+
+
+def test_run_check_wraps_krb5_errors(tmp_path: Path) -> None:
+    """Missing `krb5.conf` becomes `CheckStepError` with Kerberos context."""
+    sa = tmp_path / "sa"
+    _write_service_account(sa)
+    with pytest.raises(tekton.CheckStepError, match="Kerberos configuration"):
+        check_fbc_opt_in.run_check(["r/repo/i:1"], "https://pyxis/v1", sa, tmp_path / "cfg")
+
+
+def test_run_check_wraps_kinit_error(tmp_path: Path) -> None:
+    """A failed `kinit` command is wrapped as `CheckStepError`."""
+    sa = tmp_path / "sa"
+    cfg = tmp_path / "cfg"
+    _write_service_account(sa)
+    _write_krb5(cfg)
+
+    def _fail_kinit(*_a: object, **_k: object) -> None:
+        raise subprocess.CalledProcessError(1, "kinit")
+
+    with pytest.raises(tekton.CheckStepError, match="logging in with Kerberos"):
+        check_fbc_opt_in.run_check(
+            ["r/repo/i:1"],
+            "https://pyxis/v1",
+            sa,
+            cfg,
+            kinit=_fail_kinit,
+            get_opt_in=lambda _u, _i, _a: False,
+        )
+
+
+def test_main_writes_result_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`main` writes JSON to `RESULT_OPT_IN_RESULTS` and returns 0."""
+    rpath = tmp_path / "result"
+    sa = tmp_path / "sa"
+    cfg = tmp_path / "cfg"
+    _write_service_account(sa)
+    _write_krb5(cfg)
+    monkeypatch.setenv("RESULT_OPT_IN_RESULTS", str(rpath))
+    monkeypatch.setenv("CONTAINER_IMAGES", '["r/repo/i:1"]')
+    monkeypatch.setenv("PYXIS_URL", "https://pyxis/v1")
+    monkeypatch.setenv("IIB_SERVICE_ACCOUNT_MOUNT", str(sa))
+    monkeypatch.setenv("IIB_SERVICES_CONFIG_MOUNT", str(cfg))
+
+    with mock.patch.object(check_fbc_opt_in, "run_check", return_value=[{"x": 1}]):
+        out = check_fbc_opt_in.main()
+
+    assert out == 0
+    assert json.loads(rpath.read_text(encoding="utf-8")) == [{"x": 1}]
+
+
+def test_main_requires_pyxis_url_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`PYXIS_URL` must be set."""
+    rpath = tmp_path / "result"
+    monkeypatch.setenv("RESULT_OPT_IN_RESULTS", str(rpath))
+    monkeypatch.setenv("CONTAINER_IMAGES", '["r/repo/i:1"]')
+    monkeypatch.delenv("PYXIS_URL", raising=False)
+    with pytest.raises(SystemExit, match=r"check_fbc_opt_in\.py: PYXIS_URL must be set"):
+        check_fbc_opt_in.main()
+
+
+def test_main_missing_result_env_raises_system_exit() -> None:
+    """Missing `RESULT_OPT_IN_RESULTS` is rejected by `tekton.result_paths`."""
+    with pytest.raises(SystemExit):
+        check_fbc_opt_in.main()
+
+
+def test_main_invalid_container_images_exits(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Invalid `CONTAINER_IMAGES` raises `SystemExit` with program prefix."""
+    rpath = tmp_path / "result"
+    monkeypatch.setenv("RESULT_OPT_IN_RESULTS", str(rpath))
+    monkeypatch.setenv("CONTAINER_IMAGES", '{"bad": 1}')
+    monkeypatch.setenv("PYXIS_URL", "https://pyxis/v1")
+    with pytest.raises(SystemExit, match="check_fbc_opt_in.py"):
+        check_fbc_opt_in.main()


### PR DESCRIPTION
This commit adds a python script to replicate the functionality of the inline bash script in the check-fbc-opt-in internal task in the catalog repo. The task will be updated to use this python module instead.

Assisted-By: Cursor