### PR TITLE
feat(RELEASE-1991): add push-artifacts-to-cdn as standalone python sc…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,7 +160,7 @@ ENV PATH="$PATH:/home/publish-to-cgw-wrapper"
 # Flat imports: helpers and task scripts must be importable.
 # Tests use the same layout via pyproject [tool.pytest.ini_options] pythonpath.
 # Keep /home for other modules (e.g. pyxis, sbom) that expect it.
-ENV PYTHONPATH="/home:/home/utils:/home/scripts/python/helpers:/home/scripts/python/tasks/internal"
+ENV PYTHONPATH="/home:/home/utils:/home/scripts/python/helpers:/home/scripts/python/tasks/internal:/home/pubtools-pulp-wrapper:/home/publish-to-cgw-wrapper"
 
 # uv installs newer requests and certifi which don't use the system CA like the one installed via
 # dnf. So we need to point requests to the system CA bundle explicitly.

--- a/publish-to-cgw-wrapper/publish_to_cgw_wrapper.py
+++ b/publish-to-cgw-wrapper/publish_to_cgw_wrapper.py
@@ -1,23 +1,25 @@
 #!/usr/bin/env python3
-"""
-This script interacts with the Content Gateway (CGW) API to create and manage content files.
-It ensures each file is checked before creation and skips files that already exist.
-The script is idempotent, it can be executed multiple times as long as the label,
-short URL, and download URL remain unchanged.
+"""Interact with the Content Gateway (CGW) API to create and manage content files.
 
-### **Functionality:**
-1. Reads a JSON snapshot containing data that has been injected with contentGateway,
-   files and contentDir.
-2. Validates that all required fields are present and non-empty.
-3. For each `component` entry:
-    - Retrieves the product ID and version ID
-    - Generates metadata for each file listed in `files` and located in the
-      content directory.
-    - Checks for existing files and skips them if they match the label,
-      short URL, and downloadURL.
-    - Creates new files using the metadata.
-    - Rolls back created files if an error occurs during execution.
-4. Output all `result_data`.
+Idempotent: each file is checked before creation and skipped when it already
+exists with matching label, short URL, and download URL.
+
+Functionality:
+
+1. Read a JSON snapshot containing data injected with contentGateway,
+   files, and contentDir.
+2. Validate that all required fields are present and non-empty.
+3. For each ``component`` entry:
+
+   - Retrieve the product ID and version ID.
+   - Generate metadata for each file listed in ``files`` and located in the
+     content directory.
+   - Check for existing files and skip them when they match the label,
+     short URL, and downloadURL.
+   - Create new files using the metadata.
+   - Roll back created files if an error occurs during execution.
+
+4. Output all ``result_data``.
 """
 
 import os
@@ -32,7 +34,7 @@ from utils import cgw_idempotency
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
-def parse_args():
+def parse_args(argv=None):
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
         prog="publish_to_cgw_wrapper", description="Publish content to the Content Gateway"
@@ -53,11 +55,11 @@ def parse_args():
         help="Simulate the script without API calls",
     )
 
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def load_data(data_arg):
-    """Load JSON from string"""
+    """Load JSON from string."""
     try:
         return json.loads(data_arg)
     except json.JSONDecodeError:
@@ -65,12 +67,12 @@ def load_data(data_arg):
 
 
 def validate_components(data):
-    """
-    Validates snapshot component data. Skips components without a 'contentGateway'
-    and fails if required fields are missing in either the 'contentGateway'
-    or any listed files. Returns only the valid components.
+    """Validate snapshot component data and return only valid components.
 
-    Note: Filename is always derived from the 'source' field using basename.
+    Skip components without a ``contentGateway`` key and raise ``ValueError``
+    if required fields are missing in ``contentGateway`` or any listed file.
+
+    Note: filename is always derived from the ``source`` field using basename.
     """
     required_cg_keys = ["productCode", "productName", "productVersionName", "contentDir"]
     errors = []
@@ -122,9 +124,9 @@ def validate_components(data):
 
 
 def generate_download_url(content_dir, file_name):
-    """
-    Generate a download URL in this format:
-    /content/origin/files/sha256/{checksum[:2]}{checksum}/{file_name}
+    """Generate a CDN download URL for *file_name* inside *content_dir*.
+
+    URL format: ``/content/origin/files/sha256/{checksum[:2]}/{checksum}/{file_name}``.
     """
     prefix = "/content/origin/files/sha256"
     sha256_hash = hashlib.sha256()
@@ -146,16 +148,17 @@ def generate_metadata(
     mirror_openshift_Push,
     component_index,
 ):
-    """
-    Generate metadata for files listed in 'files' and present in the content_dir.
-    Also includes metadata for checksum files starting with 'sha256' or component name.
+    """Generate CGW file-metadata records for a component's content directory.
+
+    Includes metadata for checksum files (sha256sum.txt, .gpg, .sig) and for
+    every file in ``files`` that is present on disk.
 
     Ordering scheme:
-      - Checksum files get fixed orders 1, 2, 3.
-      - Regular files get order = component_index * 1000 + file_position.
-        This keeps each component's files in a unique range.
-    """
 
+    - Checksum files get fixed orders 1, 2, 3.
+    - Regular files get order = component_index * 1000 + file_position,
+      keeping each component's files in a unique range.
+    """
     logging.info(f"Generating metadata for files in {content_dir}")
 
     default_values_per_component = {
@@ -217,10 +220,9 @@ def generate_metadata(
 
 
 def process_component(*, host, session, component, dry_run=False, component_index):
-    """
-    Process a component retrieve product/version ID,
-    generate metadata, create files, and return the result
-    data (per component)
+    """Process one component: retrieve IDs, generate metadata, and create files.
+
+    Return a result dict with counts and IDs for created, updated, and skipped files.
     """
     productName = component["contentGateway"]["productName"]
     productCode = component["contentGateway"]["productCode"]
