### PR TITLE
fix: handle CGW duplicate record error in developer_portal_wrapper

### DIFF
--- a/developer-portal-wrapper/developer_portal_wrapper.py
+++ b/developer-portal-wrapper/developer_portal_wrapper.py
@@ -197,15 +197,30 @@ def main():
     if args.dry_run:
         LOG.info("Would have run: %s", cmd_str)
     else:
-        try:
-            LOG.info("Running %s", cmd_str)
-            subprocess.run(command, check=True)
-        except subprocess.CalledProcessError:
-            LOG.exception("Command %s failed, check exception for details", cmd_str)
-            raise
-        except Exception as exc:
-            LOG.exception("Unknown error occurred")
-            raise RuntimeError from exc
+        LOG.info("Running %s", cmd_str)
+        result = subprocess.run(command, capture_output=True, text=True)
+        combined_output = f"{result.stdout}\n{result.stderr}"
+
+        if result.returncode != 0:
+            if (
+                "Record already present" in combined_output
+                or "Cannot create new file" in combined_output
+            ):
+                LOG.warning(
+                    "CGW record already exists for %s %s, treating operation"
+                    " as idempotent",
+                    product_name,
+                    product_version_name,
+                )
+                return
+
+            LOG.error("Command %s failed:\n%s", cmd_str, combined_output.strip())
+            raise subprocess.CalledProcessError(
+                result.returncode,
+                command,
+                output=result.stdout,
+                stderr=result.stderr,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- When CGW returns "Record already present" / "Cannot create new file", treat the operation as idempotent instead of failing
- This prevents CI/CD retries from blocking releases when records have already been pushed
- Any other failure still raises `CalledProcessError`

## Problem

Disk image releases are being blocked when a CGW record already exists from a previous attempt:

```
Disk image push failed
/tekton/scripts/script-0-pggkl: ERROR 'developer_portal_wrapper --debug --product-name "${productName}" --product-code "${productCode}" --product-version-name "${productVersionName}" --cgw-hostname "https://developers.redhat.com/content-gateway/rest/admin" --content-directory "$2" --file-prefix "${filePrefix}"' failed at line 1 - exited with status 1
Traceback (most recent call last):
  File "/usr/local/bin/push-cgw-metadata", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/pubtools/_content_gateway/push_cgw.py", line 95, in main
    push_cgw.cgw_operations()
  File "/usr/local/lib/python3.9/site-packages/pubtools/_content_gateway/push_cgw.py", line 63, in cgw_operations
    raise error
  File "/usr/local/lib/python3.9/site-packages/pubtools/_content_gateway/push_cgw.py", line 52, in cgw_operations
    self.process_file(item)
  File "/usr/local/lib/python3.9/site-packages/pubtools/_content_gateway/push_base.py", line 580, in process_file
    raise CGWError("Cannot create new file. Record already present.")
pubtools._content_gateway.push_base.CGWError: Cannot create new file. Record already present.
Traceback (most recent call last):
  File "/home/developer-portal-wrapper/developer_portal_wrapper", line 211, in <module>
    main()
  File "/home/developer-portal-wrapper/developer_portal_wrapper", line 201, in main
    subprocess.run(command, check=True)
  File "/usr/lib64/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['push-cgw-metadata', '--CGW_filepath', '/tmp/cgw_metadata.yaml', '--CGW_hostname', 'https://developers.redhat.com/content-gateway/rest/admin', '--CGW_username', 'konflux-release-service-cgw']' returned non-zero exit status 1.
```

## Test plan

- [x] Existing unit tests pass
- [ ] Verify disk image release retry succeeds when CGW record already exists