### PR TITLE
feat(RELEASE-1988): add standalone process-file-updates Python script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pulp-cli==0.36.3",
     "diffused-lib==0.3.0",
     "confluent-kafka",
+    "python-gitlab>=4.0",
 ]
 
 [tool.black]

--- a/scripts/python/helpers/redact.py
+++ b/scripts/python/helpers/redact.py
@@ -1,0 +1,28 @@
+"""Redact credentials from text before logging or writing Tekton results."""
+
+from __future__ import annotations
+
+import os
+import re
+
+_HTTPS_CREDENTIAL_URL = re.compile(
+    r"https://([^/@\s:]+):([^@\s]+)@",
+    re.IGNORECASE,
+)
+_ACCESS_TOKEN_ASSIGNMENT = re.compile(
+    r"(ACCESS_TOKEN=)\S+",
+    re.IGNORECASE,
+)
+
+
+def redact_secrets(text: str) -> str:
+    """Redact credential URLs, ``ACCESS_TOKEN=...``, and the ``ACCESS_TOKEN`` env value."""
+    if not text:
+        return ""
+    out = _HTTPS_CREDENTIAL_URL.sub(r"https://\1:[REDACTED]@", text)
+    out = _ACCESS_TOKEN_ASSIGNMENT.sub(r"\1[REDACTED]", out)
+    token = os.environ.get("ACCESS_TOKEN")
+    # Skip very short values: they match substrings inside normal words (e.g. "t" in "kinit").
+    if token and len(token) >= 8:
+        out = out.replace(token, "[REDACTED]")
+    return out

--- a/scripts/python/helpers/tekton.py
+++ b/scripts/python/helpers/tekton.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 
 import argparse
 import os
-import re
 import sys
 from pathlib import Path
 from typing import NoReturn, TextIO
+
+from redact import redact_secrets
 
 
 class CheckStepError(Exception):
@@ -51,25 +52,6 @@ def result_text_from_exception(exc: BaseException, *, max_len: int = 500) -> str
     return t
 
 
-def _redact_for_tekton_result(text: str) -> str:
-    """Mask credentials before writing failure text to a Tekton result file."""
-    if not text:
-        return text
-    redacted = re.sub(
-        r"https://([^/@\s:]+):([^@\s]+)@",
-        r"https://\1:[REDACTED]@",
-        text,
-        flags=re.IGNORECASE,
-    )
-    redacted = re.sub(
-        r"(ACCESS_TOKEN=)\S+",
-        r"\1[REDACTED]",
-        redacted,
-        flags=re.IGNORECASE,
-    )
-    return redacted
-
-
 def write_failure_result(
     result_path: Path,
     program_name: str,
@@ -87,20 +69,20 @@ def write_failure_result(
     last *max_log_lines* of subprocess/git output collected during the run.
     """
     if isinstance(exc, CheckStepError):
-        why = _redact_for_tekton_result(result_text_from_exception(exc.cause))
+        why = redact_secrets(result_text_from_exception(exc.cause))
         summary = f"{program_name}: Failed while {exc.action}: {why}."
     else:
-        why = _redact_for_tekton_result(result_text_from_exception(exc))
+        why = redact_secrets(result_text_from_exception(exc))
         summary = f"{program_name}: Failed while {workflow_action}: " f"{why}"
 
     parts = [summary.strip()]
     if command_log_path is not None and command_log_path.is_file():
         lines = command_log_path.read_text(encoding="utf-8", errors="replace").splitlines()
         if lines:
-            tail = _redact_for_tekton_result("\n".join(lines[-max_log_lines:]).strip())
+            tail = redact_secrets("\n".join(lines[-max_log_lines:]).strip())
             parts.append(tail)
 
-    text = _redact_for_tekton_result("\n".join(parts))
+    text = redact_secrets("\n".join(parts))
     if len(text) > max_total_len:
         text = text[: max_total_len - 3] + "..."
     result_path.write_text(text, encoding="utf-8")

--- a/scripts/python/helpers/test_redact.py
+++ b/scripts/python/helpers/test_redact.py
@@ -1,0 +1,37 @@
+"""Tests for credential redaction helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from redact import redact_secrets
+
+
+def test_redact_secrets_oauth_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """oauth2 credentials in URLs are redacted."""
+    monkeypatch.setenv("ACCESS_TOKEN", "sekret")
+    raw = "fatal: https://oauth2:sekret@gitlab.com/org/r.git"
+    assert redact_secrets(raw) == "fatal: https://oauth2:[REDACTED]@gitlab.com/org/r.git"
+
+
+def test_redact_secrets_access_token_in_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``ACCESS_TOKEN`` values are redacted from text."""
+    monkeypatch.setenv("ACCESS_TOKEN", "my-token-xyz")
+    assert redact_secrets("error: my-token-xyz denied") == "error: [REDACTED] denied"
+
+
+def test_redact_secrets_skips_short_access_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Very short ``ACCESS_TOKEN`` values are not replaced inside unrelated words."""
+    monkeypatch.setenv("ACCESS_TOKEN", "t")
+    msg = "logging in with Kerberos (kinit): Command 'kinit' returned non-zero exit status 1."
+    assert redact_secrets(msg) == msg
+
+
+def test_redact_secrets_access_token_assignment() -> None:
+    """``ACCESS_TOKEN=...`` assignments are redacted."""
+    assert redact_secrets("env ACCESS_TOKEN=glpat-abc") == "env ACCESS_TOKEN=[REDACTED]"
+
+
+def test_redact_secrets_empty_text() -> None:
+    """Empty input is returned unchanged."""
+    assert redact_secrets("") == ""

--- a/scripts/python/helpers/vcs/git.py
+++ b/scripts/python/helpers/vcs/git.py
@@ -11,6 +11,8 @@ from typing import IO, Any
 
 import retry
 
+from redact import redact_secrets
+
 
 def repository_workdir_name(repository_url: str) -> str:
     """Directory name for *repository_url* (strip `.git` suffix)."""
@@ -20,21 +22,11 @@ def repository_workdir_name(repository_url: str) -> str:
     return base
 
 
-def _redact_credential_urls(text: str) -> str:
-    """Redact oauth2/token credentials embedded in HTTPS URLs in *text*."""
-    return re.sub(
-        r"https://([^/@\s:]+):([^@\s]+)@",
-        r"https://\1:[REDACTED]@",
-        text,
-        flags=re.IGNORECASE,
-    )
-
-
 def _append_cmd_stderr(stderr_path: Path | None, message: str) -> None:
     """Append redacted *message* to *stderr_path* when configured."""
     if stderr_path is None or not message.strip():
         return
-    safe_text = _redact_credential_urls(str(message))
+    safe_text = redact_secrets(str(message))
     with open(
         stderr_path,
         "a",
@@ -256,14 +248,23 @@ def sync_to_origin_main(
 def working_tree_diff(
     repo_dir: Path,
     *,
+    cached: bool = False,
+    other_ref: str | None = None,
     stderr_path: Path | None = None,
 ) -> str:
-    """Return unstaged working-tree diff text for *repo_dir*."""
-    return _run_git_cmd(
-        ["git", "diff"],
-        cwd=repo_dir,
-        stderr_path=stderr_path,
-    ).stdout
+    """Return diff text for *repo_dir*.
+
+    By default return unstaged working-tree diff. With *cached* true, return
+    staged diff. When *other_ref* is set with *cached*, compare the index
+    against that ref.
+    """
+    cmd = ["git", "diff"]
+    if cached:
+        cmd.append("--cached")
+    if other_ref is not None:
+        cmd.append(other_ref)
+    result = _run_git_cmd(cmd, cwd=repo_dir, stderr_path=stderr_path)
+    return result.stdout or ""
 
 
 def changed_paths_from_status(
@@ -329,27 +330,82 @@ def origin_main_has_path_matching(
     return False
 
 
+def commit_staged(
+    repo_root: Path,
+    message: str,
+    *,
+    stderr_path: Path | None = None,
+) -> None:
+    """Commit staged changes via the git CLI."""
+    _run_git_cmd(
+        ["git", "commit", "-m", message],
+        cwd=repo_root,
+        stderr_path=stderr_path,
+    )
+
+
 def index_add_commit(
     repo_root: Path,
     relative_paths: Sequence[str],
     message: str,
     *,
+    commit: bool = True,
     stderr_path: Path | None = None,
 ) -> None:
-    """Stage *relative_paths* and commit with *message* via the git CLI.
+    """Stage *relative_paths* and, when *commit* is true, commit with *message*.
 
-    Call `configure_git_global_user` first so git can identify the committer.
+    Uses the git CLI. Call `configure_git_global_user` first so git can identify
+    the committer when committing.
     """
     _run_git_cmd(
         ["git", "add", *relative_paths],
         cwd=repo_root,
         stderr_path=stderr_path,
     )
+    if commit:
+        commit_staged(repo_root, message, stderr_path=stderr_path)
+
+
+def rebase_onto_remote(
+    repo_root: Path,
+    *,
+    remote_name: str,
+    remote_repository: str,
+    revision: str,
+    stderr_path: Path | None = None,
+) -> None:
+    """Add *remote_name*, fetch *revision*, and rebase onto it."""
+    remotes = _run_git_cmd(
+        ["git", "remote"],
+        cwd=repo_root,
+        stderr_path=stderr_path,
+    ).stdout.splitlines()
+    if remote_name not in remotes:
+        _run_git_cmd(
+            ["git", "remote", "add", remote_name, remote_repository],
+            cwd=repo_root,
+            stderr_path=stderr_path,
+        )
+    fetch(repo_root, remote_name, revision, stderr_path=stderr_path)
     _run_git_cmd(
-        ["git", "commit", "-m", message],
+        ["git", "rebase", f"{remote_name}/{revision}"],
         cwd=repo_root,
         stderr_path=stderr_path,
     )
+
+
+def working_tree_status(
+    repo_root: Path,
+    *,
+    stderr_path: Path | None = None,
+) -> str:
+    """Return ``git status`` output."""
+    result = _run_git_cmd(
+        ["git", "status"],
+        cwd=repo_root,
+        stderr_path=stderr_path,
+    )
+    return result.stdout or ""
 
 
 def commit_and_push(

--- a/scripts/python/helpers/vcs/gitlab.py
+++ b/scripts/python/helpers/vcs/gitlab.py
@@ -31,8 +31,8 @@ class GitLabCredentials:
 def read_credentials_from_mount(secret_mount: Path) -> GitLabCredentials:
     """Load credentials from *secret_mount*, where each field is a separate file.
 
-    `gitlab_host`, `gitlab_access_token`, `git_author_name`,
-    `git_author_email`, `git_repo`.
+    Expected files: ``gitlab_host``, ``gitlab_access_token``, ``git_author_name``,
+    ``git_author_email``, ``git_repo``.
     """
     return GitLabCredentials(
         gitlab_host=authentication.read_mounted_text(secret_mount, "gitlab_host"),
@@ -66,6 +66,21 @@ def configure_git_oauth2_auth(access_token: str) -> None:
     os.environ["GIT_TERMINAL_PROMPT"] = "0"
     os.environ["GIT_ASKPASS"] = str(askpass)
     os.environ["GITLAB_OAUTH2_TOKEN"] = access_token
+
+
+def gitlab_project_path(repository: str) -> str:
+    """Normalize *repository* to a ``group/project`` path for the GitLab API."""
+    repo = repository.strip()
+    if "://" in repo:
+        path = repo.split("://", 1)[1]
+        if "/" in path:
+            path = path.split("/", 1)[1]
+        path = path.strip("/")
+    else:
+        path = repo.strip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    return path
 
 
 def raw_file_url(

--- a/scripts/python/helpers/vcs/test_git.py
+++ b/scripts/python/helpers/vcs/test_git.py
@@ -42,14 +42,6 @@ def test_append_cmd_stderr_redacts_oauth2_url(tmp_path: Path) -> None:
     assert "oauth2:[REDACTED]@" in text
 
 
-def test_redact_credential_urls() -> None:
-    """Mask oauth2 tokens in arbitrary text (stderr or argv)."""
-    text = "fatal: https://oauth2:secret@gitlab.com/g/r.git"
-    redacted = git._redact_credential_urls(text)
-    assert "secret" not in redacted
-    assert "oauth2:[REDACTED]@" in redacted
-
-
 def test_run_git_cmd_redacts_clone_failure_log(tmp_path: Path) -> None:
     """Failed clone must not write credential-bearing URLs to the stderr log."""
     log = tmp_path / "log.txt"
@@ -360,6 +352,80 @@ def test_index_add_commit(tmp_path: Path) -> None:
         git.index_add_commit(tmp_path, ["a.yaml"], "msg", stderr_path=None)
     assert run_cmd.call_count == 2
     assert run_cmd.call_args_list[1].args[0] == ["git", "commit", "-m", "msg"]
+
+
+def test_index_add_commit_stage_only(tmp_path: Path) -> None:
+    """When ``commit=False``, paths are staged but not committed."""
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
+        git.index_add_commit(tmp_path, ["a.yaml"], "", commit=False)
+    run_cmd.assert_called_once_with(
+        ["git", "add", "a.yaml"],
+        cwd=tmp_path,
+        stderr_path=None,
+    )
+
+
+def test_working_tree_diff_cached(tmp_path: Path) -> None:
+    """Return cached diff output from the git CLI."""
+    with mock.patch.object(
+        git,
+        "_run_git_cmd",
+        return_value=mock.MagicMock(stdout="diff\n"),
+    ):
+        assert git.working_tree_diff(tmp_path, cached=True) == "diff\n"
+
+
+def test_working_tree_diff_cached_with_other_ref(tmp_path: Path) -> None:
+    """Compare cached diff against another ref when requested."""
+    with mock.patch.object(
+        git,
+        "_run_git_cmd",
+        return_value=mock.MagicMock(stdout="diff\n"),
+    ) as run_cmd:
+        assert git.working_tree_diff(tmp_path, cached=True, other_ref="mr_1") == "diff\n"
+    assert run_cmd.call_args.args[0] == ["git", "diff", "--cached", "mr_1"]
+
+
+def test_rebase_onto_remote_adds_missing_remote(tmp_path: Path) -> None:
+    """Add remote when missing, fetch, and rebase."""
+    calls: list[list[str]] = []
+
+    def _cmd_side_effect(cmd: list[str], **_kwargs: object) -> mock.MagicMock:
+        calls.append(cmd)
+        if cmd[:2] == ["git", "remote"] and len(cmd) == 2:
+            return mock.MagicMock(stdout="origin\n")
+        return mock.MagicMock(stdout="")
+
+    with mock.patch.object(git, "_run_git_cmd", side_effect=_cmd_side_effect):
+        git.rebase_onto_remote(
+            tmp_path,
+            remote_name="glab-base",
+            remote_repository="https://gitlab.com/g/up.git",
+            revision="main",
+        )
+    assert ["git", "remote", "add", "glab-base", "https://gitlab.com/g/up.git"] in calls
+    assert ["git", "fetch", "glab-base", "main"] in calls
+    assert ["git", "rebase", "glab-base/main"] in calls
+
+
+def test_rebase_onto_remote_skips_existing_remote(tmp_path: Path) -> None:
+    """Skip ``git remote add`` when the remote already exists."""
+    calls: list[list[str]] = []
+
+    def _cmd_side_effect(cmd: list[str], **_kwargs: object) -> mock.MagicMock:
+        calls.append(cmd)
+        if cmd[:2] == ["git", "remote"] and len(cmd) == 2:
+            return mock.MagicMock(stdout="glab-base\n")
+        return mock.MagicMock(stdout="")
+
+    with mock.patch.object(git, "_run_git_cmd", side_effect=_cmd_side_effect):
+        git.rebase_onto_remote(
+            tmp_path,
+            remote_name="glab-base",
+            remote_repository="https://gitlab.com/g/up.git",
+            revision="main",
+        )
+    assert not any(cmd[:3] == ["git", "remote", "add"] for cmd in calls)
 
 
 def test_commit_and_push(tmp_path: Path) -> None:

--- a/scripts/python/helpers/vcs/test_gitlab.py
+++ b/scripts/python/helpers/vcs/test_gitlab.py
@@ -27,7 +27,7 @@ def test_read_credentials_from_mount(tmp_path: Path) -> None:
     assert creds.git_repo.endswith("r.git")
 
 
-def test_export_env_for_image_helpers(tmp_path: Path) -> None:
+def test_export_env_for_image_helpers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Export GitLab credentials to env vars for image helper scripts."""
     secret = tmp_path / "secret"
     secret.mkdir()
@@ -40,6 +40,8 @@ def test_export_env_for_image_helpers(tmp_path: Path) -> None:
     gitlab.export_env_for_image_helpers(creds)
     assert os.environ["GITLAB_HOST"] == "h"
     assert os.environ["ACCESS_TOKEN"] == "t"
+    for var in ("GITLAB_HOST", "ACCESS_TOKEN", "GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL"):
+        monkeypatch.delenv(var, raising=False)
 
 
 def test_raw_file_url() -> None:
@@ -76,3 +78,15 @@ def test_clone_project_sparse_delegates_to_git(tmp_path: Path) -> None:
     assert m.call_args.args[1] == "https://gitlab.example.com/g/r.git"
     assert m.call_args.kwargs["shallow"] is True
     assert "oauth2:" not in m.call_args.args[1]
+
+
+@pytest.mark.parametrize(
+    ("repository", "expected"),
+    [
+        ("https://gitlab.com/org/up.git", "org/up"),
+        ("org/up", "org/up"),
+    ],
+)
+def test_gitlab_project_path(repository: str, expected: str) -> None:
+    """Normalize repository URLs to ``group/project`` paths."""
+    assert gitlab.gitlab_project_path(repository) == expected

--- a/scripts/python/tasks/internal/process_file_updates.py
+++ b/scripts/python/tasks/internal/process_file_updates.py
@@ -1,0 +1,730 @@
+#!/usr/bin/env python3
+"""Apply file edits to a GitLab repository and open a merge request with the changes.
+
+Intended to be invoked by a release pipeline to automatically propagate release
+artifacts (e.g. updated image digests, version strings) into downstream
+configuration repositories, creating an MR for human review.
+
+* Reads credentials from ``/mnt/file-updates-secret/`` (or
+  ``FILE_UPDATES_SECRET_MOUNT``): ``gitlab_host``, ``gitlab_access_token``,
+  ``git_author_name``, ``git_author_email``.
+* Clones ``--repo`` at ``--ref``, rebases on ``--upstream-repo``, applies path
+  seeds and YAML replacements (``yq``/``sed``), then commits or reuses an MR.
+* Writes ``RESULT_FILE_UPDATES_*`` and internal-request name results.
+* After a valid run with result env vars, almost always exits ``0``; failures use
+  ``RESULT_FILE_UPDATES_STATE``. Invalid YAML on a replacement target exits ``1``.
+  Bad CLI flags exit before result handling (``1``; argparse uses ``2`` for
+  malformed argv).
+
+Pass ``gitlab_client`` to ``run_file_updates`` to inject a client in unit tests.
+Catalog Tekton tests mock ``git`` via ``tests/mocks/git`` on ``PATH``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import gitlab
+from gitlab.exceptions import GitlabError
+
+import file
+import redact
+import tekton
+from logger import logger
+from vcs import git as vcs_git
+from vcs import gitlab as vcs_gitlab
+
+PROG = "process_file_updates.py"
+FILE_UPDATES_SECRET_MOUNT_ENV = "FILE_UPDATES_SECRET_MOUNT"
+_REPLACEMENT_EXPRESSION = re.compile(r"^\|([^|\n]*)\|([^|\n]*)\|$")
+
+
+def _usage_text() -> str:
+    """Return the short usage summary printed to stderr on bad CLI usage."""
+    return (
+        f"usage: {PROG} --upstream-repo REPO --repo REPO --ref REF --paths JSON \\\n"
+        f"  --component-group GROUP --internal-request-pipeline-run-name NAME \\\n"
+        f"  --internal-request-task-run-name NAME [--temp-dir DIR]\n"
+    )
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse required CLI flags; help or missing values exit ``1`` (extras exit ``2``)."""
+    p = argparse.ArgumentParser(prog=PROG, add_help=False, usage=argparse.SUPPRESS)
+    p.add_argument("-h", "--help", action="store_true")
+    p.add_argument("--upstream-repo", metavar="REPO")
+    p.add_argument("--repo", metavar="REPO")
+    p.add_argument("--ref", metavar="REF")
+    p.add_argument("--paths", metavar="JSON")
+    p.add_argument("--component-group", metavar="GROUP")
+    p.add_argument("--internal-request-pipeline-run-name", metavar="NAME")
+    p.add_argument("--internal-request-task-run-name", metavar="NAME")
+    p.add_argument("--temp-dir", metavar="DIR")
+    ns = p.parse_args(argv or [])
+    if ns.help:
+        print(_usage_text(), file=sys.stderr, end="")
+        raise SystemExit(1)
+    required = (
+        "upstream_repo",
+        "repo",
+        "ref",
+        "paths",
+        "component_group",
+        "internal_request_pipeline_run_name",
+        "internal_request_task_run_name",
+    )
+    if any(not getattr(ns, f) or not str(getattr(ns, f)).strip() for f in required):
+        print(_usage_text(), file=sys.stderr, end="")
+        raise SystemExit(1)
+    return ns
+
+
+def load_file_updates_secrets(mount: Path) -> dict[str, str]:
+    """Read git/GitLab secret files under *mount*."""
+    keys = ("gitlab_host", "gitlab_access_token", "git_author_name", "git_author_email")
+    out: dict[str, str] = {}
+    for key in keys:
+        path = mount / key
+        try:
+            out[key] = path.read_text(encoding="utf-8").strip()
+        except OSError as e:
+            raise tekton.CheckStepError(f"reading secret file {key}", e) from e
+    return out
+
+
+def git_functions_init(author_name: str, author_email: str, token: str) -> None:
+    """Validate identity fields and set global git user.name and user.email."""
+    if not author_name or not author_email or not token:
+        raise tekton.CheckStepError(
+            "initializing git",
+            ValueError("GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL, and ACCESS_TOKEN are required"),
+        )
+    vcs_git.configure_git_global_user(author_name, author_email)
+
+
+def gitlab_create_mr(
+    *,
+    head: str,
+    title: str,
+    target_branch: str,
+    description: str,
+    upstream_repo: str,
+    gitlab_client: gitlab.Gitlab,
+) -> str:
+    """Create a merge request; return JSON ``{"merge_request": url}`` for Tekton results."""
+    project_path = vcs_gitlab.gitlab_project_path(upstream_repo)
+    try:
+        project = gitlab_client.projects.get(project_path)
+        mr = project.mergerequests.create(
+            {
+                "source_branch": head,
+                "target_branch": target_branch,
+                "title": title,
+                "description": description,
+            }
+        )
+    except GitlabError as e:
+        raise tekton.CheckStepError("creating GitLab merge request", e) from e
+
+    url = getattr(mr, "web_url", None) or ""
+    if url:
+        return json.dumps({"merge_request": url})
+
+    raise tekton.CheckStepError(
+        "creating GitLab merge request",
+        ValueError("merge request created but web_url was empty"),
+    )
+
+
+def list_konflux_open_mrs(upstream_repo: str, gitlab_client: gitlab.Gitlab) -> list[Any]:
+    """List open MRs in *upstream_repo* matching ``Konflux release`` (paginated)."""
+    project_path = vcs_gitlab.gitlab_project_path(upstream_repo)
+    try:
+        project = gitlab_client.projects.get(project_path)
+    except GitlabError as e:
+        raise tekton.CheckStepError("getting GitLab project", e) from e
+
+    page = 1
+    found: list[Any] = []
+    while True:
+        try:
+            batch = project.mergerequests.list(
+                state="opened",
+                search="Konflux release",
+                per_page=100,
+                page=page,
+            )
+        except GitlabError as e:
+            raise tekton.CheckStepError("listing GitLab merge requests", e) from e
+        if not batch:
+            break
+        found.extend(batch)
+        page += 1
+    return found
+
+
+def blank_lines_before_yaml(target_file: Path) -> int:
+    """Lines before first non-comment YAML line (matches legacy bash/sed numbering)."""
+    proc = subprocess.run(
+        [
+            "awk",
+            r"/[[:alpha:]]+/{ if(! match($0, \"^#\")) { print NR-1; exit } }",
+            str(target_file),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return 0
+    return int(proc.stdout.strip().splitlines()[0])
+
+
+def parse_replacement_expression(replacement: str) -> tuple[str, str] | None:
+    """Parse ``|search|replace|``; return ``None`` if the format is invalid."""
+    match = _REPLACEMENT_EXPRESSION.fullmatch(replacement)
+    if match is None:
+        return None
+    return match.group(1), match.group(2)
+
+
+def apply_replacement_block(
+    target_file: Path,
+    start_block: int,
+    value_size: int,
+    replacement: str,
+    temp_dir: Path,
+) -> tuple[str | None, Path | None]:
+    """Apply one ``|search|replace|`` sed to a YAML block; write diff to *temp_dir*.
+
+    Returns ``(None, diff_path)`` on success or ``(error, diff_path)`` on failure.
+    """
+    parsed = parse_replacement_expression(replacement)
+    if parsed is None:
+        return "Replace expression should be in '|search|replace|' format", None
+
+    search, replace = parsed
+    sed_expr = f"{start_block},+{value_size}s|{search}|{replace}|"
+    subprocess.run(["sed", "-i", sed_expr, str(target_file)], check=True)
+
+    replace_str = replace
+    result_path = temp_dir / "result.txt"
+    proc = subprocess.run(
+        ["sed", "-ne", f"{start_block},+{value_size}p", str(target_file)],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    result_path.write_text(proc.stdout, encoding="utf-8")
+
+    found_path = temp_dir / "found.txt"
+    diff_path = temp_dir / "diff.txt"
+    diff_proc = subprocess.run(
+        ["diff", "-u", str(found_path), str(result_path)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    diff_path.write_text(diff_proc.stdout, encoding="utf-8")
+
+    result_text = result_path.read_text(encoding="utf-8")
+    replaced_block_lines = len(result_text.splitlines())
+    if replaced_block_lines != value_size + 1:
+        return "Text block size differs from the original", diff_path
+
+    replaced_count = sum(1 for line in result_text.splitlines() if replace_str in line)
+    if replaced_count != 1:
+        return (
+            "Too many lines replaced. Check if the replace expression isn't too greedy",
+            diff_path,
+        )
+    return None, diff_path
+
+
+def write_error_result(info_path: Path, state_path: Path, diff_text: str, error: str) -> None:
+    """Write replacement failure JSON to result files (diff trim matches legacy bash)."""
+    trimmed = diff_text[1:3701] if diff_text else ""
+    payload = json.dumps({"str": trimmed, "error": error})
+    info_path.write_text(payload, encoding="utf-8")
+    state_path.write_text("Failed", encoding="utf-8")
+
+
+def write_json_error_result(info_path: Path, state_path: Path, error: str) -> None:
+    """Write a logical failure (e.g. no keys replaced) to both result files as JSON."""
+    payload = json.dumps({"str": error, "error": error})
+    info_path.write_text(payload, encoding="utf-8")
+    state_path.write_text("Failed", encoding="utf-8")
+
+
+@dataclass
+class PathProcessingState:
+    """Mutable outcome of seed/replacement work across all paths."""
+
+    replacements_update_error: str | None = None
+    diff_path: Path | None = None
+    replacements_performed: int | None = None
+    key_not_found: bool = False
+
+
+def configure_git_environment(secrets: dict[str, str]) -> str:
+    """Export git/GitLab env vars, configure OAuth2 auth; return the access token."""
+    token = secrets["gitlab_access_token"]
+    os.environ["GITLAB_HOST"] = secrets["gitlab_host"]
+    os.environ["ACCESS_TOKEN"] = token
+    os.environ["GIT_AUTHOR_NAME"] = secrets["git_author_name"]
+    os.environ["GIT_AUTHOR_EMAIL"] = secrets["git_author_email"]
+    vcs_gitlab.configure_git_oauth2_auth(token)
+    return token
+
+
+def _fetch_merge_request_head(repo_cwd: Path, mr_iid: int) -> str:
+    """Fetch MR *mr_iid* from ``origin`` into ``mr_<iid>``; return the local ref name."""
+    local_ref = f"mr_{mr_iid}"
+    vcs_git.fetch(repo_cwd, "origin", f"merge-requests/{mr_iid}/head:{local_ref}")
+    return local_ref
+
+
+def write_paths_manifest(paths_json: str, temp_dir: Path) -> tuple[Path, list[dict[str, Any]]]:
+    """Persist ``--paths`` JSON to *temp_dir* and return the file path and parsed data."""
+    update_paths_file = temp_dir / "updatePaths.json"
+    update_paths_file.write_text(paths_json + "\n", encoding="utf-8")
+    return update_paths_file, json.loads(paths_json)
+
+
+def sparse_dirs_from_paths(paths_data: list[dict[str, Any]]) -> list[str]:
+    """Return sparse-checkout paths covering every ``path`` entry in *paths_data*."""
+    sparse_dirs: set[str] = set()
+    for entry in paths_data:
+        entry_path = entry.get("path")
+        if not entry_path:
+            continue
+        path = Path(str(entry_path))
+        if path.parent == Path("."):
+            sparse_dirs.add(path.as_posix())
+        else:
+            sparse_dirs.add(path.parent.as_posix())
+    return sorted(sparse_dirs)
+
+
+def prepare_repository(
+    repo: str,
+    revision: str,
+    upstream_repo: str,
+    temp_dir: Path,
+    paths_data: list[dict[str, Any]],
+) -> Path:
+    """Clone *repo* at *revision*, rebase on *upstream_repo*, and return the repo cwd."""
+    logger.info("=== UPDATING %s ON BRANCH %s ===", repo, revision)
+    sparse_dirs = sparse_dirs_from_paths(paths_data)
+    if not sparse_dirs:
+        raise tekton.CheckStepError(
+            "cloning repository",
+            ValueError("paths JSON must include at least one path entry"),
+        )
+    repo_cwd = vcs_git.clone(
+        temp_dir,
+        repo,
+        revision=revision,
+        sparse_dirs=sparse_dirs,
+        shallow=True,
+    )
+    vcs_git.rebase_onto_remote(
+        repo_cwd,
+        remote_name="glab-base",
+        remote_repository=upstream_repo,
+        revision=revision,
+    )
+    return repo_cwd
+
+
+def resolve_target_file(repo_cwd: Path, entry_path: str) -> Path:
+    """Return a path under *repo_cwd* for *entry_path*, rejecting traversal and absolutes."""
+    if not entry_path or not str(entry_path).strip():
+        raise ValueError("path entry must be a non-empty relative path")
+    path_obj = Path(entry_path)
+    if path_obj.is_absolute():
+        raise ValueError(f"path entry must be relative, not absolute: {entry_path!r}")
+    if len(entry_path) >= 2 and entry_path[1] == ":":
+        raise ValueError(f"path entry must be relative, not a drive path: {entry_path!r}")
+    if ".." in path_obj.parts:
+        raise ValueError(f"path entry must not contain '..': {entry_path!r}")
+    repo_root = repo_cwd.resolve()
+    target_file = (repo_cwd / entry_path).resolve()
+    if not target_file.is_relative_to(repo_root):
+        raise ValueError(f"path entry escapes repository root: {entry_path!r}")
+    return target_file
+
+
+def seed_target_file(entry: dict[str, Any], target_file: Path, repo_cwd: Path) -> None:
+    """Create or overwrite *target_file* when the path entry includes a seed value."""
+    seed = entry.get("seed") or ""
+    if isinstance(seed, str):
+        seed = seed.strip('"')
+    logger.info("%s", seed)
+    if not seed:
+        return
+    logger.info("seed operation to perform")
+    target_file.parent.mkdir(parents=True, exist_ok=True)
+    target_file.write_text(
+        seed + ("\n" if not seed.endswith("\n") else ""),
+        encoding="utf-8",
+    )
+    logger.info("-- start targetFile --")
+    logger.info("%s", target_file.read_text(encoding="utf-8"))
+    logger.info("-- end targetFile --")
+    rel = str(target_file.relative_to(repo_cwd))
+    vcs_git.index_add_commit(repo_cwd, [rel], "", commit=False)
+    logger.info("%s", vcs_git.working_tree_status(repo_cwd))
+
+
+def apply_replacements_for_entry(
+    entry: dict[str, Any],
+    target_file: Path,
+    repo_cwd: Path,
+    temp_dir: Path,
+    state: PathProcessingState,
+) -> tuple[str, str, int] | None:
+    """Apply replacements for one path; return early tuple if YAML is invalid."""
+    replacements = entry.get("replacements") or []
+    replacements_length = len(replacements)
+    logger.info("Replacements to perform: %s", replacements_length)
+    if replacements_length == 0:
+        return None
+
+    state.replacements_performed = 0
+    blank_offset = blank_lines_before_yaml(target_file)
+
+    yaml_check = subprocess.run(
+        ["yq", str(target_file)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if yaml_check.returncode != 0:
+        msg = f"fileUpdates: the targetFile {entry['path']} is not a yaml file"
+        return msg, "", 1
+
+    for replacement_index, repl in enumerate(replacements):
+        logger.info("REPLACEMENT: #%s", replacement_index)
+        key = repl["key"]
+        replacement = repl["replacement"]
+
+        print(f"Searching for key `{key}`: ", end="", flush=True)
+        proc = subprocess.run(
+            ["yq", f"{key} | (line, .)", str(target_file)],
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        found_path = temp_dir / "found.txt"
+        found_path.write_text(proc.stdout, encoding="utf-8")
+        print(proc.stdout, end="", flush=True)
+
+        lines = proc.stdout.splitlines()
+        found_at = int(lines[0].strip()) if lines else 0
+        if found_at == 0:
+            logger.info("NOT FOUND")
+            state.key_not_found = True
+            continue
+        logger.info("FOUND")
+
+        value_proc = subprocess.run(
+            ["yq", key, str(target_file)],
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        value_size = len(value_proc.stdout.splitlines())
+        start_block = found_at + blank_offset
+
+        found_content = found_path.read_text(encoding="utf-8")
+        found_lines = found_content.splitlines()
+        if found_lines:
+            found_path.write_text(
+                "\n".join(found_lines[1:]) + ("\n" if len(found_lines) > 1 else ""),
+                encoding="utf-8",
+            )
+
+        logger.info("--start file--")
+        logger.info("%s", target_file.read_text(encoding="utf-8"))
+        logger.info("--end file--")
+
+        err, diff_path = apply_replacement_block(
+            target_file, start_block, value_size, replacement, temp_dir
+        )
+        if err:
+            state.replacements_update_error = err
+            state.diff_path = diff_path
+            return None
+        state.replacements_performed += 1
+
+    return None
+
+
+def process_all_paths(
+    paths_data: list[dict[str, Any]],
+    update_paths_file: Path,
+    repo_cwd: Path,
+    temp_dir: Path,
+) -> tuple[PathProcessingState, tuple[str, str, int] | None]:
+    """Apply seeds and replacements for all paths in *paths_data*."""
+    state = PathProcessingState()
+    logger.info("%s", update_paths_file.read_text(encoding="utf-8"))
+
+    for entry in paths_data:
+        logger.info("-- start updatePathsTmpfile --")
+        logger.info("%s", update_paths_file.read_text(encoding="utf-8"))
+        logger.info("-- end updatePathsTmpfile --")
+
+        try:
+            target_file = resolve_target_file(repo_cwd, entry["path"])
+        except ValueError as e:
+            raise tekton.CheckStepError("validating path entry", e) from e
+        logger.info("targetFile: %s", target_file.relative_to(repo_cwd.resolve()))
+
+        seed_target_file(entry, target_file, repo_cwd)
+
+        early = apply_replacements_for_entry(entry, target_file, repo_cwd, temp_dir, state)
+        if early is not None:
+            return state, early
+
+        vcs_git.index_add_commit(
+            repo_cwd,
+            [str(target_file.relative_to(repo_cwd))],
+            "",
+            commit=False,
+        )
+        if state.replacements_update_error:
+            break
+
+    return state, None
+
+
+def outcome_after_path_processing(
+    state: PathProcessingState,
+) -> tuple[str, str, int] | None:
+    """Map *state* to a result tuple, or ``None`` if the workflow should continue."""
+    if state.replacements_update_error:
+        diff_text = (
+            state.diff_path.read_text(encoding="utf-8")
+            if state.diff_path and state.diff_path.exists()
+            else ""
+        )
+        return diff_text, state.replacements_update_error, 0
+
+    if state.replacements_performed == 0:
+        if state.key_not_found:
+            err = '"no replacements were performed"'
+            return err, err, 0
+        return "nothing needs change\n", "Success", 0
+
+    return None
+
+
+def get_cached_diff(repo_cwd: Path, temp_dir: Path) -> str:
+    """Return ``git diff --cached`` output and log the staged changes banner."""
+    logger.info("*** START LOCAL CHANGES ***")
+    logger.info("*** Result from git diff --cached ***")
+    cached_diff = vcs_git.working_tree_diff(repo_cwd, cached=True)
+    (temp_dir / "tempMRFile-cached.diff").write_text(cached_diff, encoding="utf-8")
+    logger.info("%s", cached_diff)
+    logger.info("*** END LOCAL CHANGES ***")
+    return cached_diff
+
+
+def find_existing_mr_with_same_diff(
+    upstream_repo: str,
+    repo_cwd: Path,
+    temp_dir: Path,
+    gitlab_client: gitlab.Gitlab,
+) -> str | None:
+    """Return result info when an open MR already has the same staged diff."""
+    for mr in list_konflux_open_mrs(upstream_repo, gitlab_client):
+        mr_num = mr.iid
+        local_ref = _fetch_merge_request_head(repo_cwd, mr_num)
+        final_diff = vcs_git.working_tree_diff(repo_cwd, cached=True, other_ref=local_ref)
+        (temp_dir / "final.diff").write_text(final_diff, encoding="utf-8")
+        if not final_diff.strip():
+            mr_url = (
+                getattr(mr, "web_url", None) or f"{upstream_repo}/-/merge_requests/{mr_num}"
+            )
+            return (
+                "There is an existing MR with the same updates in the repo\n"
+                + json.dumps({"merge_request": mr_url})
+                + "\n"
+            )
+    return None
+
+
+def commit_and_create_mr(
+    *,
+    component_group: str,
+    revision: str,
+    upstream_repo: str,
+    repo_cwd: Path,
+    gitlab_client: gitlab.Gitlab,
+) -> tuple[str, str, int]:
+    """Commit staged changes, push a branch, and open a new GitLab merge request."""
+    working_branch = uuid.uuid4().hex[:8]
+    vcs_git.checkout(repo_cwd, working_branch)
+    vcs_git.commit_staged(repo_cwd, "fileUpdates changes")
+    vcs_git.push(repo_cwd, working_branch)
+
+    logger.info("Creating Pull Request...")
+    mr_msg = f"[Konflux release] {component_group}: fileUpdates changes {working_branch}"
+    mr_json = gitlab_create_mr(
+        head=working_branch,
+        title=mr_msg,
+        target_branch=revision,
+        description=mr_msg,
+        upstream_repo=upstream_repo,
+        gitlab_client=gitlab_client,
+    )
+    return mr_json + "\n", "Success", 0
+
+
+def run_file_updates(
+    *,
+    upstream_repo: str,
+    repo: str,
+    revision: str,
+    paths_json: str,
+    component_group: str,
+    temp_dir: Path,
+    secrets: dict[str, str],
+    gitlab_client: gitlab.Gitlab | None = None,
+) -> tuple[str, str, int]:
+    """Run clone, path updates, and MR dedup or create.
+
+    Returns ``(info_body, state_or_error, exit_code)`` for ``main`` to map to
+    Tekton results. Builds a GitLab client when *gitlab_client* is omitted.
+    """
+    logger.info("Temp Dir: %s", temp_dir)
+    temp_dir.mkdir(parents=True, exist_ok=True)
+
+    token = configure_git_environment(secrets)
+    if gitlab_client is None:
+        gitlab_client = gitlab.Gitlab(secrets["gitlab_host"], private_token=token)
+    git_functions_init(secrets["git_author_name"], secrets["git_author_email"], token)
+
+    update_paths_file, paths_data = write_paths_manifest(paths_json, temp_dir)
+    repo_cwd = prepare_repository(repo, revision, upstream_repo, temp_dir, paths_data)
+
+    path_state, early = process_all_paths(paths_data, update_paths_file, repo_cwd, temp_dir)
+    if early is not None:
+        return early
+
+    after_paths = outcome_after_path_processing(path_state)
+    if after_paths is not None:
+        return after_paths
+
+    if not get_cached_diff(repo_cwd, temp_dir).strip():
+        return "nothing needs change\n", "Success", 0
+
+    existing_mr = find_existing_mr_with_same_diff(
+        upstream_repo, repo_cwd, temp_dir, gitlab_client
+    )
+    if existing_mr is not None:
+        return existing_mr, "Success", 0
+
+    return commit_and_create_mr(
+        component_group=component_group,
+        revision=revision,
+        upstream_repo=upstream_repo,
+        repo_cwd=repo_cwd,
+        gitlab_client=gitlab_client,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse args, run file updates, and write Tekton result files."""
+    raw_argv = sys.argv if argv is None else argv
+    try:
+        args = parse_args(raw_argv[1:])
+    except SystemExit as e:
+        code = e.code
+        return code if isinstance(code, int) else 1
+
+    temp_dir = (
+        Path(args.temp_dir)
+        if args.temp_dir
+        else Path(os.environ.get("TEMP", "/tmp/file-updates"))
+    )
+
+    (
+        info_path,
+        state_path,
+        ir_pr_path,
+        ir_tr_path,
+    ) = tekton.result_paths_from_env(
+        "RESULT_FILE_UPDATES_INFO",
+        "RESULT_FILE_UPDATES_STATE",
+        "RESULT_INTERNAL_REQUEST_PIPELINE_RUN_NAME",
+        "RESULT_INTERNAL_REQUEST_TASK_RUN_NAME",
+    )
+
+    ir_pr_path.write_text(args.internal_request_pipeline_run_name, encoding="utf-8")
+    ir_tr_path.write_text(args.internal_request_task_run_name, encoding="utf-8")
+
+    mount = file.path_from_env_variable(
+        FILE_UPDATES_SECRET_MOUNT_ENV, "/mnt/file-updates-secret"
+    )
+    program = Path(raw_argv[0]).name
+
+    try:
+        secrets = load_file_updates_secrets(mount)
+        info_body, state_or_error, exit_code = run_file_updates(
+            upstream_repo=args.upstream_repo,
+            repo=args.repo,
+            revision=args.ref,
+            paths_json=args.paths,
+            component_group=args.component_group,
+            temp_dir=temp_dir,
+            secrets=secrets,
+        )
+    except tekton.CheckStepError as e:
+        why = redact.redact_secrets(tekton.result_text_from_exception(e.cause))
+        msg = f"{program}: Failed while {e.action}: {why}."
+        info_path.write_text(msg, encoding="utf-8")
+        state_path.write_text("Failed", encoding="utf-8")
+        return 0
+    except subprocess.CalledProcessError as e:
+        cmd_preview = redact.redact_secrets(
+            tekton.subprocess_cmd_preview_for_tekton_result(e.cmd)
+        )
+        detail = redact.redact_secrets(e.stderr or e.stdout or str(e))
+        msg = f"{program}: Failed while running a command: {cmd_preview}: {detail}"
+        info_path.write_text(msg[:500], encoding="utf-8")
+        state_path.write_text("Failed", encoding="utf-8")
+        return 0
+
+    if exit_code == 1:
+        info_path.write_text(info_body, encoding="utf-8")
+        return 1
+
+    if info_body == state_or_error and info_body.startswith('"'):
+        write_json_error_result(info_path, state_path, state_or_error)
+        return 0
+
+    if state_or_error != "Success":
+        write_error_result(info_path, state_path, info_body, state_or_error)
+        return 0
+
+    with info_path.open("a", encoding="utf-8") as f:
+        f.write(info_body)
+    state_path.write_text("Success", encoding="utf-8")
+    logger.info("=== FINISHED ===")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/internal/test_process_file_updates.py
+++ b/scripts/python/tasks/internal/test_process_file_updates.py
@@ -1,0 +1,1421 @@
+"""Tests for ``process_file_updates``.
+
+Catalog Tekton tests were reduced to ``test-process-file-updates-combo.yaml``.
+Former Tekton scenarios are covered by pytest:
+
+- ``replacements``: ``test_run_file_updates_creates_mr``,
+  ``test_apply_replacements_for_entry_applies_replacement``
+- ``seed``: ``test_seed_target_file_writes_and_stages``
+- ``combo``: Tekton only (integration smoke)
+- ``replacements-idempotent``: ``test_run_file_updates_returns_existing_mr``,
+  ``test_find_existing_mr_with_same_diff``
+- ``replacements-missing-file``:
+  ``test_apply_replacements_for_entry_missing_file_returns_not_yaml``,
+  ``test_main_yaml_error_exits_one``
+- ``replacements-error`` / ``replacements-success-one-error``:
+  ``test_main_writes_json_error_result``,
+  ``test_run_file_updates_short_circuit_on_path_outcome``
+- greedy replacement failure: ``test_main_writes_replacement_error_result``,
+  ``test_apply_replacement_block_too_greedy``
+- ``seed-error``: ``test_seed_target_file_propagates_git_add_failure``,
+  ``test_main_subprocess_error_writes_failed``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import process_file_updates
+import pytest
+import tekton
+from gitlab.exceptions import GitlabError
+
+FILE_UPDATES_SECRET_MOUNT = process_file_updates.FILE_UPDATES_SECRET_MOUNT_ENV
+
+_VALID_ARGS = [
+    "--upstream-repo",
+    "https://gitlab.com/org/upstream.git",
+    "--repo",
+    "https://gitlab.com/org/repo.git",
+    "--ref",
+    "main",
+    "--paths",
+    '[{"path":"f.yaml","replacements":[]}]',
+    "--component-group",
+    "my-group",
+    "--internal-request-pipeline-run-name",
+    "pr-1",
+    "--internal-request-task-run-name",
+    "tr-1",
+]
+
+
+def _write_file_updates_secret(mount: Path) -> None:
+    mount.mkdir(parents=True, exist_ok=True)
+    (mount / "gitlab_host").write_text("gitlab.example.com", encoding="utf-8")
+    (mount / "gitlab_access_token").write_text("token", encoding="utf-8")
+    (mount / "git_author_name").write_text("Author", encoding="utf-8")
+    (mount / "git_author_email").write_text("a@example.com", encoding="utf-8")
+
+
+def _setup_tekton_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, secret_mount: Path
+) -> tuple[Path, Path, Path, Path]:
+    info = tmp_path / "info"
+    state = tmp_path / "state"
+    ir_pr = tmp_path / "ir_pr"
+    ir_tr = tmp_path / "ir_tr"
+    monkeypatch.setenv("RESULT_FILE_UPDATES_INFO", str(info))
+    monkeypatch.setenv("RESULT_FILE_UPDATES_STATE", str(state))
+    monkeypatch.setenv("RESULT_INTERNAL_REQUEST_PIPELINE_RUN_NAME", str(ir_pr))
+    monkeypatch.setenv("RESULT_INTERNAL_REQUEST_TASK_RUN_NAME", str(ir_tr))
+    monkeypatch.setenv(FILE_UPDATES_SECRET_MOUNT, str(secret_mount))
+    return info, state, ir_pr, ir_tr
+
+
+def _mock_gitlab_client(
+    *,
+    list_pages: list[list[object]] | None = None,
+    create_mr: object | None = None,
+    get_error: GitlabError | None = None,
+    list_error: GitlabError | None = None,
+    create_error: GitlabError | None = None,
+) -> mock.Mock:
+    mock_mr = mock.Mock()
+    mock_mr.web_url = "https://gitlab.com/org/up/-/merge_requests/99"
+    mock_mr.iid = 99
+
+    mock_mrs = mock.Mock()
+    if list_error is not None:
+        mock_mrs.list.side_effect = list_error
+    elif list_pages is not None:
+
+        def _list(**kwargs: object) -> list[object]:
+            page = int(kwargs["page"])
+            return list_pages[page - 1] if page <= len(list_pages) else []
+
+        mock_mrs.list.side_effect = _list
+    else:
+        mock_mrs.list.return_value = []
+
+    if create_error is not None:
+        mock_mrs.create.side_effect = create_error
+    else:
+        mock_mrs.create.return_value = create_mr if create_mr is not None else mock_mr
+
+    mock_project = mock.Mock()
+    mock_project.mergerequests = mock_mrs
+    mock_gl = mock.Mock()
+    if get_error is not None:
+        mock_gl.projects.get.side_effect = get_error
+    else:
+        mock_gl.projects.get.return_value = mock_project
+    return mock_gl
+
+
+@pytest.fixture
+def secret_mount(tmp_path: Path) -> Path:
+    """Provide a temp directory with file-updates secret files."""
+    p = tmp_path / "secrets"
+    _write_file_updates_secret(p)
+    return p
+
+
+def test_parse_args_help() -> None:
+    """``-h`` prints usage and exits with code 1."""
+    with pytest.raises(SystemExit) as exc:
+        process_file_updates.parse_args(["-h"])
+    assert exc.value.code == 1
+
+
+def test_parse_args_missing_required() -> None:
+    """Missing required flags print usage and exit with code 1."""
+    with pytest.raises(SystemExit) as exc:
+        process_file_updates.parse_args(["--upstream-repo", "u", "--repo", "r"])
+    assert exc.value.code == 1
+
+
+def test_parse_args_rejects_extra() -> None:
+    """Extra argv tokens are rejected by argparse with exit 2."""
+    with pytest.raises(SystemExit) as exc:
+        process_file_updates.parse_args([*_VALID_ARGS, "extra"])
+    assert exc.value.code == 2
+
+
+def test_parse_args_ok() -> None:
+    """Valid flags yield a populated namespace."""
+    ns = process_file_updates.parse_args(_VALID_ARGS)
+    assert ns.upstream_repo == "https://gitlab.com/org/upstream.git"
+    assert ns.component_group == "my-group"
+
+
+def test_parse_replacement_expression() -> None:
+    """Replacement strings must match ``|search|replace|`` exactly."""
+    assert process_file_updates.parse_replacement_expression("|a|b|") == ("a", "b")
+    assert process_file_updates.parse_replacement_expression("|search|replace|") == (
+        "search",
+        "replace",
+    )
+    assert process_file_updates.parse_replacement_expression("|only-two") is None
+    assert process_file_updates.parse_replacement_expression("|a|b|e") is None
+    assert process_file_updates.parse_replacement_expression("|a|b|\n") is None
+    assert process_file_updates.parse_replacement_expression("|a\n|b|") is None
+
+
+def test_apply_replacement_block_rejects_bad_pipe_count(tmp_path: Path) -> None:
+    """Invalid sed pipe count returns an error."""
+    target = tmp_path / "f.yaml"
+    target.write_text("key: value\n", encoding="utf-8")
+    err, diff_path = process_file_updates.apply_replacement_block(
+        target, 1, 1, "|only-two", tmp_path
+    )
+    assert err == "Replace expression should be in '|search|replace|' format"
+    assert diff_path is None
+
+
+def test_apply_replacement_block_rejects_sed_flag_suffix(tmp_path: Path) -> None:
+    """Trailing characters after the closing delimiter must not become sed flags."""
+    target = tmp_path / "f.yaml"
+    target.write_text("key: value\n", encoding="utf-8")
+    err, diff_path = process_file_updates.apply_replacement_block(
+        target, 1, 1, "|old|new|e", tmp_path
+    )
+    assert err == "Replace expression should be in '|search|replace|' format"
+    assert diff_path is None
+
+
+def test_apply_replacement_block_builds_safe_sed_expression(tmp_path: Path) -> None:
+    """The sed command is assembled without appending untrusted suffix text."""
+    target = tmp_path / "f.yaml"
+    target.write_text("old\n", encoding="utf-8")
+    (tmp_path / "found.txt").write_text("baseline\n", encoding="utf-8")
+    sed_cmds: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if cmd[:2] == ["sed", "-i"]:
+            sed_cmds.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["diff", "-u"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "new\n", "")
+
+    with mock.patch("subprocess.run", side_effect=_fake_run):
+        err, _ = process_file_updates.apply_replacement_block(
+            target, 1, 0, "|old|new|", tmp_path
+        )
+    assert err is None
+    assert sed_cmds == [["sed", "-i", "1,+0s|old|new|", str(target)]]
+
+
+def test_load_file_updates_secrets(secret_mount: Path) -> None:
+    """Secret mount files are read into a dict."""
+    secrets = process_file_updates.load_file_updates_secrets(secret_mount)
+    assert secrets["gitlab_host"] == "gitlab.example.com"
+    assert secrets["gitlab_access_token"] == "token"
+
+
+def test_load_file_updates_secrets_missing_file(tmp_path: Path) -> None:
+    """Missing secret files raise ``CheckStepError``."""
+    with pytest.raises(tekton.CheckStepError) as exc:
+        process_file_updates.load_file_updates_secrets(tmp_path / "missing")
+    assert "reading secret file gitlab_host" in str(exc.value)
+
+
+def test_write_paths_manifest(tmp_path: Path) -> None:
+    """Paths JSON is written and parsed from the temp dir."""
+    paths_json = '[{"path":"a.yaml","replacements":[]}]'
+    manifest, data = process_file_updates.write_paths_manifest(paths_json, tmp_path)
+    assert manifest.read_text(encoding="utf-8") == paths_json + "\n"
+    assert data == [{"path": "a.yaml", "replacements": []}]
+
+
+def test_outcome_after_path_processing_replacement_error(tmp_path: Path) -> None:
+    """Replacement errors return diff text and the error message."""
+    diff_file = tmp_path / "diff.txt"
+    diff_file.write_text("---\n+++", encoding="utf-8")
+    state = process_file_updates.PathProcessingState(
+        replacements_update_error="bad replace",
+        diff_path=diff_file,
+        replacements_performed=0,
+    )
+    body, err, code = process_file_updates.outcome_after_path_processing(state)
+    assert code == 0
+    assert err == "bad replace"
+    assert body.startswith("---")
+
+
+def test_outcome_after_path_processing_key_not_found() -> None:
+    """Missing keys yield the no-replacements JSON error."""
+    state = process_file_updates.PathProcessingState(
+        replacements_performed=0,
+        key_not_found=True,
+    )
+    body, err, code = process_file_updates.outcome_after_path_processing(state)
+    assert code == 0
+    assert body == err == '"no replacements were performed"'
+
+
+def test_outcome_after_path_processing_no_changes() -> None:
+    """No replacements performed yields Success with no changes."""
+    state = process_file_updates.PathProcessingState(replacements_performed=0)
+    body, state_name, code = process_file_updates.outcome_after_path_processing(state)
+    assert (body, state_name, code) == ("nothing needs change\n", "Success", 0)
+
+
+def test_outcome_after_path_processing_continue() -> None:
+    """Successful replacements return ``None`` to continue."""
+    state = process_file_updates.PathProcessingState(replacements_performed=2)
+    assert process_file_updates.outcome_after_path_processing(state) is None
+
+
+def test_write_error_result(tmp_path: Path) -> None:
+    """Replacement failures write JSON and Failed state."""
+    info = tmp_path / "info"
+    state = tmp_path / "state"
+    process_file_updates.write_error_result(info, state, "+diff line", "oops")
+    payload = json.loads(info.read_text(encoding="utf-8"))
+    assert payload["error"] == "oops"
+    assert payload["str"] == "diff line"
+    assert state.read_text(encoding="utf-8") == "Failed"
+
+
+def test_gitlab_create_mr_returns_json() -> None:
+    """MR creation returns merge request JSON for Tekton."""
+    out = process_file_updates.gitlab_create_mr(
+        head="branch-1",
+        title="t",
+        target_branch="main",
+        description="d",
+        upstream_repo="https://gitlab.com/org/up.git",
+        gitlab_client=_mock_gitlab_client(),
+    )
+    assert json.loads(out) == {
+        "merge_request": "https://gitlab.com/org/up/-/merge_requests/99"
+    }
+
+
+def test_gitlab_create_mr_raises_when_web_url_missing() -> None:
+    """Empty ``web_url`` raises ``CheckStepError``."""
+    bare_mr = mock.Mock()
+    bare_mr.web_url = ""
+    with pytest.raises(tekton.CheckStepError) as exc:
+        process_file_updates.gitlab_create_mr(
+            head="b",
+            title="t",
+            target_branch="main",
+            description="d",
+            upstream_repo="https://gitlab.com/org/up.git",
+            gitlab_client=_mock_gitlab_client(create_mr=bare_mr),
+        )
+    assert "creating GitLab merge request" in str(exc.value)
+
+
+def test_gitlab_create_mr_raises_on_gitlab_error() -> None:
+    """GitLab API errors map to ``CheckStepError``."""
+    with pytest.raises(tekton.CheckStepError) as exc:
+        process_file_updates.gitlab_create_mr(
+            head="b",
+            title="t",
+            target_branch="main",
+            description="d",
+            upstream_repo="https://gitlab.com/org/up.git",
+            gitlab_client=_mock_gitlab_client(create_error=GitlabError("create failed")),
+        )
+    assert "creating GitLab merge request" in str(exc.value)
+
+
+def test_list_konflux_open_mrs_raises_on_project_lookup_error() -> None:
+    """Project lookup failures raise ``CheckStepError``."""
+    with pytest.raises(tekton.CheckStepError) as exc:
+        process_file_updates.list_konflux_open_mrs(
+            "org/up", _mock_gitlab_client(get_error=GitlabError("project not found"))
+        )
+    assert "getting GitLab project" in str(exc.value)
+
+
+def test_list_konflux_open_mrs_raises_on_list_error() -> None:
+    """MR list failures raise ``CheckStepError``."""
+    with pytest.raises(tekton.CheckStepError) as exc:
+        process_file_updates.list_konflux_open_mrs(
+            "org/up", _mock_gitlab_client(list_error=GitlabError("list failed"))
+        )
+    assert "listing GitLab merge requests" in str(exc.value)
+
+
+def test_main_success_writes_results(
+    tmp_path: Path, secret_mount: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Success appends info and writes Success state."""
+    info, state, ir_pr, ir_tr = _setup_tekton_env(tmp_path, monkeypatch, secret_mount)
+    monkeypatch.setenv("TEMP", str(tmp_path / "work"))
+
+    def _fake_run(**_k: object) -> tuple[str, str, int]:
+        return '{"merge_request":"https://x/mr/1"}\n', "Success", 0
+
+    with mock.patch.object(process_file_updates, "run_file_updates", side_effect=_fake_run):
+        rc = process_file_updates.main(["process_file_updates.py", *_VALID_ARGS])
+
+    assert rc == 0
+    assert state.read_text(encoding="utf-8") == "Success"
+    assert "merge_request" in info.read_text(encoding="utf-8")
+    assert ir_pr.read_text(encoding="utf-8") == "pr-1"
+    assert ir_tr.read_text(encoding="utf-8") == "tr-1"
+
+
+def test_main_maps_check_step_error_to_failed(
+    tmp_path: Path, secret_mount: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``CheckStepError`` writes Failed state and exits 0."""
+    info, state, _, _ = _setup_tekton_env(tmp_path, monkeypatch, secret_mount)
+
+    def _fail(**_k: object) -> tuple[str, str, int]:
+        raise tekton.CheckStepError("cloning", ValueError("network"))
+
+    with mock.patch.object(process_file_updates, "run_file_updates", side_effect=_fail):
+        rc = process_file_updates.main(["process_file_updates.py", *_VALID_ARGS])
+
+    assert rc == 0
+    assert state.read_text(encoding="utf-8") == "Failed"
+    assert "cloning" in info.read_text(encoding="utf-8")
+
+
+def test_main_yaml_error_exits_one(
+    tmp_path: Path, secret_mount: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Invalid YAML exits 1 after writing info."""
+    info, state, _, _ = _setup_tekton_env(tmp_path, monkeypatch, secret_mount)
+
+    def _yaml_fail(**_k: object) -> tuple[str, str, int]:
+        return "fileUpdates: not yaml", "", 1
+
+    with mock.patch.object(process_file_updates, "run_file_updates", side_effect=_yaml_fail):
+        rc = process_file_updates.main(["process_file_updates.py", *_VALID_ARGS])
+
+    assert rc == 1
+    assert "not yaml" in info.read_text(encoding="utf-8")
+    assert not state.exists()
+
+
+def test_main_subprocess_error_writes_failed(
+    tmp_path: Path, secret_mount: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Subprocess failures write Failed state and exit 0."""
+    info, state, _, _ = _setup_tekton_env(tmp_path, monkeypatch, secret_mount)
+
+    def _cmd_fail(**_k: object) -> tuple[str, str, int]:
+        raise subprocess.CalledProcessError(1, ["yq"], stderr="broken")
+
+    with mock.patch.object(process_file_updates, "run_file_updates", side_effect=_cmd_fail):
+        rc = process_file_updates.main(["process_file_updates.py", *_VALID_ARGS])
+
+    assert rc == 0
+    assert state.read_text(encoding="utf-8") == "Failed"
+    assert "yq" in info.read_text(encoding="utf-8")
+
+
+def test_run_file_updates_short_circuit_on_path_outcome(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Path outcome short-circuits before MR handling."""
+    secrets = {
+        "gitlab_host": "h",
+        "gitlab_access_token": "t",
+        "git_author_name": "n",
+        "git_author_email": "e@x.com",
+    }
+    path_state = process_file_updates.PathProcessingState(
+        replacements_performed=0,
+        key_not_found=True,
+    )
+
+    with (
+        mock.patch.object(process_file_updates, "configure_git_environment", return_value="t"),
+        mock.patch.object(process_file_updates, "git_functions_init"),
+        mock.patch.object(
+            process_file_updates,
+            "write_paths_manifest",
+            return_value=(tmp_path / "p.json", []),
+        ),
+        mock.patch.object(
+            process_file_updates, "prepare_repository", return_value=tmp_path / "repo"
+        ),
+        mock.patch.object(
+            process_file_updates,
+            "process_all_paths",
+            return_value=(path_state, None),
+        ),
+    ):
+        body, err, code = process_file_updates.run_file_updates(
+            upstream_repo="u",
+            repo="r",
+            revision="main",
+            paths_json="[]",
+            component_group="g",
+            temp_dir=tmp_path,
+            secrets=secrets,
+        )
+
+    assert code == 0
+    assert body == err == '"no replacements were performed"'
+
+
+def test_git_functions_init_configures_identity() -> None:
+    """Global git user.name and user.email are set via ``vcs.git``."""
+    with mock.patch.object(process_file_updates.vcs_git, "configure_git_global_user") as cfg:
+        process_file_updates.git_functions_init("Author", "a@example.com", "tok")
+    cfg.assert_called_once_with("Author", "a@example.com")
+
+
+def test_sparse_dirs_from_paths() -> None:
+    """Sparse checkout paths cover parent dirs and root-level files."""
+    paths = [
+        {"path": "deploy/overlays/prod/kustomization.yaml"},
+        {"path": "version.yaml"},
+        {"path": "deploy/base/kustomization.yaml"},
+    ]
+    assert process_file_updates.sparse_dirs_from_paths(paths) == [
+        "deploy/base",
+        "deploy/overlays/prod",
+        "version.yaml",
+    ]
+
+
+def test_sparse_dirs_from_paths_skips_missing_path() -> None:
+    """Entries without a path are ignored."""
+    assert process_file_updates.sparse_dirs_from_paths([{"seed": "x"}]) == []
+
+
+def test_prepare_repository(tmp_path: Path) -> None:
+    """Repository is sparse-cloned and rebased on upstream via ``vcs.git``."""
+    repo_cwd = tmp_path / "cloned"
+    repo_cwd.mkdir()
+    paths = [{"path": "deploy/image.yaml", "replacements": []}]
+    with (
+        mock.patch.object(
+            process_file_updates.vcs_git,
+            "clone",
+            return_value=repo_cwd,
+        ) as clone,
+        mock.patch.object(process_file_updates.vcs_git, "rebase_onto_remote") as rebase,
+    ):
+        out = process_file_updates.prepare_repository(
+            "https://gitlab.com/org/repo.git",
+            "main",
+            "https://gitlab.com/org/up.git",
+            tmp_path,
+            paths,
+        )
+    assert out == repo_cwd
+    clone.assert_called_once_with(
+        tmp_path,
+        "https://gitlab.com/org/repo.git",
+        revision="main",
+        sparse_dirs=["deploy"],
+        shallow=True,
+    )
+    rebase.assert_called_once()
+
+
+def test_prepare_repository_raises_when_no_paths(tmp_path: Path) -> None:
+    """An empty path list fails before cloning."""
+    with pytest.raises(tekton.CheckStepError, match="cloning repository"):
+        process_file_updates.prepare_repository(
+            "https://gitlab.com/org/repo.git",
+            "main",
+            "https://gitlab.com/org/up.git",
+            tmp_path,
+            [],
+        )
+
+
+def test_configure_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Secrets are exported to the process environment."""
+    secrets = {
+        "gitlab_host": "gitlab.example.com",
+        "gitlab_access_token": "tok123",
+        "git_author_name": "Author",
+        "git_author_email": "a@example.com",
+    }
+    with mock.patch.object(
+        process_file_updates.vcs_gitlab, "configure_git_oauth2_auth"
+    ) as auth:
+        token = process_file_updates.configure_git_environment(secrets)
+    assert token == "tok123"
+    assert os.environ["ACCESS_TOKEN"] == "tok123"
+    assert os.environ["GITLAB_HOST"] == "gitlab.example.com"
+    auth.assert_called_once_with("tok123")
+
+
+def test_git_functions_init_raises_on_missing_fields() -> None:
+    """Missing git identity fields raise ``CheckStepError``."""
+    with pytest.raises(tekton.CheckStepError) as exc:
+        process_file_updates.git_functions_init("", "a@x.com", "tok")
+    assert "initializing git" in str(exc.value)
+
+
+def test_blank_lines_before_yaml(tmp_path: Path) -> None:
+    """Leading comment/blank lines are counted before YAML."""
+    target = tmp_path / "f.yaml"
+    target.write_text("# comment\nkey: v\n", encoding="utf-8")
+    proc = subprocess.CompletedProcess(["awk"], 0, "1\n", "")
+    with mock.patch("subprocess.run", return_value=proc):
+        assert process_file_updates.blank_lines_before_yaml(target) == 1
+
+
+def test_blank_lines_before_yaml_returns_zero_on_failure(tmp_path: Path) -> None:
+    """Awk failure returns zero offset."""
+    target = tmp_path / "f.yaml"
+    target.write_text("key: v\n", encoding="utf-8")
+    proc = subprocess.CompletedProcess(["awk"], 1, "", "err")
+    with mock.patch("subprocess.run", return_value=proc):
+        assert process_file_updates.blank_lines_before_yaml(target) == 0
+
+
+def test_apply_replacement_block_success(tmp_path: Path) -> None:
+    """Valid sed replacement returns no error."""
+    target = tmp_path / "f.yaml"
+    target.write_text("old\n", encoding="utf-8")
+    (tmp_path / "found.txt").write_text("baseline\n", encoding="utf-8")
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if cmd[:2] == ["diff", "-u"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if "-i" in cmd[1]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "new\n", "")
+
+    with mock.patch("subprocess.run", side_effect=_fake_run):
+        err, diff_path = process_file_updates.apply_replacement_block(
+            target, 1, 0, "|old|new|", tmp_path
+        )
+    assert err is None
+    assert diff_path is not None
+
+
+def test_apply_replacement_block_size_mismatch(tmp_path: Path) -> None:
+    """Block size mismatch returns an error."""
+    target = tmp_path / "f.yaml"
+    target.write_text("x\n", encoding="utf-8")
+    (tmp_path / "found.txt").write_text("x\n", encoding="utf-8")
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if cmd[:2] == ["diff", "-u"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if "-i" in cmd[1]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "only\n", "")
+
+    with mock.patch("subprocess.run", side_effect=_fake_run):
+        err, _ = process_file_updates.apply_replacement_block(target, 1, 1, "|x|y|", tmp_path)
+    assert err == "Text block size differs from the original"
+
+
+def test_apply_replacement_block_too_greedy(tmp_path: Path) -> None:
+    """Greedy replacements return an error."""
+    target = tmp_path / "f.yaml"
+    target.write_text("a\na\n", encoding="utf-8")
+    (tmp_path / "found.txt").write_text("a\n", encoding="utf-8")
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if cmd[:2] == ["diff", "-u"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if "-i" in cmd[1]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "a\na\n", "")
+
+    with mock.patch("subprocess.run", side_effect=_fake_run):
+        err, _ = process_file_updates.apply_replacement_block(target, 1, 1, "|a|b|", tmp_path)
+    assert "Too many lines replaced" in (err or "")
+
+
+def test_write_json_error_result(tmp_path: Path) -> None:
+    """Logical failures write JSON to both result files."""
+    info = tmp_path / "info"
+    state = tmp_path / "state"
+    process_file_updates.write_json_error_result(info, state, '"oops"')
+    payload = json.loads(info.read_text(encoding="utf-8"))
+    assert payload["error"] == '"oops"'
+    assert state.read_text(encoding="utf-8") == "Failed"
+
+
+def test_resolve_target_file_accepts_nested_relative_path(tmp_path: Path) -> None:
+    """Relative paths under the repo root are accepted."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = process_file_updates.resolve_target_file(repo, "dir/file.yaml")
+    assert target == (repo / "dir" / "file.yaml").resolve()
+
+
+@pytest.mark.parametrize(
+    "entry_path",
+    [
+        "",
+        "/etc/passwd",
+        "../outside.yaml",
+        "foo/../../outside.yaml",
+        "C:secret.yaml",
+    ],
+)
+def test_resolve_target_file_rejects_unsafe_paths(tmp_path: Path, entry_path: str) -> None:
+    """Absolute paths, ``..`` segments, and drive paths are rejected."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pytest.raises(ValueError):
+        process_file_updates.resolve_target_file(repo, entry_path)
+
+
+def test_process_all_paths_rejects_unsafe_path_entry(tmp_path: Path) -> None:
+    """Unsafe path entries fail before seed or replacement side effects."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest = tmp_path / "paths.json"
+    manifest.write_text("[]\n", encoding="utf-8")
+    paths = [{"path": "../evil.yaml", "seed": "pwned"}]
+
+    with pytest.raises(tekton.CheckStepError) as exc:
+        process_file_updates.process_all_paths(paths, manifest, repo, tmp_path)
+    assert exc.value.action == "validating path entry"
+    assert not (tmp_path / "evil.yaml").exists()
+
+
+def test_main_rejects_unsafe_path_entry(
+    tmp_path: Path, secret_mount: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Traversal paths write Failed state and exit 0 via ``CheckStepError``."""
+    info, state, _, _ = _setup_tekton_env(tmp_path, monkeypatch, secret_mount)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    paths_json = json.dumps([{"path": "../evil.yaml", "seed": "x"}])
+    argv = [
+        "process_file_updates.py",
+        "--upstream-repo",
+        "https://gitlab.com/org/upstream.git",
+        "--repo",
+        "https://gitlab.com/org/repo.git",
+        "--ref",
+        "main",
+        "--paths",
+        paths_json,
+        "--component-group",
+        "my-group",
+        "--internal-request-pipeline-run-name",
+        "pr-1",
+        "--internal-request-task-run-name",
+        "tr-1",
+        "--temp-dir",
+        str(tmp_path / "work"),
+    ]
+
+    with (
+        mock.patch.object(
+            process_file_updates,
+            "load_file_updates_secrets",
+            return_value={
+                "gitlab_host": "h",
+                "gitlab_access_token": "t",
+                "git_author_name": "n",
+                "git_author_email": "e@x.com",
+            },
+        ),
+        mock.patch.object(process_file_updates, "configure_git_environment", return_value="t"),
+        mock.patch.object(process_file_updates, "git_functions_init"),
+        mock.patch.object(process_file_updates.gitlab, "Gitlab"),
+        mock.patch.object(process_file_updates, "prepare_repository", return_value=repo),
+    ):
+        rc = process_file_updates.main(argv)
+
+    assert rc == 0
+    assert state.read_text(encoding="utf-8") == "Failed"
+    assert "validating path entry" in info.read_text(encoding="utf-8")
+    assert not (tmp_path / "evil.yaml").exists()
+
+
+def test_seed_target_file_skips_when_no_seed(tmp_path: Path) -> None:
+    """Entries without seed skip file creation."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "new.yaml"
+    with mock.patch.object(process_file_updates.vcs_git, "index_add_commit") as stage:
+        process_file_updates.seed_target_file({"path": "new.yaml"}, target, repo)
+    stage.assert_not_called()
+
+
+def test_seed_target_file_writes_and_stages(tmp_path: Path) -> None:
+    """Seed content is written and staged with git."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "dir" / "new.yaml"
+    with (
+        mock.patch.object(process_file_updates.vcs_git, "index_add_commit") as stage,
+        mock.patch.object(
+            process_file_updates.vcs_git,
+            "working_tree_status",
+            return_value="",
+        ) as status,
+    ):
+        process_file_updates.seed_target_file(
+            {"path": "dir/new.yaml", "seed": "content"},
+            target,
+            repo,
+        )
+    assert target.read_text(encoding="utf-8") == "content\n"
+    stage.assert_called_once_with(repo, ["dir/new.yaml"], "", commit=False)
+    status.assert_called_once_with(repo)
+
+
+def test_seed_target_file_propagates_git_add_failure(tmp_path: Path) -> None:
+    """``seed-error`` Tekton: git add failure propagates (``main`` maps to Failed)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "test" / "seed-error.yaml"
+    with mock.patch.object(
+        process_file_updates.vcs_git,
+        "index_add_commit",
+        side_effect=subprocess.CalledProcessError(
+            1, ["git", "add"], stderr="simulating error"
+        ),
+    ):
+        with pytest.raises(subprocess.CalledProcessError):
+            process_file_updates.seed_target_file(
+                {"path": "test/seed-error.yaml", "seed": "indexImage: \\ntom:"},
+                target,
+                repo,
+            )
+
+
+def test_apply_replacements_for_entry_missing_file_returns_not_yaml(
+    tmp_path: Path,
+) -> None:
+    """``replacements-missing-file`` Tekton: missing path is not valid YAML."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "addons" / "missing.yaml"
+    state = process_file_updates.PathProcessingState()
+    with mock.patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(["yq"], 1, "", ""),
+    ):
+        early = process_file_updates.apply_replacements_for_entry(
+            {
+                "path": "addons/missing.yaml",
+                "replacements": [{"key": ".indexImage", "replacement": "|a|b|"}],
+            },
+            target,
+            repo,
+            tmp_path,
+            state,
+        )
+    assert early == (
+        "fileUpdates: the targetFile addons/missing.yaml is not a yaml file",
+        "",
+        1,
+    )
+
+
+def test_apply_replacements_for_entry_invalid_yaml(tmp_path: Path) -> None:
+    """Invalid YAML returns exit code 1."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "bad.yaml"
+    target.write_text("not: [valid\n", encoding="utf-8")
+    state = process_file_updates.PathProcessingState()
+    with (
+        mock.patch.object(process_file_updates, "blank_lines_before_yaml", return_value=0),
+        mock.patch(
+            "subprocess.run",
+            return_value=subprocess.CompletedProcess(["yq"], 1, "", ""),
+        ),
+    ):
+        early = process_file_updates.apply_replacements_for_entry(
+            {"path": "bad.yaml", "replacements": [{"key": ".k", "replacement": "|a|b|"}]},
+            target,
+            repo,
+            tmp_path,
+            state,
+        )
+    assert early == ("fileUpdates: the targetFile bad.yaml is not a yaml file", "", 1)
+
+
+def test_apply_replacements_for_entry_key_not_found(tmp_path: Path) -> None:
+    """Missing keys set ``key_not_found`` on state."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "f.yaml"
+    target.write_text("key: v\n", encoding="utf-8")
+    state = process_file_updates.PathProcessingState()
+
+    def _yq_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "(line, .)" in cmd[1]:
+            return subprocess.CompletedProcess(cmd, 0, "0\nnull\n", "")
+        return subprocess.CompletedProcess(cmd, 0, "v\n", "")
+
+    with (
+        mock.patch.object(process_file_updates, "blank_lines_before_yaml", return_value=0),
+        mock.patch("subprocess.run", side_effect=_yq_run),
+    ):
+        assert (
+            process_file_updates.apply_replacements_for_entry(
+                {
+                    "path": "f.yaml",
+                    "replacements": [{"key": ".missing", "replacement": "|v|w|"}],
+                },
+                target,
+                repo,
+                tmp_path,
+                state,
+            )
+            is None
+        )
+    assert state.key_not_found is True
+    assert state.replacements_performed == 0
+
+
+def test_apply_replacements_for_entry_applies_replacement(tmp_path: Path) -> None:
+    """Successful replacement increments the performed count."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "f.yaml"
+    target.write_text("key: old\n", encoding="utf-8")
+    state = process_file_updates.PathProcessingState()
+
+    def _yq_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "(line, .)" in cmd[1]:
+            return subprocess.CompletedProcess(cmd, 0, "1\nold\n", "")
+        return subprocess.CompletedProcess(cmd, 0, "old\n", "")
+
+    with (
+        mock.patch.object(process_file_updates, "blank_lines_before_yaml", return_value=0),
+        mock.patch("subprocess.run", side_effect=_yq_run),
+        mock.patch.object(
+            process_file_updates,
+            "apply_replacement_block",
+            return_value=(None, tmp_path / "diff.txt"),
+        ),
+    ):
+        assert (
+            process_file_updates.apply_replacements_for_entry(
+                {
+                    "path": "f.yaml",
+                    "replacements": [{"key": ".key", "replacement": "|old|new|"}],
+                },
+                target,
+                repo,
+                tmp_path,
+                state,
+            )
+            is None
+        )
+    assert state.replacements_performed == 1
+
+
+def test_process_all_paths_returns_early_on_yaml_error(tmp_path: Path) -> None:
+    """Invalid YAML in paths returns early."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest = tmp_path / "paths.json"
+    manifest.write_text("[]\n", encoding="utf-8")
+    paths = [
+        {
+            "path": "f.yaml",
+            "replacements": [{"key": ".k", "replacement": "|a|b|"}],
+        }
+    ]
+
+    with (
+        mock.patch.object(process_file_updates, "seed_target_file"),
+        mock.patch.object(
+            process_file_updates,
+            "apply_replacements_for_entry",
+            return_value=("fileUpdates: not yaml", "", 1),
+        ),
+        mock.patch.object(process_file_updates.vcs_git, "index_add_commit") as stage,
+    ):
+        state, early = process_file_updates.process_all_paths(paths, manifest, repo, tmp_path)
+    assert early is not None
+    stage.assert_not_called()
+
+
+def test_get_cached_diff(tmp_path: Path) -> None:
+    """Cached diff is captured and written under the temp dir."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with mock.patch.object(
+        process_file_updates.vcs_git, "working_tree_diff", return_value="diff\n"
+    ):
+        assert process_file_updates.get_cached_diff(repo, tmp_path) == "diff\n"
+    assert (tmp_path / "tempMRFile-cached.diff").read_text(encoding="utf-8") == "diff\n"
+
+
+def test_list_konflux_open_mrs_paginates() -> None:
+    """Open MR listing paginates until an empty page."""
+    page1_mr = mock.Mock()
+    page1_mr.iid = 1
+    items = process_file_updates.list_konflux_open_mrs(
+        "org/up",
+        _mock_gitlab_client(list_pages=[[page1_mr], []]),
+    )
+    assert len(items) == 1
+    assert items[0].iid == 1
+
+
+def test_find_existing_mr_with_same_diff(tmp_path: Path) -> None:
+    """Matching staged diff returns existing MR info."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    existing_mr = mock.Mock()
+    existing_mr.iid = 99
+    existing_mr.web_url = "https://gitlab.com/org/up/-/merge_requests/99"
+    with (
+        mock.patch.object(
+            process_file_updates,
+            "list_konflux_open_mrs",
+            return_value=[existing_mr],
+        ),
+        mock.patch.object(
+            process_file_updates,
+            "_fetch_merge_request_head",
+            return_value="mr_99",
+        ),
+        mock.patch.object(process_file_updates.vcs_git, "working_tree_diff", return_value=""),
+    ):
+        info = process_file_updates.find_existing_mr_with_same_diff(
+            "org/up", repo, tmp_path, _mock_gitlab_client()
+        )
+    assert info is not None
+    assert "merge_requests/99" in info
+
+
+def test_commit_and_create_mr(tmp_path: Path) -> None:
+    """Staged changes are pushed and a merge request is opened."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with (
+        mock.patch.object(process_file_updates.vcs_git, "checkout") as checkout,
+        mock.patch.object(process_file_updates.vcs_git, "commit_staged") as commit,
+        mock.patch.object(process_file_updates.vcs_git, "push") as push,
+        mock.patch.object(
+            process_file_updates,
+            "gitlab_create_mr",
+            return_value='{"merge_request":"https://x/mr/1"}',
+        ),
+        mock.patch.object(process_file_updates.uuid, "uuid4") as uid,
+    ):
+        uid.return_value.hex = "abcd1234efgh5678"
+        body, state, code = process_file_updates.commit_and_create_mr(
+            component_group="grp",
+            revision="main",
+            upstream_repo="org/up",
+            repo_cwd=repo,
+            gitlab_client=_mock_gitlab_client(),
+        )
+    checkout.assert_called_once_with(repo, "abcd1234")
+    commit.assert_called_once_with(repo, "fileUpdates changes")
+    push.assert_called_once_with(repo, "abcd1234")
+    assert code == 0 and state == "Success"
+    assert "merge_request" in body
+
+
+def test_run_file_updates_creates_mr(tmp_path: Path) -> None:
+    """Workflow creates a merge request when changes exist."""
+    secrets = {
+        "gitlab_host": "h",
+        "gitlab_access_token": "t",
+        "git_author_name": "n",
+        "git_author_email": "e@x.com",
+    }
+    path_state = process_file_updates.PathProcessingState(replacements_performed=2)
+
+    with (
+        mock.patch.object(process_file_updates, "configure_git_environment", return_value="t"),
+        mock.patch.object(process_file_updates, "git_functions_init"),
+        mock.patch.object(
+            process_file_updates,
+            "write_paths_manifest",
+            return_value=(tmp_path / "p.json", []),
+        ),
+        mock.patch.object(
+            process_file_updates, "prepare_repository", return_value=tmp_path / "repo"
+        ),
+        mock.patch.object(
+            process_file_updates,
+            "process_all_paths",
+            return_value=(path_state, None),
+        ),
+        mock.patch.object(process_file_updates, "get_cached_diff", return_value="diff\n"),
+        mock.patch.object(
+            process_file_updates, "find_existing_mr_with_same_diff", return_value=None
+        ),
+        mock.patch.object(
+            process_file_updates,
+            "commit_and_create_mr",
+            return_value=('{"merge_request":"u"}\n', "Success", 0),
+        ),
+    ):
+        body, state, code = process_file_updates.run_file_updates(
+            upstream_repo="u",
+            repo="r",
+            revision="main",
+            paths_json="[]",
+            component_group="g",
+            temp_dir=tmp_path,
+            secrets=secrets,
+        )
+    assert state == "Success" and "merge_request" in body
+
+
+def test_run_file_updates_no_cached_diff(tmp_path: Path) -> None:
+    """Empty cached diff short-circuits with Success."""
+    secrets = {
+        "gitlab_host": "h",
+        "gitlab_access_token": "t",
+        "git_author_name": "n",
+        "git_author_email": "e@x.com",
+    }
+    path_state = process_file_updates.PathProcessingState(replacements_performed=1)
+
+    with (
+        mock.patch.object(process_file_updates, "configure_git_environment", return_value="t"),
+        mock.patch.object(process_file_updates, "git_functions_init"),
+        mock.patch.object(
+            process_file_updates,
+            "write_paths_manifest",
+            return_value=(tmp_path / "p.json", []),
+        ),
+        mock.patch.object(
+            process_file_updates, "prepare_repository", return_value=tmp_path / "repo"
+        ),
+        mock.patch.object(
+            process_file_updates,
+            "process_all_paths",
+            return_value=(path_state, None),
+        ),
+        mock.patch.object(process_file_updates, "get_cached_diff", return_value=""),
+    ):
+        body, state, code = process_file_updates.run_file_updates(
+            upstream_repo="u",
+            repo="r",
+            revision="main",
+            paths_json="[]",
+            component_group="g",
+            temp_dir=tmp_path,
+            secrets=secrets,
+        )
+    assert (body, state, code) == ("nothing needs change\n", "Success", 0)
+
+
+def test_main_writes_replacement_error_result(
+    tmp_path: Path, secret_mount: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Replacement errors write JSON Failed results."""
+    info, state, _, _ = _setup_tekton_env(tmp_path, monkeypatch, secret_mount)
+
+    def _fail(**_k: object) -> tuple[str, str, int]:
+        return "diff", "block size differs", 0
+
+    with mock.patch.object(process_file_updates, "run_file_updates", side_effect=_fail):
+        rc = process_file_updates.main(["process_file_updates.py", *_VALID_ARGS])
+
+    assert rc == 0
+    assert state.read_text(encoding="utf-8") == "Failed"
+    payload = json.loads(info.read_text(encoding="utf-8"))
+    assert payload["error"] == "block size differs"
+
+
+def test_main_writes_json_error_result(
+    tmp_path: Path, secret_mount: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """JSON logical errors write Failed results."""
+    info, state, _, _ = _setup_tekton_env(tmp_path, monkeypatch, secret_mount)
+    err = '"no replacements were performed"'
+
+    def _fail(**_k: object) -> tuple[str, str, int]:
+        return err, err, 0
+
+    with mock.patch.object(process_file_updates, "run_file_updates", side_effect=_fail):
+        rc = process_file_updates.main(["process_file_updates.py", *_VALID_ARGS])
+
+    assert rc == 0
+    payload = json.loads(info.read_text(encoding="utf-8"))
+    assert payload["error"] == err
+    assert state.read_text(encoding="utf-8") == "Failed"
+
+
+def test_main_missing_result_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing result env vars exit before updates run."""
+    monkeypatch.delenv("RESULT_FILE_UPDATES_INFO", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        process_file_updates.main(["process_file_updates.py", *_VALID_ARGS])
+    assert exc.value.code == 1
+
+
+def test_run_file_updates_builds_gitlab_client_when_not_provided(tmp_path: Path) -> None:
+    """``run_file_updates`` builds a client when omitted."""
+    secrets = {
+        "gitlab_host": "gitlab.example.com",
+        "gitlab_access_token": "t",
+        "git_author_name": "n",
+        "git_author_email": "e@x.com",
+    }
+    mock_gl = mock.Mock()
+    with (
+        mock.patch.object(process_file_updates, "configure_git_environment", return_value="t"),
+        mock.patch.object(process_file_updates.gitlab, "Gitlab", return_value=mock_gl) as mk,
+        mock.patch.object(process_file_updates, "git_functions_init"),
+        mock.patch.object(
+            process_file_updates,
+            "write_paths_manifest",
+            return_value=(tmp_path / "p.json", []),
+        ),
+        mock.patch.object(
+            process_file_updates, "prepare_repository", return_value=tmp_path / "repo"
+        ),
+        mock.patch.object(
+            process_file_updates,
+            "process_all_paths",
+            return_value=(process_file_updates.PathProcessingState(), ("early", "", 1)),
+        ),
+    ):
+        process_file_updates.run_file_updates(
+            upstream_repo="u",
+            repo="r",
+            revision="main",
+            paths_json="[]",
+            component_group="g",
+            temp_dir=tmp_path,
+            secrets=secrets,
+        )
+    mk.assert_called_once_with("gitlab.example.com", private_token="t")
+
+
+def test_apply_replacements_for_entry_skips_empty_replacements(
+    tmp_path: Path,
+) -> None:
+    """Empty replacement lists are skipped."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "f.yaml"
+    target.write_text("k: v\n", encoding="utf-8")
+    state = process_file_updates.PathProcessingState()
+    assert (
+        process_file_updates.apply_replacements_for_entry(
+            {"path": "f.yaml", "replacements": []},
+            target,
+            repo,
+            tmp_path,
+            state,
+        )
+        is None
+    )
+
+
+def test_apply_replacements_for_entry_records_block_error(tmp_path: Path) -> None:
+    """Replacement block errors update state."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "f.yaml"
+    target.write_text("key: old\n", encoding="utf-8")
+    state = process_file_updates.PathProcessingState()
+    diff_path = tmp_path / "diff.txt"
+    diff_path.write_text("---\n", encoding="utf-8")
+
+    def _yq_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "(line, .)" in cmd[1]:
+            return subprocess.CompletedProcess(cmd, 0, "1\nold\n", "")
+        return subprocess.CompletedProcess(cmd, 0, "old\n", "")
+
+    with (
+        mock.patch.object(process_file_updates, "blank_lines_before_yaml", return_value=0),
+        mock.patch("subprocess.run", side_effect=_yq_run),
+        mock.patch.object(
+            process_file_updates,
+            "apply_replacement_block",
+            return_value=("greedy replace", diff_path),
+        ),
+    ):
+        assert (
+            process_file_updates.apply_replacements_for_entry(
+                {
+                    "path": "f.yaml",
+                    "replacements": [{"key": ".key", "replacement": "|old|new|"}],
+                },
+                target,
+                repo,
+                tmp_path,
+                state,
+            )
+            is None
+        )
+    assert state.replacements_update_error == "greedy replace"
+    assert state.diff_path == diff_path
+
+
+def test_process_all_paths_stages_then_breaks_on_replacement_error(
+    tmp_path: Path,
+) -> None:
+    """Replacement errors stop after staging the file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "f.yaml"
+    target.write_text("k: v\n", encoding="utf-8")
+    manifest = tmp_path / "paths.json"
+    manifest.write_text("[]\n", encoding="utf-8")
+    paths = [{"path": "f.yaml", "replacements": [{"key": ".k", "replacement": "|a|b|"}]}]
+
+    def _apply(
+        entry: dict,
+        target_file: Path,
+        repo_cwd: Path,
+        temp_dir: Path,
+        st: process_file_updates.PathProcessingState,
+    ) -> None:
+        st.replacements_update_error = "sed failed"
+        st.diff_path = temp_dir / "diff.txt"
+
+    with (
+        mock.patch.object(process_file_updates, "seed_target_file"),
+        mock.patch.object(
+            process_file_updates, "apply_replacements_for_entry", side_effect=_apply
+        ),
+        mock.patch.object(process_file_updates.vcs_git, "index_add_commit") as stage,
+    ):
+        out_state, early = process_file_updates.process_all_paths(
+            paths, manifest, repo, tmp_path
+        )
+
+    assert early is None
+    assert out_state.replacements_update_error == "sed failed"
+    stage.assert_called_once_with(repo, ["f.yaml"], "", commit=False)
+
+
+def test_find_existing_mr_returns_none_when_diff_differs(tmp_path: Path) -> None:
+    """Non-matching MR diffs return ``None``."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    existing_mr = mock.Mock()
+    existing_mr.iid = 1
+    existing_mr.web_url = "https://gitlab.com/org/up/-/merge_requests/1"
+    with (
+        mock.patch.object(
+            process_file_updates,
+            "list_konflux_open_mrs",
+            return_value=[existing_mr],
+        ),
+        mock.patch.object(
+            process_file_updates,
+            "_fetch_merge_request_head",
+            return_value="mr_1",
+        ),
+        mock.patch.object(
+            process_file_updates.vcs_git,
+            "working_tree_diff",
+            return_value="not empty\n",
+        ),
+    ):
+        assert (
+            process_file_updates.find_existing_mr_with_same_diff(
+                "org/up", repo, tmp_path, mock.Mock()
+            )
+            is None
+        )
+
+
+def test_run_file_updates_returns_early_from_process_all_paths(
+    tmp_path: Path,
+) -> None:
+    """Early path processing result is returned."""
+    secrets = {
+        "gitlab_host": "h",
+        "gitlab_access_token": "t",
+        "git_author_name": "n",
+        "git_author_email": "e@x.com",
+    }
+    with (
+        mock.patch.object(process_file_updates, "configure_git_environment", return_value="t"),
+        mock.patch.object(process_file_updates, "git_functions_init"),
+        mock.patch.object(
+            process_file_updates,
+            "write_paths_manifest",
+            return_value=(tmp_path / "p.json", []),
+        ),
+        mock.patch.object(
+            process_file_updates, "prepare_repository", return_value=tmp_path / "repo"
+        ),
+        mock.patch.object(
+            process_file_updates,
+            "process_all_paths",
+            return_value=(
+                process_file_updates.PathProcessingState(),
+                ("not yaml", "", 1),
+            ),
+        ),
+    ):
+        body, state, code = process_file_updates.run_file_updates(
+            upstream_repo="u",
+            repo="r",
+            revision="main",
+            paths_json="[]",
+            component_group="g",
+            temp_dir=tmp_path,
+            secrets=secrets,
+        )
+    assert code == 1 and body == "not yaml"
+
+
+def test_run_file_updates_returns_existing_mr(tmp_path: Path) -> None:
+    """Existing MR info is returned when found."""
+    secrets = {
+        "gitlab_host": "h",
+        "gitlab_access_token": "t",
+        "git_author_name": "n",
+        "git_author_email": "e@x.com",
+    }
+    path_state = process_file_updates.PathProcessingState(replacements_performed=1)
+    existing = "existing MR\n"
+
+    with (
+        mock.patch.object(process_file_updates, "configure_git_environment", return_value="t"),
+        mock.patch.object(process_file_updates, "git_functions_init"),
+        mock.patch.object(
+            process_file_updates,
+            "write_paths_manifest",
+            return_value=(tmp_path / "p.json", []),
+        ),
+        mock.patch.object(
+            process_file_updates, "prepare_repository", return_value=tmp_path / "repo"
+        ),
+        mock.patch.object(
+            process_file_updates,
+            "process_all_paths",
+            return_value=(path_state, None),
+        ),
+        mock.patch.object(process_file_updates, "get_cached_diff", return_value="diff\n"),
+        mock.patch.object(
+            process_file_updates,
+            "find_existing_mr_with_same_diff",
+            return_value=existing,
+        ),
+    ):
+        body, state, code = process_file_updates.run_file_updates(
+            upstream_repo="u",
+            repo="r",
+            revision="main",
+            paths_json="[]",
+            component_group="g",
+            temp_dir=tmp_path,
+            secrets=secrets,
+        )
+    assert (body, state, code) == (existing, "Success", 0)
+
+
+def test_main_parse_args_non_int_exit_code() -> None:
+    """Non-int ``SystemExit`` from argparse maps to exit 1."""
+    with mock.patch.object(
+        process_file_updates,
+        "parse_args",
+        side_effect=SystemExit("usage"),
+    ):
+        assert process_file_updates.main(["process_file_updates.py"]) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1545,6 +1545,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-gitlab"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/96/c20b37e7fd86481e1bf2b1922e84b98dc5477fd9aafd30e5c5086f94d922/python_gitlab-8.4.0.tar.gz", hash = "sha256:f36f20ec3f09138f3b12089394941f4dbe5a407021bed71b70a04bbdd37b8a74", size = 410803, upload-time = "2026-05-28T02:43:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/af/1c3540dbdccb85fca0b0bbc58cdaf514d0a830d7e0302b2059a6c627b172/python_gitlab-8.4.0-py3-none-any.whl", hash = "sha256:102c747d9c107820e215cc5913627388001592a9a3ba1b43fc341a40f6943e72", size = 148242, upload-time = "2026-05-28T02:43:31.505Z" },
+]
+
+[[package]]
 name = "python-qpid-proton"
 version = "0.40.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1743,6 +1756,7 @@ dependencies = [
     { name = "pubtools-pyxis" },
     { name = "pubtools-sign" },
     { name = "pulp-cli" },
+    { name = "python-gitlab" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "requests-kerberos" },
@@ -1773,6 +1787,7 @@ requires-dist = [
     { name = "pubtools-pyxis", specifier = "==1.3.8" },
     { name = "pubtools-sign", specifier = "==1.0.6" },
     { name = "pulp-cli", specifier = "==0.36.3" },
+    { name = "python-gitlab", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "requests" },
     { name = "requests-kerberos" },
@@ -1837,6 +1852,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901, upload-time = "2024-03-29T03:54:29.446Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/97/ec/889fbc557727da0c34a33850950310240f2040f3b1955175fdb2b36a8910/requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563", size = 27695, upload-time = "2024-03-29T03:54:27.64Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Describe your changes
Adds a standalone python script for the process-file-updates internal task logic so it can run from the utils image instead of an inline catalog script.

## Relevant Jira
[RELEASE-1988](https://redhat.atlassian.net/browse/RELEASE-1988)

Assisted-by: Claude

[RELEASE-1988]: https://redhat.atlassian.net/browse/RELEASE-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