@@ -293,79 +295,80 @@ def process_component(*, host, session, component, dry_run=False, component_inde
     return result_data
 
 
-def main():
-    try:
-        args = parse_args()
+def main(argv=None):
+    """Run the CGW publishing workflow end-to-end and return all result records."""
+    args = parse_args(argv)
 
-        USERNAME = os.getenv("CGW_USERNAME")
-        PASSWORD = os.getenv("CGW_PASSWORD")
+    USERNAME = os.getenv("CGW_USERNAME")
+    PASSWORD = os.getenv("CGW_PASSWORD")
 
-        if not USERNAME or not PASSWORD:
-            raise ValueError(
-                "CGW_USERNAME and CGW_PASSWORD environment variables are required"
-            )
+    if not USERNAME or not PASSWORD:
+        raise ValueError("CGW_USERNAME and CGW_PASSWORD environment variables are required")
 
-        session = requests.Session()
-        session.auth = HTTPBasicAuth(USERNAME, PASSWORD)
-        session.headers.update(
-            {
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            }
+    session = requests.Session()
+    session.auth = HTTPBasicAuth(USERNAME, PASSWORD)
+    session.headers.update(
+        {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+    )
+
+    data = load_data(args.data_json)
+    components = validate_components(data)
+    if not components:
+        logging.warning("No components eligible for publishing")
+        return []
+
+    all_results = []
+    for num, component in enumerate(components, start=1):
+        content_gateway = component["contentGateway"]
+        logging.info(
+            f"Processing component: {num}/{len(components)} "
+            f"(productName: {content_gateway['productName']} "
+            f"productVersionName: {content_gateway['productVersionName']})"
         )
-
-        data = load_data(args.data_json)
-        components = validate_components(data)
-        if not components:
-            # Exit without error if there are no valid components to publish
-            logging.warning("No components eligible for publishing")
-            exit(0)
-
-        all_results = []
-        for num, component in enumerate(components, start=1):
-            content_gateway = component["contentGateway"]
-            logging.info(
-                f"Processing component: {num}/{len(components)} "
-                f"(productName: {content_gateway['productName']} "
-                f"productVersionName: {content_gateway['productVersionName']})"
+        try:
+            result_data = process_component(
+                host=args.cgw_host,
+                session=session,
+                component=component,
+                dry_run=args.dry_run,
+                component_index=num,
             )
-            try:
-                result_data = process_component(
-                    host=args.cgw_host,
-                    session=session,
-                    component=component,
-                    dry_run=args.dry_run,
-                    component_index=num,
-                )
-                if result_data is None:
-                    continue
+            if result_data is None:
+                continue
 
-                all_results.append(result_data)
+            all_results.append(result_data)
 
-            except Exception as e:
-                if all_results:
-                    logging.warning("Rolling back all created files due to error.")
-                    for result in all_results:
-                        cgw_idempotency.rollback_files(
-                            host=args.cgw_host,
-                            session=session,
-                            product_id=result["product_id"],
-                            version_id=result["product_version_id"],
-                            created_file_ids=result["created_file_ids"],
-                        )
-                raise RuntimeError(
-                    f"Error processing component {num} "
-                    f"(productName: {content_gateway.get('productName')}, "
-                    f"productVersionName: {content_gateway.get('productVersionName')}): {e}"
-                )
-
-        logging.info("Processed result:\n%s", json.dumps(all_results, indent=2))
-        logging.info("All files processed successfully.")
-        return all_results
-    except Exception as e:
-        logging.error(e)
-        exit(1)
+        except Exception as e:
+            if all_results:
+                logging.warning("Rolling back all created files due to error.")
+                for result in all_results:
+                    cgw_idempotency.rollback_files(
+                        host=args.cgw_host,
+                        session=session,
+                        product_id=result["product_id"],
+                        version_id=result["product_version_id"],
+                        created_file_ids=result["created_file_ids"],
+                    )
+            logging.error(
+                "Error processing component %d "
+                "(productName: %s, productVersionName: %s): %s",
+                num,
+                content_gateway.get("productName"),
+                content_gateway.get("productVersionName"),
+                e,
+            )
+            raise SystemExit(1) from e
+    logging.info("Processed result:\n%s", json.dumps(all_results, indent=2))
+    logging.info("All files processed successfully.")
+    return all_results
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        logging.error(e)
+        raise SystemExit(1) from e

--- a/pubtools-pulp-wrapper/pulp_push_wrapper.py
+++ b/pubtools-pulp-wrapper/pulp_push_wrapper.py
@@ -1,30 +1,23 @@
 #!/usr/bin/env python3
-"""
-Python script to push staged content to CDN using rhsm-pulp and exodus-gw integration.
+"""Push staged content to CDN using rhsm-pulp and exodus-gw integration.
 
-This is a simple wrapper pubtools-pulp-push command that is able to push and publish
-content via Pulp. This wrapper supports pushing content only from staged source
-with unit types supported in rhsm-pulp (as of July 2024).
+Wrapper around ``pubtools-pulp-push`` that supports staged sources with unit
+types supported by rhsm-pulp (as of July 2024).
 
-For more information please refer to documentation:
+Documentation:
+
 * https://release-engineering.github.io/pubtools-pulp/
 * https://release-engineering.github.io/pubtools-exodus/
 * https://release-engineering.github.io/pushsource/
 
 Required env vars for exodus-gw integration:
-* EXODUS_PULP_HOOK_ENABLED
-* EXODUS_GW_CERT
-* EXODUS_GW_KEY
-* EXODUS_GW_URL
-* EXODUS_GW_ENV
+``EXODUS_PULP_HOOK_ENABLED``, ``EXODUS_GW_CERT``, ``EXODUS_GW_KEY``,
+``EXODUS_GW_URL``, ``EXODUS_GW_ENV``.
 
-Optional env vars:
-* EXODUS_GW_TIMEOUT
+Optional: ``EXODUS_GW_TIMEOUT``.
 
-UD cache flush credentials:
-* either use username/password via CLI args
-* or set path to cert/key with env vars: UDCACHE_CERT and UDCACHE_KEY
-
+UD cache flush credentials: pass ``--udcache-user`` / ``--udcache-password``
+via CLI args, or set ``UDCACHE_CERT`` and ``UDCACHE_KEY`` env vars.
 """
 
 import argparse
@@ -55,7 +48,8 @@ EXODUS_ENV_VARS_STRICT = (
 EXODUS_ENV_VARS_OTHERS = ("EXODUS_GW_TIMEOUT",)
 
 
-def parse_args():
+def parse_args(argv=None):
+    """Parse and return command-line arguments for the Pulp push wrapper."""
     parser = argparse.ArgumentParser(
         prog="pulp_push_wrapper",
         description="Push staged content to CDN via rhsm-pulp and exodus-gw.",
@@ -120,10 +114,11 @@ def parse_args():
         default=False,
     )
 
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def get_source_url(stagedirs):
+    """Validate *stagedirs* paths and return a ``staged:`` source URL."""
     for item in stagedirs:
         if not re.match(r"^/[^,]{1,4000}$", item):
             raise ValueError("Not a valid staging directory: %s" % item)
@@ -132,12 +127,14 @@ def get_source_url(stagedirs):
 
 
 def get_source_dirs(source_url):
+    """Return the list of staging directories encoded in *source_url*."""
     if not source_url.startswith("staged:"):
         return []
     return [item for item in source_url.removeprefix("staged:").split(",") if item]
 
 
 def normalize_timestamped_name(filename):
+    """Return *filename* with any embedded timestamp token removed."""
     tokens = filename.split("-")
     for idx, token in enumerate(tokens):
         # Remove a timestamp-like token between stable filename parts.
@@ -147,6 +144,7 @@ def normalize_timestamped_name(filename):
 
 
 def build_timestamp_search_patterns(filename):
+    """Return sorted regex patterns that match *filename* and its timestamped variants."""
     tokens = filename.split("-")
     patterns = set()
 
@@ -170,6 +168,7 @@ def build_timestamp_search_patterns(filename):
 
 
 def build_repo_file_map(stagedirs):
+    """Return a mapping of repo name → set of filenames found in each staging directory."""
     repo_to_files = {}
     for stagedir in stagedirs:
         if not os.path.isdir(stagedir):
@@ -191,6 +190,7 @@ def build_repo_file_map(stagedirs):
 
 
 def make_ssl_context(cert_file=None, key_file=None):
+    """Create an SSL context, optionally loading a client certificate."""
     ctx = ssl.create_default_context()
     if cert_file and key_file:
         ctx.load_cert_chain(certfile=cert_file, keyfile=key_file)
@@ -200,6 +200,7 @@ def make_ssl_context(cert_file=None, key_file=None):
 
 
 def pulp_request(url, context, payload=None):
+    """Send a JSON request to *url* using *context* and return the decoded response."""
     data = None
     headers = {}
     if payload is not None:
@@ -214,6 +215,7 @@ def pulp_request(url, context, payload=None):
 
 
 def wait_for_task(task_href, context):
+    """Poll *task_href* until the Pulp task finishes, raising on error or timeout."""
     task_url = task_href
     deadline = time.time() + POLL_TIMEOUT_SECONDS
     while time.time() < deadline:
@@ -234,6 +236,7 @@ def wait_for_task(task_href, context):
 
 
 def prune_matching_content_before_push(parsed):
+    """Remove Pulp units that match the staged content before re-pushing."""
     if parsed.no_clean:
         return
 
@@ -310,6 +313,7 @@ def prune_matching_content_before_push(parsed):
 
 
 def settings_to_args(parsed):
+    """Convert parsed arguments to a ``pubtools-pulp-push`` CLI argument list."""
     settings_to_arg_map = {
         "pulp_url": "--pulp-url",
         "pulp_cert": "--pulp-certificate",
@@ -334,11 +338,13 @@ def settings_to_args(parsed):
 
 
 def log_exodus_env():
+    """Log the current values of all exodus-gw environment variables at DEBUG level."""
     for item in EXODUS_ENV_VARS_STRICT + EXODUS_ENV_VARS_OTHERS:
         LOG.debug("%s:%s", item, os.getenv(item, "UNSET"))
 
 
 def validate_args(args):
+    """Assert required exodus-gw env vars are set and convert source list to URL."""
     assert all([os.getenv(item) for item in EXODUS_ENV_VARS_STRICT]), (
         f"Provide all required exodus-gw environment variables: "
         f"{', '.join(EXODUS_ENV_VARS_STRICT)}"
@@ -348,8 +354,9 @@ def validate_args(args):
     return args
 
 
-def main():
-    args = validate_args(parse_args())
+def main(argv=None):
+    """Configure logging, validate arguments, and run ``pubtools-pulp-push``."""
+    args = validate_args(parse_args(argv))
 
     loglevel = logging.DEBUG if args.debug else logging.INFO
 
@@ -389,6 +396,7 @@ def main():
 
 
 def entrypoint():
+    """Entry point for the installed console script."""
     main()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ pythonpath = [
   "scripts/python/helpers",
   "scripts/python/tasks/internal",
   "utils",
+  "pubtools-pulp-wrapper",
+  "publish-to-cgw-wrapper",
 ]
 
 [dependency-groups]

--- a/scripts/python/helpers/authentication.py
+++ b/scripts/python/helpers/authentication.py
@@ -8,8 +8,10 @@ service-account / secret file layouts.
 from __future__ import annotations
 
 import base64
+import json
 import os
 import subprocess
+import tempfile
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -17,10 +19,11 @@ import retry
 
 
 def read_mounted_text(mount: Path, filename: str) -> str:
-    """
-    Read a UTF-8 file (``mount / filename``) and return the text with leading
-    and trailing whitespace removed. Use for one-line secret values (API base URL,
-    principal name) when a pod mounts a volume as a directory of small files.
+    """Read a UTF-8 file (``mount / filename``) and return stripped text.
+
+    Returns the text with leading and trailing whitespace removed.
+    Use for one-line secret values (API base URL, principal name) when
+    a pod mounts a volume as a directory of small files.
     """
     return (mount / filename).read_text(encoding="utf-8").strip()
 
@@ -31,8 +34,7 @@ def load_keytab_from_mount(
     principal_file: str,
     keytab_b64_file: str,
 ) -> tuple[str, bytes]:
-    """
-    Load a Kerberos principal and raw keytab from files under *mount*.
+    """Load a Kerberos principal and raw keytab from files under *mount*.
 
     *principal_file* is a one-line text file (principal). *keytab_b64_file*
     is the same for a base64-encoded keytab. Returns the principal string and
@@ -50,16 +52,16 @@ def load_service_account(
     principal_file: str,
     keytab_b64_file: str,
 ) -> tuple[str, bytes, dict[str, str]]:
-    """
-    Load a mounted Kubernetes-style service account: principal, keytab, and extra
-    one-value string files (API base URL, usernames, etc.).
+    """Load a mounted Kubernetes-style service account from the filesystem.
+
+    Reads the principal, keytab, and extra one-value string files
+    (API base URL, usernames, etc.) from *mount*.
 
     *principal_file* and *keytab_b64_file* are passed through to
     ``load_keytab_from_mount``. It then reads each additional filename in
-    ``text_files`` and returns a
-    dict mapping that filename to stripped text (for example an API base URL
-    in one file). You can list several files; each name becomes a key in the
-    returned dict.
+    ``text_files`` and returns a dict mapping that filename to stripped text
+    (for example an API base URL in one file). You can list several files;
+    each name becomes a key in the returned dict.
     """
     princ, keytab = load_keytab_from_mount(
         mount, principal_file=principal_file, keytab_b64_file=keytab_b64_file
@@ -69,8 +71,7 @@ def load_service_account(
 
 
 def patch_krb5_config(source: str) -> str:
-    """
-    Return ``source`` with one line added immediately after ``[libdefaults]``.
+    """Return ``source`` with one line added immediately after ``[libdefaults]``.
 
     Inserts ``dns_canonicalize_hostname = false`` to avoid
     "Invalid UID in persistent keyring name" / hostname canonicalization
@@ -92,8 +93,7 @@ def patch_krb5_config(source: str) -> str:
 def kinit_with_retry(
     princ: str, keytab: Path, extra_env: dict[str, str], *, max_attempts: int = 5
 ) -> None:
-    """
-    Run ``kinit`` with a keytab, retrying a few times on non-zero exit.
+    """Run ``kinit`` with a keytab, retrying a few times on non-zero exit.
 
     Merges ``os.environ`` with ``extra_env`` for the ``kinit`` child only.
     If every attempt fails, the last ``CalledProcessError`` is raised. **princ** is
@@ -123,3 +123,57 @@ def kinit_with_retry(
         retry_on=subprocess.CalledProcessError,
         base_sleep_seconds=5,
     )
+
+
+def write_docker_config(config_json: str) -> None:
+    """Write *config_json* to ``~/.docker/config.json``, creating the directory if needed.
+
+    Shared by helpers that authenticate to container registries (Quay, Red Hat workloads
+    registry) before pulling or pushing OCI artifacts.  The caller is responsible for
+    obtaining the JSON string (reading a mounted secret file, stripping noise, etc.).
+
+    The directory is created with mode 0700 and the file is written atomically with
+    mode 0600 to prevent other processes from reading registry credentials.
+    """
+    docker_dir = Path.home() / ".docker"
+    docker_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    config_path = docker_dir / "config.json"
+    fd, tmp_path = tempfile.mkstemp(dir=docker_dir)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(config_json)
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, config_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def setup_docker_config(
+    path: Path,
+    *,
+    strip_noise: bool = False,
+    optional: bool = False,
+) -> None:
+    """Read a dockerconfigjson file and write it to ``~/.docker/config.json``.
+
+    *path* is the full path to a ``.dockerconfigjson`` file (typically a mounted
+    Kubernetes secret).  When *optional* is ``True`` and the file is absent or empty,
+    the function returns without writing anything — useful for mounts that may not be
+    present in all environments.  When *strip_noise* is ``True``, any leading/trailing
+    non-JSON characters (e.g. outer quotes added by some k8s secret encodings) are
+    stripped before writing.
+    """
+    if optional and (not path.is_file() or path.stat().st_size == 0):
+        return
+    raw = path.read_text(encoding="utf-8")
+    if strip_noise:
+        first = raw.find("{")
+        last = raw.rfind("}")
+        if first == -1 or last == -1 or first > last:
+            raise ValueError(f"No valid JSON object found in {path}")
+        raw = json.dumps(json.loads(raw[first : last + 1]))
+    write_docker_config(raw)

--- a/scripts/python/helpers/build_checksum_map.py
+++ b/scripts/python/helpers/build_checksum_map.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Build an OCI artifact containing a checksum map of published files.
+
+For each component's ``ready_for_distribution`` directory, computes sha256 checksums
+for all files (excluding ``sha256sum.txt*``) and assembles them into a JSON manifest.
+The manifest is packaged as a tar archive and pushed to OCI using ``oras push``.
+The resulting ``store@digest`` reference is returned by ``run()`` for the caller to record.
+The manifest is stored as an OCI artifact so that downstream advisory tooling has a stable,
+addressable pointer it can pull independently to construct PURLs for released files.
+
+Secret mounts:
+  ``TRUSTED_ARTIFACTS_DOCKERCONFIG_MOUNT``  (default: ``/mnt/trusted_artifacts_dockerconfig``)
+
+Other env vars:
+  ``SNAPSHOT_JSON``        – JSON string of the Snapshot spec
+  ``CONTENT_DIR``          – override base directory (default: ``/shared/artifacts``)
+  ``SHARED_DIR``           – override shared volume root (default: ``/shared``)
+  ``OCI_STORE``            – OCI repository for checksum map artifacts
+                             (default:
+                             ``quay.io/konflux-ci/release-service-trusted-artifacts``)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import tarfile
+import tempfile
+from pathlib import Path
+
+import authentication
+import file as file_utils
+import oras_utils
+
+PROG = "build_checksum_map.py"
+
+TRUSTED_ARTIFACTS_DOCKERCONFIG_MOUNT = Path(
+    os.environ.get(
+        "TRUSTED_ARTIFACTS_DOCKERCONFIG_MOUNT", "/mnt/trusted_artifacts_dockerconfig"
+    )
+)
+CONTENT_DIR = Path(os.environ.get("CONTENT_DIR", "/shared/artifacts"))
+SHARED_DIR = Path(os.environ.get("SHARED_DIR", "/shared"))
+
+OCI_STORE = os.environ.get("OCI_STORE", "quay.io/konflux-ci/release-service-trusted-artifacts")
+
+logger = logging.getLogger(__name__)
+
+
+def _setup_docker_config() -> None:
+    """Copy the mounted dockerconfig into ~/.docker/config.json if present and non-empty."""
+    authentication.setup_docker_config(
+        TRUSTED_ARTIFACTS_DOCKERCONFIG_MOUNT / ".dockerconfigjson",
+        optional=True,
+    )
+    logger.info("Docker config loaded for OCI push")
+
+
+def run() -> str:
+    """Build a checksum manifest, push as an OCI artifact, and return the store@digest ref."""
+    shared_snapshot = SHARED_DIR / "snapshot.json"
+    if shared_snapshot.exists():
+        snapshot = json.loads(shared_snapshot.read_text())
+    else:
+        snapshot = json.loads(os.environ["SNAPSHOT_JSON"])
+
+    _setup_docker_config()
+
+    checksum_manifest: list[dict] = []
+
+    for component in snapshot.get("components", []):
+        name = component.get("name", "")
+        ready_dir = CONTENT_DIR / name / "ready_for_distribution"
+
+        logger.info("Generating checksum manifest for component: %s", name)
+
+        if not ready_dir.is_dir():
+            logger.warning("ready_for_distribution directory not found for %s", name)
+            continue
+
+        checksum_files: dict[str, str] = {}
+        for f in sorted(ready_dir.rglob("*")):
+            if f.is_file() and not f.name.startswith("sha256sum.txt"):
+                checksum = file_utils.sha256(f)
+                checksum_files[f.name] = f"sha256:{checksum}"
+
+        checksum_manifest.append({"component": name, "files": checksum_files})
+
+    archive_dir = Path(tempfile.mkdtemp())
+    try:
+        manifest_path = archive_dir / "checksum_map.json"
+        manifest_path.write_text(json.dumps(checksum_manifest, separators=(",", ":")))
+        logger.info("Checksum manifest contents:")
+        logger.info("%s", manifest_path.read_text())
+
+        archive_path = archive_dir / "checksum_map"
+        with tarfile.open(str(archive_path), "w:gz", compresslevel=9) as tf:
+            tf.add(str(manifest_path), arcname="checksum_map.json")
+
+        pushed_digest = oras_utils.oras_push(
+            OCI_STORE, archive_dir, "checksum_map", "checksum_map"
+        )
+        ref = f"{OCI_STORE}@{pushed_digest}"
+        logger.info("Checksum map pushed to OCI: %s", ref)
+        return ref
+    finally:
+        shutil.rmtree(str(archive_dir), ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run checksum map build and push; return exit code."""
+    logging.basicConfig(level=logging.INFO)
+    try:
+        ref = run()
+        logger.info("Checksum map pushed to: %s", ref)
+    except Exception as exc:
+        logger.error("ERROR: %s", exc)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/helpers/compress_artifacts.py
+++ b/scripts/python/helpers/compress_artifacts.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Pull signed binaries from Quay, restore supplementary files, and compress artifacts.
+
+For each component:
+* Pulls signed macOS and Windows OCI artifacts from Quay into a ``signed/`` directory.
+* Restores supplementary files (readme, license, changelog) that were held during signing.
+* Compresses each file entry into the final deliverable format:
+  - macOS / Linux → ``.tar.gz`` (from ``os/arch/`` directory)
+  - Windows → ``.zip`` (from ``os/arch/`` directory, extension corrected from
+    ``.tar.gz``/``.tar``)
+* Updates ``SNAPSHOT_JSON`` to reflect corrected Windows filenames in ``files[]``.
+* Saves the modified snapshot to ``/shared/snapshot.json`` for downstream use.
+
+CLI arguments:
+  ``--quay-url``
+
+Secret mounts:
+  ``QUAY_SECRET_MOUNT``  (default: ``/mnt/quaySecret``)
+
+Other env vars:
+  ``SNAPSHOT_JSON``   – JSON string of the Snapshot spec
+  ``CONTENT_DIR``     – override base directory (default: ``/shared/artifacts``)
+  ``SHARED_DIR``      – override shared volume root (default: ``/shared``)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tarfile
+import zipfile
+from pathlib import Path
+
+import oras_utils
+
+PROG = "compress_artifacts.py"
+
+QUAY_SECRET_MOUNT = Path(os.environ.get("QUAY_SECRET_MOUNT", "/mnt/quaySecret"))
+CONTENT_DIR = Path(os.environ.get("CONTENT_DIR", "/shared/artifacts"))
+SHARED_DIR = Path(os.environ.get("SHARED_DIR", "/shared"))
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse and return CLI arguments."""
+    p = argparse.ArgumentParser(prog=PROG)
+    p.add_argument("--quay-url", required=True, help="Quay repository URL base")
+    return p.parse_args(argv)
+
+
+def _pull_signed_content(quay_url: str, component_name: str, component_dir: Path) -> None:
+    """Pull signed Mac and Windows OCI artifacts from Quay into the component's signed/ dir."""
+    signed_dir = component_dir / "signed"
+    signed_dir.mkdir(parents=True, exist_ok=True)
+
+    if (component_dir / "has_mac").exists():
+        signed_mac_digest = (component_dir / "signed_mac_digest.txt").read_text().strip()
+        subprocess.check_call(
+            ["oras", "pull", f"{quay_url}/signed/{component_name}@{signed_mac_digest}"],
+            cwd=str(signed_dir),
+        )
+
+    if (component_dir / "has_windows").exists():
+        signed_windows_digest = (
+            (component_dir / "signed_windows_digest.txt").read_text().strip()
+        )
+        signed_windows_digest = signed_windows_digest.strip()
+        subprocess.check_call(
+            ["oras", "pull", f"{quay_url}/signed/{component_name}@{signed_windows_digest}"],
+            cwd=str(signed_dir),
+        )
+
+
+def _restore_supplementary(component_dir: Path) -> None:
+    """Move supplementary files from the hold directory back into the signed content tree."""
+    signed_dir = component_dir / "signed"
+    supp_hold = component_dir / "supplementary"
+    for os_name in ("macos", "windows"):
+        supp_os_dir = supp_hold / os_name
+        if not supp_os_dir.is_dir():
+            continue
+        for file in supp_os_dir.rglob("*"):
+            if file.is_file():
+                rel = file.relative_to(supp_os_dir)
+                dest = signed_dir / os_name / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(file), str(dest))
+                logger.info("  Restored supplementary file: %s/%s", os_name, rel)
+
+
+def _windows_filename(source_filename: str) -> str:
+    """Replace .tar.gz or .tar extension with .zip for Windows archives."""
+    if source_filename.endswith(".tar.gz"):
+        return source_filename[: -len(".tar.gz")] + ".zip"
+    if source_filename.endswith(".tar"):
+        return source_filename[: -len(".tar")] + ".zip"
+    return source_filename
+
+
+def _compress_file_entry(
+    entry: dict, array_name: str, component_dir: Path, ready_dir: Path
+) -> str:
+    """Compress one file entry into ready_dir and return the (possibly normalized) source path.
+
+    For macOS and Linux entries the source path is returned unchanged. For Windows entries
+    the archive is created as a ``.zip`` instead of ``.tar.gz``/``.tar``, and the returned
+    source path reflects the corrected filename so the snapshot can be updated accordingly.
+
+    Raises RuntimeError on failure (missing source, unknown OS, or empty arch directory).
+
+    Note: all files are currently compressed regardless of type. ISOs should be
+    passed through as-is rather than wrapped in a tarball — this will need to be
+    addressed before ISO delivery is supported.
+    """
+    source = entry.get("source")
+    if not source:
+        raise RuntimeError(f"Missing source field in {array_name}[] entry: {entry}")
+
+    source_filename = Path(source).name
+    os_name = entry.get("os", "")
+    arch = entry.get("arch", "")
+
+    arch_dir = oras_utils.os_arch_dir(
+        os_name,
+        arch,
+        mac_windows_base=component_dir / "signed",
+        linux_base=component_dir / "linux",
+    )
+    if arch_dir is None:
+        raise RuntimeError(f"Unknown OS '{os_name}' in {array_name}[] entry (arch: {arch})")
+
+    if not arch_dir.is_dir() or not any(arch_dir.iterdir()):
+        raise RuntimeError(f"Architecture directory is empty or not found: {arch_dir}")
+
+    # macOS and Linux follow the Unix convention of tar.gz archives; Windows uses zip
+    # because that is the standard expected by Windows users and Developer Portal tooling.
+    if os_name in ("darwin", "linux"):
+        out_path = ready_dir / source_filename
+        with tarfile.open(str(out_path), "w:gz") as tf:
+            for item in sorted(arch_dir.rglob("*")):
+                if item.is_file():
+                    tf.add(str(item), arcname=str(item.relative_to(arch_dir)))
+        logger.info("  Created (%s): %s", array_name, source_filename)
+        return source
+
+    win_filename = _windows_filename(source_filename)
+    out_path = ready_dir / win_filename
+    with zipfile.ZipFile(str(out_path), "w", zipfile.ZIP_DEFLATED) as zf:
+        for item in sorted(arch_dir.rglob("*")):
+            if item.is_file():
+                zf.write(str(item), arcname=str(item.relative_to(arch_dir)))
+    logger.info("  Created (%s): %s", array_name, win_filename)
+    return str(Path(source).parent / win_filename)
+
+
+def compress_component(component: dict, snapshot: dict) -> dict:
+    """Compress all file entries for one component. Returns updated component dict."""
+    name = component.get("name", "")
+    component_dir = CONTENT_DIR / name
+    ready_dir = component_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Compressing artifacts for component: %s", name)
+
+    # files[] entries are for Developer Portal delivery; staged.files[] entries are
+    # for Customer Portal (Pulp/CDN) delivery.  Both produce archives in
+    # ready_for_distribution/, but only files[] source paths are updated in the snapshot
+    # (Windows .zip correction).
+    files_entries = list(component.get("files") or [])
+    staged_entries = list((component.get("staged") or {}).get("files") or [])
+
+    normalized_files = []
+    if files_entries:
+        logger.info(
+            "  Processing %d files from files[] (Developer Portal):", len(files_entries)
+        )
+        for entry in files_entries:
+            normalized_source = _compress_file_entry(entry, "files", component_dir, ready_dir)
+            normalized_entry = dict(entry)
+            # no-op for mac/linux, .zip correction for windows
+            normalized_entry["source"] = normalized_source
+            normalized_files.append(normalized_entry)
+
+    if staged_entries:
+        logger.info(
+            "  Processing %d files from staged.files[] (Customer Portal):", len(staged_entries)
+        )
+        for entry in staged_entries:
+            _compress_file_entry(entry, "staged.files", component_dir, ready_dir)
+
+    updated_component = dict(component)
+    if files_entries:
+        updated_component["files"] = normalized_files
+
+    return updated_component
+
+
+def run(quay_url: str) -> None:
+    """Pull signed artifacts, restore supplementary files, and compress all components."""
+    snapshot = json.loads(os.environ["SNAPSHOT_JSON"])
+
+    quay_user = (QUAY_SECRET_MOUNT / "username").read_text().strip()
+    quay_pass = (QUAY_SECRET_MOUNT / "password").read_text().strip()
+
+    # Log in to the quay.io registry using the hostname only; quay_url contains the full
+    # repository path (e.g. quay.io/org/repo) and is passed to oras pull commands below.
+    logger.info("Logging into Quay...")
+    oras_utils.oras_login("quay.io", quay_user, quay_pass)
+
+    updated_components = []
+    for component in snapshot.get("components", []):
+        name = component.get("name", "")
+        component_dir = CONTENT_DIR / name
+
+        _pull_signed_content(quay_url, name, component_dir)
+        _restore_supplementary(component_dir)
+
+        updated = compress_component(component, snapshot)
+        updated_components.append(updated)
+
+    snapshot["components"] = updated_components
+    snapshot_path = SHARED_DIR / "snapshot.json"
+    snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+    logger.info("Saved modified snapshot to %s", snapshot_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and run artifact compression; return exit code."""
+    logging.basicConfig(level=logging.INFO)
+    args = parse_args(argv[1:] if argv is not None else None)
+    try:
+        run(args.quay_url)
+    except Exception as exc:
+        logger.error("ERROR: %s", exc)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/helpers/extract_artifacts.py
+++ b/scripts/python/helpers/extract_artifacts.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Extract artifacts from container images.
+
+For each component in SNAPSHOT_JSON that has ``files`` or ``staged.files`` entries:
+* Pulls the container image with ``skopeo copy`` (authenticated via ``select-oci-auth``).
+* Identifies the specific files listed in the RPA and extracts them from the container layers.
+* Creates OS flag files (``has_mac``, ``has_windows``, ``has_linux``) to indicate
+  which signing paths are needed.
+
+Components are processed in parallel, bounded by ``--concurrent-limit``.
+
+CLI arguments:
+  ``--concurrent-limit``
+
+Secret mounts (paths can be overridden via env vars for testing):
+  ``REDHAT_WORKLOADS_TOKEN_MOUNT``  (default: ``/mnt/redhat-workloads-token``)
+
+Other env vars:
+  ``SNAPSHOT_JSON``   – JSON string of the Snapshot spec (set by the task)
+  ``CONTENT_DIR``     – override base directory (default: ``/shared/artifacts``)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import authentication
+
+PROG = "extract_artifacts.py"
+
+REDHAT_WORKLOADS_TOKEN_MOUNT = Path(
+    os.environ.get("REDHAT_WORKLOADS_TOKEN_MOUNT", "/mnt/redhat-workloads-token")
+)
+CONTENT_DIR = Path(os.environ.get("CONTENT_DIR", "/shared/artifacts"))
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse and return CLI arguments."""
+    p = argparse.ArgumentParser(prog=PROG)
+    p.add_argument(
+        "--concurrent-limit",
+        type=int,
+        default=3,
+        help="Maximum number of components to process in parallel",
+    )
+    return p.parse_args(argv)
+
+
+def _setup_docker_config() -> None:
+    """Write ~/.docker/config.json from the mounted dockerconfig secret."""
+    authentication.setup_docker_config(
+        REDHAT_WORKLOADS_TOKEN_MOUNT / ".dockerconfigjson",
+        strip_noise=True,
+    )
+
+
+def _get_source_paths(component: dict) -> tuple[list[str], list[str]]:
+    """Return (wanted_files, layer_extract_dirs) from files[] and staged.files[] entries."""
+    wanted: list[str] = []
+    # Parent directories to extract from container image layers via `tar`. We extract
+    # whole directories rather than individual files because tar requires the full path
+    # prefix to be present in the layer for selective extraction to work.
+    layer_extract_dirs: list[str] = []
+
+    for entry in list(component.get("files") or []) + list(
+        (component.get("staged") or {}).get("files") or []
+    ):
+        source = entry.get("source", "")
+        if not source:
+            continue
+        stripped = source.lstrip("/")
+        wanted.append(stripped)
+        parent = str(Path(stripped).parent)
+        if parent and parent != ".":
+            layer_extract_dirs.append(parent)
+
+    if not layer_extract_dirs:
+        # No explicit parent directories from the RPA entries (e.g. source paths are bare
+        # filenames with no directory component).  Fall back to "releases/", which is the
+        # conventional top-level directory used in Red Hat release container images.
+        layer_extract_dirs = ["releases"]
+
+    unique_files = sorted(set(wanted))
+    unique_dirs = sorted(set(layer_extract_dirs))
+    return unique_files, unique_dirs
+
+
+def _safe_extract_layer(
+    tf: tarfile.TarFile, image_path: str, target_dir: Path, layer_name: str
+) -> bool:
+    """Extract members under image_path/ from a layer tarfile with path safety checks.
+
+    Returns True if any matching members were found, False otherwise.
+    Raises RuntimeError for unsafe entries (path traversal, symlinks, hardlinks, devices).
+    """
+    target_real = target_dir.resolve()
+    found = False
+    for member in tf.getmembers():
+        if not (member.name == image_path or member.name.startswith(f"{image_path}/")):
+            continue
+        found = True
+        if member.issym() or member.islnk() or member.isdev():
+            raise RuntimeError(
+                f"Layer {layer_name} contains unsupported entry type: {member.name}"
+            )
+        member_real = (target_dir / member.name).resolve()
+        if member_real != target_real and target_real not in member_real.parents:
+            raise RuntimeError(f"Layer {layer_name} contains unsafe path: {member.name}")
+        tf.extract(member, path=str(target_dir), filter="data")
+    return found
+
+
+def process_component(component: dict) -> None:
+    """Pull and extract one component's artifacts into CONTENT_DIR/<name>/."""
+    name = component.get("name")
+
+    num_files = len(component.get("files") or [])
+    # staged files are for Customer Portal (Pulp)
+    num_staged = len((component.get("staged") or {}).get("files") or [])
+    if num_files == 0 and num_staged == 0:
+        logger.info(
+            "Skipping component '%s' - no files defined (not a binary artifact component)",
+            name,
+        )
+        return
+
+    pullspec = component.get("containerImage")
+    if not pullspec:
+        raise ValueError(f"Component '{name}' is missing 'containerImage'")
+
+    destination = CONTENT_DIR / name
+    logger.info("Extracting component '%s' to: %s", name, destination)
+    destination.mkdir(parents=True, exist_ok=True)
+
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        auth_file: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(mode="wb", delete=False) as auth_fp:
+                auth_file = Path(auth_fp.name)
+                auth_data = subprocess.check_output(
+                    ["select-oci-auth", pullspec], stderr=subprocess.PIPE
+                )
+                auth_fp.write(auth_data)
+
+            subprocess.check_call(
+                [
+                    "skopeo",
+                    "copy",
+                    "--retry-times",
+                    "3",
+                    "--authfile",
+                    str(auth_file),
+                    f"docker://{pullspec}",
+                    f"dir:{tmp_dir}",
+                ]
+            )
+        finally:
+            if auth_file is not None:
+                auth_file.unlink(missing_ok=True)
+
+        wanted_files, extract_dirs = _get_source_paths(component)
+        logger.info("Files to extract from RPA: %s", wanted_files)
+
+        manifest = json.loads((tmp_dir / "manifest.json").read_text())
+        layer_digests = [layer["digest"] for layer in manifest.get("layers", [])]
+
+        for digest in layer_digests:
+            layer_file = tmp_dir / digest.removeprefix("sha256:")
+            if not layer_file.exists():
+                continue
+            with tarfile.open(str(layer_file)) as tf:
+                for image_path in extract_dirs:
+                    if _safe_extract_layer(tf, image_path, tmp_dir, layer_file.name):
+                        logger.info("Extracting %s/ from %s...", image_path, layer_file.name)
+                    else:
+                        logger.info(
+                            "skipping %s. It doesn't contain the %s dir",
+                            layer_file.name,
+                            image_path,
+                        )
+
+        for wanted in wanted_files:
+            src = tmp_dir / wanted
+            if src.is_file():
+                shutil.copy2(str(src), str(destination / src.name))
+            else:
+                logger.error("Expected file not found in container: %s", wanted)
+                raise RuntimeError(
+                    f"File '{wanted}' declared in RPA was not found in any container layer"
+                )
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def _create_os_flag_files(snapshot: dict) -> None:
+    """Create has_mac / has_windows / has_linux flag files based on RPA entries."""
+    for component in snapshot.get("components", []):
+        name = component.get("name", "")
+        component_dir = CONTENT_DIR / name
+        if not component_dir.is_dir():
+            continue
+
+        logger.info("Checking configured OS types for component: %s", name)
+
+        all_file_entries = list(component.get("files") or []) + list(
+            (component.get("staged") or {}).get("files") or []
+        )
+
+        def _matches(entry: dict, os_name: str) -> bool:
+            """Return True if the file entry is associated with the given OS."""
+            if entry.get("os") == os_name:
+                return True
+            for field in ("source", "filename"):
+                if os_name in (entry.get(field) or ""):
+                    return True
+            return False
+
+        if any(_matches(e, "darwin") for e in all_file_entries):
+            (component_dir / "has_mac").touch()
+            logger.info("  - macOS content detected")
+
+        if any(_matches(e, "windows") for e in all_file_entries):
+            (component_dir / "has_windows").touch()
+            logger.info("  - Windows content detected")
+
+        if any(_matches(e, "linux") for e in all_file_entries):
+            (component_dir / "has_linux").touch()
+            logger.info("  - Linux content detected")
+
+
+def run(concurrent_limit: int) -> None:
+    """Extract artifacts from all snapshot components and write OS flag files."""
+    snapshot = json.loads(os.environ["SNAPSHOT_JSON"])
+
+    _setup_docker_config()
+    CONTENT_DIR.mkdir(parents=True, exist_ok=True)
+
+    components = snapshot.get("components", [])
+    errors: list[str] = []
+
+    with ThreadPoolExecutor(max_workers=concurrent_limit) as executor:
+        futures = {
+            executor.submit(process_component, comp): comp.get("name", f"index {idx}")
+            for idx, comp in enumerate(components)
+        }
+        for future in as_completed(futures):
+            comp_name = futures[future]
+            try:
+                future.result()
+            except Exception as exc:
+                errors.append(f"Component '{comp_name}': {exc}")
+
+    if errors:
+        raise RuntimeError("\n".join(errors))
+
+    _create_os_flag_files(snapshot)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and run artifact extraction; return exit code."""
+    logging.basicConfig(level=logging.INFO)
+    args = parse_args(argv[1:] if argv is not None else None)
+    try:
+        run(args.concurrent_limit)
+    except Exception as exc:
+        logger.error("ERROR: %s", exc)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/helpers/file.py
+++ b/scripts/python/helpers/file.py
@@ -2,25 +2,33 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import tempfile
 from pathlib import Path
+
+
+def sha256(path: Path) -> str:
+    """Return the hex SHA-256 digest of the file at *path*."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
 
 
 def path_from_env_variable(
     name: str,
     default: str | Path,
 ) -> Path:
-    """
-    Return a filesystem path from the string value of an environment variable, or
-    a default.
+    """Return a filesystem path from the named environment variable, or *default*.
 
-    The value of name in ``os.environ`` (if set and not blank after
-    ``str.strip``) is interpreted as a path; it is not a path to a file whose
-    contents you read, and this function does not open or stat paths.
+    The value of *name* in ``os.environ`` (if set and non-blank after
+    ``str.strip``) is interpreted as a path; this function does not open or
+    stat paths.
 
-    If the variable is missing or only whitespace, default is returned (a str
-    or an existing ``Path``).
+    If the variable is missing or only whitespace, *default* is returned (a
+    str or an existing ``Path``).
 
     Typical use: a Tekton or pod env var that holds a mount directory path, with
     tests setting the same variable to a temp directory. Existence of the path
@@ -36,8 +44,7 @@ def make_tempfile_path(
     prefix: str,
     data: bytes | None = None,
 ) -> Path:
-    """
-    Create a secure private temp file and return a pathlib.Path to it.
+    """Create a secure private temp file and return a pathlib.Path to it.
 
     Uses the standard library ``tempfile.mkstemp``, which creates a new file and
     returns a file handle (a safe pattern). We never use the old ``mktemp`` API

--- a/scripts/python/helpers/generate_checksums.py
+++ b/scripts/python/helpers/generate_checksums.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Generate and GPG-sign a merged sha256sum.txt for all component archives.
+
+Generates checksums for all archive files across all components' ``ready_for_distribution``
+directories into a single ``sha256sum.txt`` file, then signs it once on the checksum host:
+* ``--clearsign`` → ``sha256sum.txt.sig``
+* ``--gpgsign``   → ``sha256sum.txt.gpg``
+
+The merged checksum file and its signatures are placed in the first component's
+``ready_for_distribution`` directory.
+
+Note: if multiple components targeting the same CGW product version are released in
+separate releases, the sha256sum.txt from the later release will overwrite the earlier
+one. All components for a given CGW product version should be in the same release.
+
+CLI arguments:
+  ``--kerberos-realm``
+  ``--pipeline-run-uid``
+
+Secret mounts:
+  ``CHECKSUM_CREDENTIALS_MOUNT``  (default: ``/mnt/checksum_credentials``)
+
+Other env vars:
+  ``AUTHOR``             – release author for rpm-sign (set by task from ``params.author``)
+  ``SIGNING_KEY_NAME``   – GPG key name (set by task from ``params.signingKeyName``)
+  ``SNAPSHOT_JSON``      – JSON string of the Snapshot spec
+  ``CONTENT_DIR``        – override base directory (default: ``/shared/artifacts``)
+  ``SHARED_DIR``         – override shared volume root (default: ``/shared``)
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import authentication
+import file as file_utils
+
+PROG = "generate_checksums.py"
+
+CHECKSUM_CREDENTIALS_MOUNT = Path(
+    os.environ.get("CHECKSUM_CREDENTIALS_MOUNT", "/mnt/checksum_credentials")
+)
+CONTENT_DIR = Path(os.environ.get("CONTENT_DIR", "/shared/artifacts"))
+SHARED_DIR = Path(os.environ.get("SHARED_DIR", "/shared"))
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse and return CLI arguments."""
+    p = argparse.ArgumentParser(prog=PROG)
+    p.add_argument(
+        "--kerberos-realm",
+        default="IPA.REDHAT.COM",
+        # IPA.REDHAT.COM is the production Red Hat Kerberos realm; override only for testing.
+        help="Kerberos realm for the checksum host",
+    )
+    p.add_argument("--pipeline-run-uid", required=True, help="Unique ID for this pipeline run")
+    return p.parse_args(argv)
+
+
+def _kinit(checksum_user: str, kerberos_realm: str, keytab_b64: bytes) -> None:
+    """Obtain a Kerberos ticket-granting ticket using the supplied base64-encoded keytab."""
+    krb5cc = Path(f"/tmp/krb5cc_{os.getuid()}")
+    os.environ["KRB5CCNAME"] = f"FILE:{krb5cc}"
+
+    fd, keytab_path = tempfile.mkstemp(suffix=".keytab")
+    keytab = Path(keytab_path)
+    try:
+        os.write(fd, base64.b64decode(keytab_b64))
+        os.close(fd)
+        authentication.kinit_with_retry(
+            f"{checksum_user}@{kerberos_realm}",
+            keytab,
+            {"KRB5CCNAME": f"FILE:{krb5cc}"},
+        )
+    finally:
+        keytab.unlink(missing_ok=True)
+
+
+def run(kerberos_realm: str, pipeline_run_uid: str) -> None:
+    """Generate sha256sum.txt and sign it on the checksum host via SSH."""
+    author = os.environ.get("AUTHOR", "").strip()
+    if not author:
+        raise ValueError("AUTHOR env var is required (set by task from params.author)")
+    signing_key_name = os.environ.get("SIGNING_KEY_NAME", "").strip()
+    if not signing_key_name:
+        raise ValueError(
+            "SIGNING_KEY_NAME env var is required (set by task from params.signingKeyName)"
+        )
+
+    checksum_user = (CHECKSUM_CREDENTIALS_MOUNT / "user").read_text().strip()
+    checksum_host = (CHECKSUM_CREDENTIALS_MOUNT / "host").read_text().strip()
+    keytab_b64 = (CHECKSUM_CREDENTIALS_MOUNT / "keytab").read_bytes()
+
+    _kinit(checksum_user, kerberos_realm, keytab_b64)
+
+    ssh_dir = Path("/tmp/.ssh")
+    ssh_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    known_hosts = ssh_dir / "known_hosts"
+    shutil.copy2(str(CHECKSUM_CREDENTIALS_MOUNT / "fingerprint"), str(known_hosts))
+    known_hosts.chmod(0o600)
+
+    ssh_opts = [
+        "-o",
+        "UserKnownHostsFile=/tmp/.ssh/known_hosts",
+        "-o",
+        "GSSAPIAuthentication=yes",
+        "-o",
+        "GSSAPIDelegateCredentials=yes",
+        "-o",
+        "IdentitiesOnly=yes",
+    ]
+
+    shared_snapshot = SHARED_DIR / "snapshot.json"
+    if shared_snapshot.exists():
+        snapshot = json.loads(shared_snapshot.read_text())
+    else:
+        snapshot = json.loads(os.environ["SNAPSHOT_JSON"])
+
+    components = snapshot.get("components", [])
+
+    sha_sums_path = Path("/tmp/sha256sum.txt")
+    sha_sums_path.write_text("")
+    first_ready_dir: Path | None = None
+
+    for component in components:
+        name = component.get("name", "")
+        ready_dir = CONTENT_DIR / name / "ready_for_distribution"
+
+        if first_ready_dir is None:
+            first_ready_dir = ready_dir
+
+        logger.info("Generating checksums for component: %s", name)
+
+        archive_files = (
+            sorted(
+                f
+                for f in ready_dir.iterdir()
+                if f.is_file() and not f.name.startswith("sha256sum.txt")
+            )
+            if ready_dir.exists()
+            else []
+        )
+
+        with sha_sums_path.open("a") as out:
+            for archive in archive_files:
+                checksum = file_utils.sha256(archive)
+                out.write(f"{checksum}  {archive.name}\n")
+
+    if first_ready_dir is None:
+        raise RuntimeError("No components found in snapshot")
+
+    if not sha_sums_path.stat().st_size:
+        raise RuntimeError("No archives found to checksum across all components")
+
+    remote_dir = f"{pipeline_run_uid}_merged"
+    remote_base = f"/home/{checksum_user}/{remote_dir}"
+    remote_checksum_dir = f"{remote_base}/checksum"
+    remote_input = f"{remote_checksum_dir}/sha256sum.txt"
+    remote_target = f"{checksum_user}@{checksum_host}"
+
+    subprocess.check_call(
+        [
+            "ssh",
+            *ssh_opts,
+            remote_target,
+            "mkdir -p " + shlex.quote(remote_checksum_dir),
+        ]
+    )
+    subprocess.check_call(
+        [
+            "scp",
+            *ssh_opts,
+            str(sha_sums_path),
+            f"{remote_target}:{remote_checksum_dir}",
+        ]
+    )
+
+    logger.info("Signing merged sha256sum.txt with --clearsign")
+    subprocess.check_call(
+        [
+            "ssh",
+            *ssh_opts,
+            remote_target,
+            " ".join(
+                [
+                    "rpm-sign",
+                    "--nat",
+                    "--clearsign",
+                    "--key",
+                    shlex.quote(signing_key_name),
+                    f"--onbehalfof={shlex.quote(author)}",
+                    "--output",
+                    shlex.quote(f"{remote_input}.sig"),
+                    shlex.quote(remote_input),
+                ]
+            ),
+        ]
+    )
+
+    logger.info("Signing merged sha256sum.txt with --gpgsign")
+    subprocess.check_call(
+        [
+            "ssh",
+            *ssh_opts,
+            remote_target,
+            " ".join(
+                [
+                    "rpm-sign",
+                    "--nat",
+                    "--gpgsign",
+                    "--key",
+                    shlex.quote(signing_key_name),
+                    f"--onbehalfof={shlex.quote(author)}",
+                    "--output",
+                    shlex.quote(f"{remote_input}.gpg"),
+                    shlex.quote(remote_input),
+                ]
+            ),
+        ]
+    )
+
+    first_ready_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(str(sha_sums_path), str(first_ready_dir / "sha256sum.txt"))
+
+    subprocess.check_call(
+        [
+            "scp",
+            *ssh_opts,
+            f"{remote_target}:{remote_checksum_dir}/sha256sum.txt.sig",
+            str(first_ready_dir / "sha256sum.txt.sig"),
+        ]
+    )
+
+    subprocess.check_call(
+        [
+            "scp",
+            *ssh_opts,
+            f"{remote_target}:{remote_checksum_dir}/sha256sum.txt.gpg",
+            str(first_ready_dir / "sha256sum.txt.gpg"),
+        ]
+    )
+
+    subprocess.check_call(
+        [
+            "ssh",
+            *ssh_opts,
+            remote_target,
+            "rm -rf " + shlex.quote(remote_base),
+        ]
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and run checksum generation and signing; return exit code."""
+    logging.basicConfig(level=logging.INFO)
+    args = parse_args(argv[1:] if argv is not None else None)
+    try:
+        run(args.kerberos_realm, args.pipeline_run_uid)
+    except Exception as exc:
+        logger.error("ERROR: %s", exc)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/helpers/oras_utils.py
+++ b/scripts/python/helpers/oras_utils.py
@@ -1,0 +1,71 @@
+"""Shared helpers for OCI artifact operations using the oras CLI."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+def oras_login(registry: str, username: str, password: str) -> None:
+    """Log in to an OCI registry via oras using username/password credentials.
+
+    Credentials are passed via stdin to avoid exposing them in process arguments.
+    Raises ``subprocess.CalledProcessError`` if the login fails.
+    """
+    subprocess.run(
+        ["oras", "login", registry, "-u", username, "--password-stdin"],
+        input=password,
+        text=True,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def oras_push(tag: str, directory: Path, subdirectory: str, component_name: str) -> str:
+    """Push *subdirectory* inside *directory* to an OCI registry via oras.
+
+    Runs ``oras push --annotation=quay.expires-after=1d <tag> <subdirectory>`` with
+    *directory* as the working directory and returns the ``sha256:<hex>`` digest string.
+
+    Raises ``RuntimeError`` if the digest cannot be extracted from the oras output,
+    which typically indicates a failed or incomplete push.
+    """
+    result = subprocess.check_output(
+        [
+            "oras",
+            "push",
+            "--annotation=quay.expires-after=1d",
+            tag,
+            subdirectory,
+        ],
+        cwd=str(directory),
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    match = re.search(r"Digest:\s+(\S+)", result)
+    if not match:
+        raise RuntimeError(
+            f"Could not extract digest from oras push output for {component_name}:\n{result}"
+        )
+    return match.group(1)
+
+
+def os_arch_dir(
+    os_name: str, arch: str, *, mac_windows_base: Path, linux_base: Path
+) -> Path | None:
+    """Return the OS/arch content directory for *os_name* and *arch*, or ``None``.
+
+    For macOS and Windows, the directory sits under *mac_windows_base* (e.g.
+    ``component_dir / "unsigned"`` or ``component_dir / "signed"``); for Linux it sits
+    under *linux_base* (typically ``component_dir / "linux"``).  Returns ``None`` for
+    unrecognised OS names so callers can skip or raise as appropriate.
+    """
+    if os_name == "darwin":
+        return mac_windows_base / "macos" / arch
+    if os_name == "linux":
+        return linux_base / arch
+    if os_name == "windows":
+        return mac_windows_base / "windows" / arch
+    return None

--- a/scripts/python/helpers/push_artifacts.py
+++ b/scripts/python/helpers/push_artifacts.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Push release artifacts to the Customer Portal (Pulp), CDN (exodus-rsync), and/or CGW.
+
+Routing logic per component:
+* If component has ``staged`` data → push to Customer Portal via ``pulp_push_wrapper``.
+* If component has only ``contentGateway`` data (no ``staged``) → push to CDN via
+  ``rsync`` with exodus-rsync.
+* If component has ``contentGateway`` data (with or without ``staged``) → publish to
+  Content Gateway via ``publish_to_cgw_wrapper``.
+
+Also validates that the Exodus Gateway, Pulp, and UDCache TLS certificates are not
+close to expiry before proceeding.
+
+Writes the list of published filenames to the path specified by ``RESULT_PUBLISHED_FILES``.
+
+CLI arguments:
+  ``--exodus-gw-env``
+  ``--cgw-hostname``
+  ``--cert-expiration-warn-days``
+
+Output env var:
+  ``RESULT_PUBLISHED_FILES``  – file path to write the published-files list to
+
+Secret mounts:
+  ``EXODUS_GW_SECRET_MOUNT``  (default: ``/mnt/exodusGwSecret``)
+  ``PULP_SECRET_MOUNT``       (default: ``/mnt/pulpSecret``)
+  ``UDCACHE_SECRET_MOUNT``    (default: ``/mnt/udcacheSecret``)
+  ``CGW_SECRET_MOUNT``        (default: ``/mnt/cgwSecret``)
+
+Other env vars:
+  ``SNAPSHOT_JSON``      – JSON string of the Snapshot spec
+  ``REQUESTS_CA_BUNDLE`` – set by task to use system CA bundle
+  ``CONTENT_DIR``        – override base directory (default: ``/shared/artifacts``)
+  ``SHARED_DIR``         – override shared volume root (default: ``/shared``)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import publish_to_cgw_wrapper
+import pulp_push_wrapper
+import yaml  # type: ignore
+
+PROG = "push_artifacts.py"
+
+EXODUS_GW_SECRET_MOUNT = Path(os.environ.get("EXODUS_GW_SECRET_MOUNT", "/mnt/exodusGwSecret"))
+PULP_SECRET_MOUNT = Path(os.environ.get("PULP_SECRET_MOUNT", "/mnt/pulpSecret"))
+UDCACHE_SECRET_MOUNT = Path(os.environ.get("UDCACHE_SECRET_MOUNT", "/mnt/udcacheSecret"))
+CGW_SECRET_MOUNT = Path(os.environ.get("CGW_SECRET_MOUNT", "/mnt/cgwSecret"))
+CONTENT_DIR = Path(os.environ.get("CONTENT_DIR", "/shared/artifacts"))
+SHARED_DIR = Path(os.environ.get("SHARED_DIR", "/shared"))
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse and return CLI arguments."""
+    p = argparse.ArgumentParser(prog=PROG)
+    p.add_argument(
+        "--exodus-gw-env", required=True, help="Exodus Gateway environment [live|pre]"
+    )
+    p.add_argument("--cgw-hostname", required=True, help="Content Gateway hostname")
+    p.add_argument(
+        "--cert-expiration-warn-days",
+        type=int,
+        default=7,
+        help="Days before cert expiry to warn",
+    )
+    return p.parse_args(argv)
+
+
+def _check_cert_expiration(cert_path: str, warn_days: int) -> None:
+    """Run check_cert_expiration utility; raise on failure."""
+    result = subprocess.run(
+        ["check_cert_expiration", cert_path, str(warn_days)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Certificate validation failed for {cert_path}: {result.stdout}{result.stderr}"
+        )
+
+
+def _write_cert_files(
+    exodus_cert: str,
+    exodus_key: str,
+    pulp_cert: str,
+    pulp_key: str,
+    udc_cert: str,
+    udc_key: str,
+) -> tuple[Path, Path, Path, Path, Path, Path]:
+    """Write certificate and key material to /tmp files; return the six resulting paths."""
+
+    def _write(name: str, content: str) -> Path:
+        """Write content to /tmp/<name> with restricted permissions and return the path."""
+        p = Path(f"/tmp/{name}")
+        p.write_text(content.strip() + "\n")
+        p.chmod(0o600)
+        return p
+
+    return (
+        _write("exodus.crt", exodus_cert),
+        _write("exodus.key", exodus_key),
+        _write("pulp.crt", pulp_cert),
+        _write("pulp.key", pulp_key),
+        _write("udc.crt", udc_cert),
+        _write("udc.key", udc_key),
+    )
+
+
+def _create_exodus_conf(
+    conf_path: Path,
+    gw_cert: Path,
+    gw_key: Path,
+    gw_url: str,
+    gw_env: str,
+) -> None:
+    """Write an exodus-rsync configuration file to conf_path."""
+    logger.info("Creating Exodus configuration file.....")
+    conf_content = (
+        f"gwcert:   {gw_cert}\n"
+        f"gwkey:    {gw_key}\n"
+        f"gwurl:    {gw_url}\n"
+        f"gwenv:    {gw_env}\n"
+        "\n"
+        "logger: file:/proc/1/fd/1\n"
+        "loglevel: info\n"
+        "\n"
+        "environments:\n"
+        "  - prefix: exodus\n"
+    )
+    conf_path.write_text(conf_content)
+
+
+def _push_component_to_pulp(
+    component_name: str,
+    snapshot: dict,
+    pulp_url: str,
+    pulp_cert: Path,
+    pulp_key: Path,
+    udc_url: str,
+) -> None:
+    """Stage component files and invoke pulp_push_wrapper to push to the Customer Portal."""
+    component = next(
+        (c for c in snapshot.get("components", []) if c.get("name") == component_name), {}
+    )
+    staged = component.get("staged") or {}
+    version = staged.get("version", "")
+    staged_destination = staged.get("destination", "")
+
+    if not version or not staged_destination:
+        raise RuntimeError(
+            f"Pulp push requires both staged.version and staged.destination "
+            f"for component {component_name}"
+        )
+
+    logger.info("Pushing component %s to customer portal with pulp", component_name)
+
+    component_dir = CONTENT_DIR / component_name / "ready_for_distribution"
+    staging_dir = Path(tempfile.mkdtemp())
+    try:
+        dest_files_dir = staging_dir / staged_destination / "FILES"
+        dest_files_dir.mkdir(parents=True)
+
+        staged_files = (component.get("staged") or {}).get("files") or []
+        if not staged_files:
+            logger.warning(
+                "No staged.files specified in RPA for Customer Portal push for %s",
+                component_name,
+            )
+            return
+
+        for sf in staged_files:
+            source_path = sf.get("source", "")
+            dest_filename = sf.get("filename", "")
+            if not source_path:
+                continue
+
+            source_filename = Path(source_path).name
+            # Handle windows .tar.gz/.tar → .zip conversion
+            if "windows" in source_filename:
+                for old_ext, new_ext in [(".tar.gz", ".zip"), (".tar", ".zip")]:
+                    if source_filename.endswith(old_ext):
+                        candidate = source_filename[: -len(old_ext)] + new_ext
+                        if (component_dir / candidate).exists():
+                            source_filename = candidate
+                            if dest_filename.endswith(old_ext):
+                                dest_filename = dest_filename[: -len(old_ext)] + new_ext
+                        break
+
+            if not dest_filename:
+                dest_filename = source_filename
+
+            src = component_dir / source_filename
+            if src.is_file():
+                shutil.copy2(str(src), str(dest_files_dir / dest_filename))
+                logger.info(
+                    "  Including file for Customer Portal: %s -> %s",
+                    source_filename,
+                    dest_filename,
+                )
+            else:
+                logger.warning("  File not found: %s", source_filename)
+
+        staged_json: dict = {"header": {"version": "0.2"}, "payload": {"files": []}}
+        for f in sorted(staging_dir.rglob("*")):
+            if f.is_file():
+                staged_json["payload"]["files"].append(
+                    {
+                        "filename": f.name,
+                        "relative_path": str(f.relative_to(staging_dir)),
+                        "version": version,
+                    }
+                )
+
+        staged_yaml_path = staging_dir / "staged.yaml"
+        staged_yaml_path.write_text(yaml.dump(staged_json, indent=4, default_flow_style=False))
+
+        pulp_push_wrapper.main(
+            [
+                "--source",
+                str(staging_dir),
+                "--pulp-url",
+                pulp_url,
+                "--pulp-cert",
+                str(pulp_cert),
+                "--pulp-key",
+                str(pulp_key),
+                "--udcache-url",
+                udc_url,
+            ]
+        )
+    finally:
+        shutil.rmtree(str(staging_dir), ignore_errors=True)
+
+
+def _push_component_to_cdn(
+    component_name: str, exodus_conf_path: Path, exclude: set[str] | None = None
+) -> None:
+    """Push files in a component's ready_for_distribution dir to CDN via exodus-rsync.
+
+    Files whose names appear in ``exclude`` are skipped. This is used when a component
+    publishes to both Pulp and CGW: staged files are already pushed to CDN by Pulp, so
+    only CGW files and the shared checksum files need to be exodus-rsync'd.
+    """
+    component_dir = CONTENT_DIR / component_name / "ready_for_distribution"
+    exclude = exclude or set()
+    logger.info("Pushing component %s to CDN with exodus-rsync", component_name)
+    prefix = "exodus:/content/origin/files/sha256"
+
+    for file in sorted(component_dir.rglob("*")):
+        if not file.is_file():
+            continue
+        if file.name in exclude:
+            logger.info("  Skipping %s (owned by Pulp on CDN)", file.name)
+            continue
+        h = hashlib.sha256()
+        with open(file, "rb") as fh:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                h.update(chunk)
+        checksum = h.hexdigest()
+        destination_path = f"{prefix}/{checksum[:2]}/{checksum}/{file.name}"
+        subprocess.check_call(
+            ["rsync", "--exodus-conf", str(exodus_conf_path), str(file), destination_path]
+        )
+
+
+def run(exodus_gw_env: str, cgw_hostname: str, cert_expiration_warn_days: int) -> None:
+    """Validate certificates and push artifacts to Pulp/CDN/CGW for each component."""
+    logger.info("=== Checking certificate expiration ===")
+    logger.info("Checking Exodus Gateway certificate")
+    _check_cert_expiration(str(EXODUS_GW_SECRET_MOUNT / "cert"), cert_expiration_warn_days)
+    logger.info("Checking Pulp certificate")
+    _check_cert_expiration(
+        str(PULP_SECRET_MOUNT / "konflux-release-rhsm-pulp.crt"), cert_expiration_warn_days
+    )
+    logger.info("Checking UDCache certificate")
+    _check_cert_expiration(str(UDCACHE_SECRET_MOUNT / "cert"), cert_expiration_warn_days)
+    logger.info("=== All certificates are valid ===")
+
+    shared_snapshot = SHARED_DIR / "snapshot.json"
+    if shared_snapshot.exists():
+        snapshot = json.loads(shared_snapshot.read_text())
+    else:
+        snapshot = json.loads(os.environ["SNAPSHOT_JSON"])
+
+    exodus_cert = (EXODUS_GW_SECRET_MOUNT / "cert").read_text()
+    exodus_key = (EXODUS_GW_SECRET_MOUNT / "key").read_text()
+    exodus_url = (EXODUS_GW_SECRET_MOUNT / "url").read_text().strip()
+    pulp_url = (PULP_SECRET_MOUNT / "pulp_url").read_text().strip()
+    pulp_cert_raw = (PULP_SECRET_MOUNT / "konflux-release-rhsm-pulp.crt").read_text()
+    pulp_key_raw = (PULP_SECRET_MOUNT / "konflux-release-rhsm-pulp.key").read_text()
+    udc_url = (UDCACHE_SECRET_MOUNT / "url").read_text().strip()
+    udc_cert_raw = (UDCACHE_SECRET_MOUNT / "cert").read_text()
+    udc_key_raw = (UDCACHE_SECRET_MOUNT / "key").read_text()
+    cgw_username = (CGW_SECRET_MOUNT / "username").read_text().strip()
+    cgw_password = (CGW_SECRET_MOUNT / "token").read_text().strip()
+
+    os.environ["CGW_USERNAME"] = cgw_username
+    os.environ["CGW_PASSWORD"] = cgw_password
+
+    exodus_gw_cert, exodus_gw_key, pulp_cert, pulp_key, udc_cert, udc_key = _write_cert_files(
+        exodus_cert, exodus_key, pulp_cert_raw, pulp_key_raw, udc_cert_raw, udc_key_raw
+    )
+    exodus_conf_path = Path("/tmp/exodus-rsync.conf")
+
+    os.environ["EXODUS_GW_CERT"] = str(exodus_gw_cert)
+    os.environ["EXODUS_GW_KEY"] = str(exodus_gw_key)
+    os.environ["PULP_CERT_FILE"] = str(pulp_cert)
+    os.environ["PULP_KEY_FILE"] = str(pulp_key)
+    os.environ["UDCACHE_CERT"] = str(udc_cert)
+    os.environ["UDCACHE_KEY"] = str(udc_key)
+    os.environ["EXODUS_GW_ENV"] = exodus_gw_env
+    os.environ["EXODUS_GW_URL"] = exodus_url
+    os.environ["EXODUS_PULP_HOOK_ENABLED"] = "True"
+    os.environ["EXODUS_GW_TIMEOUT"] = "7200"
+
+    result_published_path = Path(os.environ["RESULT_PUBLISHED_FILES"])
+    published_files = []
+    for ready_dir in sorted(CONTENT_DIR.glob("*/ready_for_distribution")):
+        for f in sorted(ready_dir.iterdir()):
+            if f.is_file():
+                published_files.append(f.name)
+
+    result_published_path.write_text("\n".join(published_files), encoding="utf-8")
+
+    for component in snapshot.get("components", []):
+        name = component.get("name", "")
+        has_staged = bool(component.get("staged"))
+        has_cgw = bool(component.get("contentGateway"))
+
+        logger.info("Processing component: %s (staged=%s, cgw=%s)", name, has_staged, has_cgw)
+
+        if has_staged:
+            _push_component_to_pulp(name, snapshot, pulp_url, pulp_cert, pulp_key, udc_url)
+
+        if has_cgw:
+            _create_exodus_conf(
+                exodus_conf_path, exodus_gw_cert, exodus_gw_key, exodus_url, exodus_gw_env
+            )
+            # When a component has both staged and CGW content, exclude staged filenames
+            # from the CDN push — Pulp owns those files on CDN. CGW-only files (files[])
+            # and the shared checksum files must still be exodus-rsync'd so the CGW
+            # downloadURLs resolve on the CDN origin.
+            staged_filenames: set[str] = set()
+            if has_staged:
+                for sf in (component.get("staged") or {}).get("files") or []:
+                    src = sf.get("source", "")
+                    if src:
+                        staged_filenames.add(Path(src).name)
+            _push_component_to_cdn(name, exodus_conf_path, exclude=staged_filenames)
+
+        if has_cgw:
+            component_dir = CONTENT_DIR / name / "ready_for_distribution"
+            cg = component.get("contentGateway") or {}
+            cg["contentDir"] = str(component_dir)
+            component["contentGateway"] = cg
+
+    cgw_push = any(bool(c.get("contentGateway")) for c in snapshot.get("components", []))
+    if cgw_push:
+        logger.info("Publishing all components to CGW...")
+        if "developers.qa.redhat.com" in cgw_hostname:
+            os.environ["HTTP_PROXY"] = "http://squid.corp.redhat.com:3128"
+            os.environ["HTTPS_PROXY"] = "http://squid.corp.redhat.com:3128"
+            logger.info("Using squid proxy for preprod CGW access")
+
+        publish_to_cgw_wrapper.main(
+            [
+                "--cgw_host",
+                cgw_hostname,
+                "--data_json",
+                json.dumps(snapshot),
+            ]
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and push artifacts to all configured destinations; return exit code."""
+    logging.basicConfig(level=logging.INFO)
+    args = parse_args(argv[1:] if argv is not None else None)
+    try:
+        run(args.exodus_gw_env, args.cgw_hostname, args.cert_expiration_warn_days)
+    except Exception as exc:
+        logger.error("ERROR: %s", exc)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/helpers/push_unsigned.py
+++ b/scripts/python/helpers/push_unsigned.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Organise extracted binaries by OS/arch and push unsigned Mac/Windows content to Quay.
+
+For each component that has ``files`` or ``staged.files``:
+* Unpacks each archive into an ``unsigned/<os>/<arch>/`` directory tree.
+* Moves supplementary files (readme, license, changelog) out of signing directories so
+  signing tools don't attempt to process them.
+* Pushes the unsigned macOS and Windows content to Quay as OCI artifacts with a 1-day
+  expiry tag so the signing steps can pull them.
+
+CLI arguments:
+  ``--quay-url``
+  ``--pipeline-run-uid``
+
+Secret mounts:
+  ``QUAY_SECRET_MOUNT``  (default: ``/mnt/quaySecret``)
+
+Other env vars:
+  ``SNAPSHOT_JSON``   – JSON string of the Snapshot spec
+  ``CONTENT_DIR``     – override base directory (default: ``/shared/artifacts``)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import tarfile
+from pathlib import Path
+
+import oras_utils
+
+PROG = "push_unsigned.py"
+
+QUAY_SECRET_MOUNT = Path(os.environ.get("QUAY_SECRET_MOUNT", "/mnt/quaySecret"))
+CONTENT_DIR = Path(os.environ.get("CONTENT_DIR", "/shared/artifacts"))
+
+SUPPLEMENTARY_NAMES = {"readme", "license", "changelog"}
+SUPPLEMENTARY_EXTS = {".md", ".txt"}
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse and return CLI arguments."""
+    p = argparse.ArgumentParser(prog=PROG)
+    p.add_argument("--quay-url", required=True, help="Quay repository URL base")
+    p.add_argument("--pipeline-run-uid", required=True, help="Unique ID for this pipeline run")
+    return p.parse_args(argv)
+
+
+def is_supplementary_file(path: Path) -> bool:
+    """Return True if a file is a supplementary (readme/license/changelog) file."""
+    lower = path.name.lower()
+    if "." in lower:
+        base, ext = lower.rsplit(".", 1)
+        ext = f".{ext}"
+    else:
+        base, ext = lower, ""
+    if base in SUPPLEMENTARY_NAMES:
+        if not ext:
+            return True
+        if ext in SUPPLEMENTARY_EXTS:
+            return True
+    return False
+
+
+def move_supplementary_out(src_root: Path, hold_root: Path) -> None:
+    """Move supplementary files from src_root to hold_root, preserving relative paths."""
+    if not src_root.is_dir():
+        return
+    for file in src_root.rglob("*"):
+        if file.is_file() and is_supplementary_file(file):
+            rel = file.relative_to(src_root)
+            dest = hold_root / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(file), str(dest))
+            logger.info("  Held supplementary file: %s", rel)
+
+
+def _unpack_file_entries(entries: list[dict], component_dir: Path, unsigned_dir: Path) -> None:
+    """Extract each archive from entries into its OS/arch subdirectory under unsigned_dir."""
+    for entry in entries:
+        source = entry.get("source", "")
+        os_name = entry.get("os", "")
+        arch = entry.get("arch", "")
+        if not source or not os_name or not arch:
+            continue
+
+        archive_name = Path(source).name
+        archive_path = component_dir / archive_name
+
+        if not archive_path.is_file():
+            logger.warning("  Archive not found: %s", archive_path)
+            continue
+
+        target_dir = oras_utils.os_arch_dir(
+            os_name, arch, mac_windows_base=unsigned_dir, linux_base=component_dir / "linux"
+        )
+        if target_dir is None:
+            continue
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(str(archive_path)) as tf:
+            _safe_extract_archive(tf, target_dir, archive_name)
+        archive_path.unlink()
+
+
+def _safe_extract_archive(tf: tarfile.TarFile, target_dir: Path, archive_name: str) -> None:
+    """Extract tar entries while preventing traversal and unsafe links/devices."""
+    target_real = target_dir.resolve()
+    for member in tf.getmembers():
+        member_path = target_dir / member.name
+        member_real = member_path.resolve()
+        if member_real != target_real and target_real not in member_real.parents:
+            raise RuntimeError(f"Archive {archive_name} contains unsafe path: {member.name}")
+        if member.issym() or member.islnk() or member.isdev():
+            raise RuntimeError(
+                f"Archive {archive_name} contains unsupported entry type: {member.name}"
+            )
+        tf.extract(member, path=str(target_dir), filter="data")
+
+
+def run(quay_url: str, pipeline_run_uid: str) -> None:
+    """Organise extracted binaries and push unsigned Mac/Windows content to Quay."""
+    snapshot = json.loads(os.environ["SNAPSHOT_JSON"])
+
+    quay_user = (QUAY_SECRET_MOUNT / "username").read_text().strip()
+    quay_pass = (QUAY_SECRET_MOUNT / "password").read_text().strip()
+
+    logger.info("Logging into Quay...")
+    oras_utils.oras_login("quay.io", quay_user, quay_pass)
+
+    for component in snapshot.get("components", []):
+        name = component.get("name", "")
+        logger.info("Processing component: %s", name)
+
+        num_files = len(component.get("files") or [])
+        num_staged = len((component.get("staged") or {}).get("files") or [])
+        if num_files == 0 and num_staged == 0:
+            logger.info("Skipping component '%s' - no files or staged.files defined", name)
+            continue
+
+        component_dir = CONTENT_DIR / name
+        unsigned_dir = component_dir / "unsigned"
+
+        has_mac = (component_dir / "has_mac").exists()
+        has_windows = (component_dir / "has_windows").exists()
+        has_linux = (component_dir / "has_linux").exists()
+
+        if has_mac:
+            (unsigned_dir / "macos").mkdir(parents=True, exist_ok=True)
+        if has_windows:
+            (unsigned_dir / "windows").mkdir(parents=True, exist_ok=True)
+        if has_linux:
+            (component_dir / "linux").mkdir(parents=True, exist_ok=True)
+
+        _unpack_file_entries(component.get("files") or [], component_dir, unsigned_dir)
+        _unpack_file_entries(
+            (component.get("staged") or {}).get("files") or [], component_dir, unsigned_dir
+        )
+
+        supp_hold = component_dir / "supplementary"
+        logger.info("Moving supplementary files out of signing directories...")
+        move_supplementary_out(unsigned_dir / "macos", supp_hold / "macos")
+        move_supplementary_out(unsigned_dir / "windows", supp_hold / "windows")
+
+        if has_mac:
+            logger.info("Pushing unsigned macOS content for %s to %s...", name, quay_url)
+            tag = f"{quay_url}/unsigned/{name}:{pipeline_run_uid}-mac"
+            mac_digest = oras_utils.oras_push(tag, unsigned_dir, "macos", name)
+            logger.info("Digest for %s mac content: %s", name, mac_digest)
+            (component_dir / "unsigned_mac_digest.txt").write_text(mac_digest)
+        else:
+            logger.info("No macOS content for %s, skipping unsigned push...", name)
+
+        if has_windows:
+            logger.info("Pushing unsigned Windows content for %s to %s...", name, quay_url)
+            tag = f"{quay_url}/unsigned/{name}:{pipeline_run_uid}-windows"
+            win_digest = oras_utils.oras_push(tag, unsigned_dir, "windows", name)
+            logger.info("Digest for %s windows content: %s", name, win_digest)
+            (component_dir / "unsigned_windows_digest.txt").write_text(win_digest)
+        else:
+            logger.info("No Windows content for %s, skipping unsigned push...", name)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and run unsigned artifact push; return exit code."""
+    logging.basicConfig(level=logging.INFO)
+    args = parse_args(argv[1:] if argv is not None else None)
+    try:
+        run(args.quay_url, args.pipeline_run_uid)
+    except Exception as exc:
+        logger.error("ERROR: %s", exc)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/helpers/sign_mac.py
+++ b/scripts/python/helpers/sign_mac.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Sign macOS binaries on a remote Mac host via SSH.
+
+For each component with a ``has_mac`` flag file:
+* Generates a shell script that pulls the unsigned OCI artifact from Quay,
+  signs with ``xcrun codesign``, notarizes with ``xcrun notarytool``, and pushes
+  the signed content back to Quay.
+* SCPs the script to the Mac host and executes it via SSH.
+* Copies the resulting signed digest back and writes it to
+  ``<component_dir>/signed_mac_digest.txt``.
+* Always cleans up the remote temporary directory.
+
+CLI arguments:
+  ``--quay-url``
+  ``--pipeline-run-uid``
+
+Secret mounts:
+  ``MAC_SSH_KEY_MOUNT``         (default: ``/mnt/secrets``)
+  ``MAC_HOST_CREDS_MOUNT``      (default: ``/mnt/macHostCredentials``)
+  ``MAC_SIGNING_CREDS_MOUNT``   (default: ``/mnt/macSigningCredentials``)
+  ``QUAY_SECRET_MOUNT``         (default: ``/mnt/quaySecret``)
+
+Other env vars:
+  ``SNAPSHOT_JSON``   – JSON string of the Snapshot spec
+  ``CONTENT_DIR``     – override base directory (default: ``/shared/artifacts``)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+PROG = "sign_mac.py"
+
+MAC_SSH_KEY_MOUNT = Path(os.environ.get("MAC_SSH_KEY_MOUNT", "/mnt/secrets"))
+MAC_HOST_CREDS_MOUNT = Path(os.environ.get("MAC_HOST_CREDS_MOUNT", "/mnt/macHostCredentials"))
+MAC_SIGNING_CREDS_MOUNT = Path(
+    os.environ.get("MAC_SIGNING_CREDS_MOUNT", "/mnt/macSigningCredentials")
+)
+QUAY_SECRET_MOUNT = Path(os.environ.get("QUAY_SECRET_MOUNT", "/mnt/quaySecret"))
+CONTENT_DIR = Path(os.environ.get("CONTENT_DIR", "/shared/artifacts"))
+
+logger = logging.getLogger(__name__)
+
+
+def _build_signing_script(
+    *,
+    quay_url: str,
+    quay_user: str,
+    quay_pass: str,
+    component_name: str,
+    unsigned_digest: str,
+    pipeline_run_uid: str,
+    temp_dir: str,
+    binary_path: str,
+    zip_path: str,
+    digest_file: str,
+    keychain_password: str,
+    signing_identity: str,
+    apple_id: str,
+    team_id: str,
+    app_specific_password: str,
+) -> str:
+    """Build the remote shell script that pulls, signs, notarizes, and pushes Mac binaries."""
+    return f"""#!/bin/bash
+set -eux
+
+mkdir -p {temp_dir}
+mkdir -p {binary_path}
+
+cd {temp_dir}
+set +x
+export QUAY_PASS={shlex.quote(quay_pass)}
+echo "$QUAY_PASS" | /usr/local/bin/oras login quay.io -u {quay_user} --password-stdin
+unset QUAY_PASS
+set -x
+/usr/local/bin/oras pull {quay_url}/unsigned/{component_name}@{unsigned_digest} -o "{binary_path}"  # noqa: E501
+CONTENT_DIR_MAC="{binary_path}/macos"
+
+set +x
+export KEYCHAIN_PASSWORD={shlex.quote(keychain_password)}
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" login.keychain
+unset KEYCHAIN_PASSWORD
+set -x
+echo "Signing files in the $CONTENT_DIR_MAC directory..."
+find "$CONTENT_DIR_MAC" -type f | while IFS= read -r file; do
+    echo "Signing: $file"
+    if ! xcrun codesign --sign "Developer ID Application: {signing_identity}" \\
+        --options runtime --timestamp --force "$file"; then
+        echo "Failed to sign file: $file"
+        exit 1
+    fi
+done
+
+cd "{binary_path}"
+zip -r "{zip_path}" macos
+
+echo "Submitting ZIP file to Apple notary service..."
+set +x
+export NOTARY_PASSWORD={shlex.quote(app_specific_password)}
+xcrun notarytool submit "{zip_path}" \\
+    --wait \\
+    --apple-id "{apple_id}" \\
+    --team-id "{team_id}" \\
+    --password "$NOTARY_PASSWORD"
+unset NOTARY_PASSWORD
+set -x
+
+SIGNED_TAG="{pipeline_run_uid}-mac"
+PUSH_OUTPUT=$(/usr/local/bin/oras push --annotation=quay.expires-after=1d \\
+  "{quay_url}/signed/{component_name}:$SIGNED_TAG" macos)
+SIGNED_DIGEST=$(echo "$PUSH_OUTPUT" | grep 'Digest:' | awk '{{print $2}}')
+echo -n "$SIGNED_DIGEST" >> "{digest_file}"
+echo "Process completed successfully."
+"""
+
+
+def _ssh_opts(key_path: str, known_hosts: str) -> list[str]:
+    """Return SSH option flags for key-based authentication with a fixed known_hosts file."""
+    return [
+        "-i",
+        key_path,
+        "-o",
+        f"UserKnownHostsFile={known_hosts}",
+        "-o",
+        "IdentitiesOnly=yes",
+    ]
+
+
+def run(quay_url: str, pipeline_run_uid: str) -> None:
+    """Sign macOS binaries on the remote Mac host for every component with a has_mac flag."""
+    snapshot = json.loads(os.environ["SNAPSHOT_JSON"])
+    quay_url = quay_url.rstrip("/")
+
+    mac_user = (MAC_HOST_CREDS_MOUNT / "username").read_text().strip()
+    mac_host = (MAC_HOST_CREDS_MOUNT / "host").read_text().strip()
+    keychain_password = (MAC_SIGNING_CREDS_MOUNT / "keychain_password").read_text().strip()
+    signing_identity = (MAC_SIGNING_CREDS_MOUNT / "signing_identity").read_text().strip()
+    apple_id = (MAC_SIGNING_CREDS_MOUNT / "apple_id").read_text().strip()
+    team_id = (MAC_SIGNING_CREDS_MOUNT / "team_id").read_text().strip()
+    app_specific_password = (
+        (MAC_SIGNING_CREDS_MOUNT / "app_specific_password").read_text().strip()
+    )
+    quay_user = (QUAY_SECRET_MOUNT / "username").read_text().strip()
+    quay_pass = (QUAY_SECRET_MOUNT / "password").read_text().strip()
+
+    ssh_dir = Path("/tmp/.ssh")
+    ssh_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    id_rsa = ssh_dir / "id_rsa"
+    known_hosts = ssh_dir / "known_hosts"
+    shutil.copy2(str(MAC_SSH_KEY_MOUNT / "mac_id_rsa"), str(id_rsa))
+    shutil.copy2(str(MAC_SSH_KEY_MOUNT / "mac_fingerprint"), str(known_hosts))
+    id_rsa.chmod(0o600)
+    known_hosts.chmod(0o600)
+
+    ssh_opts = _ssh_opts(str(id_rsa), str(known_hosts))
+
+    for component in snapshot.get("components", []):
+        name = component.get("name", "")
+        component_dir = CONTENT_DIR / name
+
+        if not (component_dir / "has_mac").exists():
+            logger.info("No macOS content for component %s, skipping Mac signing...", name)
+            continue
+
+        logger.info("Signing Mac binaries for component: %s", name)
+
+        unsigned_digest = (component_dir / "unsigned_mac_digest.txt").read_text().strip()
+
+        mac_script_path = f"/tmp/mac_signing_script_{pipeline_run_uid}_{name}.sh"
+        temp_dir = f"/tmp/{pipeline_run_uid}_{name}"
+        binary_path = f"{temp_dir}/unsigned"
+        zip_path = f"{temp_dir}/signed_content.zip"
+        digest_file = f"{temp_dir}/push_digest.txt"
+
+        script_content = _build_signing_script(
+            quay_url=quay_url,
+            quay_user=quay_user,
+            quay_pass=quay_pass,
+            component_name=name,
+            unsigned_digest=unsigned_digest,
+            pipeline_run_uid=pipeline_run_uid,
+            temp_dir=temp_dir,
+            binary_path=binary_path,
+            zip_path=zip_path,
+            digest_file=digest_file,
+            keychain_password=keychain_password,
+            signing_identity=signing_identity,
+            apple_id=apple_id,
+            team_id=team_id,
+            app_specific_password=app_specific_password,
+        )
+
+        fd, script_path = tempfile.mkstemp(suffix=".sh")
+        local_script = Path(script_path)
+        os.write(fd, script_content.encode())
+        os.close(fd)
+
+        try:
+            # Output is intentionally not captured — the script contains plaintext
+            # credentials and routing SCP output through the logger could expose them.
+            subprocess.check_call(
+                ["scp"]
+                + ssh_opts
+                + [str(local_script), f"{mac_user}@{mac_host}:{mac_script_path}"]
+            )
+
+            ssh_exit = 0
+            failed_op = ""
+            result = subprocess.run(
+                ["ssh"] + ssh_opts + [f"{mac_user}@{mac_host}", "bash", mac_script_path]
+            )
+            if result.returncode != 0:
+                ssh_exit = result.returncode
+                failed_op = "signing"
+
+            if ssh_exit == 0:
+                scp_result = subprocess.run(
+                    ["scp"]
+                    + ssh_opts
+                    + [
+                        f"{mac_user}@{mac_host}:{temp_dir}/push_digest.txt",
+                        str(component_dir / "signed_mac_digest.txt"),
+                    ]
+                )
+                if scp_result.returncode != 0:
+                    ssh_exit = scp_result.returncode
+                    failed_op = "scp of signed digest"
+
+            cleanup = subprocess.run(
+                ["ssh"]
+                + ssh_opts
+                + [
+                    f"{mac_user}@{mac_host}",
+                    "rm -rf " + shlex.quote(temp_dir) + " " + shlex.quote(mac_script_path),
+                ],
+                check=False,
+            )
+            if cleanup.returncode != 0:
+                logger.warning(
+                    "Remote cleanup failed for %s (exit code: %d) — "
+                    "%s and %s may remain on the Mac host",
+                    name,
+                    cleanup.returncode,
+                    temp_dir,
+                    mac_script_path,
+                )
+
+            if ssh_exit != 0:
+                raise RuntimeError(
+                    f"Mac {failed_op} failed for component: {name} (exit code: {ssh_exit})"
+                )
+        finally:
+            local_script.unlink(missing_ok=True)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse and return CLI arguments."""
+    p = argparse.ArgumentParser(prog=PROG)
+    p.add_argument("--quay-url", required=True, help="Quay repository URL base")
+    p.add_argument("--pipeline-run-uid", required=True, help="Unique ID for this pipeline run")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and run Mac signing; return exit code."""
+    logging.basicConfig(level=logging.INFO)
+    args = parse_args(argv[1:] if argv is not None else None)
+    try:
+        run(args.quay_url, args.pipeline_run_uid)
+    except Exception as exc:
+        logger.error("ERROR: %s", exc)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/helpers/sign_windows.py
+++ b/scripts/python/helpers/sign_windows.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Sign Windows binaries on a remote Windows host via SSH.
+
+For each component with a ``has_windows`` flag file:
+* Generates a Windows batch script that pulls unsigned OCI artifacts, runs
+  ``signtool`` to sign and verify all binaries, pushes signed content back to
+  Quay, and writes the digest to a file.
+* SCPs the script to the Windows host and executes it via SSH.
+* Copies the resulting signed digest back, normalises line endings, and writes
+  it to ``<component_dir>/signed_windows_digest.txt``.
+* Always cleans up the remote temporary directory.
+
+CLI arguments:
+  ``--quay-url``
+  ``--pipeline-run-uid``
+
+Secret mounts:
+  ``WINDOWS_SSH_KEY_MOUNT``      (default: ``/mnt/secrets``)
+  ``WINDOWS_CREDS_MOUNT``        (default: ``/mnt/windowsCredentials``)
+  ``QUAY_SECRET_MOUNT``          (default: ``/mnt/quaySecret``)
+
+Other env vars:
+  ``SNAPSHOT_JSON``   – JSON string of the Snapshot spec
+  ``CONTENT_DIR``     – override base directory (default: ``/shared/artifacts``)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+PROG = "sign_windows.py"
+
+WINDOWS_SSH_KEY_MOUNT = Path(os.environ.get("WINDOWS_SSH_KEY_MOUNT", "/mnt/secrets"))
+WINDOWS_CREDS_MOUNT = Path(os.environ.get("WINDOWS_CREDS_MOUNT", "/mnt/windowsCredentials"))
+QUAY_SECRET_MOUNT = Path(os.environ.get("QUAY_SECRET_MOUNT", "/mnt/quaySecret"))
+CONTENT_DIR = Path(os.environ.get("CONTENT_DIR", "/shared/artifacts"))
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse and return CLI arguments."""
+    p = argparse.ArgumentParser(prog=PROG)
+    p.add_argument("--quay-url", required=True, help="Quay repository URL base")
+    p.add_argument("--pipeline-run-uid", required=True, help="Unique ID for this pipeline run")
+    return p.parse_args(argv)
+
+
+def _build_batch_script(
+    *,
+    quay_url: str,
+    quay_user: str,
+    quay_pass: str,
+    component_name: str,
+    unsigned_digest: str,
+    pipeline_run_uid: str,
+    windows_temp_dir: str,
+) -> str:
+    """Build the remote batch script that pulls, signs, verifies, and pushes binaries."""
+    return f"""
+mkdir %TEMP%\\{windows_temp_dir} && cd /d %TEMP%\\{windows_temp_dir}
+@echo off
+oras login quay.io -u {quay_user} -p {quay_pass}
+@echo on
+oras pull {quay_url}/unsigned/{component_name}@{unsigned_digest} -o unsigned
+REM The content is extracted to unsigned\\windows with os/arch/ subdirectories
+
+REM Recursively sign all files in unsigned\\windows directory tree
+for /r unsigned\\windows %%f in (*) do (
+  signtool sign /v /n "Red Hat" /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 "%%f"
+  if errorlevel 1 (
+    echo Signing of %%f failed
+    exit /B %ERRORLEVEL%
+  )
+)
+
+REM Recursively verify all signed files
+for /r unsigned\\windows %%f in (*) do (
+  signtool verify /v /pa "%%f"
+  if errorlevel 1 (
+    echo Verification of %%f failed
+    exit /B %ERRORLEVEL%
+  )
+)
+
+echo [%DATE% %TIME%] Signing of Windows binaries for {component_name} completed successfully
+
+cd unsigned
+oras push ^
+  --annotation=quay.expires-after=1d ^
+  {quay_url}/signed/{component_name}:{pipeline_run_uid}-windows ^
+  windows
+if %ERRORLEVEL% neq 0 (
+  echo ERROR: oras push failed with error %ERRORLEVEL%
+  exit /B %ERRORLEVEL%
+)
+"""
+
+
+def run(quay_url: str, pipeline_run_uid: str) -> None:
+    """Sign Windows binaries on the remote host for every component with a has_windows flag."""
+    snapshot = json.loads(os.environ["SNAPSHOT_JSON"])
+
+    windows_user = (WINDOWS_CREDS_MOUNT / "username").read_text().strip()
+    windows_port = (WINDOWS_CREDS_MOUNT / "port").read_text().strip()
+    windows_host = (WINDOWS_CREDS_MOUNT / "host").read_text().strip()
+    quay_user = (QUAY_SECRET_MOUNT / "username").read_text().strip()
+    quay_pass = (QUAY_SECRET_MOUNT / "password").read_text().strip()
+
+    ssh_dir = Path("/tmp/.ssh")
+    ssh_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    id_rsa = ssh_dir / "id_rsa"
+    known_hosts = ssh_dir / "known_hosts"
+    shutil.copy2(str(WINDOWS_SSH_KEY_MOUNT / "windows_id_rsa"), str(id_rsa))
+    shutil.copy2(str(WINDOWS_SSH_KEY_MOUNT / "windows_fingerprint"), str(known_hosts))
+    id_rsa.chmod(0o600)
+    known_hosts.chmod(0o600)
+
+    ssh_opts = [
+        "-i",
+        str(id_rsa),
+        "-o",
+        f"UserKnownHostsFile={known_hosts}",
+        "-o",
+        "IdentitiesOnly=yes",
+        "-p",
+        windows_port,
+    ]
+    scp_opts = [
+        "-i",
+        str(id_rsa),
+        "-o",
+        f"UserKnownHostsFile={known_hosts}",
+        "-o",
+        "IdentitiesOnly=yes",
+        "-P",
+        windows_port,
+    ]
+
+    for component in snapshot.get("components", []):
+        name = component.get("name", "")
+        component_dir = CONTENT_DIR / name
+
+        if not (component_dir / "has_windows").exists():
+            logger.info(
+                "No Windows content for component %s, skipping Windows signing...", name
+            )
+            continue
+
+        logger.info("Signing Windows binaries for component: %s", name)
+
+        unsigned_digest = (component_dir / "unsigned_windows_digest.txt").read_text().strip()
+
+        windows_temp_dir = f"{pipeline_run_uid}_{name}"
+        win_temp_base = f"C:/Users/{windows_user}/AppData/Local/Temp"
+        windows_script_path = (
+            f"{win_temp_base}/windows_signing_script_file_{windows_temp_dir}.bat"
+        )
+
+        script_content = _build_batch_script(
+            quay_url=quay_url,
+            quay_user=quay_user,
+            quay_pass=quay_pass,
+            component_name=name,
+            unsigned_digest=unsigned_digest,
+            pipeline_run_uid=pipeline_run_uid,
+            windows_temp_dir=windows_temp_dir,
+        )
+
+        fd, script_path = tempfile.mkstemp(suffix=".bat")
+        local_script = Path(script_path)
+        os.write(fd, script_content.encode())
+        os.close(fd)
+
+        try:
+            # Output is intentionally not captured — the script contains plaintext
+            # credentials and routing SCP output through the logger could expose them.
+            subprocess.check_call(
+                ["scp"]
+                + scp_opts
+                + [str(local_script), f"{windows_user}@{windows_host}:{windows_script_path}"]
+            )
+
+            ssh_exit = 0
+            failed_op = ""
+            result = subprocess.run(
+                ["ssh"] + ssh_opts + [f"{windows_user}@{windows_host}", windows_script_path],
+                capture_output=True,
+                text=True,
+            )
+            logger.info("%s", result.stdout)
+            if result.stderr:
+                logger.info("%s", result.stderr)
+            if result.returncode != 0:
+                ssh_exit = result.returncode
+                failed_op = "signing"
+
+            if ssh_exit == 0:
+                digest = None
+                for line in result.stdout.splitlines():
+                    if line.strip().startswith("Digest:"):
+                        digest = line.strip().split()[-1]
+                if digest:
+                    (component_dir / "signed_windows_digest.txt").write_text(
+                        digest, encoding="utf-8"
+                    )
+                else:
+                    ssh_exit = 1
+                    failed_op = "parsing Digest from oras push output"
+
+            cleanup_path = (
+                f"C:\\\\Users\\\\{windows_user}\\\\AppData\\\\Local\\\\Temp"
+                f"\\\\{windows_temp_dir}"
+            )
+            cleanup = subprocess.run(
+                ["ssh"]
+                + ssh_opts
+                + [
+                    f"{windows_user}@{windows_host}",
+                    f"Remove-Item -LiteralPath '{cleanup_path}' -Force -Recurse; "
+                    f"Remove-Item -LiteralPath '{windows_script_path}' -Force",
+                ],
+                check=False,
+            )
+            if cleanup.returncode != 0:
+                logger.warning(
+                    "Remote cleanup failed for %s (exit code: %d) — "
+                    "%s and %s may remain on the Windows host",
+                    name,
+                    cleanup.returncode,
+                    cleanup_path,
+                    windows_script_path,
+                )
+
+            if ssh_exit != 0:
+                raise RuntimeError(
+                    f"Windows {failed_op} failed for component: {name} (exit code: {ssh_exit})"
+                )
+        finally:
+            local_script.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and run Windows signing; return exit code."""
+    logging.basicConfig(level=logging.INFO)
+    args = parse_args(argv[1:] if argv is not None else None)
+    try:
+        run(args.quay_url, args.pipeline_run_uid)
+    except Exception as exc:
+        logger.error("ERROR: %s", exc)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/helpers/test_authentication.py
+++ b/scripts/python/helpers/test_authentication.py
@@ -1,4 +1,4 @@
-"""Tests for the ``authentication`` helper module."""
+"""Tests for authentication helpers."""
 
 from __future__ import annotations
 
@@ -11,124 +11,189 @@ import pytest
 
 import authentication
 
-
-def test_read_mounted_text_strips_whitespace(tmp_path: Path) -> None:
-    """Stripped file contents are returned without surrounding whitespace."""
-    f = tmp_path / "f"
-    f.write_text("  a\nb  ", encoding="utf-8")
-    assert authentication.read_mounted_text(tmp_path, "f") == "a\nb"
+# ---------------------------------------------------------------------------
+# read_mounted_text
+# ---------------------------------------------------------------------------
 
 
-def test_load_keytab_from_mount_resolves_princ_and_keytab(tmp_path: Path) -> None:
-    """Principal and decoded keytab bytes come from the paths given by the keyword args."""
-    d = tmp_path
-    (d / "name").write_text("p@REALM", encoding="utf-8")
-    (d / "base64_keytab").write_text(
-        base64.b64encode(b"ktab").decode("ascii"), encoding="utf-8"
+def test_read_mounted_text(tmp_path: Path) -> None:
+    """File content is read as UTF-8 and returned with surrounding whitespace stripped."""
+    f = tmp_path / "secret"
+    f.write_text("  value\n", encoding="utf-8")
+    assert authentication.read_mounted_text(tmp_path, "secret") == "value"
+
+
+# ---------------------------------------------------------------------------
+# load_keytab_from_mount
+# ---------------------------------------------------------------------------
+
+
+def test_load_keytab_from_mount(tmp_path: Path) -> None:
+    """Principal string and base64-decoded keytab bytes are returned from mounted files."""
+    raw_keytab = b"\x05\x02keytab-bytes"
+    encoded = base64.b64encode(raw_keytab).decode("ascii")
+    (tmp_path / "principal").write_text("user@REALM\n", encoding="utf-8")
+    (tmp_path / "keytab.b64").write_text(encoded + "\n", encoding="utf-8")
+
+    princ, keytab = authentication.load_keytab_from_mount(
+        tmp_path, principal_file="principal", keytab_b64_file="keytab.b64"
     )
-    princ, raw = authentication.load_keytab_from_mount(
-        d, principal_file="name", keytab_b64_file="base64_keytab"
+    assert princ == "user@REALM"
+    assert keytab == raw_keytab
+
+
+# ---------------------------------------------------------------------------
+# load_service_account
+# ---------------------------------------------------------------------------
+
+
+def test_load_service_account(tmp_path: Path) -> None:
+    """Principal, keytab, and extra text files are all loaded and returned correctly."""
+    raw_keytab = b"\x05\x02data"
+    encoded = base64.b64encode(raw_keytab).decode("ascii")
+    (tmp_path / "principal").write_text("sa@REALM", encoding="utf-8")
+    (tmp_path / "keytab.b64").write_text(encoded, encoding="utf-8")
+    (tmp_path / "api_url").write_text("https://api.example.com  ", encoding="utf-8")
+
+    princ, keytab, extra = authentication.load_service_account(
+        tmp_path,
+        ("api_url",),
+        principal_file="principal",
+        keytab_b64_file="keytab.b64",
     )
-    assert princ == "p@REALM" and raw == b"ktab"
+    assert princ == "sa@REALM"
+    assert keytab == raw_keytab
+    assert extra == {"api_url": "https://api.example.com"}
 
 
-def test_load_keytab_from_mount_renamed_files(tmp_path: Path) -> None:
-    """
-    Any filenames passed as *principal_file* and *keytab_b64_file* are read
-    under the mount.
-    """
-    d = tmp_path
-    (d / "x").write_text("other", encoding="utf-8")
-    (d / "y").write_text(base64.b64encode(b"A").decode("ascii"), encoding="utf-8")
-    princ, raw = authentication.load_keytab_from_mount(
-        d, principal_file="x", keytab_b64_file="y"
-    )
-    assert princ == "other" and raw == b"A"
+# ---------------------------------------------------------------------------
+# patch_krb5_config
+# ---------------------------------------------------------------------------
 
 
-def test_load_service_account_includes_text_files_in_dict(tmp_path: Path) -> None:
-    """*text_files* entries are the third return value, keyed by filename."""
-    d = tmp_path
-    (d / "name").write_text("u1", encoding="utf-8")
-    (d / "base64_keytab").write_text(base64.b64encode(b"ab").decode("ascii"), encoding="utf-8")
-    (d / "api_url").write_text("https://ex/a", encoding="utf-8")
-    n, raw, files = authentication.load_service_account(
-        d, ("api_url",), principal_file="name", keytab_b64_file="base64_keytab"
-    )
-    assert n == "u1" and raw == b"ab" and files == {"api_url": "https://ex/a"}
+def test_patch_krb5_config_inserts_after_libdefaults() -> None:
+    """dns_canonicalize_hostname setting is inserted on the line after [libdefaults]."""
+    source = "[libdefaults]\n default_realm = EXAMPLE.COM\n"
+    result = authentication.patch_krb5_config(source)
+    lines = result.splitlines()
+    idx = lines.index("[libdefaults]")
+    assert "dns_canonicalize_hostname = false" in lines[idx + 1]
 
 
-def test_load_service_account_multiple_text_files(tmp_path: Path) -> None:
-    """*text_files* can name several strip-read files; values map by filename."""
-    d = tmp_path
-    (d / "name").write_text("p", encoding="utf-8")
-    (d / "base64_keytab").write_text(base64.b64encode(b"x").decode("ascii"), encoding="utf-8")
-    (d / "errata_api").write_text("https://errata/", encoding="utf-8")
-    (d / "other").write_text("o", encoding="utf-8")
-    _, _, files = authentication.load_service_account(
-        d, ("errata_api", "other"), principal_file="name", keytab_b64_file="base64_keytab"
-    )
-    assert files == {"errata_api": "https://errata/", "other": "o"}
+def test_patch_krb5_config_no_libdefaults_unchanged() -> None:
+    """Source text without a [libdefaults] section is returned unchanged."""
+    source = "[realms]\n EXAMPLE.COM = {}\n"
+    assert authentication.patch_krb5_config(source) == source
 
 
-def test_patch_krb5_inserts_after_libdefaults() -> None:
-    """A line is inserted right after the ``[libdefaults]`` section header."""
-    src = "[libdefaults]\n# c\n[realms]\n"
-    out = authentication.patch_krb5_config(src)
-    assert "dns_canonicalize_hostname = false" in out
-    assert out.index("[libdefaults]") < out.index("dns_canonicalize_hostname")
+# ---------------------------------------------------------------------------
+# kinit_with_retry
+# ---------------------------------------------------------------------------
 
 
-def test_kinit_succeeds_first_try(tmp_path: Path) -> None:
-    """A successful kinit is not retried; environment keys are passed through."""
-    kt = tmp_path / "t.kt"
-    kt.write_bytes(b"x")
-    cc = tmp_path / "cc"
-    cfg = tmp_path / "c.conf"
-    cc.write_text("x", encoding="utf-8")
-    cfg.write_text("x", encoding="utf-8")
-    calls: list = []
+def test_kinit_with_retry_success(tmp_path: Path) -> None:
+    """The kinit command is called once with the correct principal and keytab on success."""
+    keytab = tmp_path / "test.keytab"
+    keytab.write_bytes(b"fake")
 
-    def _fake_run(
-        cmd: list[str] | str,
-        check: object,
-        env: dict,  # noqa: ARG001
-    ) -> object:  # type: ignore[no-untyped-def]
-        del check
-        calls.append((list(cmd) if isinstance(cmd, list) else [cmd], env.get("KRB5CCNAME")))
-        r = mock.MagicMock()
-        r.returncode = 0
-        return r
+    with mock.patch("subprocess.run") as mock_run:
+        mock_run.return_value = mock.Mock(returncode=0)
+        authentication.kinit_with_retry("user@REALM", keytab, {})
 
-    with mock.patch("authentication.subprocess.run", side_effect=_fake_run):
-        authentication.kinit_with_retry(
-            "p", kt, {"KRB5CCNAME": str(cc), "KRB5_CONFIG": str(cfg)}
-        )
-    assert len(calls) == 1
-    assert calls[0][0][0:4] == ["kinit", "p", "-k", "-t"]
+    mock_run.assert_called_once()
+    args = mock_run.call_args[0][0]
+    assert args[0] == "kinit"
+    assert "user@REALM" in args
 
 
-def test_kinit_fails_five_times(tmp_path: Path) -> None:
-    """After ``max_attempts`` failures, the last ``CalledProcessError`` is raised."""
-    kt = tmp_path / "t.kt"
-    kt.write_bytes(b"x")
-    cc = tmp_path / "cc"
-    cfg = tmp_path / "c.conf"
-    cc.write_text("x", encoding="utf-8")
-    cfg.write_text("x", encoding="utf-8")
+def test_kinit_with_retry_fails_after_max_attempts(tmp_path: Path) -> None:
+    """CalledProcessError is raised after exhausting max_attempts retries."""
+    keytab = tmp_path / "test.keytab"
+    keytab.write_bytes(b"fake")
 
-    def _fail(*args, **kwargs) -> object:  # type: ignore[no-untyped-def]
-        del args, kwargs
-        r = mock.MagicMock()
-        r.returncode = 1
-        return r
-
-    with (
-        mock.patch("authentication.subprocess.run", side_effect=_fail),
-        mock.patch("authentication.retry.time.sleep") as sleep_mock,
-    ):
+    with mock.patch("subprocess.run") as mock_run, mock.patch("time.sleep"):
+        mock_run.return_value = mock.Mock(returncode=1)
         with pytest.raises(subprocess.CalledProcessError):
-            authentication.kinit_with_retry(
-                "p", kt, {"KRB5CCNAME": str(cc), "KRB5_CONFIG": str(cfg)}
-            )
-    sleep_mock.assert_has_calls([mock.call(5), mock.call(10), mock.call(20), mock.call(40)])
+            authentication.kinit_with_retry("user@REALM", keytab, {}, max_attempts=2)
+
+    assert mock_run.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# write_docker_config
+# ---------------------------------------------------------------------------
+
+
+def test_write_docker_config(tmp_path: Path) -> None:
+    """config.json is written with mode 0600 inside a 0700 .docker directory."""
+    with mock.patch("pathlib.Path.home", return_value=tmp_path):
+        authentication.write_docker_config('{"auths":{}}')
+    config = tmp_path / ".docker" / "config.json"
+    assert config.read_text() == '{"auths":{}}'
+    assert oct(config.stat().st_mode & 0o777) == oct(0o600)
+    assert oct((tmp_path / ".docker").stat().st_mode & 0o777) == oct(0o700)
+
+
+# ---------------------------------------------------------------------------
+# setup_docker_config
+# ---------------------------------------------------------------------------
+
+
+def test_setup_docker_config_writes_file(tmp_path: Path) -> None:
+    """Docker config JSON from a mounted secret file is written to ~/.docker/config.json."""
+    secret = tmp_path / "secret" / ".dockerconfigjson"
+    secret.parent.mkdir()
+    secret.write_text('{"auths":{}}', encoding="utf-8")
+
+    home = tmp_path / "home"
+    home.mkdir()
+    with mock.patch("pathlib.Path.home", return_value=home):
+        authentication.setup_docker_config(secret)
+
+    assert (home / ".docker" / "config.json").read_text() == '{"auths":{}}'
+
+
+def test_setup_docker_config_optional_missing_file(tmp_path: Path) -> None:
+    """A missing optional secret file is silently skipped without writing anything."""
+    missing = tmp_path / ".dockerconfigjson"
+    home = tmp_path / "home"
+    home.mkdir()
+    with mock.patch("pathlib.Path.home", return_value=home):
+        authentication.setup_docker_config(missing, optional=True)
+
+    assert not (home / ".docker" / "config.json").exists()
+
+
+def test_setup_docker_config_optional_empty_file(tmp_path: Path) -> None:
+    """An empty optional secret file is silently skipped without writing anything."""
+    empty = tmp_path / ".dockerconfigjson"
+    empty.write_bytes(b"")
+    home = tmp_path / "home"
+    home.mkdir()
+    with mock.patch("pathlib.Path.home", return_value=home):
+        authentication.setup_docker_config(empty, optional=True)
+
+    assert not (home / ".docker" / "config.json").exists()
+
+
+def test_setup_docker_config_strip_noise(tmp_path: Path) -> None:
+    """Leading/trailing non-JSON characters are stripped before writing config.json."""
+    secret = tmp_path / ".dockerconfigjson"
+    # k8s sometimes wraps the JSON in outer single-quotes or other noise characters
+    secret.write_text("'{\"auths\":{}}'", encoding="utf-8")
+
+    home = tmp_path / "home"
+    home.mkdir()
+    with mock.patch("pathlib.Path.home", return_value=home):
+        authentication.setup_docker_config(secret, strip_noise=True)
+
+    written = (home / ".docker" / "config.json").read_text()
+    assert written.startswith("{")
+    assert written.endswith("}")
+
+
+def test_setup_docker_config_required_missing_raises(tmp_path: Path) -> None:
+    """A missing non-optional secret file raises FileNotFoundError."""
+    missing = tmp_path / ".dockerconfigjson"
+    with pytest.raises(FileNotFoundError):
+        authentication.setup_docker_config(missing)

--- a/scripts/python/helpers/test_build_checksum_map.py
+++ b/scripts/python/helpers/test_build_checksum_map.py
@@ -1,0 +1,364 @@
+"""Tests for build_checksum_map.py."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import build_checksum_map
+import file as file_utils
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+SNAPSHOT = {
+    "components": [
+        {
+            "name": "testproduct",
+            "staged": {
+                "destination": "testproduct-amd64",
+                "version": "1.3",
+            },
+        }
+    ]
+}
+
+
+def _setup_dockerconfig(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    mount = tmp_path / "dockerconfig"
+    mount.mkdir()
+    (mount / ".dockerconfigjson").write_text('{"auths":{}}')
+    monkeypatch.setattr(build_checksum_map, "TRUSTED_ARTIFACTS_DOCKERCONFIG_MOUNT", mount)
+    return mount
+
+
+def _make_ready_dir(base: Path, name: str, files: dict[str, bytes]) -> Path:
+    d = base / name / "ready_for_distribution"
+    d.mkdir(parents=True)
+    for fname, content in files.items():
+        (d / fname).write_bytes(content)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# file_utils.sha256 (shared helper, tested in test_file.py)
+# ---------------------------------------------------------------------------
+
+
+def test_sha256_correct(tmp_path: Path) -> None:
+    """SHA-256 hex digest matches hashlib reference for non-empty file content."""
+    f = tmp_path / "data.bin"
+    content = b"hello world"
+    f.write_bytes(content)
+    expected = hashlib.sha256(content).hexdigest()
+    assert file_utils.sha256(f) == expected
+
+
+def test_sha256_empty_file(tmp_path: Path) -> None:
+    """SHA-256 of an empty file matches the known empty-string digest."""
+    f = tmp_path / "empty"
+    f.write_bytes(b"")
+    expected = hashlib.sha256(b"").hexdigest()
+    assert file_utils.sha256(f) == expected
+
+
+# ---------------------------------------------------------------------------
+# _setup_docker_config
+# ---------------------------------------------------------------------------
+
+
+def test_setup_docker_config_copies_to_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A valid .dockerconfigjson in the mount is copied to ~/.docker/config.json."""
+    mount = tmp_path / "dockerconfig"
+    mount.mkdir()
+    (mount / ".dockerconfigjson").write_text('{"auths":{}}')
+    monkeypatch.setattr(build_checksum_map, "TRUSTED_ARTIFACTS_DOCKERCONFIG_MOUNT", mount)
+
+    home = tmp_path / "home"
+    home.mkdir()
+    with mock.patch("pathlib.Path.home", return_value=home):
+        build_checksum_map._setup_docker_config()
+
+    assert (home / ".docker" / "config.json").exists()
+    assert json.loads((home / ".docker" / "config.json").read_text()) == {"auths": {}}
+
+
+def test_setup_docker_config_skips_missing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing .dockerconfigjson in the mount dir does not create config.json."""
+    mount = tmp_path / "empty_mount"
+    mount.mkdir()
+    # No .dockerconfigjson file
+    monkeypatch.setattr(build_checksum_map, "TRUSTED_ARTIFACTS_DOCKERCONFIG_MOUNT", mount)
+
+    home = tmp_path / "home"
+    home.mkdir()
+    with mock.patch("pathlib.Path.home", return_value=home):
+        build_checksum_map._setup_docker_config()
+
+    assert not (home / ".docker" / "config.json").exists()
+
+
+def test_setup_docker_config_skips_empty_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty .dockerconfigjson in the mount dir does not create config.json."""
+    mount = tmp_path / "empty_dockerconfig"
+    mount.mkdir()
+    (mount / ".dockerconfigjson").write_bytes(b"")
+    monkeypatch.setattr(build_checksum_map, "TRUSTED_ARTIFACTS_DOCKERCONFIG_MOUNT", mount)
+
+    home = tmp_path / "home"
+    home.mkdir()
+    with mock.patch("pathlib.Path.home", return_value=home):
+        build_checksum_map._setup_docker_config()
+
+    assert not (home / ".docker" / "config.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+def test_run_writes_oci_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """run() returns a valid OCI reference containing the oras push digest."""
+    monkeypatch.setattr(build_checksum_map, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(build_checksum_map, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "snapshot.json").write_text(json.dumps(SNAPSHOT))
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": []}))  # ignored
+    _setup_dockerconfig(tmp_path, monkeypatch)
+
+    _make_ready_dir(
+        tmp_path / "artifacts",
+        "testproduct",
+        {"archive.tar.gz": b"data"},
+    )
+
+    def fake_check_output(cmd, **kwargs):
+        if cmd[0] == "select-oci-auth":
+            return b'{"auths":{}}'
+        if cmd[0] == "oras":
+            return "Digest: sha256:" + "a" * 64 + "\n"
+        return b""
+
+    with (
+        mock.patch("pathlib.Path.home", return_value=tmp_path / "home"),
+        mock.patch("subprocess.check_output", side_effect=fake_check_output),
+    ):
+        (tmp_path / "home").mkdir()
+        oci_result = build_checksum_map.run()
+
+    assert build_checksum_map.OCI_STORE in oci_result
+    assert "sha256:" in oci_result
+
+
+def test_run_uses_shared_snapshot_over_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run() should prefer snapshot.json from shared dir over SNAPSHOT_JSON env."""
+    monkeypatch.setattr(build_checksum_map, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(build_checksum_map, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "snapshot.json").write_text(json.dumps(SNAPSHOT))
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [{"name": "IGNORED"}]}))
+    _setup_dockerconfig(tmp_path, monkeypatch)
+
+    _make_ready_dir(
+        tmp_path / "artifacts",
+        "testproduct",
+        {"archive.tar.gz": b"data"},
+    )
+
+    def fake_check_output(cmd, **kwargs):
+        if cmd[0] == "select-oci-auth":
+            return b'{"auths":{}}'
+        if cmd[0] == "oras":
+            return "Digest: sha256:" + "b" * 64 + "\n"
+        return b""
+
+    with (
+        mock.patch("pathlib.Path.home", return_value=tmp_path / "home"),
+        mock.patch("subprocess.check_output", side_effect=fake_check_output),
+    ):
+        (tmp_path / "home").mkdir()
+        result = build_checksum_map.run()
+
+    assert "sha256:" in result
+
+
+def test_run_uses_env_snapshot_when_no_shared_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SNAPSHOT_JSON env var is used as fallback when no shared snapshot.json exists."""
+    monkeypatch.setattr(build_checksum_map, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(build_checksum_map, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    # No snapshot.json in shared dir
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps(SNAPSHOT))
+    _setup_dockerconfig(tmp_path, monkeypatch)
+
+    _make_ready_dir(
+        tmp_path / "artifacts",
+        "testproduct",
+        {"archive.tar.gz": b"data"},
+    )
+
+    def fake_check_output(cmd, **kwargs):
+        if cmd[0] == "select-oci-auth":
+            return b'{"auths":{}}'
+        if cmd[0] == "oras":
+            return "Digest: sha256:" + "c" * 64 + "\n"
+        return b""
+
+    with (
+        mock.patch("pathlib.Path.home", return_value=tmp_path / "home"),
+        mock.patch("subprocess.check_output", side_effect=fake_check_output),
+    ):
+        (tmp_path / "home").mkdir()
+        result = build_checksum_map.run()
+
+    assert "sha256:" in result
+
+
+def test_run_raises_on_missing_oras_digest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RuntimeError is raised when the oras push output contains no digest line."""
+    monkeypatch.setattr(build_checksum_map, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(build_checksum_map, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "snapshot.json").write_text(json.dumps(SNAPSHOT))
+    _setup_dockerconfig(tmp_path, monkeypatch)
+
+    _make_ready_dir(
+        tmp_path / "artifacts",
+        "testproduct",
+        {"archive.tar.gz": b"data"},
+    )
+
+    def fake_check_output(cmd, **kwargs):
+        if cmd[0] == "select-oci-auth":
+            return b'{"auths":{}}'
+        if cmd[0] == "oras":
+            return "no digest here\n"
+        return b""
+
+    with (
+        mock.patch("pathlib.Path.home", return_value=tmp_path / "home"),
+        mock.patch("subprocess.check_output", side_effect=fake_check_output),
+    ):
+        (tmp_path / "home").mkdir()
+        with pytest.raises(RuntimeError, match="digest"):
+            build_checksum_map.run()
+
+
+def test_run_skips_missing_ready_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Components whose ready_for_distribution dir is absent are skipped with a warning."""
+    monkeypatch.setattr(build_checksum_map, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(build_checksum_map, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "snapshot.json").write_text(
+        json.dumps({"components": [{"name": "missing"}]})
+    )
+    _setup_dockerconfig(tmp_path, monkeypatch)
+
+    def fake_check_output(cmd, **kwargs):
+        if cmd[0] == "select-oci-auth":
+            return b'{"auths":{}}'
+        if cmd[0] == "oras":
+            return "Digest: sha256:" + "d" * 64 + "\n"
+        return b""
+
+    with (
+        caplog.at_level(logging.WARNING, logger="build_checksum_map"),
+        mock.patch("pathlib.Path.home", return_value=tmp_path / "home"),
+        mock.patch("subprocess.check_output", side_effect=fake_check_output),
+    ):
+        (tmp_path / "home").mkdir()
+        result = build_checksum_map.run()
+
+    assert "sha256:" in result
+    assert "not found" in caplog.text
+
+
+def test_run_excludes_sha256sum_from_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Checksum files (sha256sum.txt*) are excluded from the OCI manifest file list."""
+    monkeypatch.setattr(build_checksum_map, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(build_checksum_map, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "snapshot.json").write_text(json.dumps(SNAPSHOT))
+    _setup_dockerconfig(tmp_path, monkeypatch)
+
+    _make_ready_dir(
+        tmp_path / "artifacts",
+        "testproduct",
+        {
+            "archive.tar.gz": b"data",
+            "sha256sum.txt": b"checksums",
+            "sha256sum.txt.sig": b"sig",
+        },
+    )
+
+    captured_manifests = []
+
+    def fake_check_output(cmd, **kwargs):
+        if cmd[0] == "select-oci-auth":
+            return b'{"auths":{}}'
+        if cmd[0] == "oras":
+            # Read the checksum_map.json from the cwd
+            cwd = kwargs.get("cwd", ".")
+            manifest_file = Path(cwd) / "checksum_map.json"
+            if manifest_file.exists():
+                captured_manifests.append(json.loads(manifest_file.read_text()))
+            return "Digest: sha256:" + "e" * 64 + "\n"
+        return b""
+
+    with (
+        mock.patch("pathlib.Path.home", return_value=tmp_path / "home"),
+        mock.patch("subprocess.check_output", side_effect=fake_check_output),
+    ):
+        (tmp_path / "home").mkdir()
+        build_checksum_map.run()
+
+    assert len(captured_manifests) == 1
+    manifest = captured_manifests[0]
+    assert len(manifest) == 1
+    files = manifest[0]["files"]
+    assert "archive.tar.gz" in files
+    assert "sha256sum.txt" not in files
+    assert "sha256sum.txt.sig" not in files
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_success() -> None:
+    """main() returns 0 when run() succeeds."""
+    ref = f"{build_checksum_map.OCI_STORE}@sha256:abc123"
+    with mock.patch.object(build_checksum_map, "run", return_value=ref):
+        rc = build_checksum_map.main(["build_checksum_map.py"])
+    assert rc == 0
+
+
+def test_main_exception_returns_error() -> None:
+    """main() returns 1 when run() raises an exception."""
+    with mock.patch.object(build_checksum_map, "run", side_effect=RuntimeError("oras fail")):
+        rc = build_checksum_map.main(["build_checksum_map.py"])
+    assert rc == 1

--- a/scripts/python/helpers/test_compress_artifacts.py
+++ b/scripts/python/helpers/test_compress_artifacts.py
@@ -1,0 +1,390 @@
+"""Tests for compress_artifacts.py."""
+
+from __future__ import annotations
+
+import json
+import tarfile
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import compress_artifacts
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+COMPONENT_LINUX = {
+    "name": "testproduct",
+    "files": [
+        {"source": "/releases/binary-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"},
+    ],
+}
+
+COMPONENT_DARWIN = {
+    "name": "testproduct",
+    "files": [
+        {"source": "/releases/binary-darwin-amd64.tar.gz", "os": "darwin", "arch": "amd64"},
+    ],
+}
+
+COMPONENT_WINDOWS = {
+    "name": "testproduct",
+    "files": [
+        {"source": "/releases/binary-windows-amd64.tar.gz", "os": "windows", "arch": "amd64"},
+    ],
+}
+
+
+def _setup_quay_secret(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    quay = tmp_path / "quay"
+    quay.mkdir()
+    (quay / "username").write_text("quser")
+    (quay / "password").write_text("qpass")
+    monkeypatch.setattr(compress_artifacts, "QUAY_SECRET_MOUNT", quay)
+
+
+def _make_arch_dir(base: Path, os_name: str, arch: str, binary_name: str = "mybinary") -> Path:
+    d = base / os_name / arch
+    d.mkdir(parents=True)
+    (d / binary_name).write_bytes(b"binary content")
+    return d
+
+
+# ---------------------------------------------------------------------------
+# _windows_filename
+# ---------------------------------------------------------------------------
+
+
+def test_windows_filename_tar_gz() -> None:
+    """A .tar.gz filename is converted to the equivalent .zip name."""
+    assert compress_artifacts._windows_filename("binary-amd64.tar.gz") == "binary-amd64.zip"
+
+
+def test_windows_filename_tar() -> None:
+    """A .tar filename is converted to the equivalent .zip name."""
+    assert compress_artifacts._windows_filename("binary-amd64.tar") == "binary-amd64.zip"
+
+
+def test_windows_filename_already_zip() -> None:
+    """A filename already ending in .zip is returned unchanged."""
+    assert compress_artifacts._windows_filename("binary-amd64.zip") == "binary-amd64.zip"
+
+
+def test_windows_filename_exe() -> None:
+    """A .exe filename that is not a tar archive is returned unchanged."""
+    assert compress_artifacts._windows_filename("binary.exe") == "binary.exe"
+
+
+# ---------------------------------------------------------------------------
+# _compress_file_entry
+# ---------------------------------------------------------------------------
+
+
+def test_compress_file_entry_linux(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Linux tarball is produced in ready_for_distribution from the arch source dir."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    # Linux: component_dir / "linux" / arch
+    _make_arch_dir(comp_dir, "linux", "amd64")
+
+    result = compress_artifacts._compress_file_entry(
+        {"source": "/releases/binary-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"},
+        "files",
+        comp_dir,
+        ready_dir,
+    )
+    archive = ready_dir / "binary-linux-amd64.tar.gz"
+    assert archive.exists()
+    assert tarfile.is_tarfile(str(archive))
+    assert result == "/releases/binary-linux-amd64.tar.gz"
+
+
+def test_compress_file_entry_darwin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A macOS tarball is produced from the signed/macos arch source directory."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    # Darwin: component_dir / "signed" / "macos" / arch
+    _make_arch_dir(comp_dir / "signed", "macos", "amd64")
+
+    result = compress_artifacts._compress_file_entry(
+        {"source": "/releases/binary-darwin-amd64.tar.gz", "os": "darwin", "arch": "amd64"},
+        "files",
+        comp_dir,
+        ready_dir,
+    )
+    assert (ready_dir / "binary-darwin-amd64.tar.gz").exists()
+    assert result == "/releases/binary-darwin-amd64.tar.gz"
+
+
+def test_compress_file_entry_windows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Windows zip archive is produced and the source path is updated to .zip."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    # Windows: component_dir / "signed" / "windows" / arch
+    _make_arch_dir(comp_dir / "signed", "windows", "amd64", "mybinary.exe")
+
+    result = compress_artifacts._compress_file_entry(
+        {"source": "/releases/binary-windows-amd64.tar.gz", "os": "windows", "arch": "amd64"},
+        "files",
+        comp_dir,
+        ready_dir,
+    )
+    zip_file = ready_dir / "binary-windows-amd64.zip"
+    assert zip_file.exists()
+    assert zipfile.is_zipfile(str(zip_file))
+    # source is updated to .zip
+    assert result is not None and result.endswith(".zip")
+
+
+def test_compress_file_entry_missing_arch_dir_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RuntimeError is raised when the expected arch directory does not exist."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+    # No arch directory created
+
+    with pytest.raises(RuntimeError, match="not found"):
+        compress_artifacts._compress_file_entry(
+            {"source": "/releases/binary-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"},
+            "files",
+            comp_dir,
+            ready_dir,
+        )
+
+
+def test_compress_file_entry_empty_arch_dir_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RuntimeError is raised when the arch directory exists but contains no files."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+    (comp_dir / "linux" / "amd64").mkdir(parents=True)  # empty dir
+
+    with pytest.raises(RuntimeError, match="empty or not found"):
+        compress_artifacts._compress_file_entry(
+            {"source": "/releases/binary-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"},
+            "files",
+            comp_dir,
+            ready_dir,
+        )
+
+
+def test_compress_file_entry_missing_source_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RuntimeError is raised when the file entry has no ``source`` key."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    with pytest.raises(RuntimeError, match="Missing source"):
+        compress_artifacts._compress_file_entry(
+            {"os": "linux", "arch": "amd64"}, "files", comp_dir, ready_dir
+        )
+
+
+def test_compress_file_entry_unknown_os_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RuntimeError is raised for an unsupported OS value in the file entry."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    with pytest.raises(RuntimeError, match="Unknown OS"):
+        compress_artifacts._compress_file_entry(
+            {"source": "/releases/binary.tar.gz", "os": "solaris", "arch": "sparc"},
+            "files",
+            comp_dir,
+            ready_dir,
+        )
+
+
+# ---------------------------------------------------------------------------
+# _pull_signed_content
+# ---------------------------------------------------------------------------
+
+
+def test_pull_signed_content_skips_when_no_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No oras pull is made when the component has neither has_mac nor has_windows flags."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+
+    with mock.patch("subprocess.check_call") as mock_cc:
+        compress_artifacts._pull_signed_content("quay.io/org", "prod", comp_dir)
+
+    mock_cc.assert_not_called()
+
+
+def test_pull_signed_content_pulls_mac_and_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two oras pull commands are issued when both has_mac and has_windows flags are set."""
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    (comp_dir / "has_mac").touch()
+    (comp_dir / "has_windows").touch()
+    (comp_dir / "signed_mac_digest.txt").write_text("sha256:mac")
+    (comp_dir / "signed_windows_digest.txt").write_text("sha256:win ")
+
+    calls = []
+
+    def fake_check_call(cmd, **kwargs):
+        calls.append(cmd[0:3])
+
+    with mock.patch("subprocess.check_call", side_effect=fake_check_call):
+        compress_artifacts._pull_signed_content("quay.io/org", "prod", comp_dir)
+
+    assert len(calls) == 2
+    assert all(c[0] == "oras" for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# _restore_supplementary
+# ---------------------------------------------------------------------------
+
+
+def test_restore_supplementary_restores_files(tmp_path: Path) -> None:
+    """Supplementary files are moved back into signed arch dirs and the hold dir is cleared."""
+    comp_dir = tmp_path / "prod"
+    supp = comp_dir / "supplementary"
+    signed = comp_dir / "signed"
+
+    for os_name in ("macos", "windows"):
+        (supp / os_name / "amd64").mkdir(parents=True)
+        (supp / os_name / "amd64" / "README.md").write_text("readme")
+        (signed / os_name / "amd64").mkdir(parents=True)
+        (signed / os_name / "amd64" / "binary").write_bytes(b"bin")
+
+    compress_artifacts._restore_supplementary(comp_dir)
+
+    assert (signed / "macos" / "amd64" / "README.md").exists()
+    assert (signed / "windows" / "amd64" / "README.md").exists()
+    assert not (supp / "macos" / "amd64" / "README.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# compress_component
+# ---------------------------------------------------------------------------
+
+
+def test_compress_component_linux(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Linux component produces a tarball in ready_for_distribution with correct source."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    # component name is "testproduct" → CONTENT_DIR / "testproduct"
+    comp_dir = tmp_path / "testproduct"
+    _make_arch_dir(comp_dir, "linux", "amd64")
+
+    updated = compress_artifacts.compress_component(
+        COMPONENT_LINUX, {"components": [COMPONENT_LINUX]}
+    )
+    assert (comp_dir / "ready_for_distribution" / "binary-linux-amd64.tar.gz").exists()
+    assert updated["files"][0]["source"] == "/releases/binary-linux-amd64.tar.gz"
+
+
+def test_compress_component_windows_updates_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Windows component source path is updated to .zip after compression."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "testproduct"
+    _make_arch_dir(comp_dir / "signed", "windows", "amd64", "binary.exe")
+
+    updated = compress_artifacts.compress_component(
+        COMPONENT_WINDOWS, {"components": [COMPONENT_WINDOWS]}
+    )
+    assert (comp_dir / "ready_for_distribution" / "binary-windows-amd64.zip").exists()
+    assert updated["files"][0]["source"].endswith(".zip")
+
+
+def test_compress_component_staged_files_processed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Files listed under staged.files are compressed just like top-level files."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    component = {
+        "name": "prod",
+        "staged": {
+            "files": [
+                {
+                    "source": "/releases/binary-linux-amd64.tar.gz",
+                    "os": "linux",
+                    "arch": "amd64",
+                }
+            ]
+        },
+    }
+    comp_dir = tmp_path / "prod"
+    _make_arch_dir(comp_dir, "linux", "amd64")
+
+    compress_artifacts.compress_component(component, {"components": [component]})
+    assert (comp_dir / "ready_for_distribution" / "binary-linux-amd64.tar.gz").exists()
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+def test_run_saves_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """run() writes the updated snapshot JSON to the shared directory."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(compress_artifacts, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [COMPONENT_LINUX]}))
+    _setup_quay_secret(tmp_path, monkeypatch)
+
+    # CONTENT_DIR = tmp_path / "artifacts"; component name = "testproduct"
+    comp_dir = tmp_path / "artifacts" / "testproduct"
+    _make_arch_dir(comp_dir, "linux", "amd64")
+
+    with (
+        mock.patch("subprocess.check_call"),
+        mock.patch("subprocess.run"),
+    ):
+        compress_artifacts.run("quay.io/org")
+
+    snap = json.loads((tmp_path / "shared" / "snapshot.json").read_text())
+    assert "components" in snap
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_success() -> None:
+    """main() returns 0 and calls run() with the quay URL on success."""
+    with mock.patch.object(compress_artifacts, "run") as mock_run:
+        rc = compress_artifacts.main(["compress_artifacts.py", "--quay-url", "quay.io/org"])
+    assert rc == 0
+    mock_run.assert_called_once_with("quay.io/org")
+
+
+def test_main_exception_returns_error() -> None:
+    """main() returns 1 when run() raises an exception."""
+    with mock.patch.object(compress_artifacts, "run", side_effect=RuntimeError("oras fail")):
+        rc = compress_artifacts.main(["compress_artifacts.py", "--quay-url", "quay.io/org"])
+    assert rc == 1

--- a/scripts/python/helpers/test_extract_artifacts.py
+++ b/scripts/python/helpers/test_extract_artifacts.py
@@ -1,0 +1,453 @@
+"""Tests for extract_artifacts.py."""
+
+from __future__ import annotations
+
+import json
+import logging
+import tarfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import extract_artifacts
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+SNAPSHOT_ONE = {
+    "components": [
+        {
+            "name": "testproduct",
+            "containerImage": "quay.io/org/test@sha256:abc",
+            "files": [
+                {
+                    "source": "/releases/binary-linux-amd64.tar.gz",
+                    "os": "linux",
+                    "arch": "amd64",
+                },
+                {
+                    "source": "/releases/binary-darwin-amd64.tar.gz",
+                    "os": "darwin",
+                    "arch": "amd64",
+                },
+                {
+                    "source": "/releases/binary-windows-amd64.tar.gz",
+                    "os": "windows",
+                    "arch": "amd64",
+                },
+            ],
+        }
+    ]
+}
+
+SNAPSHOT_NO_FILES = {
+    "components": [
+        {
+            "name": "operator",
+            "containerImage": "quay.io/org/operator@sha256:abc",
+        }
+    ]
+}
+
+SNAPSHOT_STAGED = {
+    "components": [
+        {
+            "name": "testproduct",
+            "containerImage": "quay.io/org/test@sha256:abc",
+            "staged": {
+                "destination": "dest",
+                "version": "1.0",
+                "files": [
+                    {
+                        "source": "/releases/binary-linux-amd64.tar.gz",
+                        "os": "linux",
+                        "arch": "amd64",
+                    },
+                ],
+            },
+        }
+    ]
+}
+
+
+def _setup_token_mount(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    mount = tmp_path / "token"
+    mount.mkdir()
+    (mount / ".dockerconfigjson").write_text('{"auths":{}}')
+    monkeypatch.setenv("REDHAT_WORKLOADS_TOKEN_MOUNT", str(mount))
+    return mount
+
+
+# ---------------------------------------------------------------------------
+# _get_source_paths
+# ---------------------------------------------------------------------------
+
+
+def test_get_source_paths_files_array() -> None:
+    """Source paths and parent directories are extracted from the files array."""
+    component = {
+        "files": [
+            {"source": "/releases/binary-linux-amd64.tar.gz"},
+            {"source": "/releases/binary-darwin-amd64.tar.gz"},
+        ]
+    }
+    wanted, dirs = extract_artifacts._get_source_paths(component)
+    assert "releases/binary-linux-amd64.tar.gz" in wanted
+    assert "releases/binary-darwin-amd64.tar.gz" in wanted
+    assert "releases" in dirs
+
+
+def test_get_source_paths_staged_files() -> None:
+    """Source paths are extracted from the staged.files array."""
+    component = {
+        "staged": {
+            "files": [
+                {"source": "/releases/binary-linux-amd64.tar.gz"},
+            ]
+        }
+    }
+    wanted, dirs = extract_artifacts._get_source_paths(component)
+    assert "releases/binary-linux-amd64.tar.gz" in wanted
+
+
+def test_get_source_paths_both_arrays_deduplicates() -> None:
+    """Duplicate paths present in both files and staged.files are deduplicated."""
+    component = {
+        "files": [{"source": "/releases/binary-linux-amd64.tar.gz"}],
+        "staged": {"files": [{"source": "/releases/binary-linux-amd64.tar.gz"}]},
+    }
+    wanted, dirs = extract_artifacts._get_source_paths(component)
+    assert wanted.count("releases/binary-linux-amd64.tar.gz") == 1
+
+
+def test_get_source_paths_default_dir_when_no_parent() -> None:
+    """A source with no parent directory falls back to the default 'releases' directory."""
+    component = {"files": [{"source": "binary.tar.gz"}]}
+    _, dirs = extract_artifacts._get_source_paths(component)
+    assert "releases" in dirs
+
+
+def test_get_source_paths_no_source_skipped() -> None:
+    """File entries without a source key are silently skipped."""
+    component = {"files": [{"os": "linux"}]}
+    wanted, _ = extract_artifacts._get_source_paths(component)
+    assert wanted == []
+
+
+# ---------------------------------------------------------------------------
+# _create_os_flag_files
+# ---------------------------------------------------------------------------
+
+
+def _make_component_dir(base: Path, name: str) -> Path:
+    d = base / name
+    d.mkdir(parents=True)
+    return d
+
+
+def test_create_os_flag_files_darwin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A darwin OS file creates has_mac flag and no other OS flags."""
+    monkeypatch.setattr(extract_artifacts, "CONTENT_DIR", tmp_path)
+    _make_component_dir(tmp_path, "prod")
+    snapshot = {
+        "components": [
+            {
+                "name": "prod",
+                "files": [{"source": "/releases/bin-darwin-amd64.tar.gz", "os": "darwin"}],
+            }
+        ]
+    }
+    extract_artifacts._create_os_flag_files(snapshot)
+    assert (tmp_path / "prod" / "has_mac").exists()
+    assert not (tmp_path / "prod" / "has_windows").exists()
+    assert not (tmp_path / "prod" / "has_linux").exists()
+
+
+def test_create_os_flag_files_windows_by_source_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 'windows' substring in the source path creates the has_windows flag."""
+    monkeypatch.setattr(extract_artifacts, "CONTENT_DIR", tmp_path)
+    _make_component_dir(tmp_path, "prod")
+    snapshot = {
+        "components": [
+            {
+                "name": "prod",
+                "files": [{"source": "/releases/binary-windows-amd64.tar.gz"}],
+            }
+        ]
+    }
+    extract_artifacts._create_os_flag_files(snapshot)
+    assert (tmp_path / "prod" / "has_windows").exists()
+
+
+def test_create_os_flag_files_linux(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A linux OS file entry creates the has_linux flag file."""
+    monkeypatch.setattr(extract_artifacts, "CONTENT_DIR", tmp_path)
+    _make_component_dir(tmp_path, "prod")
+    snapshot = {
+        "components": [
+            {
+                "name": "prod",
+                "files": [{"os": "linux", "source": "/releases/binary-linux.tar.gz"}],
+            }
+        ]
+    }
+    extract_artifacts._create_os_flag_files(snapshot)
+    assert (tmp_path / "prod" / "has_linux").exists()
+
+
+def test_create_os_flag_files_from_staged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """OS flags are created from staged.files entries just like regular files."""
+    monkeypatch.setattr(extract_artifacts, "CONTENT_DIR", tmp_path)
+    _make_component_dir(tmp_path, "prod")
+    snapshot = {
+        "components": [
+            {
+                "name": "prod",
+                "staged": {
+                    "files": [{"os": "darwin", "source": "/releases/bin-darwin.tar.gz"}]
+                },
+            }
+        ]
+    }
+    extract_artifacts._create_os_flag_files(snapshot)
+    assert (tmp_path / "prod" / "has_mac").exists()
+
+
+def test_create_os_flag_files_skips_missing_component_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Components whose directory does not exist are silently skipped."""
+    monkeypatch.setattr(extract_artifacts, "CONTENT_DIR", tmp_path)
+    # No directory created for "missing"
+    snapshot = {"components": [{"name": "missing", "files": [{"os": "linux"}]}]}
+    extract_artifacts._create_os_flag_files(snapshot)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# process_component
+# ---------------------------------------------------------------------------
+
+
+def test_process_component_skips_no_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Components with no files or staged.files are skipped with an INFO log."""
+    monkeypatch.setattr(extract_artifacts, "CONTENT_DIR", tmp_path)
+    with caplog.at_level(logging.INFO, logger="extract_artifacts"):
+        extract_artifacts.process_component({"name": "op"})
+    assert "Skipping" in caplog.text
+
+
+def test_process_component_missing_containerimage_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ValueError is raised when the component has files but no containerImage."""
+    monkeypatch.setattr(extract_artifacts, "CONTENT_DIR", tmp_path)
+    with pytest.raises(ValueError, match="containerImage"):
+        extract_artifacts.process_component(
+            {"name": "p", "files": [{"source": "/r/f.tar.gz"}]}
+        )
+
+
+def test_process_component_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Artifacts declared in files are extracted from the container image into CONTENT_DIR."""
+    monkeypatch.setattr(extract_artifacts, "CONTENT_DIR", tmp_path)
+
+    component = {
+        "name": "prod",
+        "containerImage": "quay.io/org/prod@sha256:abc",
+        "files": [{"source": "/releases/binary.tar.gz"}],
+    }
+
+    # Create a fake container dir with a manifest and a layer containing our file
+    import shutil
+    import tempfile
+
+    tmp_layer_dir = Path(tempfile.mkdtemp())
+    try:
+        layer_file = tmp_layer_dir / "abc123"
+        releases_dir = tmp_layer_dir / "releases"
+        releases_dir.mkdir()
+        (releases_dir / "binary.tar.gz").write_bytes(b"fake-binary")
+        with tarfile.open(str(layer_file), "w") as tf:
+            tf.add(str(releases_dir / "binary.tar.gz"), arcname="releases/binary.tar.gz")
+
+        manifest = {
+            "layers": [{"digest": "sha256:abc123"}],
+        }
+
+        def fake_select_oci_auth(pullspec):
+            return b'{"auths":{}}'
+
+        def fake_subprocess_check_output(cmd, **kwargs):
+            if cmd[0] == "select-oci-auth":
+                return b'{"auths":{}}'
+            raise ValueError(f"unexpected command: {cmd}")
+
+        def fake_subprocess_check_call(cmd, **kwargs):
+            if cmd[0] == "skopeo":
+                # Populate the temp dir with layer + manifest
+                dest_dir_flag = cmd.index(next(a for a in cmd if a.startswith("dir:")))
+                dest_path = cmd[dest_dir_flag].removeprefix("dir:")
+                dest = Path(dest_path)
+                shutil.copy2(str(layer_file), str(dest / "abc123"))
+                (dest / "manifest.json").write_text(json.dumps(manifest))
+                return
+            if cmd[0] == "tar" and "-xzvf" in cmd:
+                # Simulate extraction by creating the expected file in cwd
+                cwd = Path(kwargs.get("cwd", "."))
+                (cwd / "releases").mkdir(parents=True, exist_ok=True)
+                (cwd / "releases" / "binary.tar.gz").write_bytes(b"fake-binary")
+                return
+            if cmd[0] == "tar":
+                return
+            raise ValueError(f"unexpected command: {cmd}")
+
+        with (
+            mock.patch("subprocess.check_output", side_effect=fake_subprocess_check_output),
+            mock.patch("subprocess.check_call", side_effect=fake_subprocess_check_call),
+            mock.patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = mock.Mock(stdout="releases/binary.tar.gz\n", returncode=0)
+            extract_artifacts.process_component(component)
+
+        assert (tmp_path / "prod").is_dir()
+    finally:
+        shutil.rmtree(str(tmp_layer_dir), ignore_errors=True)
+
+
+def test_process_component_raises_when_file_missing_from_container(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file declared in the RPA but absent from all layers must raise RuntimeError."""
+    monkeypatch.setattr(extract_artifacts, "CONTENT_DIR", tmp_path)
+
+    component = {
+        "name": "prod",
+        "containerImage": "quay.io/org/prod@sha256:abc",
+        "files": [{"source": "/releases/missing-binary.tar.gz"}],
+    }
+
+    import shutil
+    import tempfile
+
+    tmp_layer_dir = Path(tempfile.mkdtemp())
+    try:
+        layer_file = tmp_layer_dir / "abc123"
+        with tarfile.open(str(layer_file), "w"):
+            pass  # empty layer — file is not present
+
+        manifest = {"layers": [{"digest": "sha256:abc123"}]}
+
+        def fake_subprocess_check_output(cmd, **kwargs):
+            if cmd[0] == "select-oci-auth":
+                return b'{"auths":{}}'
+            raise ValueError(f"unexpected command: {cmd}")
+
+        def fake_subprocess_check_call(cmd, **kwargs):
+            if cmd[0] == "skopeo":
+                dest_dir_flag = cmd.index(next(a for a in cmd if a.startswith("dir:")))
+                dest_path = cmd[dest_dir_flag].removeprefix("dir:")
+                dest = Path(dest_path)
+                shutil.copy2(str(layer_file), str(dest / "abc123"))
+                (dest / "manifest.json").write_text(json.dumps(manifest))
+                return
+            if cmd[0] == "tar":
+                return
+            raise ValueError(f"unexpected command: {cmd}")
+
+        with (
+            mock.patch("subprocess.check_output", side_effect=fake_subprocess_check_output),
+            mock.patch("subprocess.check_call", side_effect=fake_subprocess_check_call),
+            mock.patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = mock.Mock(stdout="", returncode=0)
+            with pytest.raises(RuntimeError, match="releases/missing-binary.tar.gz"):
+                extract_artifacts.process_component(component)
+    finally:
+        shutil.rmtree(str(tmp_layer_dir), ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# _setup_docker_config
+# ---------------------------------------------------------------------------
+
+
+def test_setup_docker_config_strips_noise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Docker config from the mount is written to ~/.docker/config.json."""
+    mount = tmp_path / "mount"
+    mount.mkdir()
+    (mount / ".dockerconfigjson").write_text('{"auths":{}}')
+    monkeypatch.setattr(extract_artifacts, "REDHAT_WORKLOADS_TOKEN_MOUNT", mount)
+    home = tmp_path / "home"
+    home.mkdir()
+    with mock.patch("pathlib.Path.home", return_value=home):
+        extract_artifacts._setup_docker_config()
+    assert (home / ".docker" / "config.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+def test_run_skips_no_files_component(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """run() does not create an artifact directory for a component with no files."""
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps(SNAPSHOT_NO_FILES))
+    monkeypatch.setattr(extract_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(extract_artifacts, "REDHAT_WORKLOADS_TOKEN_MOUNT", tmp_path / "tok")
+    (tmp_path / "tok").mkdir()
+    (tmp_path / "tok" / ".dockerconfigjson").write_text('{"auths":{}}')
+    with mock.patch("pathlib.Path.home", return_value=tmp_path / "home"):
+        (tmp_path / "home").mkdir()
+        extract_artifacts.run(3)
+    # no artifacts directory created for skipped component
+    assert not (tmp_path / "artifacts" / "operator").is_dir()
+
+
+def test_run_propagates_component_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exceptions raised by process_component propagate out of run()."""
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps(SNAPSHOT_ONE))
+    monkeypatch.setattr(extract_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(extract_artifacts, "REDHAT_WORKLOADS_TOKEN_MOUNT", tmp_path / "tok")
+    (tmp_path / "tok").mkdir()
+    (tmp_path / "tok" / ".dockerconfigjson").write_text('{"auths":{}}')
+    with (
+        mock.patch("pathlib.Path.home", return_value=tmp_path / "home"),
+        mock.patch.object(
+            extract_artifacts, "process_component", side_effect=RuntimeError("skopeo fail")
+        ),
+    ):
+        (tmp_path / "home").mkdir()
+        with pytest.raises(RuntimeError, match="skopeo fail"):
+            extract_artifacts.run(3)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_success() -> None:
+    """main() returns 0 and passes the concurrent-limit argument to run()."""
+    with mock.patch.object(extract_artifacts, "run") as mock_run:
+        rc = extract_artifacts.main(["extract_artifacts.py", "--concurrent-limit", "2"])
+    assert rc == 0
+    mock_run.assert_called_once_with(2)
+
+
+def test_main_exception_returns_error() -> None:
+    """main() returns 1 when run() raises an exception."""
+    with mock.patch.object(extract_artifacts, "run", side_effect=RuntimeError("boom")):
+        rc = extract_artifacts.main(["extract_artifacts.py"])
+    assert rc == 1

--- a/scripts/python/helpers/test_generate_checksums.py
+++ b/scripts/python/helpers/test_generate_checksums.py
@@ -1,0 +1,288 @@
+"""Tests for generate_checksums.py."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import generate_checksums
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_checksum_creds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    mount = tmp_path / "checksum_creds"
+    mount.mkdir()
+    (mount / "user").write_text("csuser")
+    (mount / "host").write_text("cshost.example.com")
+    (mount / "fingerprint").write_text("ssh-rsa AAAA...")
+    (mount / "keytab").write_bytes(base64.b64encode(b"fake-keytab"))
+    monkeypatch.setattr(generate_checksums, "CHECKSUM_CREDENTIALS_MOUNT", mount)
+    return mount
+
+
+def _make_ready_dir(base: Path, name: str, files: dict[str, bytes]) -> Path:
+    d = base / name / "ready_for_distribution"
+    d.mkdir(parents=True)
+    for fname, content in files.items():
+        (d / fname).write_bytes(content)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# file_utils.sha256 (shared helper, tested in test_file.py)
+# ---------------------------------------------------------------------------
+
+
+def test_sha256sum_correct(tmp_path: Path) -> None:
+    """SHA-256 hex digest matches hashlib reference for a known file."""
+    import file as file_utils
+
+    f = tmp_path / "data.bin"
+    content = b"hello world"
+    f.write_bytes(content)
+    expected = hashlib.sha256(content).hexdigest()
+    assert file_utils.sha256(f) == expected
+
+
+# ---------------------------------------------------------------------------
+# _kinit
+# ---------------------------------------------------------------------------
+
+
+def test_kinit_calls_kinit_with_keytab(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_kinit passes the correct principal (user@REALM) to kinit_with_retry."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    calls = []
+
+    def fake_kinit_with_retry(princ, keytab, extra_env, **kwargs):
+        calls.append(princ)
+
+    with mock.patch("authentication.kinit_with_retry", side_effect=fake_kinit_with_retry):
+        generate_checksums._kinit("user", "REALM.COM", base64.b64encode(b"fakekey"))
+
+    assert calls == ["user@REALM.COM"]
+
+
+def test_kinit_cleans_up_keytab(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Temporary keytab file is deleted from disk after kinit completes."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    created_keytabs = []
+
+    orig_write_bytes = Path.write_bytes
+
+    def track_write(self, data):
+        if str(self).endswith(".keytab"):
+            created_keytabs.append(self)
+        return orig_write_bytes(self, data)
+
+    with (
+        mock.patch("authentication.kinit_with_retry"),
+        mock.patch.object(Path, "write_bytes", track_write),
+    ):
+        generate_checksums._kinit("user", "REALM", base64.b64encode(b"key"))
+
+    # keytab file should be deleted after kinit
+    for p in created_keytabs:
+        assert not p.exists()
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+def _mock_subprocess_for_run(monkeypatch, first_ready_dir: Path) -> list:
+    """Patch subprocess.check_call to simulate SSH/SCP by writing the .sig/.gpg files."""
+    calls = []
+
+    def fake_check_call(cmd, **kwargs):
+        calls.append(cmd)
+        cmd_list = cmd if isinstance(cmd, list) else [str(cmd)]
+        cmd_str = " ".join(str(c) for c in cmd_list)
+        # Simulate scp of .sig and .gpg files
+        if "sha256sum.txt.sig" in cmd_str and cmd_list and cmd_list[0] == "scp":
+            (first_ready_dir / "sha256sum.txt.sig").write_bytes(b"SIG")
+        if "sha256sum.txt.gpg" in cmd_str and cmd_list and cmd_list[0] == "scp":
+            (first_ready_dir / "sha256sum.txt.gpg").write_bytes(b"GPG")
+
+    monkeypatch.setattr("subprocess.check_call", fake_check_call)
+    return calls
+
+
+def _patch_checksum_ssh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch chmod calls that target hardcoded /tmp/.ssh paths."""
+    monkeypatch.setattr("pathlib.Path.chmod", lambda self, mode, **kw: None)
+
+
+def test_run_generates_checksums(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """run() creates sha256sum.txt listing all archives in ready_for_distribution."""
+    monkeypatch.setattr(generate_checksums, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(generate_checksums, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [{"name": "prod"}]}))
+    monkeypatch.setenv("AUTHOR", "testuser")
+    monkeypatch.setenv("SIGNING_KEY_NAME", "testkey")
+    _setup_checksum_creds(tmp_path, monkeypatch)
+    _patch_checksum_ssh(monkeypatch)
+
+    ready_dir = _make_ready_dir(
+        tmp_path / "artifacts",
+        "prod",
+        {"binary-linux-amd64.tar.gz": b"archive content"},
+    )
+
+    with mock.patch.object(generate_checksums, "_kinit"):
+        _mock_subprocess_for_run(monkeypatch, ready_dir)
+        generate_checksums.run("IPA.REDHAT.COM", "uid-123")
+
+    assert (ready_dir / "sha256sum.txt").exists()
+    content = (ready_dir / "sha256sum.txt").read_text()
+    assert "binary-linux-amd64.tar.gz" in content
+
+
+def test_run_uses_shared_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """run() prefers the shared snapshot.json over the SNAPSHOT_JSON env var."""
+    monkeypatch.setattr(generate_checksums, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(generate_checksums, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+
+    modified_snapshot = {"components": [{"name": "prod"}]}
+    (tmp_path / "shared" / "snapshot.json").write_text(json.dumps(modified_snapshot))
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [{"name": "ignored"}]}))
+    monkeypatch.setenv("AUTHOR", "testuser")
+    monkeypatch.setenv("SIGNING_KEY_NAME", "testkey")
+    _setup_checksum_creds(tmp_path, monkeypatch)
+    _patch_checksum_ssh(monkeypatch)
+
+    ready_dir = _make_ready_dir(
+        tmp_path / "artifacts",
+        "prod",
+        {"archive.tar.gz": b"data"},
+    )
+
+    with mock.patch.object(generate_checksums, "_kinit"):
+        _mock_subprocess_for_run(monkeypatch, ready_dir)
+        generate_checksums.run("IPA.REDHAT.COM", "uid-123")
+
+    assert (ready_dir / "sha256sum.txt").exists()
+
+
+def test_run_raises_on_no_components(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """RuntimeError is raised when no ready_for_distribution directory exists."""
+    monkeypatch.setattr(generate_checksums, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(generate_checksums, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [{"name": "prod"}]}))
+    monkeypatch.setenv("AUTHOR", "testuser")
+    monkeypatch.setenv("SIGNING_KEY_NAME", "testkey")
+    _setup_checksum_creds(tmp_path, monkeypatch)
+    _patch_checksum_ssh(monkeypatch)
+    # No ready_for_distribution dir created
+
+    with (
+        mock.patch.object(generate_checksums, "_kinit"),
+        mock.patch("shutil.copy2"),
+        mock.patch("subprocess.check_call"),
+    ):
+        with pytest.raises(RuntimeError, match="No archives"):
+            generate_checksums.run("IPA.REDHAT.COM", "uid-123")
+
+
+def test_run_raises_on_no_archives(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """RuntimeError is raised when ready_for_distribution exists but contains no archives."""
+    monkeypatch.setattr(generate_checksums, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(generate_checksums, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [{"name": "prod"}]}))
+    monkeypatch.setenv("AUTHOR", "testuser")
+    monkeypatch.setenv("SIGNING_KEY_NAME", "testkey")
+    _setup_checksum_creds(tmp_path, monkeypatch)
+    _patch_checksum_ssh(monkeypatch)
+
+    # Empty ready_for_distribution dir
+    ready_dir = tmp_path / "artifacts" / "prod" / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    with (
+        mock.patch.object(generate_checksums, "_kinit"),
+        mock.patch("shutil.copy2"),
+        mock.patch("subprocess.check_call"),
+    ):
+        with pytest.raises(RuntimeError, match="No archives"):
+            generate_checksums.run("IPA.REDHAT.COM", "uid-123")
+
+
+def test_run_excludes_sha256sum_from_checksums(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """sha256sum.txt files themselves should not be checksummed."""
+    monkeypatch.setattr(generate_checksums, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(generate_checksums, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [{"name": "prod"}]}))
+    monkeypatch.setenv("AUTHOR", "testuser")
+    monkeypatch.setenv("SIGNING_KEY_NAME", "testkey")
+    _setup_checksum_creds(tmp_path, monkeypatch)
+    _patch_checksum_ssh(monkeypatch)
+
+    ready_dir = _make_ready_dir(
+        tmp_path / "artifacts",
+        "prod",
+        {"archive.tar.gz": b"data", "sha256sum.txt": b"old checksum"},
+    )
+
+    with mock.patch.object(generate_checksums, "_kinit"):
+        _mock_subprocess_for_run(monkeypatch, ready_dir)
+        generate_checksums.run("IPA.REDHAT.COM", "uid-123")
+
+    content = (ready_dir / "sha256sum.txt").read_text()
+    assert "archive.tar.gz" in content
+    # sha256sum.txt itself should not appear as a file being checksummed
+    lines = [line for line in content.strip().splitlines() if line]
+    assert all("sha256sum.txt" not in line.split("  ")[-1] for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_success() -> None:
+    """main() returns 0 and calls run() with realm and pipeline-run-uid."""
+    with mock.patch.object(generate_checksums, "run") as mock_run:
+        rc = generate_checksums.main(
+            [
+                "generate_checksums.py",
+                "--kerberos-realm",
+                "REALM.COM",
+                "--pipeline-run-uid",
+                "uid",
+            ]
+        )
+    assert rc == 0
+    mock_run.assert_called_once_with("REALM.COM", "uid")
+
+
+def test_main_exception_returns_error() -> None:
+    """main() returns 1 when run() raises an exception."""
+    with mock.patch.object(generate_checksums, "run", side_effect=RuntimeError("kinit fail")):
+        rc = generate_checksums.main(
+            [
+                "generate_checksums.py",
+                "--kerberos-realm",
+                "REALM.COM",
+                "--pipeline-run-uid",
+                "uid",
+            ]
+        )
+    assert rc == 1

--- a/scripts/python/helpers/test_push_artifacts.py
+++ b/scripts/python/helpers/test_push_artifacts.py
@@ -1,0 +1,523 @@
+"""Tests for push_artifacts.py."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import push_artifacts
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+SNAPSHOT_STAGED = {
+    "components": [
+        {
+            "name": "testproduct",
+            "staged": {
+                "destination": "testproduct-amd64",
+                "version": "1.3",
+                "files": [
+                    {
+                        "source": "/releases/binary-linux-amd64.tar.gz",
+                        "os": "linux",
+                        "arch": "amd64",
+                    }
+                ],
+            },
+        }
+    ]
+}
+
+SNAPSHOT_CGW_ONLY = {
+    "components": [
+        {
+            "name": "testproduct",
+            "contentGateway": {
+                "productCode": "Code",
+                "productName": "MyName",
+                "productVersionName": "1.3-staging",
+            },
+        }
+    ]
+}
+
+SNAPSHOT_BOTH = {
+    "components": [
+        {
+            "name": "testproduct",
+            "staged": {
+                "destination": "testproduct-amd64",
+                "version": "1.3",
+                "files": [
+                    {
+                        "source": "/releases/binary-linux-amd64.tar.gz",
+                        "os": "linux",
+                        "arch": "amd64",
+                    }
+                ],
+            },
+            "contentGateway": {
+                "productCode": "Code",
+                "productName": "MyName",
+                "productVersionName": "1.3-staging",
+            },
+        }
+    ]
+}
+
+
+def _setup_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    for secret, files in {
+        "exodus": {"cert": "CERT", "key": "KEY", "url": "https://exodus.example.com"},
+        "pulp": {
+            "pulp_url": "https://pulp.example.com",
+            "konflux-release-rhsm-pulp.crt": "PULPCERT",
+            "konflux-release-rhsm-pulp.key": "PULPKEY",
+        },
+        "udc": {"url": "https://udc.example.com", "cert": "UDCCERT", "key": "UDCKEY"},
+        "cgw": {"username": "cgwuser", "token": "cgwtoken"},
+    }.items():
+        d = tmp_path / secret
+        d.mkdir()
+        for fname, content in files.items():
+            (d / fname).write_text(content)
+
+    monkeypatch.setattr(push_artifacts, "EXODUS_GW_SECRET_MOUNT", tmp_path / "exodus")
+    monkeypatch.setattr(push_artifacts, "PULP_SECRET_MOUNT", tmp_path / "pulp")
+    monkeypatch.setattr(push_artifacts, "UDCACHE_SECRET_MOUNT", tmp_path / "udc")
+    monkeypatch.setattr(push_artifacts, "CGW_SECRET_MOUNT", tmp_path / "cgw")
+
+
+def _setup_published_files_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    pub = tmp_path / "published"
+    monkeypatch.setenv("RESULT_PUBLISHED_FILES", str(pub))
+    return pub
+
+
+# ---------------------------------------------------------------------------
+# _check_cert_expiration
+# ---------------------------------------------------------------------------
+
+
+def test_check_cert_expiration_success() -> None:
+    """No exception is raised when openssl reports the certificate has not expired."""
+    with mock.patch("subprocess.run") as mock_run:
+        mock_run.return_value = mock.Mock(returncode=0)
+        push_artifacts._check_cert_expiration("/mnt/cert", 7)
+    mock_run.assert_called_once()
+
+
+def test_check_cert_expiration_raises_on_failure() -> None:
+    """RuntimeError is raised when openssl reports the certificate has expired."""
+    with mock.patch("subprocess.run") as mock_run:
+        mock_run.return_value = mock.Mock(returncode=1, stdout="expired", stderr="")
+        with pytest.raises(RuntimeError, match="expired"):
+            push_artifacts._check_cert_expiration("/mnt/cert", 7)
+
+
+# ---------------------------------------------------------------------------
+# _write_cert_files
+# ---------------------------------------------------------------------------
+
+
+def test_write_cert_files_creates_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All six certificate files are written to disk with the provided PEM content."""
+    monkeypatch.chdir(tmp_path)
+    with mock.patch("pathlib.Path", wraps=Path):
+        ec, ek, pc, pk, uc, uk = push_artifacts._write_cert_files(
+            "ECERT", "EKEY", "PCERT", "PKEY", "UCERT", "UKEY"
+        )
+    assert ec.read_text().strip() == "ECERT"
+    assert ek.read_text().strip() == "EKEY"
+    assert pc.read_text().strip() == "PCERT"
+    assert pk.read_text().strip() == "PKEY"
+    assert uc.read_text().strip() == "UCERT"
+    assert uk.read_text().strip() == "UKEY"
+
+
+# ---------------------------------------------------------------------------
+# _create_exodus_conf
+# ---------------------------------------------------------------------------
+
+
+def test_create_exodus_conf_contains_required_fields(tmp_path: Path) -> None:
+    """Generated exodus-rsync.conf includes gwcert, gwkey, gwurl, gwenv, and profile."""
+    conf = tmp_path / "exodus-rsync.conf"
+    push_artifacts._create_exodus_conf(
+        conf,
+        Path("/tmp/exodus.crt"),
+        Path("/tmp/exodus.key"),
+        "https://exodus.example.com",
+        "live",
+    )
+    text = conf.read_text()
+    assert "gwcert" in text
+    assert "gwkey" in text
+    assert "gwurl" in text
+    assert "gwenv" in text
+    assert "live" in text
+    assert "exodus" in text
+
+
+# ---------------------------------------------------------------------------
+# _push_component_to_pulp
+# ---------------------------------------------------------------------------
+
+
+def test_push_component_to_pulp_calls_pulp_push_wrapper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """pulp_push_wrapper.main is called once for a component with staged files."""
+    monkeypatch.setattr(push_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    comp_dir = tmp_path / "artifacts" / "testproduct" / "ready_for_distribution"
+    comp_dir.mkdir(parents=True)
+    (comp_dir / "binary-linux-amd64.tar.gz").write_bytes(b"archive")
+
+    with mock.patch("pulp_push_wrapper.main") as mock_pulp:
+        push_artifacts._push_component_to_pulp(
+            "testproduct",
+            SNAPSHOT_STAGED,
+            "https://pulp.example.com",
+            Path("/tmp/pulp.crt"),
+            Path("/tmp/pulp.key"),
+            "https://udc.example.com",
+        )
+
+    mock_pulp.assert_called_once()
+
+
+def test_push_component_to_pulp_raises_on_missing_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RuntimeError is raised when staged destination exists but version is missing."""
+    monkeypatch.setattr(push_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    snapshot = {
+        "components": [
+            {
+                "name": "prod",
+                "staged": {"destination": "dest"},  # missing version
+            }
+        ]
+    }
+    with pytest.raises(RuntimeError, match="staged.version"):
+        push_artifacts._push_component_to_pulp(
+            "prod",
+            snapshot,
+            "https://pulp.example.com",
+            Path("/tmp/p.crt"),
+            Path("/tmp/p.key"),
+            "https://udc.example.com",
+        )
+
+
+def test_push_component_to_pulp_skips_no_staged_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A warning is logged and pulp is skipped when staged has no files list."""
+    monkeypatch.setattr(push_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    snapshot = {
+        "components": [
+            {
+                "name": "prod",
+                "staged": {"destination": "dest", "version": "1.0"},
+            }
+        ]
+    }
+    with (
+        caplog.at_level(logging.WARNING, logger="push_artifacts"),
+        mock.patch("pulp_push_wrapper.main"),
+    ):
+        push_artifacts._push_component_to_pulp(
+            "prod",
+            snapshot,
+            "https://pulp.example.com",
+            Path("/tmp/p.crt"),
+            Path("/tmp/p.key"),
+            "https://udc.example.com",
+        )
+    assert "No staged.files" in caplog.text
+
+
+def test_push_component_to_pulp_handles_windows_zip_rename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A .tar.gz source with a matching .zip on disk is renamed before the Pulp push."""
+    monkeypatch.setattr(push_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    comp_dir = tmp_path / "artifacts" / "prod" / "ready_for_distribution"
+    comp_dir.mkdir(parents=True)
+    (comp_dir / "binary-windows-amd64.zip").write_bytes(b"data")
+
+    snapshot = {
+        "components": [
+            {
+                "name": "prod",
+                "staged": {
+                    "destination": "dest",
+                    "version": "1.0",
+                    "files": [
+                        {
+                            "source": "/releases/binary-windows-amd64.tar.gz",
+                            "filename": "binary-windows-amd64.tar.gz",
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+    with mock.patch("pulp_push_wrapper.main") as mock_pulp:
+        push_artifacts._push_component_to_pulp(
+            "prod",
+            snapshot,
+            "https://pulp.example.com",
+            Path("/tmp/p.crt"),
+            Path("/tmp/p.key"),
+            "https://udc.example.com",
+        )
+
+    mock_pulp.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _push_component_to_cdn
+# ---------------------------------------------------------------------------
+
+
+def test_push_component_to_cdn_calls_rsync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The rsync command is invoked with a CDN sha256-based destination path per archive."""
+    monkeypatch.setattr(push_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    comp_dir = tmp_path / "artifacts" / "prod" / "ready_for_distribution"
+    comp_dir.mkdir(parents=True)
+    (comp_dir / "file.tar.gz").write_bytes(b"archive")
+
+    rsync_calls = []
+
+    def fake_check_call(cmd, **kwargs):
+        if cmd[0] == "rsync":
+            rsync_calls.append(cmd)
+
+    with mock.patch("subprocess.check_call", side_effect=fake_check_call):
+        push_artifacts._push_component_to_cdn("prod", tmp_path / "exodus.conf")
+
+    assert len(rsync_calls) == 1
+    # Verify CDN path structure: exodus:/content/origin/files/sha256/xx/sha256hash/filename
+    dest = rsync_calls[0][-1]
+    assert dest.startswith("exodus:/content/origin/files/sha256/")
+
+
+# ---------------------------------------------------------------------------
+# run - routing logic
+# ---------------------------------------------------------------------------
+
+
+def test_run_staged_calls_pulp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """run() invokes pulp_push_wrapper for a snapshot with staged-only components."""
+    monkeypatch.setattr(push_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(push_artifacts, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps(SNAPSHOT_STAGED))
+    _setup_secrets(tmp_path, monkeypatch)
+    _setup_published_files_env(tmp_path, monkeypatch)
+
+    comp_dir = tmp_path / "artifacts" / "testproduct" / "ready_for_distribution"
+    comp_dir.mkdir(parents=True)
+    (comp_dir / "binary-linux-amd64.tar.gz").write_bytes(b"data")
+
+    def fake_check_cert(_path, _days):
+        pass
+
+    with (
+        mock.patch.object(
+            push_artifacts, "_check_cert_expiration", side_effect=fake_check_cert
+        ),
+        mock.patch("pulp_push_wrapper.main") as mock_pulp,
+    ):
+        push_artifacts.run("pre", "https://cgw.example.com", 7)
+
+    mock_pulp.assert_called_once()
+
+
+def test_run_cgw_only_calls_rsync(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """run() invokes rsync for a snapshot with CGW-only (no staged) components."""
+    monkeypatch.setattr(push_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(push_artifacts, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps(SNAPSHOT_CGW_ONLY))
+    _setup_secrets(tmp_path, monkeypatch)
+    _setup_published_files_env(tmp_path, monkeypatch)
+
+    comp_dir = tmp_path / "artifacts" / "testproduct" / "ready_for_distribution"
+    comp_dir.mkdir(parents=True)
+    (comp_dir / "file.tar.gz").write_bytes(b"data")
+
+    rsync_calls = []
+
+    def fake_check_cert(_path, _days):
+        pass
+
+    def fake_check_call(cmd, **kwargs):
+        if cmd[0] == "rsync":
+            rsync_calls.append(cmd)
+
+    with (
+        mock.patch.object(
+            push_artifacts, "_check_cert_expiration", side_effect=fake_check_cert
+        ),
+        mock.patch("subprocess.check_call", side_effect=fake_check_call),
+        mock.patch("publish_to_cgw_wrapper.main"),
+    ):
+        push_artifacts.run("pre", "https://cgw.example.com", 7)
+
+    assert any(c[0] == "rsync" for c in rsync_calls)
+
+
+def test_run_both_calls_pulp_and_cgw(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """run() invokes both pulp and CGW wrappers for a snapshot that has both destinations."""
+    monkeypatch.setattr(push_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(push_artifacts, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps(SNAPSHOT_BOTH))
+    _setup_secrets(tmp_path, monkeypatch)
+    _setup_published_files_env(tmp_path, monkeypatch)
+
+    comp_dir = tmp_path / "artifacts" / "testproduct" / "ready_for_distribution"
+    comp_dir.mkdir(parents=True)
+    (comp_dir / "binary-linux-amd64.tar.gz").write_bytes(b"data")
+
+    def fake_check_cert(_path, _days):
+        pass
+
+    with (
+        mock.patch.object(
+            push_artifacts, "_check_cert_expiration", side_effect=fake_check_cert
+        ),
+        mock.patch("pulp_push_wrapper.main") as mock_pulp,
+        mock.patch("publish_to_cgw_wrapper.main") as mock_cgw,
+        mock.patch("subprocess.check_call"),
+    ):
+        push_artifacts.run("pre", "https://cgw.example.com", 7)
+
+    mock_pulp.assert_called_once()
+    mock_cgw.assert_called_once()
+
+
+def test_run_uses_shared_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """run() reads from shared snapshot.json instead of SNAPSHOT_JSON env when present."""
+    monkeypatch.setattr(push_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(push_artifacts, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "snapshot.json").write_text(json.dumps({"components": []}))
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps(SNAPSHOT_STAGED))  # should be ignored
+    _setup_secrets(tmp_path, monkeypatch)
+    _setup_published_files_env(tmp_path, monkeypatch)
+
+    def fake_check_cert(_path, _days):
+        pass
+
+    with mock.patch.object(
+        push_artifacts, "_check_cert_expiration", side_effect=fake_check_cert
+    ):
+        push_artifacts.run("pre", "https://cgw.example.com", 7)
+    # No pulp call expected when components list is empty
+    # (just verifying no crash)
+
+
+def test_run_cert_failure_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """RuntimeError from cert expiration check propagates out of run()."""
+    monkeypatch.setattr(push_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(push_artifacts, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps(SNAPSHOT_STAGED))
+    _setup_secrets(tmp_path, monkeypatch)
+    _setup_published_files_env(tmp_path, monkeypatch)
+
+    with mock.patch.object(
+        push_artifacts,
+        "_check_cert_expiration",
+        side_effect=RuntimeError("cert expired"),
+    ):
+        with pytest.raises(RuntimeError, match="cert expired"):
+            push_artifacts.run("pre", "https://cgw.example.com", 7)
+
+
+def test_run_preprod_sets_squid_proxy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTP_PROXY is set to the Squid proxy URL when the CGW hostname is a pre-prod URL."""
+    monkeypatch.setattr(push_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(push_artifacts, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps(SNAPSHOT_CGW_ONLY))
+    _setup_secrets(tmp_path, monkeypatch)
+    _setup_published_files_env(tmp_path, monkeypatch)
+
+    comp_dir = tmp_path / "artifacts" / "testproduct" / "ready_for_distribution"
+    comp_dir.mkdir(parents=True)
+    (comp_dir / "file.tar.gz").write_bytes(b"data")
+
+    def fake_check_cert(_path, _days):
+        pass
+
+    env_captured = {}
+
+    def fake_cgw_main(argv):
+        import os
+
+        env_captured["HTTP_PROXY"] = os.environ.get("HTTP_PROXY", "")
+
+    with (
+        mock.patch.object(
+            push_artifacts, "_check_cert_expiration", side_effect=fake_check_cert
+        ),
+        mock.patch("subprocess.check_call"),
+        mock.patch("publish_to_cgw_wrapper.main", side_effect=fake_cgw_main),
+    ):
+        push_artifacts.run("pre", "https://developers.qa.redhat.com", 7)
+
+    assert "squid" in env_captured.get("HTTP_PROXY", "")
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_success() -> None:
+    """main() returns 0 and calls run() with the correct arguments."""
+    with mock.patch.object(push_artifacts, "run") as mock_run:
+        rc = push_artifacts.main(
+            [
+                "push_artifacts.py",
+                "--exodus-gw-env",
+                "pre",
+                "--cgw-hostname",
+                "https://cgw.example.com",
+                "--cert-expiration-warn-days",
+                "7",
+            ]
+        )
+    assert rc == 0
+    mock_run.assert_called_once_with("pre", "https://cgw.example.com", 7)
+
+
+def test_main_exception_returns_error() -> None:
+    """main() returns 1 when run() raises an exception."""
+    with mock.patch.object(push_artifacts, "run", side_effect=RuntimeError("pulp down")):
+        rc = push_artifacts.main(
+            [
+                "push_artifacts.py",
+                "--exodus-gw-env",
+                "pre",
+                "--cgw-hostname",
+                "https://cgw.example.com",
+            ]
+        )
+    assert rc == 1

--- a/scripts/python/helpers/test_push_unsigned.py
+++ b/scripts/python/helpers/test_push_unsigned.py
@@ -1,0 +1,442 @@
+"""Tests for push_unsigned.py."""
+
+from __future__ import annotations
+
+import json
+import logging
+import tarfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import oras_utils
+import push_unsigned
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+SNAPSHOT = {
+    "components": [
+        {
+            "name": "testproduct",
+            "files": [
+                {
+                    "source": "/releases/binary-linux-amd64.tar.gz",
+                    "os": "linux",
+                    "arch": "amd64",
+                },
+                {
+                    "source": "/releases/binary-darwin-amd64.tar.gz",
+                    "os": "darwin",
+                    "arch": "amd64",
+                },
+                {
+                    "source": "/releases/binary-windows-amd64.tar.gz",
+                    "os": "windows",
+                    "arch": "amd64",
+                },
+            ],
+        }
+    ]
+}
+
+
+def _make_quay_secret(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    mount = tmp_path / "quay"
+    mount.mkdir()
+    (mount / "username").write_text("quser")
+    (mount / "password").write_text("qpass")
+    monkeypatch.setattr(push_unsigned, "QUAY_SECRET_MOUNT", mount)
+    return mount
+
+
+def _make_component_dir(
+    base: Path,
+    name: str,
+    has_mac: bool = False,
+    has_windows: bool = False,
+    has_linux: bool = False,
+) -> Path:
+    d = base / name
+    d.mkdir(parents=True)
+    if has_mac:
+        (d / "has_mac").touch()
+    if has_windows:
+        (d / "has_windows").touch()
+    if has_linux:
+        (d / "has_linux").touch()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# is_supplementary_file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "README",
+        "readme",
+        "Readme",
+        "README.md",
+        "readme.md",
+        "README.MD",
+        "README.txt",
+        "readme.TXT",
+        "LICENSE",
+        "license",
+        "LICENSE.md",
+        "LICENSE.txt",
+        "LICENSE.TXT",
+        "LICENSE.MD",
+        "CHANGELOG",
+        "changelog",
+        "CHANGELOG.md",
+        "changelog.txt",
+        "CHANGELOG.TXT",
+        "Changelog.MD",
+        "/some/path/README.md",
+        "amd64/LICENSE",
+    ],
+)
+def test_is_supplementary_file_true(filename: str) -> None:
+    """Parametrized filenames that should be identified as supplementary."""
+    assert push_unsigned.is_supplementary_file(Path(filename))
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "NOTES.TXT",
+        "RELEASE_NOTES.TXT",
+        "INSTALL.md",
+        "CONTRIBUTING.md",
+        "setup.cfg",
+        "Makefile",
+        "config.json",
+        "binary-name",
+        "README.rst",
+        "README.html",
+        "LICENSE.html",
+        "CHANGELOG.rst",
+        "readme.doc",
+        "LICENSE-MIT",
+        "README-dev.md",
+        "my-binary.exe",
+    ],
+)
+def test_is_supplementary_file_false(filename: str) -> None:
+    """Parametrized filenames that should NOT be identified as supplementary."""
+    assert not push_unsigned.is_supplementary_file(Path(filename))
+
+
+# ---------------------------------------------------------------------------
+# move_supplementary_out
+# ---------------------------------------------------------------------------
+
+
+def test_move_supplementary_out_moves_supplementary(tmp_path: Path) -> None:
+    """Supplementary files are moved to the hold dir while non-supplementary files remain."""
+    src = tmp_path / "unsigned" / "macos" / "amd64"
+    hold = tmp_path / "supplementary" / "macos"
+    src.mkdir(parents=True)
+
+    (src / "my-binary").write_bytes(b"binary")
+    (src / "README.md").write_text("readme")
+    (src / "LICENSE").write_text("license")
+    (src / "CHANGELOG.txt").write_text("changelog")
+
+    push_unsigned.move_supplementary_out(src, hold)
+
+    assert (src / "my-binary").exists()
+    assert not (src / "README.md").exists()
+    assert not (src / "LICENSE").exists()
+    assert not (src / "CHANGELOG.txt").exists()
+    assert (hold / "README.md").exists()
+    assert (hold / "LICENSE").exists()
+    assert (hold / "CHANGELOG.txt").exists()
+
+
+def test_move_supplementary_out_missing_src_is_noop(tmp_path: Path) -> None:
+    """A missing source directory is handled silently without raising."""
+    push_unsigned.move_supplementary_out(tmp_path / "nonexistent", tmp_path / "hold")
+
+
+def test_move_supplementary_out_preserves_subdirs(tmp_path: Path) -> None:
+    """Supplementary files in subdirectories are moved preserving the sub-path structure."""
+    src = tmp_path / "src"
+    hold = tmp_path / "hold"
+    sub = src / "arm64"
+    sub.mkdir(parents=True)
+    (sub / "readme.TXT").write_text("r")
+    (sub / "my-binary").write_bytes(b"b")
+
+    push_unsigned.move_supplementary_out(src, hold)
+
+    assert not (src / "arm64" / "readme.TXT").exists()
+    assert (src / "arm64" / "my-binary").exists()
+    assert (hold / "arm64" / "readme.TXT").exists()
+
+
+# ---------------------------------------------------------------------------
+# _unpack_file_entries
+# ---------------------------------------------------------------------------
+
+
+def _make_tar(path: Path, files: dict[str, bytes]) -> None:
+    """Create a tar.gz at *path* containing the given filenames→contents."""
+    with tarfile.open(str(path), "w:gz") as tf:
+        for name, content in files.items():
+            import io
+
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            tf.addfile(info, io.BytesIO(content))
+
+
+def test_unpack_file_entries_linux(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Linux tarball is extracted into the linux/<arch> directory."""
+    monkeypatch.setattr(push_unsigned, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    archive = comp_dir / "binary-linux-amd64.tar.gz"
+    _make_tar(archive, {"mybinary": b"data"})
+
+    push_unsigned._unpack_file_entries(
+        [{"source": "/releases/binary-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"}],
+        comp_dir,
+        comp_dir / "unsigned",
+    )
+    assert (comp_dir / "linux" / "amd64" / "mybinary").exists()
+    assert not archive.exists()
+
+
+def test_unpack_file_entries_darwin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Darwin tarball is extracted into the unsigned/macos/<arch> directory."""
+    monkeypatch.setattr(push_unsigned, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    unsigned_dir = comp_dir / "unsigned"
+    archive = comp_dir / "binary-darwin-amd64.tar.gz"
+    _make_tar(archive, {"mybinary": b"data"})
+
+    push_unsigned._unpack_file_entries(
+        [{"source": "/releases/binary-darwin-amd64.tar.gz", "os": "darwin", "arch": "amd64"}],
+        comp_dir,
+        unsigned_dir,
+    )
+    assert (unsigned_dir / "macos" / "amd64" / "mybinary").exists()
+    assert not archive.exists()
+
+
+def test_unpack_file_entries_windows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Windows tarball is extracted into the unsigned/windows/<arch> directory."""
+    monkeypatch.setattr(push_unsigned, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    unsigned_dir = comp_dir / "unsigned"
+    archive = comp_dir / "binary-windows-amd64.tar.gz"
+    _make_tar(archive, {"mybinary.exe": b"data"})
+
+    push_unsigned._unpack_file_entries(
+        [
+            {
+                "source": "/releases/binary-windows-amd64.tar.gz",
+                "os": "windows",
+                "arch": "amd64",
+            }
+        ],
+        comp_dir,
+        unsigned_dir,
+    )
+    assert (unsigned_dir / "windows" / "amd64" / "mybinary.exe").exists()
+    assert not archive.exists()
+
+
+def test_unpack_file_entries_missing_archive_is_warned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A warning is logged when the archive file referenced in an entry does not exist."""
+    monkeypatch.setattr(push_unsigned, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+
+    with caplog.at_level(logging.WARNING, logger="push_unsigned"):
+        push_unsigned._unpack_file_entries(
+            [{"source": "/releases/missing.tar.gz", "os": "linux", "arch": "amd64"}],
+            comp_dir,
+            comp_dir / "unsigned",
+        )
+    assert "Archive not found" in caplog.text
+
+
+def test_unpack_file_entries_skips_missing_fields(tmp_path: Path) -> None:
+    """File entries without source, os, or arch fields are silently skipped."""
+    push_unsigned._unpack_file_entries(
+        [{"os": "linux"}],
+        tmp_path,
+        tmp_path / "unsigned",
+    )
+    # no crash
+
+
+def test_unpack_file_entries_rejects_path_traversal(tmp_path: Path) -> None:
+    """RuntimeError is raised when a tar entry contains an unsafe path traversal sequence."""
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    archive = comp_dir / "binary-linux-amd64.tar.gz"
+
+    with tarfile.open(str(archive), "w:gz") as tf:
+        import io
+
+        payload = b"oops"
+        info = tarfile.TarInfo(name="../../escape.txt")
+        info.size = len(payload)
+        tf.addfile(info, io.BytesIO(payload))
+
+    with pytest.raises(RuntimeError, match="unsafe path"):
+        push_unsigned._unpack_file_entries(
+            [
+                {
+                    "source": "/releases/binary-linux-amd64.tar.gz",
+                    "os": "linux",
+                    "arch": "amd64",
+                }
+            ],
+            comp_dir,
+            comp_dir / "unsigned",
+        )
+
+
+# ---------------------------------------------------------------------------
+# oras_utils.oras_push
+# ---------------------------------------------------------------------------
+
+
+def test_oras_push_returns_digest(tmp_path: Path) -> None:
+    """oras_push returns the sha256 digest parsed from the oras push output."""
+    with mock.patch("subprocess.check_output", return_value="Digest: sha256:abc123\n"):
+        digest = oras_utils.oras_push("quay.io/org/prod:tag", tmp_path, "macos", "prod")
+    assert digest == "sha256:abc123"
+
+
+def test_oras_push_raises_on_missing_digest(tmp_path: Path) -> None:
+    """RuntimeError is raised when oras push output contains no Digest line."""
+    with mock.patch("subprocess.check_output", return_value="no digest here"):
+        with pytest.raises(RuntimeError, match="digest"):
+            oras_utils.oras_push("quay.io/org/prod:tag", tmp_path, "macos", "prod")
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+def test_run_skips_no_files_component(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A component with no files or staged.files entries is skipped with a log message."""
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [{"name": "op"}]}))
+    monkeypatch.setattr(push_unsigned, "CONTENT_DIR", tmp_path)
+    _make_quay_secret(tmp_path, monkeypatch)
+
+    with (
+        caplog.at_level(logging.INFO, logger="push_unsigned"),
+        mock.patch("oras_utils.oras_login"),
+    ):
+        push_unsigned.run("quay.io/org", "uid-123")
+
+    assert "Skipping" in caplog.text
+
+
+def test_run_pushes_mac_and_windows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two oras push calls are made for a component with both mac and windows artifacts."""
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps(SNAPSHOT))
+    monkeypatch.setattr(push_unsigned, "CONTENT_DIR", tmp_path / "artifacts")
+    _make_quay_secret(tmp_path, monkeypatch)
+
+    comp_dir = _make_component_dir(
+        tmp_path / "artifacts", "testproduct", has_mac=True, has_windows=True, has_linux=True
+    )
+    # Create fake archives
+    for fname, os_name, arch in [
+        ("binary-darwin-amd64.tar.gz", "darwin", "amd64"),
+        ("binary-windows-amd64.tar.gz", "windows", "amd64"),
+        ("binary-linux-amd64.tar.gz", "linux", "amd64"),
+    ]:
+        archive = comp_dir / fname
+        _make_tar(archive, {"binary": b"data"})
+
+    oras_calls = []
+
+    def fake_check_output(cmd, **kwargs):
+        if cmd[0] == "oras" and cmd[1] == "push":
+            oras_calls.append(cmd)
+            return "Digest: sha256:fakedigest\n"
+        raise ValueError(f"unexpected: {cmd}")
+
+    with (
+        mock.patch("oras_utils.oras_login"),
+        mock.patch("subprocess.check_output", side_effect=fake_check_output),
+    ):
+        push_unsigned.run("quay.io/org", "uid-123")
+
+    assert len(oras_calls) == 2  # mac + windows
+    assert (comp_dir / "unsigned_mac_digest.txt").read_text() == "sha256:fakedigest"
+    assert (comp_dir / "unsigned_windows_digest.txt").read_text() == "sha256:fakedigest"
+
+
+def test_run_no_mac_or_windows_skips_pushes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No oras push is made when the component has neither has_mac nor has_windows flags."""
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps(SNAPSHOT))
+    monkeypatch.setattr(push_unsigned, "CONTENT_DIR", tmp_path / "artifacts")
+    _make_quay_secret(tmp_path, monkeypatch)
+
+    comp_dir = _make_component_dir(tmp_path / "artifacts", "testproduct", has_linux=True)
+    _make_tar(comp_dir / "binary-linux-amd64.tar.gz", {"binary": b"data"})
+    # No has_mac or has_windows flag files
+
+    oras_push_calls = []
+
+    def fake_check_output(cmd, **kwargs):
+        if cmd[0] == "oras" and cmd[1] == "push":
+            oras_push_calls.append(cmd)
+            return "Digest: sha256:x\n"
+        return b""
+
+    with (
+        mock.patch("oras_utils.oras_login"),
+        mock.patch("subprocess.check_output", side_effect=fake_check_output),
+    ):
+        push_unsigned.run("quay.io/org", "uid-123")
+
+    assert oras_push_calls == []
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_success() -> None:
+    """main() returns 0 and passes quay URL and pipeline-run-uid to run()."""
+    with mock.patch.object(push_unsigned, "run") as mock_run:
+        rc = push_unsigned.main(
+            ["push_unsigned.py", "--quay-url", "quay.io/org", "--pipeline-run-uid", "uid"]
+        )
+    assert rc == 0
+    mock_run.assert_called_once_with("quay.io/org", "uid")
+
+
+def test_main_exception_returns_error() -> None:
+    """main() returns 1 when run() raises an exception."""
+    with mock.patch.object(push_unsigned, "run", side_effect=RuntimeError("oras fail")):
+        rc = push_unsigned.main(
+            ["push_unsigned.py", "--quay-url", "quay.io/org", "--pipeline-run-uid", "uid"]
+        )
+    assert rc == 1

--- a/scripts/python/helpers/test_sign_mac.py
+++ b/scripts/python/helpers/test_sign_mac.py
@@ -1,0 +1,220 @@
+"""Tests for sign_mac.py."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import sign_mac
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_mounts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ssh_key = tmp_path / "mac_ssh"
+    ssh_key.mkdir()
+    (ssh_key / "mac_id_rsa").write_text("FAKE_KEY")
+    (ssh_key / "mac_fingerprint").write_text("FAKE_FP")
+    monkeypatch.setattr(sign_mac, "MAC_SSH_KEY_MOUNT", ssh_key)
+
+    host_creds = tmp_path / "mac_host"
+    host_creds.mkdir()
+    (host_creds / "username").write_text("macuser")
+    (host_creds / "host").write_text("mac-host.example.com")
+    monkeypatch.setattr(sign_mac, "MAC_HOST_CREDS_MOUNT", host_creds)
+
+    signing_creds = tmp_path / "mac_signing"
+    signing_creds.mkdir()
+    (signing_creds / "keychain_password").write_text("kpwd")
+    (signing_creds / "signing_identity").write_text("My Identity")
+    (signing_creds / "apple_id").write_text("dev@example.com")
+    (signing_creds / "team_id").write_text("TEAMID123")
+    (signing_creds / "app_specific_password").write_text("app-pwd")
+    monkeypatch.setattr(sign_mac, "MAC_SIGNING_CREDS_MOUNT", signing_creds)
+
+    quay = tmp_path / "quay"
+    quay.mkdir()
+    (quay / "username").write_text("quser")
+    (quay / "password").write_text("qpass")
+    monkeypatch.setattr(sign_mac, "QUAY_SECRET_MOUNT", quay)
+
+
+# ---------------------------------------------------------------------------
+# _build_signing_script
+# ---------------------------------------------------------------------------
+
+
+def test_build_signing_script_contains_key_commands() -> None:
+    """Generated signing script includes codesign, notarytool, oras pull/push, and keys."""
+    script = sign_mac._build_signing_script(
+        quay_url="quay.io/org",
+        quay_user="user",
+        quay_pass="pass",
+        component_name="prod",
+        unsigned_digest="sha256:abc",
+        pipeline_run_uid="uid-123",
+        temp_dir="/tmp/uid-123_prod",
+        binary_path="/tmp/uid-123_prod/unsigned",
+        zip_path="/tmp/uid-123_prod/signed_content.zip",
+        digest_file="/tmp/uid-123_prod/push_digest.txt",
+        keychain_password="kpwd",
+        signing_identity="My Identity",
+        apple_id="dev@example.com",
+        team_id="TEAMID123",
+        app_specific_password="app-pwd",
+    )
+    assert "xcrun codesign" in script
+    assert "xcrun notarytool" in script
+    assert "oras pull" in script
+    assert "oras push" in script
+    assert "sha256:abc" in script
+    assert "uid-123-mac" in script
+    assert "My Identity" in script
+
+
+# ---------------------------------------------------------------------------
+# _ssh_opts
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_opts_returns_list() -> None:
+    """Returned SSH options list includes identity file, IdentitiesOnly, and known hosts."""
+    opts = sign_mac._ssh_opts("/tmp/.ssh/id_rsa", "/tmp/.ssh/known_hosts")
+    assert "-i" in opts
+    assert "/tmp/.ssh/id_rsa" in opts
+    assert "IdentitiesOnly=yes" in opts
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+def _patch_ssh_setup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch all filesystem ops that touch the hardcoded /tmp/.ssh path."""
+    monkeypatch.setattr(
+        "pathlib.Path.chmod",
+        lambda self, mode, **kw: None,
+    )
+
+
+def test_run_skips_component_without_has_mac(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A component without a has_mac flag file is skipped with an INFO log message."""
+    monkeypatch.setenv(
+        "SNAPSHOT_JSON",
+        json.dumps(
+            {"components": [{"name": "prod", "containerImage": "q.io/prod@sha256:abc"}]}
+        ),
+    )
+    monkeypatch.setattr(sign_mac, "CONTENT_DIR", tmp_path)
+    _setup_mounts(tmp_path, monkeypatch)
+    _patch_ssh_setup(monkeypatch)
+
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    # No has_mac file
+
+    with (
+        caplog.at_level(logging.INFO, logger="sign_mac"),
+        mock.patch("shutil.copy2"),
+        mock.patch("subprocess.run"),
+    ):
+        sign_mac.run("quay.io/org", "uid-123")
+
+    assert "skipping Mac signing" in caplog.text
+
+
+def test_run_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Signed digest is written to signed_mac_digest.txt after a successful Mac signing run."""
+    monkeypatch.setenv(
+        "SNAPSHOT_JSON",
+        json.dumps({"components": [{"name": "prod"}]}),
+    )
+    monkeypatch.setattr(sign_mac, "CONTENT_DIR", tmp_path)
+    _setup_mounts(tmp_path, monkeypatch)
+    _patch_ssh_setup(monkeypatch)
+
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    (comp_dir / "has_mac").touch()
+    (comp_dir / "unsigned_mac_digest.txt").write_text("sha256:unsigned")
+
+    # signed digest written back
+    signed_digest_content = "sha256:signed"
+
+    def fake_subprocess_run(cmd, **kwargs):
+        # When it's the scp that copies the digest back, create the file
+        if cmd[0] == "scp" and "push_digest.txt" in " ".join(cmd):
+            (comp_dir / "signed_mac_digest.txt").write_text(signed_digest_content)
+        return mock.Mock(returncode=0)
+
+    with (
+        mock.patch("shutil.copy2"),
+        mock.patch("subprocess.check_call"),
+        mock.patch("subprocess.run", side_effect=fake_subprocess_run),
+    ):
+        sign_mac.run("quay.io/org", "uid-123")
+
+    assert (comp_dir / "signed_mac_digest.txt").read_text() == signed_digest_content
+
+
+def test_run_raises_on_ssh_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """RuntimeError with 'Mac signing failed' is raised when the remote SSH command fails."""
+    monkeypatch.setenv(
+        "SNAPSHOT_JSON",
+        json.dumps({"components": [{"name": "prod"}]}),
+    )
+    monkeypatch.setattr(sign_mac, "CONTENT_DIR", tmp_path)
+    _setup_mounts(tmp_path, monkeypatch)
+    _patch_ssh_setup(monkeypatch)
+
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    (comp_dir / "has_mac").touch()
+    (comp_dir / "unsigned_mac_digest.txt").write_text("sha256:unsigned")
+
+    def fake_subprocess_run(cmd, **kwargs):
+        # The first subprocess.run is the SSH signing call; fail it
+        if cmd[0] == "ssh" and len(cmd) >= 4 and "bash" in cmd:
+            return mock.Mock(returncode=1)
+        return mock.Mock(returncode=0)
+
+    with (
+        mock.patch("shutil.copy2"),
+        mock.patch("subprocess.check_call"),
+        mock.patch("subprocess.run", side_effect=fake_subprocess_run),
+    ):
+        with pytest.raises(RuntimeError, match="Mac signing failed"):
+            sign_mac.run("quay.io/org", "uid-123")
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_success() -> None:
+    """main() returns 0 and passes quay URL and pipeline-run-uid to run()."""
+    with mock.patch.object(sign_mac, "run") as mock_run:
+        rc = sign_mac.main(
+            ["sign_mac.py", "--quay-url", "quay.io/org", "--pipeline-run-uid", "uid"]
+        )
+    assert rc == 0
+    mock_run.assert_called_once_with("quay.io/org", "uid")
+
+
+def test_main_exception_returns_error() -> None:
+    """main() returns 1 when run() raises an exception."""
+    with mock.patch.object(sign_mac, "run", side_effect=RuntimeError("ssh down")):
+        rc = sign_mac.main(
+            ["sign_mac.py", "--quay-url", "quay.io/org", "--pipeline-run-uid", "uid"]
+        )
+    assert rc == 1

--- a/scripts/python/helpers/test_sign_windows.py
+++ b/scripts/python/helpers/test_sign_windows.py
@@ -1,0 +1,248 @@
+"""Tests for sign_windows.py."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import sign_windows
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_mounts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ssh_key = tmp_path / "win_ssh"
+    ssh_key.mkdir()
+    (ssh_key / "windows_id_rsa").write_text("FAKE_KEY")
+    (ssh_key / "windows_fingerprint").write_text("FAKE_FP")
+    monkeypatch.setattr(sign_windows, "WINDOWS_SSH_KEY_MOUNT", ssh_key)
+
+    creds = tmp_path / "win_creds"
+    creds.mkdir()
+    (creds / "username").write_text("winuser")
+    (creds / "port").write_text("22")
+    (creds / "host").write_text("win-host.example.com")
+    monkeypatch.setattr(sign_windows, "WINDOWS_CREDS_MOUNT", creds)
+
+    quay = tmp_path / "quay"
+    quay.mkdir()
+    (quay / "username").write_text("quser")
+    (quay / "password").write_text("qpass")
+    monkeypatch.setattr(sign_windows, "QUAY_SECRET_MOUNT", quay)
+
+
+# ---------------------------------------------------------------------------
+# _build_batch_script
+# ---------------------------------------------------------------------------
+
+
+def test_build_batch_script_contains_signtool() -> None:
+    """Generated batch script includes signtool sign/verify, oras pull/push, and key values."""
+    script = sign_windows._build_batch_script(
+        quay_url="quay.io/org",
+        quay_user="user",
+        quay_pass="pass",
+        component_name="prod",
+        unsigned_digest="sha256:unsigned",
+        pipeline_run_uid="uid-123",
+        windows_temp_dir="uid-123_prod",
+    )
+    assert "signtool sign" in script
+    assert "signtool verify" in script
+    assert "oras pull" in script
+    assert "oras push" in script
+    assert "sha256:unsigned" in script
+    assert "uid-123-windows" in script
+    assert "Red Hat" in script
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+def _patch_ssh_setup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch chmod on hardcoded /tmp/.ssh paths."""
+    monkeypatch.setattr(
+        "pathlib.Path.chmod",
+        lambda self, mode, **kw: None,
+    )
+
+
+def test_run_skips_component_without_has_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A component without a has_windows flag file is skipped with an INFO log message."""
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [{"name": "prod"}]}))
+    monkeypatch.setattr(sign_windows, "CONTENT_DIR", tmp_path)
+    _setup_mounts(tmp_path, monkeypatch)
+    _patch_ssh_setup(monkeypatch)
+
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    # No has_windows
+
+    with (
+        caplog.at_level(logging.INFO, logger="sign_windows"),
+        mock.patch("shutil.copy2"),
+        mock.patch("subprocess.run"),
+    ):
+        sign_windows.run("quay.io/org", "uid-123")
+
+    assert "skipping Windows signing" in caplog.text
+
+
+def test_run_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Signed digest is written to signed_windows_digest.txt after a successful signing run."""
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [{"name": "prod"}]}))
+    monkeypatch.setattr(sign_windows, "CONTENT_DIR", tmp_path)
+    _setup_mounts(tmp_path, monkeypatch)
+    _patch_ssh_setup(monkeypatch)
+
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    (comp_dir / "has_windows").touch()
+    (comp_dir / "unsigned_windows_digest.txt").write_text("sha256:unsigned")
+
+    def fake_subprocess_run(cmd, **kwargs):
+        if cmd[0] == "ssh" and "Remove-Item" not in " ".join(str(a) for a in cmd):
+            m = mock.Mock(returncode=0)
+            m.stdout = (
+                "Signing completed\n"
+                "Pushed [registry] quay.io/org/signed/prod:uid-123-windows\n"
+                "ArtifactType: application/vnd.unknown.artifact.v1\n"
+                "Digest: sha256:signed\n"
+            )
+            m.stderr = ""
+            return m
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    with (
+        mock.patch("shutil.copy2"),
+        mock.patch("subprocess.check_call"),
+        mock.patch("subprocess.run", side_effect=fake_subprocess_run),
+    ):
+        sign_windows.run("quay.io/org", "uid-123")
+
+    digest = (comp_dir / "signed_windows_digest.txt").read_text()
+    assert digest == "sha256:signed"
+
+
+def test_run_raises_on_signing_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RuntimeError with 'Windows signing failed' is raised when the SSH command fails."""
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [{"name": "prod"}]}))
+    monkeypatch.setattr(sign_windows, "CONTENT_DIR", tmp_path)
+    _setup_mounts(tmp_path, monkeypatch)
+    _patch_ssh_setup(monkeypatch)
+
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    (comp_dir / "has_windows").touch()
+    (comp_dir / "unsigned_windows_digest.txt").write_text("sha256:unsigned")
+
+    def fake_subprocess_run(cmd, **kwargs):
+        # Fail the SSH signing call (not the cleanup call with Remove-Item)
+        if cmd[0] == "ssh" and "Remove-Item" not in " ".join(str(a) for a in cmd):
+            return mock.Mock(returncode=1)
+        return mock.Mock(returncode=0)
+
+    with (
+        mock.patch("shutil.copy2"),
+        mock.patch("subprocess.check_call"),
+        mock.patch("subprocess.run", side_effect=fake_subprocess_run),
+    ):
+        with pytest.raises(RuntimeError, match="Windows signing failed"):
+            sign_windows.run("quay.io/org", "uid-123")
+
+
+def test_run_cleans_up_even_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cleanup SSH call (Remove-Item) is always made even when signing fails."""
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [{"name": "prod"}]}))
+    monkeypatch.setattr(sign_windows, "CONTENT_DIR", tmp_path)
+    _setup_mounts(tmp_path, monkeypatch)
+    _patch_ssh_setup(monkeypatch)
+
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    (comp_dir / "has_windows").touch()
+    (comp_dir / "unsigned_windows_digest.txt").write_text("sha256:unsigned")
+
+    ssh_calls = []
+
+    def fake_subprocess_run(cmd, **kwargs):
+        if cmd[0] == "ssh":
+            ssh_calls.append(list(cmd))
+        # Fail the signing SSH call but let cleanup succeed
+        if cmd[0] == "ssh" and "Remove-Item" not in " ".join(str(a) for a in cmd):
+            return mock.Mock(returncode=1)
+        return mock.Mock(returncode=0)
+
+    with (
+        mock.patch("shutil.copy2"),
+        mock.patch("subprocess.check_call"),
+        mock.patch("subprocess.run", side_effect=fake_subprocess_run),
+    ):
+        with pytest.raises(RuntimeError):
+            sign_windows.run("quay.io/org", "uid-123")
+
+    # cleanup ssh call should have been made (Remove-Item call)
+    cleanup_calls = [c for c in ssh_calls if any("Remove-Item" in str(a) for a in c)]
+    assert len(cleanup_calls) > 0
+
+
+# ---------------------------------------------------------------------------
+# parse_args
+# ---------------------------------------------------------------------------
+
+
+def test_parse_args_requires_quay_url() -> None:
+    """SystemExit is raised when --quay-url is omitted."""
+    with pytest.raises(SystemExit):
+        sign_windows.parse_args(["--pipeline-run-uid", "uid"])
+
+
+def test_parse_args_requires_pipeline_run_uid() -> None:
+    """SystemExit is raised when --pipeline-run-uid is omitted."""
+    with pytest.raises(SystemExit):
+        sign_windows.parse_args(["--quay-url", "quay.io/org"])
+
+
+def test_parse_args_ok() -> None:
+    """Both required arguments are parsed correctly when provided."""
+    args = sign_windows.parse_args(["--quay-url", "quay.io/org", "--pipeline-run-uid", "uid"])
+    assert args.quay_url == "quay.io/org"
+    assert args.pipeline_run_uid == "uid"
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_success() -> None:
+    """main() returns 0 and passes quay URL and pipeline-run-uid to run()."""
+    with mock.patch.object(sign_windows, "run") as mock_run:
+        rc = sign_windows.main(
+            ["sign_windows.py", "--quay-url", "quay.io/org", "--pipeline-run-uid", "uid"]
+        )
+    assert rc == 0
+    mock_run.assert_called_once_with("quay.io/org", "uid")
+
+
+def test_main_exception_returns_error() -> None:
+    """main() returns 1 when run() raises an exception."""
+    with mock.patch.object(sign_windows, "run", side_effect=RuntimeError("ssh fail")):
+        rc = sign_windows.main(
+            ["sign_windows.py", "--quay-url", "quay.io/org", "--pipeline-run-uid", "uid"]
+        )
+    assert rc == 1

--- a/scripts/python/tasks/internal/push_artifacts_to_cdn.py
+++ b/scripts/python/tasks/internal/push_artifacts_to_cdn.py
@@ -1,0 +1,157 @@
+"""Entry point for the push-artifacts-to-cdn Tekton task.
+
+Called as a single step from the catalog task, this script runs each stage
+in sequence: extract, push unsigned, sign (Mac and Windows), compress,
+generate checksums, push to CDN, and build the advisory checksum map.
+
+Any exception raised by a stage is caught here: the Tekton result file
+receives a short error description and the script exits with code 0 so
+Tekton records the result text rather than masking it with a generic
+step-failure message.
+
+## Shared file-system layout
+
+All stages read and write under ``CONTENT_DIR`` (default ``/shared/artifacts``).
+The tree below shows how a component directory evolves across stages::
+
+  /shared/
+  ├── snapshot.json          ← written by compress_artifacts; read by generate_checksums
+  │                             and build_checksum_map (contains updated Windows filenames)
+  └── artifacts/
+      └── <component>/
+          │
+          │  [after extract_artifacts]
+          ├── has_mac                    ← flag: component has macOS binaries
+          ├── has_windows                ← flag: component has Windows binaries
+          ├── has_linux                  ← flag: component has Linux binaries
+          ├── unsigned/
+          │   ├── macos/amd64/           ← raw macOS binaries (pre-signing)
+          │   ├── windows/amd64/         ← raw Windows binaries (pre-signing)
+          │   └── linux/amd64/           ← raw Linux binaries
+          │
+          │  [after push_unsigned — Mac/Windows uploaded to Quay as OCI artifacts]
+          ├── unsigned_mac_digest.txt    ← Quay digest of pushed unsigned Mac OCI artifact
+          ├── unsigned_windows_digest.txt
+          ├── supplementary/             ← readme/license/changelog held out during signing
+          │   ├── macos/
+          │   └── windows/
+          │
+          │  [after sign_mac / sign_windows — signed artifacts pulled back from Quay]
+          ├── signed_mac_digest.txt      ← Quay digest of signed Mac OCI artifact
+          ├── signed_windows_digest.txt
+          ├── signed/
+          │   ├── macos/                 ← signed macOS binaries
+          │   └── windows/              ← signed Windows binaries
+          │
+          │  [after compress_artifacts — supplementary/ restored, archives created]
+          └── ready_for_distribution/
+              ├── product-macos-amd64.tar.gz
+              ├── product-windows-amd64.zip
+              ├── product-linux-amd64.tar.gz
+              │
+              │  [after generate_checksums]
+              ├── sha256sum.txt          ← merged checksums for all components
+              ├── sha256sum.txt.sig      ← GPG clearsign
+              └── sha256sum.txt.gpg      ← GPG detached signature
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import tekton
+
+import build_checksum_map
+import compress_artifacts
+import extract_artifacts
+import generate_checksums
+import push_artifacts as push_artifacts_mod
+import push_unsigned
+import sign_mac
+import sign_windows
+
+PROG = "push_artifacts_to_cdn.py"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Return parsed arguments for the wrapper."""
+    p = argparse.ArgumentParser(
+        prog=PROG,
+        description="Run all push-artifacts-to-cdn steps sequentially.",
+    )
+    p.add_argument(
+        "--concurrent-limit",
+        type=int,
+        default=3,
+        help="Maximum number of images to pull at once",
+    )
+    p.add_argument("--quay-url", required=True, help="Quay repository URL base")
+    p.add_argument(
+        "--pipeline-run-uid",
+        required=True,
+        help="Unique ID for this pipeline run",
+    )
+    p.add_argument(
+        "--kerberos-realm",
+        default="IPA.REDHAT.COM",
+        help="Kerberos realm for the checksum host",
+    )
+    p.add_argument(
+        "--exodus-gw-env",
+        required=True,
+        help="Environment to use in the Exodus Gateway",
+    )
+    p.add_argument("--cgw-hostname", required=True, help="Content Gateway hostname")
+    p.add_argument(
+        "--cert-expiration-warn-days",
+        type=int,
+        default=7,
+        help="Days before certificate expiration to warn",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point: run every step in order and write Tekton results."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+    args = parse_args(argv[1:] if argv is not None else None)
+
+    rpath, cmap_path, published_path = tekton.result_paths_from_env(
+        "RESULT_RESULT",
+        "RESULT_CHECKSUM_MAP",
+        "RESULT_PUBLISHED_FILES",
+    )
+
+    # push_artifacts.run() reads RESULT_PUBLISHED_FILES to know where to
+    # write the published-files list.
+    os.environ["RESULT_PUBLISHED_FILES"] = str(published_path)
+
+    checksum_map_ref = ""
+    try:
+        extract_artifacts.run(args.concurrent_limit)
+        push_unsigned.run(args.quay_url, args.pipeline_run_uid)
+        sign_mac.run(args.quay_url, args.pipeline_run_uid)
+        sign_windows.run(args.quay_url, args.pipeline_run_uid)
+        compress_artifacts.run(args.quay_url)
+        generate_checksums.run(args.kerberos_realm, args.pipeline_run_uid)
+        push_artifacts_mod.run(
+            args.exodus_gw_env,
+            args.cgw_hostname,
+            args.cert_expiration_warn_days,
+        )
+        checksum_map_ref = build_checksum_map.run()
+    except Exception as exc:
+        rpath.write_text(f"{PROG}: ERROR {exc}", encoding="utf-8")
+        cmap_path.write_text(checksum_map_ref, encoding="utf-8")
+        return 0
+
+    rpath.write_text("Success", encoding="utf-8")
+    cmap_path.write_text(checksum_map_ref, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/python/tasks/internal/test_push_artifacts_to_cdn.py
+++ b/scripts/python/tasks/internal/test_push_artifacts_to_cdn.py
@@ -1,0 +1,282 @@
+"""Tests for the push_artifacts_to_cdn.py wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest import mock
+
+import build_checksum_map
+import compress_artifacts
+import extract_artifacts
+import generate_checksums
+import push_artifacts as push_artifacts_mod
+import push_unsigned
+import pytest
+import sign_mac
+import sign_windows
+
+_WRAPPER_PATH = Path(__file__).parent / "push_artifacts_to_cdn.py"
+_spec = importlib.util.spec_from_file_location("push_artifacts_to_cdn_wrapper", _WRAPPER_PATH)
+wrapper = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(wrapper)
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+REQUIRED_ARGS = [
+    "push_artifacts_to_cdn.py",
+    "--quay-url",
+    "quay.io/org",
+    "--pipeline-run-uid",
+    "uid-123",
+    "--exodus-gw-env",
+    "pre",
+    "--cgw-hostname",
+    "https://cgw.example.com",
+]
+
+
+def _setup_result_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[Path, Path, Path]:
+    """Create result file paths and set the required env vars."""
+    rpath = tmp_path / "result"
+    cmap_path = tmp_path / "checksum_map"
+    published_path = tmp_path / "published_files"
+    monkeypatch.setenv("RESULT_RESULT", str(rpath))
+    monkeypatch.setenv("RESULT_CHECKSUM_MAP", str(cmap_path))
+    monkeypatch.setenv("RESULT_PUBLISHED_FILES", str(published_path))
+    return rpath, cmap_path, published_path
+
+
+# ---------------------------------------------------------------------------
+# parse_args
+# ---------------------------------------------------------------------------
+
+
+def test_parse_args_defaults() -> None:
+    """Default values for concurrent_limit, kerberos_realm, and cert_expiration_warn_days."""
+    args = wrapper.parse_args(
+        [
+            "--quay-url",
+            "quay.io/org",
+            "--pipeline-run-uid",
+            "uid",
+            "--exodus-gw-env",
+            "pre",
+            "--cgw-hostname",
+            "cgw.example.com",
+        ]
+    )
+    assert args.concurrent_limit == 3
+    assert args.kerberos_realm == "IPA.REDHAT.COM"
+    assert args.cert_expiration_warn_days == 7
+
+
+def test_parse_args_explicit_values() -> None:
+    """All arguments are correctly parsed when all are supplied explicitly."""
+    args = wrapper.parse_args(
+        [
+            "--quay-url",
+            "quay.io/myorg",
+            "--pipeline-run-uid",
+            "my-uid",
+            "--exodus-gw-env",
+            "live",
+            "--cgw-hostname",
+            "cgw.mycompany.com",
+            "--concurrent-limit",
+            "5",
+            "--kerberos-realm",
+            "MY.REALM",
+            "--cert-expiration-warn-days",
+            "14",
+        ]
+    )
+    assert args.quay_url == "quay.io/myorg"
+    assert args.pipeline_run_uid == "my-uid"
+    assert args.exodus_gw_env == "live"
+    assert args.cgw_hostname == "cgw.mycompany.com"
+    assert args.concurrent_limit == 5
+    assert args.kerberos_realm == "MY.REALM"
+    assert args.cert_expiration_warn_days == 14
+
+
+# ---------------------------------------------------------------------------
+# main – success path
+# ---------------------------------------------------------------------------
+
+
+def test_main_success_calls_all_steps(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """All pipeline steps are called with the correct arguments on a successful run."""
+    rpath, cmap_path, _ = _setup_result_env(tmp_path, monkeypatch)
+    ref = "quay.io/org/checksum-map@sha256:abc123"
+
+    with (
+        mock.patch.object(extract_artifacts, "run") as m_extract,
+        mock.patch.object(push_unsigned, "run") as m_push_unsigned,
+        mock.patch.object(sign_mac, "run") as m_sign_mac,
+        mock.patch.object(sign_windows, "run") as m_sign_windows,
+        mock.patch.object(compress_artifacts, "run") as m_compress,
+        mock.patch.object(generate_checksums, "run") as m_checksums,
+        mock.patch.object(push_artifacts_mod, "run") as m_push,
+        mock.patch.object(build_checksum_map, "run", return_value=ref) as m_cmap,
+    ):
+        rc = wrapper.main(REQUIRED_ARGS)
+
+    assert rc == 0
+    assert rpath.read_text(encoding="utf-8") == "Success"
+    assert cmap_path.read_text(encoding="utf-8") == ref
+
+    m_extract.assert_called_once_with(3)
+    m_push_unsigned.assert_called_once_with("quay.io/org", "uid-123")
+    m_sign_mac.assert_called_once_with("quay.io/org", "uid-123")
+    m_sign_windows.assert_called_once_with("quay.io/org", "uid-123")
+    m_compress.assert_called_once_with("quay.io/org")
+    m_checksums.assert_called_once_with("IPA.REDHAT.COM", "uid-123")
+    m_push.assert_called_once_with("pre", "https://cgw.example.com", 7)
+    m_cmap.assert_called_once()
+
+
+def test_main_sets_result_published_files_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RESULT_PUBLISHED_FILES env var points to the published files result path during push."""
+    rpath, _, published_path = _setup_result_env(tmp_path, monkeypatch)
+
+    captured: dict[str, str] = {}
+
+    def capture_push_artifacts(exodus_gw_env: str, cgw_hostname: str, days: int) -> None:
+        import os
+
+        captured["RESULT_PUBLISHED_FILES"] = os.environ.get("RESULT_PUBLISHED_FILES", "")
+
+    with (
+        mock.patch.object(extract_artifacts, "run"),
+        mock.patch.object(push_unsigned, "run"),
+        mock.patch.object(sign_mac, "run"),
+        mock.patch.object(sign_windows, "run"),
+        mock.patch.object(compress_artifacts, "run"),
+        mock.patch.object(generate_checksums, "run"),
+        mock.patch.object(push_artifacts_mod, "run", side_effect=capture_push_artifacts),
+        mock.patch.object(build_checksum_map, "run", return_value=""),
+    ):
+        wrapper.main(REQUIRED_ARGS)
+
+    assert captured["RESULT_PUBLISHED_FILES"] == str(published_path)
+
+
+# ---------------------------------------------------------------------------
+# main – failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_main_extract_fails_stops_pipeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure in extract_artifacts stops all subsequent steps and records the error."""
+    rpath, cmap_path, _ = _setup_result_env(tmp_path, monkeypatch)
+
+    with (
+        mock.patch.object(extract_artifacts, "run", side_effect=RuntimeError("oras down")),
+        mock.patch.object(push_unsigned, "run") as m_push_unsigned,
+    ):
+        rc = wrapper.main(REQUIRED_ARGS)
+
+    assert rc == 0
+    assert "oras down" in rpath.read_text(encoding="utf-8")
+    assert cmap_path.read_text(encoding="utf-8") == ""
+    m_push_unsigned.assert_not_called()
+
+
+def test_main_mid_step_failure_writes_partial_cmap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """checksum_map_ref stays empty when a step before build_checksum_map fails."""
+    rpath, cmap_path, _ = _setup_result_env(tmp_path, monkeypatch)
+
+    with (
+        mock.patch.object(extract_artifacts, "run"),
+        mock.patch.object(push_unsigned, "run"),
+        mock.patch.object(sign_mac, "run"),
+        mock.patch.object(sign_windows, "run"),
+        mock.patch.object(compress_artifacts, "run"),
+        mock.patch.object(generate_checksums, "run", side_effect=RuntimeError("kinit fail")),
+        mock.patch.object(push_artifacts_mod, "run") as m_push,
+        mock.patch.object(build_checksum_map, "run") as m_cmap,
+    ):
+        rc = wrapper.main(REQUIRED_ARGS)
+
+    assert rc == 0
+    assert "kinit fail" in rpath.read_text(encoding="utf-8")
+    assert cmap_path.read_text(encoding="utf-8") == ""
+    m_push.assert_not_called()
+    m_cmap.assert_not_called()
+
+
+def test_main_missing_result_env_raises_system_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SystemExit with code 1 is raised when the RESULT_RESULT env var is missing."""
+    monkeypatch.delenv("RESULT_RESULT", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        wrapper.main(REQUIRED_ARGS)
+    assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# main – custom argument values forwarded correctly
+# ---------------------------------------------------------------------------
+
+
+def test_main_custom_args_forwarded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Custom CLI argument values are forwarded correctly to each pipeline step."""
+    _setup_result_env(tmp_path, monkeypatch)
+
+    calls: dict[str, tuple] = {}
+
+    def fake_extract(limit: int) -> None:
+        calls["extract"] = (limit,)
+
+    def fake_checksums(realm: str, uid: str) -> None:
+        calls["checksums"] = (realm, uid)
+
+    def fake_push(env: str, host: str, days: int) -> None:
+        calls["push"] = (env, host, days)
+
+    with (
+        mock.patch.object(extract_artifacts, "run", side_effect=fake_extract),
+        mock.patch.object(push_unsigned, "run"),
+        mock.patch.object(sign_mac, "run"),
+        mock.patch.object(sign_windows, "run"),
+        mock.patch.object(compress_artifacts, "run"),
+        mock.patch.object(generate_checksums, "run", side_effect=fake_checksums),
+        mock.patch.object(push_artifacts_mod, "run", side_effect=fake_push),
+        mock.patch.object(build_checksum_map, "run", return_value=""),
+    ):
+        rc = wrapper.main(
+            [
+                "push_artifacts_to_cdn.py",
+                "--quay-url",
+                "quay.io/myorg",
+                "--pipeline-run-uid",
+                "custom-uid",
+                "--exodus-gw-env",
+                "live",
+                "--cgw-hostname",
+                "cgw.custom.com",
+                "--concurrent-limit",
+                "5",
+                "--kerberos-realm",
+                "CUSTOM.REALM",
+                "--cert-expiration-warn-days",
+                "14",
+            ]
+        )
+
+    assert rc == 0
+    assert calls["extract"] == (5,)
+    assert calls["checksums"] == ("CUSTOM.REALM", "custom-uid")
+    assert calls["push"] == ("live", "cgw.custom.com", 14)


### PR DESCRIPTION
Convert the push-artifacts-to-cdn internal task's embedded bash
steps into standalone Python scripts under
scripts/python/tasks/internal/push_artifacts_to_cdn/.

Will eventually coincide with https://github.com/konflux-ci/release-service-catalog/pull/2228
For now, this one will not be invoked by the catalog until e2e is implemented as described here:
https://redhat.atlassian.net/browse/RELEASE-2543


Unit tests achieve 98% coverage across all 8 scripts.
