### PR TITLE
feat(RELEASE-1985): add create_advisory python script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,7 +160,7 @@ ENV PATH="$PATH:/home/publish-to-cgw-wrapper"
 # Flat imports: helpers and task scripts must be importable.
 # Tests use the same layout via pyproject [tool.pytest.ini_options] pythonpath.
 # Keep /home for other modules (e.g. pyxis, sbom) that expect it.
-ENV PYTHONPATH="/home:/home/scripts/python/helpers:/home/scripts/python/tasks/internal"
+ENV PYTHONPATH="/home:/home/utils:/home/scripts/python/helpers:/home/scripts/python/tasks/internal"
 
 # uv installs newer requests and certifi which don't use the system CA like the one installed via
 # dnf. So we need to point requests to the system CA bundle explicitly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,13 @@ description = "Konflux Release Service Utils"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "GitPython>=3.1.40",
+    "PyYAML>=6.0.1",
     "requests",
     "requests-kerberos",
     "jinja2",
     "check-jsonschema",
+    "jsonschema>=4.23",
     "jinja2-ansible-filters",
     "packaging",
     "packageurl-python",
@@ -32,6 +35,7 @@ pythonpath = [
   "integration-tests/lib",
   "scripts/python/helpers",
   "scripts/python/tasks/internal",
+  "utils",
 ]
 
 [dependency-groups]

--- a/scripts/python/helpers/advisory_data.py
+++ b/scripts/python/helpers/advisory_data.py
@@ -1,0 +1,307 @@
+"""Decode advisory task payloads and content filtering (idempotency rules)."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _strip_checksum_from_purl(purl: str) -> str:
+    """Strip `checksum` query/fragment parts from a package URL for comparison."""
+    # purl checksum may appear as `&checksum=` (extra param), `?checksum=` in
+    # the query, or trailing `?checksum=` before end — strip all three shapes.
+    stripped = re.sub(r"&checksum=[^&]*", "", purl)
+    stripped = re.sub(r"\?checksum=[^&]*&", "?", stripped)
+    stripped = re.sub(r"\?checksum=[^&]*$", "", stripped)
+    return stripped
+
+
+def _filter_image(content: list[Any], existing: list[Any]) -> list[Any]:
+    """Drop image rows that already exist (same image, tags, repository)."""
+    # `tags` is compared as JSON lists (order and length must match).
+    out: list[Any] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        container_image = item.get("containerImage")
+        tags = item.get("tags")
+        repo = item.get("repository")
+        is_duplicate = False
+        for existing_row in existing:
+            if not isinstance(existing_row, dict):
+                continue
+            if (
+                existing_row.get("containerImage") == container_image
+                and existing_row.get("tags") == tags
+                and existing_row.get("repository") == repo
+            ):
+                is_duplicate = True
+                break
+        if not is_duplicate:
+            out.append(item)
+    return out
+
+
+def _filter_rpm(content: list[Any], existing: list[Any]) -> list[Any]:
+    """Drop artifact rows whose `purl` exactly matches an existing row."""
+    existing_purls = {
+        existing_row.get("purl")
+        for existing_row in existing
+        if isinstance(existing_row, dict) and existing_row.get("purl") is not None
+    }
+    out: list[Any] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        purl = item.get("purl")
+        # Without `purl` there is nothing to compare; skip the row.
+        if purl is None or purl not in existing_purls:
+            out.append(item)
+    return out
+
+
+def _filter_generic_binary(content: list[Any], existing: list[Any]) -> list[Any]:
+    """Drop rows whose `purl` matches existing after stripping `checksum`."""
+    # Re-signing can change checksum query params; compare logical purls only.
+    stripped_existing = {
+        _strip_checksum_from_purl(str(existing_row["purl"]))
+        for existing_row in existing
+        if isinstance(existing_row, dict) and existing_row.get("purl") is not None
+    }
+    out: list[Any] = []
+    for item in content:
+        if not isinstance(item, dict) or item.get("purl") is None:
+            continue
+        if _strip_checksum_from_purl(str(item["purl"])) not in stripped_existing:
+            out.append(item)
+    return out
+
+
+def decode_advisory_param(advisory_b64gzip: str) -> dict[str, Any]:
+    """Decode `ADVISORY_JSON` (base64 + gzip) to a dict."""
+    # Task param is a single string; pipeline supplies gzip then base64.
+    b64_decoded = base64.standard_b64decode(advisory_b64gzip.strip())
+    gzip_decoded = gzip.decompress(b64_decoded)
+    return json.loads(gzip_decoded.decode("utf-8"))
+
+
+def content_array_from_decoded(root: dict[str, Any], content_list_path: str) -> list[Any]:
+    """
+    Return the list at *content_list_path* under advisory *root*, or `[]` if
+    missing or not a list.
+
+    *content_list_path* is a dotted path with an optional leading dot, for
+    example `.content.images` or `.content.artifacts`.
+
+    Each segment is the next dict key under *root*; the value stepped through
+    along the path must stay a dict until the final key, which must hold a list.
+    """
+    # Decoded advisory JSON stores `content` at the top level (not under `spec`).
+    segments = [s for s in content_list_path.strip(".").split(".") if s]
+    current_value: Any = root
+    for segment in segments:
+        if not isinstance(current_value, dict):
+            return []
+        current_value = current_value.get(segment)
+    if current_value is None:
+        return []
+    return current_value if isinstance(current_value, list) else []
+
+
+def set_decoded_content_array(
+    root: dict[str, Any],
+    content_list_path: str,
+    content_rows: list[Any],
+) -> None:
+    """Set `root['content'][images|artifacts]` from *content_list_path*."""
+    # Only `.content.images` and `.content.artifacts` are valid paths here.
+    segments = [s for s in content_list_path.strip(".").split(".") if s]
+    if len(segments) != 2 or segments[0] != "content":
+        msg = f"unsupported content list path for merge: {content_list_path!r}"
+        raise ValueError(msg)
+    images_or_artifacts_key = segments[1]
+    if "content" not in root or not isinstance(root["content"], dict):
+        root["content"] = {}
+    root["content"][images_or_artifacts_key] = content_rows
+
+
+def append_signing_key_to_content(
+    root: dict[str, Any],
+    content_list_path: str,
+    signing_key: str,
+) -> None:
+    """Set `signingKey` on each content row that does not already have one."""
+    # Mutates *root* in place.
+    for item in content_array_from_decoded(root, content_list_path):
+        if isinstance(item, dict) and not item.get("signingKey"):
+            item["signingKey"] = signing_key
+
+
+def load_advisory_yaml(path: Path) -> dict[str, Any]:
+    """Load `advisory.yaml` (or any YAML document) as a `dict`."""
+    yaml_source = path.read_text(encoding="utf-8")
+    data = yaml.safe_load(yaml_source)
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        msg = f"YAML root must be a mapping: {path}"
+        raise TypeError(msg)
+    return data
+
+
+def spec_content_array_from_advisory_yaml(
+    doc: dict[str, Any],
+    content_list_path: str,
+) -> list[Any]:
+    """
+    Return the list at *content_list_path* under `doc['spec']` from an advisory
+    YAML document (`metadata` / `spec` layout).
+
+    Use the same dotted path as for decoded JSON (e.g. `.content.images`); it
+    is applied under `spec`, not at the document root.
+
+    Walking starts at `doc['spec']`; each segment is the next dict key, same
+    rules as `content_array_from_decoded`.
+    """
+    # Repo advisories nest the payload under `spec` (alongside `metadata`).
+    segments = [s for s in content_list_path.strip(".").split(".") if s]
+    current_value: Any = doc.get("spec")
+    if not isinstance(current_value, dict):
+        return []
+    for segment in segments:
+        if not isinstance(current_value, dict):
+            return []
+        current_value = current_value.get(segment)
+    if current_value is None:
+        return []
+    return current_value if isinstance(current_value, list) else []
+
+
+def get_advisory_spec_type(doc: dict[str, Any]) -> str:
+    """Return `spec.type` from an advisory YAML document."""
+    spec = doc.get("spec")
+    if isinstance(spec, dict) and spec.get("type") is not None:
+        return str(spec["type"])
+    return ""
+
+
+def get_advisory_metadata_name(doc: dict[str, Any]) -> str:
+    """Return `metadata.name` from an advisory YAML document."""
+    metadata = doc.get("metadata")
+    if isinstance(metadata, dict) and metadata.get("name") is not None:
+        return str(metadata["name"])
+    return ""
+
+
+def template_data_for_apply(keyed_advisory: dict[str, Any]) -> dict[str, Any]:
+    """Build the `{"advisory": {"spec": ...}}` object for `apply_template`."""
+    return {"advisory": {"spec": keyed_advisory}}
+
+
+def template_context_merge(
+    tmpl_data: dict[str, Any],
+    advisory_name: str,
+    ship_date: str,
+) -> dict[str, Any]:
+    """
+    Merge *advisory_name* and *ship_date* into *tmpl_data* for Jinja.
+
+    Duplicate top-level keys keep the value already in *tmpl_data* (later dict
+    in the merge wins).
+    """
+    # `{**a, **b}`: keys from *b* overwrite duplicates from *a*.
+    return {
+        **{"advisory_name": advisory_name, "advisory_ship_date": ship_date},
+        **tmpl_data,
+    }
+
+
+def json_dict_to_yaml_text(document: Any) -> str:
+    """Serialize *document* to multi-line YAML (readable advisory file)."""
+    # `sort_keys=False` keeps stable-ish ordering for tag-preservation checks.
+    return yaml.safe_dump(
+        document,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )
+
+
+def spec_content_json_pointer(content_type: str) -> str:
+    """Return the dotted *content_list_path* for *content_type* (under `spec` in YAML)."""
+    if content_type == "image":
+        return ".content.images"
+    if content_type in ("binary", "generic", "rpm"):
+        return ".content.artifacts"
+    msg = f"Unsupported contentType: {content_type}"
+    raise ValueError(msg)
+
+
+def advisory_url_prefix(git_repo: str) -> str:
+    """Return the customer portal errata URL for *git_repo*."""
+    if "/rhtap-release/" in git_repo:
+        return "https://access.stage.redhat.com/errata"
+    return "https://access.redhat.com/errata"
+
+
+def list_existing_advisory_subdirs(advisory_base: Path) -> list[str]:
+    """List `year/num` paths under *advisory_base*, newest leaf mtime first."""
+    if not advisory_base.is_dir():
+        return []
+    pairs: list[tuple[float, str]] = []
+    for year_dir in advisory_base.iterdir():
+        if not year_dir.is_dir():
+            continue
+        for num_dir in year_dir.iterdir():
+            if not num_dir.is_dir():
+                continue
+            rel = f"{year_dir.name}/{num_dir.name}"
+            # Sort by leaf dir mtime so `year/num` matches `find … -printf %T@`.
+            pairs.append((num_dir.stat().st_mtime, rel))
+    pairs.sort(key=lambda mtime_and_relpath: -mtime_and_relpath[0])
+    return [relpath for _mtime, relpath in pairs]
+
+
+def filter_content_by_existing(
+    content_type: str,
+    content_file: Path,
+    existing_file: Path,
+    *,
+    stderr_path: Path | None,
+) -> str:
+    """
+    Return compact JSON array text: *content_file* rows not already in
+    *existing_file* (idempotency rules for image / rpm / generic / binary).
+    """
+    try:
+        content_rows = json.loads(content_file.read_text(encoding="utf-8"))
+        existing_rows = json.loads(existing_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        if stderr_path is not None:
+            with open(
+                stderr_path,
+                "a",
+                encoding="utf-8",
+                errors="replace",
+            ) as errf:
+                errf.write(f"\nfilter_content_by_existing: invalid JSON: {exc}\n")
+        raise
+    if not isinstance(content_rows, list) or not isinstance(existing_rows, list):
+        msg = "content and existing JSON must be arrays"
+        raise TypeError(msg)
+
+    if content_type in ("generic", "binary"):
+        filtered = _filter_generic_binary(content_rows, existing_rows)
+    elif content_type == "rpm":
+        filtered = _filter_rpm(content_rows, existing_rows)
+    else:
+        filtered = _filter_image(content_rows, existing_rows)
+
+    # Compact JSON (no extra spaces) for small temp files in the idempotency loop.
+    return json.dumps(filtered, separators=(",", ":"))

--- a/scripts/python/helpers/http_client.py
+++ b/scripts/python/helpers/http_client.py
@@ -23,8 +23,8 @@ MAX_404_ATTEMPTS = 3
 BASE_SLEEP_TIME_SECONDS = 1
 
 
-def _retries() -> Retry:
-    """Transients similar to common ``curl --retry 3`` (connection + some HTTP)."""
+def _retries(*, allowed_methods: frozenset[str]) -> Retry:
+    """Transients similar to common `curl --retry 3` (connection + some HTTP)."""
     return Retry(
         total=3,
         connect=3,
@@ -32,9 +32,18 @@ def _retries() -> Retry:
         status=2,
         backoff_factor=0.4,
         status_forcelist=(500, 502, 503, 504),
-        allowed_methods=frozenset({"GET"}),
+        allowed_methods=allowed_methods,
         raise_on_status=False,
     )
+
+
+def post_session() -> requests.Session:
+    """`requests.Session` with retries on transient connection/HTTP errors for POST."""
+    session = requests.Session()
+    adapter = HTTPAdapter(max_retries=_retries(allowed_methods=frozenset({"POST"})))
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
 
 
 def get_session() -> requests.Session:
@@ -43,7 +52,7 @@ def get_session() -> requests.Session:
     ``get_text`` uses this. Tests can patch this function to supply a custom session.
     """
     s = requests.Session()
-    a = HTTPAdapter(max_retries=_retries())
+    a = HTTPAdapter(max_retries=_retries(allowed_methods=frozenset({"GET"})))
     s.mount("https://", a)
     s.mount("http://", a)
     return s

--- a/scripts/python/helpers/internal_request.py
+++ b/scripts/python/helpers/internal_request.py
@@ -1,0 +1,22 @@
+"""Helpers for interacting with InternalRequests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+
+def write_result_paths(
+    result_paths: Mapping[str, Path],
+    *,
+    pipeline_run_name: str,
+    task_run_name: str,
+) -> None:
+    """
+    Write pipeline and task run names to the internal-request Tekton results.
+
+    *result_paths* must include ``internal_pr_name`` and ``internal_task_run_name``
+    keys mapping to the result file paths from the task step.
+    """
+    result_paths["internal_pr_name"].write_text(pipeline_run_name, encoding="utf-8")
+    result_paths["internal_task_run_name"].write_text(task_run_name, encoding="utf-8")

--- a/scripts/python/helpers/subprocess_cmd.py
+++ b/scripts/python/helpers/subprocess_cmd.py
@@ -1,0 +1,59 @@
+"""Run subprocess commands with optional stderr log file."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+def run_cmd(
+    cmd: Sequence[str | Path],
+    *,
+    cwd: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    stdin: str | bytes | None = None,
+    stderr_path: Path | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run *cmd*; capture stdout as text; optionally append stderr to *stderr_path*."""
+    # Child must inherit pod env (PATH, KUBECONFIG, etc.); only overlay *env*.
+    merged: dict[str, str] = {**os.environ, **dict(env or {})}
+    err_f: Any = subprocess.DEVNULL
+    fh: Any = None
+    try:
+        if stderr_path is not None:
+            fh = open(
+                stderr_path,
+                "a",
+                encoding="utf-8",
+                errors="replace",
+            )
+            err_f = fh
+        argv = [str(x) for x in cmd]
+        try:
+            return subprocess.run(
+                argv,
+                cwd=cwd,
+                env=merged,
+                input=stdin,
+                stdout=subprocess.PIPE,
+                stderr=err_f,
+                text=True,
+                check=check,
+            )
+        except subprocess.CalledProcessError:
+            if stderr_path is not None:
+                with open(
+                    stderr_path,
+                    "a",
+                    encoding="utf-8",
+                    errors="replace",
+                ) as errf:
+                    errf.write(f"\ncommand exited with failure: {' '.join(argv)}\n")
+            raise
+    finally:
+        if fh is not None:
+            fh.close()

--- a/scripts/python/helpers/tekton.py
+++ b/scripts/python/helpers/tekton.py
@@ -1,15 +1,16 @@
-"""Shared helpers for Tekton ``result``-file and step-error conventions in task scripts.
+"""Shared helpers for Tekton `result`-file and step-error conventions in task scripts.
 
 The catalog passes result file locations via environment variables
-(``env.value: $(results.foo.path)`` on the task step). Tasks that require those
+(`env.value: $(results.foo.path)` on the task step). Tasks that require those
 paths should fail fast in the same way: print to stderr and exit 1, since
-downstream can only interpret ``result`` bodies when the step was intended to
+downstream can only interpret `result` bodies when the step was intended to
 write them.
 """
 
 from __future__ import annotations
 
 import os
+import re
 import sys
 from pathlib import Path
 from typing import TextIO
@@ -19,9 +20,9 @@ class CheckStepError(Exception):
     """
     Pairs a short *human* description of what the task was doing (the first
     argument) with the real exception, for the Tekton one-line result file.
-    The standard library and ``requests`` only know about the underlying failure
+    The standard library and `requests` only know about the underlying failure
     (HTTP, I/O, exit code) — not which high-level action was running; attach
-    that at each ``raise`` site.
+    that at each `raise` site.
     """
 
     def __init__(self, action: str, cause: BaseException) -> None:
@@ -32,7 +33,7 @@ class CheckStepError(Exception):
 
 def result_text_from_exception(exc: BaseException, *, max_len: int = 500) -> str:
     """
-    ``str(exc)`` in a form suitable for a Tekton ``result`` value.
+    `str(exc)` in a form suitable for a Tekton `result` value.
 
     Reuses each exception’s normal string (no custom wording per type).
     Newlines are flattened and the text is cut at *max_len* so the value
@@ -44,17 +45,60 @@ def result_text_from_exception(exc: BaseException, *, max_len: int = 500) -> str
     return t
 
 
-def result_text_for_check_step_error(program_name: str, e: CheckStepError) -> str:
-    """
-    Text to put in a Tekton ``result`` when a task step failed with
-    ``CheckStepError`` — the *action* from the error plus
-    ``result_text_from_exception`` on the underlying *cause*.
+def _redact_for_tekton_result(text: str) -> str:
+    """Mask credentials before writing failure text to a Tekton result file."""
+    if not text:
+        return text
+    redacted = re.sub(
+        r"https://([^/@\s:]+):([^@\s]+)@",
+        r"https://\1:[REDACTED]@",
+        text,
+        flags=re.IGNORECASE,
+    )
+    redacted = re.sub(
+        r"(ACCESS_TOKEN=)\S+",
+        r"\1[REDACTED]",
+        redacted,
+        flags=re.IGNORECASE,
+    )
+    return redacted
 
-    *program_name* is usually the basename of ``sys.argv[0]`` for messages that
-    look like a log line prefix.
+
+def write_failure_result(
+    result_path: Path,
+    program_name: str,
+    exc: BaseException,
+    *,
+    command_log_path: Path | None = None,
+    workflow_action: str = "running the workflow",
+    max_log_lines: int = 20,
+    max_total_len: int = 8192,
+) -> None:
     """
-    why = result_text_from_exception(e.cause)
-    return f"{program_name}: Failed while {e.action}: {why}."
+    Write Tekton `result` text for a failed step.
+
+    Includes a one-line summary (`CheckStepError` uses its *action*; other
+    exceptions use *workflow_action*) and, when *command_log_path* is set, the
+    last *max_log_lines* of subprocess/git output collected during the run.
+    """
+    if isinstance(exc, CheckStepError):
+        why = _redact_for_tekton_result(result_text_from_exception(exc.cause))
+        summary = f"{program_name}: Failed while {exc.action}: {why}."
+    else:
+        why = _redact_for_tekton_result(result_text_from_exception(exc))
+        summary = f"{program_name}: Failed while {workflow_action}: " f"{why}"
+
+    parts = [summary.strip()]
+    if command_log_path is not None and command_log_path.is_file():
+        lines = command_log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+        if lines:
+            tail = _redact_for_tekton_result("\n".join(lines[-max_log_lines:]).strip())
+            parts.append(tail)
+
+    text = _redact_for_tekton_result("\n".join(parts))
+    if len(text) > max_total_len:
+        text = text[: max_total_len - 3] + "..."
+    result_path.write_text(text, encoding="utf-8")
 
 
 def subprocess_cmd_preview_for_tekton_result(
@@ -63,9 +107,9 @@ def subprocess_cmd_preview_for_tekton_result(
     max_len: int = 200,
 ) -> str:
     """
-    One-line description of a subprocess *cmd* for Tekton ``result`` files.
+    One-line description of a subprocess *cmd* for Tekton `result` files.
 
-    ``CalledProcessError`` (and some APIs) expose *cmd* as a string, a list of
+    `CalledProcessError` (and some APIs) expose *cmd* as a string, a list of
     argv pieces, or another object. Result lines stay short, so the joined or
     string form is cut to *max_len* characters.
     """
@@ -88,17 +132,31 @@ def _join_var_names(names: list[str]) -> str:
     return f"{', '.join(names[:-1])}, and {names[-1]}"
 
 
+def require_env(name: str, *, file: TextIO = sys.stderr) -> str:
+    """
+    Return the non-empty string value of an environment variable.
+
+    If *name* is unset or only whitespace, print `{name} must be set` to
+    *file* and raise `SystemExit(1)`.
+    """
+    value = os.environ.get(name)
+    if value is None or not str(value).strip():
+        print(f"{name} must be set", file=file)
+        raise SystemExit(1)
+    return str(value).strip()
+
+
 def result_paths_from_env(*env_var_names: str, file: TextIO = sys.stderr) -> tuple[Path, ...]:
     """
     Return pathlib Paths for the given environment variable names, in order.
 
     In Tekton, each result file is often wired as an env var whose value is the
-    path the step must write. For every name you pass, the value in ``os.environ``
+    path the step must write. For every name you pass, the value in `os.environ`
     must be non-empty. If any are missing or empty, a single error line is
-    printed to ``file`` and ``SystemExit(1)`` is raised, so the step can stop
+    printed to *file* and `SystemExit(1)` is raised, so the step can stop
     before it tries to write to unknown locations.
 
-    Example names: ``"RESULT_RESULT"``, ``"RESULT_EMBARGOED_CVES"``.
+    Example names: `RESULT_RESULT`, `RESULT_EMBARGOED_CVES`.
     """
     if not env_var_names:
         raise ValueError("at least one environment variable name is required")

--- a/scripts/python/helpers/test_advisory_data.py
+++ b/scripts/python/helpers/test_advisory_data.py
@@ -1,0 +1,323 @@
+"""Tests for `advisory_data`."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import os
+import time
+from pathlib import Path
+
+import advisory_data
+import pytest
+
+
+def _gzip_b64(obj: dict) -> str:
+    raw = json.dumps(obj).encode("utf-8")
+    gz = gzip.compress(raw)
+    return base64.standard_b64encode(gz).decode("ascii")
+
+
+def test_spec_content_json_pointer_image() -> None:
+    assert advisory_data.spec_content_json_pointer("image") == ".content.images"
+
+
+def test_spec_content_json_pointer_artifacts() -> None:
+    for t in ("binary", "generic", "rpm"):
+        assert advisory_data.spec_content_json_pointer(t) == ".content.artifacts"
+
+
+def test_spec_content_json_pointer_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="Unsupported"):
+        advisory_data.spec_content_json_pointer("disk-image")
+
+
+def test_advisory_url_prefix_stage() -> None:
+    assert (
+        advisory_data.advisory_url_prefix("https://gitlab.com/foo/rhtap-release/bar.git")
+        == "https://access.stage.redhat.com/errata"
+    )
+
+
+def test_advisory_url_prefix_prod() -> None:
+    assert (
+        advisory_data.advisory_url_prefix("https://gitlab.com/org/repo.git")
+        == "https://access.redhat.com/errata"
+    )
+
+
+def test_decode_advisory_param_roundtrip() -> None:
+    data = {"type": "RHSA", "live_id": None, "content": {"images": []}}
+    out = advisory_data.decode_advisory_param(_gzip_b64(data))
+    assert out == data
+
+
+def test_content_array_from_decoded() -> None:
+    d = {"content": {"images": [{"x": 1}]}}
+    assert advisory_data.content_array_from_decoded(d, ".content.images") == [{"x": 1}]
+    assert advisory_data.content_array_from_decoded({}, ".content.images") == []
+
+
+def test_set_decoded_content_array() -> None:
+    d: dict = {"type": "RHSA"}
+    advisory_data.set_decoded_content_array(d, ".content.images", [{"a": 1}])
+    assert d["content"]["images"] == [{"a": 1}]
+
+
+def test_load_advisory_yaml_roundtrip(tmp_path: Path) -> None:
+    p = tmp_path / "a.yaml"
+    p.write_text(
+        "metadata:\n  name: '2024:1'\nspec:\n  type: RHSA\n  content:\n" "    images: []\n",
+        encoding="utf-8",
+    )
+    doc = advisory_data.load_advisory_yaml(p)
+    assert advisory_data.get_advisory_metadata_name(doc) == "2024:1"
+    assert advisory_data.get_advisory_spec_type(doc) == "RHSA"
+    assert advisory_data.spec_content_array_from_advisory_yaml(doc, ".content.images") == []
+
+
+def test_template_context_merge_order() -> None:
+    # `tmpl_data` is merged after fixed keys, so it wins on duplicate top-level keys.
+    base = {"advisory": {"spec": {"k": 1}}}
+    out = advisory_data.template_context_merge(base, "n", "d")
+    assert out["advisory_name"] == "n"
+    assert out["advisory_ship_date"] == "d"
+    assert out["advisory"]["spec"]["k"] == 1
+
+
+def test_json_dict_to_yaml_text_roundtrip() -> None:
+    document = {"spec": {"type": "RHSA", "content": {"images": [{"tags": ["a"]}]}}}
+    yml = advisory_data.json_dict_to_yaml_text(document)
+    assert "RHSA" in yml
+    assert "tags:" in yml
+
+
+def test_list_existing_advisory_subdirs_order(tmp_path: Path) -> None:
+    base = tmp_path / "t"
+    d_old = base / "2024" / "0001"
+    d_new = base / "2025" / "0002"
+    d_old.mkdir(parents=True)
+    d_new.mkdir(parents=True)
+    t_old = time.time() - 100
+    t_new = time.time()
+    os.utime(d_old, (t_old, t_old))
+    os.utime(d_new, (t_new, t_new))
+    rel = advisory_data.list_existing_advisory_subdirs(base)
+    assert rel == ["2025/0002", "2024/0001"]
+
+
+def test_list_existing_advisory_subdirs_missing(tmp_path: Path) -> None:
+    assert advisory_data.list_existing_advisory_subdirs(tmp_path / "nope") == []
+
+
+def test_filter_content_by_existing_image(tmp_path: Path) -> None:
+    content = tmp_path / "c.json"
+    existing = tmp_path / "e.json"
+    content.write_text(
+        json.dumps(
+            [
+                {
+                    "containerImage": "q.io/i@sha256:a",
+                    "tags": ["t1"],
+                    "repository": "r1",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    existing.write_text(
+        json.dumps(
+            [
+                {
+                    "containerImage": "q.io/i@sha256:a",
+                    "tags": ["t1"],
+                    "repository": "r1",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    out = advisory_data.filter_content_by_existing(
+        "image", content, existing, stderr_path=None
+    )
+    assert json.loads(out) == []
+
+
+def test_filter_image_keeps_when_no_match(tmp_path: Path) -> None:
+    rows = [{"containerImage": "a", "tags": ["1"], "repository": "r"}]
+    content = tmp_path / "c.json"
+    existing = tmp_path / "e.json"
+    content.write_text(json.dumps(rows), encoding="utf-8")
+    existing.write_text(
+        json.dumps([{"containerImage": "b", "tags": ["1"], "repository": "r"}]),
+        encoding="utf-8",
+    )
+    out = advisory_data.filter_content_by_existing(
+        "image", content, existing, stderr_path=None
+    )
+    assert json.loads(out) == rows
+
+
+def test_filter_rpm_exact_purl(tmp_path: Path) -> None:
+    content = tmp_path / "c.json"
+    existing = tmp_path / "e.json"
+    p = "pkg:golang/example@1.0"
+    content.write_text(json.dumps([{"purl": p}]), encoding="utf-8")
+    existing.write_text(json.dumps([{"purl": p}]), encoding="utf-8")
+    out = advisory_data.filter_content_by_existing("rpm", content, existing, stderr_path=None)
+    assert json.loads(out) == []
+
+
+def test_filter_generic_strips_checksum_for_match(tmp_path: Path) -> None:
+    content = tmp_path / "c.json"
+    existing = tmp_path / "e.json"
+    content.write_text(
+        json.dumps([{"purl": "pkg:x?checksum=new123"}]),
+        encoding="utf-8",
+    )
+    existing.write_text(
+        json.dumps([{"purl": "pkg:x?checksum=old456"}]),
+        encoding="utf-8",
+    )
+    out = advisory_data.filter_content_by_existing(
+        "generic", content, existing, stderr_path=None
+    )
+    assert json.loads(out) == []
+
+
+def test_filter_invalid_json_appends_stderr(tmp_path: Path) -> None:
+    content = tmp_path / "c.json"
+    existing = tmp_path / "e.json"
+    content.write_text("not-json", encoding="utf-8")
+    existing.write_text("[]", encoding="utf-8")
+    err = tmp_path / "err.log"
+    with pytest.raises(json.JSONDecodeError):
+        advisory_data.filter_content_by_existing("image", content, existing, stderr_path=err)
+    assert "invalid JSON" in err.read_text(encoding="utf-8")
+
+
+def test_filter_requires_arrays(tmp_path: Path) -> None:
+    content = tmp_path / "c.json"
+    existing = tmp_path / "e.json"
+    content.write_text('"x"', encoding="utf-8")
+    existing.write_text("[]", encoding="utf-8")
+    with pytest.raises(TypeError, match="arrays"):
+        advisory_data.filter_content_by_existing("image", content, existing, stderr_path=None)
+
+
+def test_append_signing_key_to_content() -> None:
+    root = {"content": {"images": [{"a": 1}, {"b": 2}]}}
+    advisory_data.append_signing_key_to_content(root, ".content.images", "k1")
+    for row in root["content"]["images"]:
+        assert row["signingKey"] == "k1"
+
+
+def test_append_signing_key_skips_existing() -> None:
+    root = {
+        "content": {
+            "images": [
+                {"signingKey": "existing"},
+                {"signingKey": ""},
+                {"a": 1},
+            ]
+        }
+    }
+    advisory_data.append_signing_key_to_content(root, ".content.images", "k1")
+    assert root["content"]["images"][0]["signingKey"] == "existing"
+    assert root["content"]["images"][1]["signingKey"] == "k1"
+    assert root["content"]["images"][2]["signingKey"] == "k1"
+
+
+def test_filter_image_skips_non_dict_rows() -> None:
+    out = advisory_data._filter_image(
+        ["x", {"containerImage": "a", "tags": [], "repository": "r"}],
+        [],
+    )
+    assert len(out) == 1
+
+
+def test_filter_image_skips_non_dict_existing() -> None:
+    rows = [{"containerImage": "a", "tags": ["t"], "repository": "r"}]
+    out = advisory_data._filter_image(rows, ["bad", {"containerImage": "b"}])
+    assert out == rows
+
+
+def test_filter_rpm_skips_non_dict_and_keeps_unknown_purl() -> None:
+    out = advisory_data._filter_rpm(
+        ["x", {"purl": None}, {"purl": "pkg:a"}],
+        [{"purl": "pkg:b"}],
+    )
+    assert out == [{"purl": None}, {"purl": "pkg:a"}]
+
+
+def test_filter_generic_skips_invalid_rows() -> None:
+    out = advisory_data._filter_generic_binary(
+        ["x", {"purl": None}, {"purl": "pkg:new"}],
+        [{"purl": "pkg:base?checksum=1"}],
+    )
+    assert len(out) == 1
+
+
+def test_content_array_from_decoded_none_segment() -> None:
+    d = {"content": {"images": None}}
+    assert advisory_data.content_array_from_decoded(d, ".content.images") == []
+
+
+def test_set_decoded_content_array_bad_path() -> None:
+    with pytest.raises(ValueError, match="unsupported"):
+        advisory_data.set_decoded_content_array({}, ".bad.path", [])
+
+
+def test_load_advisory_yaml_empty_document(tmp_path: Path) -> None:
+    p = tmp_path / "empty.yaml"
+    p.write_text("", encoding="utf-8")
+    assert advisory_data.load_advisory_yaml(p) == {}
+
+
+def test_load_advisory_yaml_rejects_non_mapping(tmp_path: Path) -> None:
+    p = tmp_path / "list.yaml"
+    p.write_text("- a\n", encoding="utf-8")
+    with pytest.raises(TypeError, match="mapping"):
+        advisory_data.load_advisory_yaml(p)
+
+
+def test_spec_content_array_from_advisory_yaml_paths() -> None:
+    doc = {"spec": {"content": {"images": [{"i": 1}]}}}
+    assert advisory_data.spec_content_array_from_advisory_yaml(doc, ".content.images") == [
+        {"i": 1}
+    ]
+    assert advisory_data.spec_content_array_from_advisory_yaml({}, ".content.images") == []
+    bad = {"spec": "not-a-dict"}
+    assert advisory_data.spec_content_array_from_advisory_yaml(bad, ".content.images") == []
+    assert (
+        advisory_data.spec_content_array_from_advisory_yaml(
+            {"spec": {"content": []}}, ".content.images"
+        )
+        == []
+    )
+    assert (
+        advisory_data.spec_content_array_from_advisory_yaml(
+            {"spec": {"content": {}}}, ".content.images"
+        )
+        == []
+    )
+
+
+def test_get_advisory_spec_type_and_name_defaults() -> None:
+    assert advisory_data.get_advisory_spec_type({}) == ""
+    assert advisory_data.get_advisory_metadata_name({}) == ""
+
+
+def test_template_data_for_apply() -> None:
+    assert advisory_data.template_data_for_apply({"type": "RHSA"}) == {
+        "advisory": {"spec": {"type": "RHSA"}}
+    }
+
+
+def test_list_existing_advisory_subdirs_skips_files(tmp_path: Path) -> None:
+    base = tmp_path / "t"
+    (base / "2024").mkdir(parents=True)
+    (base / "2024" / "notadir.txt").write_text("x", encoding="utf-8")
+    (base / "file.txt").write_text("y", encoding="utf-8")
+    assert advisory_data.list_existing_advisory_subdirs(base) == []

--- a/scripts/python/helpers/test_http_client.py
+++ b/scripts/python/helpers/test_http_client.py
@@ -13,7 +13,7 @@ import http_client
 
 def test_retries_policy_defaults() -> None:
     """The shared retry config matches the module defaults."""
-    r = http_client._retries()
+    r = http_client._retries(allowed_methods=frozenset({"GET"}))
     assert r.total == 3
     assert r.connect == 3
     assert r.read == 3
@@ -22,6 +22,23 @@ def test_retries_policy_defaults() -> None:
     assert r.raise_on_status is False
     assert set(r.status_forcelist) == {500, 502, 503, 504}
     assert set(r.allowed_methods) == {"GET"}
+
+
+def test_retries_policy_post() -> None:
+    """POST sessions retry transient connection and 5xx HTTP errors."""
+    r = http_client._retries(allowed_methods=frozenset({"POST"}))
+    assert r.total == 3
+    assert set(r.allowed_methods) == {"POST"}
+    assert set(r.status_forcelist) == {500, 502, 503, 504}
+    assert r.raise_on_status is False
+
+
+def test_post_session_mounts_post_retry_adapter() -> None:
+    """`post_session` mounts an adapter that retries POST on transients."""
+    session = http_client.post_session()
+    adapter = session.adapters["https://"]
+    assert isinstance(adapter, HTTPAdapter)
+    assert set(adapter.max_retries.allowed_methods) == {"POST"}
 
 
 def test_get_session_mounts_retry_adapter() -> None:

--- a/scripts/python/helpers/test_internal_request.py
+++ b/scripts/python/helpers/test_internal_request.py
@@ -1,0 +1,19 @@
+"""Tests for `internal_request`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import internal_request
+
+
+def test_write_result_paths(tmp_path: Path) -> None:
+    pr_path = tmp_path / "pr"
+    tr_path = tmp_path / "tr"
+    internal_request.write_result_paths(
+        {"internal_pr_name": pr_path, "internal_task_run_name": tr_path},
+        pipeline_run_name="pr-123",
+        task_run_name="tr-456",
+    )
+    assert pr_path.read_text(encoding="utf-8") == "pr-123"
+    assert tr_path.read_text(encoding="utf-8") == "tr-456"

--- a/scripts/python/helpers/test_subprocess_cmd.py
+++ b/scripts/python/helpers/test_subprocess_cmd.py
@@ -1,0 +1,33 @@
+"""Tests for `subprocess_cmd`."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+import subprocess_cmd
+
+
+def test_run_cmd_captures_stdout() -> None:
+    out = subprocess_cmd.run_cmd(["echo", "hi"], check=True).stdout.strip()
+    assert out == "hi"
+
+
+def test_run_cmd_check_false(tmp_path) -> None:
+    r = subprocess_cmd.run_cmd(["false"], cwd=tmp_path, check=False)
+    assert r.returncode != 0
+
+
+def test_run_cmd_stderr_path_logs_failed_command(tmp_path) -> None:
+    log = tmp_path / "log.txt"
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess_cmd.run_cmd(["false"], stderr_path=log, check=True)
+    text = log.read_text(encoding="utf-8")
+    assert "command exited with failure" in text
+    assert "false" in text
+
+
+def test_run_cmd_stderr_path_on_success(tmp_path) -> None:
+    log = tmp_path / "log.txt"
+    subprocess_cmd.run_cmd(["echo", "ok"], stderr_path=log, check=True)
+    assert log.read_text(encoding="utf-8") == ""

--- a/scripts/python/helpers/test_tekton.py
+++ b/scripts/python/helpers/test_tekton.py
@@ -1,4 +1,4 @@
-"""Tests for the ``tekton`` helper module."""
+"""Tests for the `tekton` helper module."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ import tekton
 
 
 def test_check_step_error() -> None:
-    """``CheckStepError`` stores the human *action* and the underlying *cause*."""
+    """`CheckStepError` stores the human *action* and the underlying *cause*."""
     inner = KeyError("k")
     err = tekton.CheckStepError("step", inner)
     assert err.action == "step" and err.cause is inner
@@ -24,16 +24,19 @@ def test_result_text_from_exception_truncates() -> None:
     assert len(s) == 40
 
 
-def test_result_text_for_check_step_error_includes_action_and_cause() -> None:
-    """Result text includes the user-facing *action* and the cause string."""
+def test_write_failure_result_check_step_error(tmp_path: Path) -> None:
+    """`CheckStepError` uses its *action* in the result summary."""
     inner = ValueError("token request failed")
-    s = tekton.result_text_for_check_step_error(
+    result = tmp_path / "result.txt"
+    tekton.write_failure_result(
+        result,
         "check_embargoed_cves.py",
         tekton.CheckStepError("getting an OSIDB access token (HTTP request)", inner),
     )
-    assert "OSIDB access token" in s
-    assert "token request failed" in s
-    assert "Failed while" in s
+    text = result.read_text(encoding="utf-8")
+    assert "OSIDB access token" in text
+    assert "token request failed" in text
+    assert "Failed while" in text
 
 
 def test_subprocess_cmd_preview_for_tekton_result() -> None:
@@ -52,10 +55,26 @@ def test_subprocess_cmd_preview_for_string_cmd() -> None:
     assert s == "echo hi"
 
 
+def test_require_env_returns_stripped_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-empty values are returned with surrounding whitespace removed."""
+    monkeypatch.setenv("TASK_PARAM", "  value  ")
+    assert tekton.require_env("TASK_PARAM") == "value"
+
+
+def test_require_env_missing_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset or blank env values print the variable name and exit with code 1."""
+    buf = io.StringIO()
+    monkeypatch.delenv("MISSING_PARAM", raising=False)
+    with pytest.raises(SystemExit) as ex:
+        tekton.require_env("MISSING_PARAM", file=buf)
+    assert ex.value.code == 1
+    assert buf.getvalue().strip() == "MISSING_PARAM must be set"
+
+
 def test_result_paths_from_env_returns_in_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Each set env var yields a ``Path`` in the same order as the arguments."""
+    """Each set env var yields a `Path` in the same order as the arguments."""
     a = tmp_path / "a"
     b = tmp_path / "b"
     a.write_text("x", encoding="utf-8")
@@ -64,6 +83,31 @@ def test_result_paths_from_env_returns_in_order(
     monkeypatch.setenv("RESULT_EMBARGOED_CVES", str(b))
     one, two = tekton.result_paths_from_env("RESULT_RESULT", "RESULT_EMBARGOED_CVES")
     assert (one, two) == (a, b)
+
+
+def test_result_paths_from_env_one_missing_name_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single missing env var is named directly in the exit message."""
+    buf = io.StringIO()
+    monkeypatch.delenv("ONLY_MISSING", raising=False)
+    with pytest.raises(SystemExit) as ex:
+        tekton.result_paths_from_env("ONLY_MISSING", file=buf)
+    assert ex.value.code == 1
+    assert buf.getvalue().strip() == "ONLY_MISSING must be set"
+
+
+def test_result_paths_from_env_two_missing_names_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two missing env vars are joined with `and` in the exit message."""
+    buf = io.StringIO()
+    monkeypatch.delenv("A", raising=False)
+    monkeypatch.delenv("B", raising=False)
+    with pytest.raises(SystemExit) as ex:
+        tekton.result_paths_from_env("A", "B", file=buf)
+    assert ex.value.code == 1
+    assert "A and B must be set" in buf.getvalue()
 
 
 def test_result_paths_from_env_missing_exits(
@@ -99,3 +143,54 @@ def test_result_paths_from_env_no_names() -> None:
     """Calling `result_paths_from_env` with no var names is a programming error."""
     with pytest.raises(ValueError, match="at least one"):
         tekton.result_paths_from_env()
+
+
+def test_write_failure_result_truncates_long_text(tmp_path: Path) -> None:
+    """The written result body respects *max_total_len* and ends with `...`."""
+    result = tmp_path / "result.txt"
+    tekton.write_failure_result(
+        result,
+        "create_advisory.py",
+        ValueError("x"),
+        max_total_len=20,
+    )
+    text = result.read_text(encoding="utf-8")
+    assert len(text) == 20
+    assert text.endswith("...")
+
+
+def test_write_failure_result_appends_command_log(tmp_path: Path) -> None:
+    """The last *max_log_lines* from the command log are appended to the result."""
+    log = tmp_path / "log.txt"
+    log.write_text("line1\nline2\nline3\n", encoding="utf-8")
+    result = tmp_path / "result.txt"
+    tekton.write_failure_result(
+        result,
+        "create_advisory.py",
+        ValueError("bad input"),
+        command_log_path=log,
+        max_log_lines=2,
+    )
+    text = result.read_text(encoding="utf-8")
+    assert "bad input" in text
+    assert "line2" in text and "line3" in text
+    assert "line1" not in text
+
+
+def test_write_failure_result_redacts_command_log(tmp_path: Path) -> None:
+    """OAuth tokens in the command log are masked before writing the result."""
+    log = tmp_path / "log.txt"
+    log.write_text(
+        "fatal: https://oauth2:leaked@gitlab.com/g/r.git\n",
+        encoding="utf-8",
+    )
+    result = tmp_path / "result.txt"
+    tekton.write_failure_result(
+        result,
+        "create_advisory.py",
+        ValueError("failed"),
+        command_log_path=log,
+    )
+    text = result.read_text(encoding="utf-8")
+    assert "leaked" not in text
+    assert "oauth2:[REDACTED]@" in text

--- a/scripts/python/helpers/vcs/__init__.py
+++ b/scripts/python/helpers/vcs/__init__.py
@@ -1,0 +1,1 @@
+"""Version-control helpers (`git` and `gitlab` submodules)."""

--- a/scripts/python/helpers/vcs/git.py
+++ b/scripts/python/helpers/vcs/git.py
@@ -1,0 +1,172 @@
+"""Host-agnostic Git operations via GitPython."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import TypeVar
+
+import git
+from git.exc import GitCommandError
+
+_T = TypeVar("_T")
+
+
+def repository_workdir_name(repository_url: str) -> str:
+    """Directory name for *repository_url* (strip `.git` suffix)."""
+    base = Path(repository_url.rstrip("/")).name
+    if base.endswith(".git"):
+        return base[: -len(".git")]
+    return base
+
+
+def _append_git_stderr(stderr_path: Path | None, exc: BaseException) -> None:
+    # GitPython does not tee subprocess stderr to a file; append on failure only.
+    if stderr_path is None:
+        return
+    err = getattr(exc, "stderr", None)
+    if err is None:
+        err = str(exc)
+    if not str(err).strip():
+        return
+    safe_text = str(err)
+    # Git errors often echo clone URLs with embedded oauth2 / token credentials.
+    safe_text = re.sub(
+        r"https://([^/@\s:]+):([^@\s]+)@",
+        r"https://\1:[REDACTED]@",
+        safe_text,
+        flags=re.IGNORECASE,
+    )
+    with open(
+        stderr_path,
+        "a",
+        encoding="utf-8",
+        errors="replace",
+    ) as errf:
+        errf.write(f"\n{safe_text}\n")
+
+
+def _with_git_stderr(stderr_path: Path | None, action: Callable[[], _T]) -> _T:
+    try:
+        return action()
+    except GitCommandError as exc:
+        _append_git_stderr(stderr_path, exc)
+        raise
+
+
+def configure_git_global_user(name: str, email: str) -> None:
+    """Set `user.name` and `user.email` in the global Git config."""
+    git_global = git.Git()
+    git_global.config("--global", "user.name", name)
+    git_global.config("--global", "user.email", email)
+
+
+def clone(
+    parent_dir: Path,
+    clone_url: str,
+    *,
+    directory_name: str | None = None,
+    revision: str,
+    sparse_dirs: Sequence[str],
+    stderr_path: Path | None = None,
+) -> Path:
+    """
+    Shallow clone *clone_url* with sparse checkout of *sparse_dirs* at *revision*.
+    """
+    dir_name = directory_name or repository_workdir_name(clone_url)
+    repo_dir = parent_dir / dir_name
+
+    def _clone() -> Path:
+        git.Repo.clone_from(
+            clone_url,
+            str(repo_dir),
+            multi_options=[
+                "--filter=blob:none",
+                "--no-checkout",
+                "--depth",
+                "1",
+                "--branch",
+                revision,
+            ],
+        )
+        repo = git.Repo(repo_dir)
+        # Sparse paths must be set after clone metadata exists, before checkout.
+        repo.git.sparse_checkout("set", *sparse_dirs)
+        repo.git.checkout(revision)
+        return repo_dir
+
+    return _with_git_stderr(stderr_path, _clone)
+
+
+def origin_ls_tree_name_only(
+    repo_root: Path,
+    ref: str,
+    *,
+    stderr_path: Path | None,
+) -> str:
+    """Return `git ls-tree -r --name-only` stdout for *ref*."""
+
+    def _ls_tree() -> str:
+        return git.Repo(repo_root).git.ls_tree("-r", "--name-only", ref)
+
+    return _with_git_stderr(stderr_path, _ls_tree)
+
+
+def index_add_commit(
+    repo_root: Path,
+    relative_paths: Sequence[str],
+    message: str,
+    *,
+    stderr_path: Path | None,
+) -> None:
+    """Stage *relative_paths* and commit with *message*."""
+
+    def _commit() -> None:
+        repo = git.Repo(repo_root)
+        repo.index.add(list(relative_paths))
+        repo.index.commit(message)
+
+    _with_git_stderr(stderr_path, _commit)
+
+
+def push(
+    repo_root: Path,
+    branch: str,
+    *,
+    remote: str = "origin",
+    retries: int = 0,
+    stderr_path: Path | None = None,
+) -> None:
+    """
+    Push *branch* to *remote*.
+
+    On rejection, run `pull --rebase` and retry until *retries* recovery cycles
+    are exhausted, then raise `CalledProcessError`.
+    """
+    repo = git.Repo(repo_root)
+    attempt = 0
+    while True:
+        try:
+            remote_obj = getattr(repo.remotes, remote)
+            remote_obj.push(branch).raise_if_error()
+            return
+        except GitCommandError as push_error:
+            _append_git_stderr(stderr_path, push_error)
+            attempt += 1
+            try:
+                repo.git.pull("--rebase", remote, branch)
+            except GitCommandError as pull_error:
+                _append_git_stderr(stderr_path, pull_error)
+                raise
+            # After each failed push: increment counter, pull, then retry push.
+            # Stop and raise once `attempt` exceeds *retries*.
+            if attempt > retries:
+                code = getattr(push_error, "status", None)
+                if code is None:
+                    code = 1
+                raise subprocess.CalledProcessError(
+                    int(code),
+                    f"git push {remote}",
+                ) from push_error

--- a/scripts/python/helpers/vcs/gitlab.py
+++ b/scripts/python/helpers/vcs/gitlab.py
@@ -1,0 +1,104 @@
+"""GitLab-specific helpers (OAuth2 git auth, raw file URLs, sparse clone)."""
+
+from __future__ import annotations
+
+import atexit
+import os
+import stat
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import authentication
+
+from . import git
+
+DEFAULT_BRANCH = "main"
+
+
+@dataclass(frozen=True)
+class GitLabCredentials:
+    """GitLab host, token, and Git author identity for repository operations."""
+
+    gitlab_host: str
+    access_token: str
+    git_author_name: str
+    git_author_email: str
+    git_repo: str
+
+
+def read_credentials_from_mount(secret_mount: Path) -> GitLabCredentials:
+    """
+    Load credentials from *secret_mount*, where each field is a separate file:
+
+    `gitlab_host`, `gitlab_access_token`, `git_author_name`,
+    `git_author_email`, `git_repo`.
+    """
+    return GitLabCredentials(
+        gitlab_host=authentication.read_mounted_text(secret_mount, "gitlab_host"),
+        access_token=authentication.read_mounted_text(secret_mount, "gitlab_access_token"),
+        git_author_name=authentication.read_mounted_text(secret_mount, "git_author_name"),
+        git_author_email=authentication.read_mounted_text(secret_mount, "git_author_email"),
+        git_repo=authentication.read_mounted_text(secret_mount, "git_repo"),
+    )
+
+
+def export_env_for_image_helpers(credentials: GitLabCredentials) -> None:
+    """Set env vars some Git helpers in the task image expect."""
+    os.environ["GITLAB_HOST"] = credentials.gitlab_host
+    os.environ["ACCESS_TOKEN"] = credentials.access_token
+    os.environ["GIT_AUTHOR_NAME"] = credentials.git_author_name
+    os.environ["GIT_AUTHOR_EMAIL"] = credentials.git_author_email
+
+
+def configure_git_oauth2_auth(access_token: str) -> None:
+    """
+    Set process env so git HTTPS uses OAuth2 without embedding the token in URLs.
+
+    Installs a small `GIT_ASKPASS` helper for clone, fetch, and push in this
+    process. Call once before any GitLab git operations.
+    """
+    fd, path = tempfile.mkstemp(prefix="git-askpass-", suffix=".sh")
+    askpass = Path(path)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write('#!/bin/sh\nexec echo "$GITLAB_OAUTH2_TOKEN"\n')
+    askpass.chmod(askpass.stat().st_mode | stat.S_IXUSR)
+    atexit.register(lambda: askpass.unlink(missing_ok=True))
+    os.environ["GIT_TERMINAL_PROMPT"] = "0"
+    os.environ["GIT_ASKPASS"] = str(askpass)
+    os.environ["GITLAB_OAUTH2_TOKEN"] = access_token
+
+
+def raw_file_url(
+    git_repo: str,
+    repo_relative_path: str,
+    *,
+    branch: str = DEFAULT_BRANCH,
+) -> str:
+    """Return the GitLab `/-/raw/<branch>/<path>` URL for a file in the repo."""
+    return git_repo.replace(".git", "") + f"/-/raw/{branch}/{repo_relative_path}"
+
+
+def clone_project_sparse(
+    repository: str,
+    revision: str,
+    sparse_dirs: Sequence[str],
+    *,
+    parent_dir: Path,
+    stderr_path: Path | None,
+) -> Path:
+    """
+    Shallow sparse clone of a GitLab *repository* HTTPS URL.
+
+    Requires `configure_git_oauth2_auth()` in this process so git can
+    authenticate without a token embedded in the clone URL.
+    """
+    return git.clone(
+        parent_dir,
+        repository,
+        directory_name=git.repository_workdir_name(repository),
+        revision=revision,
+        sparse_dirs=sparse_dirs,
+        stderr_path=stderr_path,
+    )

--- a/scripts/python/helpers/vcs/test_git.py
+++ b/scripts/python/helpers/vcs/test_git.py
@@ -1,0 +1,220 @@
+"""Tests for `vcs.git`."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from git.exc import GitCommandError
+
+from . import git
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://gitlab.com/org/repo.git", "repo"),
+        ("https://gitlab.com/org/repo/", "repo"),
+        ("https://gitlab.com/org/repo.git/", "repo"),
+        ("https://gitlab.com/org/repo", "repo"),
+    ],
+)
+def test_repository_workdir_name(url: str, expected: str) -> None:
+    """Derive the clone directory name from a repository URL."""
+    assert git.repository_workdir_name(url) == expected
+
+
+def test_append_git_stderr_skips_when_path_none() -> None:
+    """Do nothing when no stderr log path is configured."""
+    git._append_git_stderr(None, GitCommandError(["git"], 1, "err"))
+
+
+def test_append_git_stderr_skips_empty_message(tmp_path: Path) -> None:
+    """Do not create a log file when the error message is blank."""
+    log = tmp_path / "log.txt"
+    git._append_git_stderr(log, Exception("   "))
+    assert not log.exists()
+
+
+def test_append_git_stderr_uses_str_when_no_stderr_attr(tmp_path: Path) -> None:
+    """Append `str(exc)` when the exception has no `stderr` attribute."""
+    log = tmp_path / "log.txt"
+    git._append_git_stderr(log, Exception("plain"))
+    assert "plain" in log.read_text(encoding="utf-8")
+
+
+def test_append_git_stderr_redacts_oauth2_url(tmp_path: Path) -> None:
+    """Mask oauth2 tokens embedded in clone URLs written to the stderr log."""
+    log = tmp_path / "log.txt"
+    git._append_git_stderr(
+        log,
+        GitCommandError(
+            ["git", "clone"],
+            1,
+            "fatal: https://oauth2:secret@gitlab.com/g/r.git",
+        ),
+    )
+    text = log.read_text(encoding="utf-8")
+    assert "secret" not in text
+    assert "oauth2:[REDACTED]@" in text
+
+
+def test_configure_git_global_user() -> None:
+    """Set global `user.name` and `user.email` via GitPython."""
+    with mock.patch("vcs.git.git.Git") as git_cls:
+        git.configure_git_global_user("Name", "e@x.com")
+    inst = git_cls.return_value
+    inst.config.assert_any_call("--global", "user.name", "Name")
+    inst.config.assert_any_call("--global", "user.email", "e@x.com")
+
+
+def test_clone_shallow_sparse(tmp_path: Path) -> None:
+    """Sparse-checkout clone checks out the requested revision."""
+    repo_dir = tmp_path / "proj"
+    mock_repo = mock.MagicMock()
+    with mock.patch("vcs.git.git.Repo") as repo_cls:
+        repo_cls.clone_from.return_value = mock_repo
+        repo_cls.return_value = mock_repo
+        out = git.clone(
+            tmp_path,
+            "https://x/proj.git",
+            directory_name="proj",
+            revision="main",
+            sparse_dirs=["schema"],
+        )
+    assert out == repo_dir
+    mock_repo.git.sparse_checkout.assert_called_once_with("set", "schema")
+    mock_repo.git.checkout.assert_called_once_with("main")
+
+
+def test_clone_appends_stderr(tmp_path: Path) -> None:
+    """Write clone failures to the optional stderr log file."""
+    log = tmp_path / "log.txt"
+    with mock.patch(
+        "vcs.git.git.Repo.clone_from", side_effect=GitCommandError(["git"], 1, "clone fail")
+    ):
+        with pytest.raises(GitCommandError):
+            git.clone(
+                tmp_path,
+                "https://x/p.git",
+                revision="main",
+                sparse_dirs=["a"],
+                stderr_path=log,
+            )
+    assert "clone fail" in log.read_text(encoding="utf-8")
+
+
+def test_origin_ls_tree_name_only(tmp_path: Path) -> None:
+    """Return `git ls-tree -r --name-only` output for a ref."""
+    mock_repo = mock.MagicMock()
+    mock_repo.git.ls_tree.return_value = "path/a\npath/b\n"
+    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
+        out = git.origin_ls_tree_name_only(tmp_path, "origin/main", stderr_path=None)
+    assert "path/a" in out
+
+
+def test_origin_ls_tree_logs_stderr(tmp_path: Path) -> None:
+    """Append `ls-tree` failures to the optional stderr log file."""
+    log = tmp_path / "log.txt"
+    with mock.patch("vcs.git.git.Repo") as repo_cls:
+        repo_cls.return_value.git.ls_tree.side_effect = GitCommandError(["git"], 1, "ls fail")
+        with pytest.raises(GitCommandError):
+            git.origin_ls_tree_name_only(tmp_path, "origin/main", stderr_path=log)
+    assert "ls fail" in log.read_text(encoding="utf-8")
+
+
+def test_index_add_commit(tmp_path: Path) -> None:
+    """Stage paths and commit without an explicit author."""
+    mock_repo = mock.MagicMock()
+    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
+        git.index_add_commit(tmp_path, ["a.yaml"], "msg", stderr_path=None)
+    mock_repo.index.add.assert_called_once_with(["a.yaml"])
+    mock_repo.index.commit.assert_called_once_with("msg")
+
+
+def test_index_add_commit_logs_stderr(tmp_path: Path) -> None:
+    """Append stage/commit failures to the optional stderr log file."""
+    log = tmp_path / "log.txt"
+    with mock.patch("vcs.git.git.Repo") as repo_cls:
+        repo_cls.return_value.index.add.side_effect = GitCommandError(["git"], 1, "add fail")
+        with pytest.raises(GitCommandError):
+            git.index_add_commit(tmp_path, ["a.yaml"], "msg", stderr_path=log)
+    assert "add fail" in log.read_text(encoding="utf-8")
+
+
+def test_push_success_first_try(tmp_path: Path) -> None:
+    """Return immediately when the first push succeeds."""
+    mock_repo = mock.MagicMock()
+    push_result = mock.MagicMock()
+    mock_repo.remotes.origin.push.return_value = push_result
+    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
+        git.push(tmp_path, "main", retries=2, stderr_path=None)
+    mock_repo.remotes.origin.push.assert_called_once_with("main")
+    push_result.raise_if_error.assert_called_once()
+
+
+def test_push_rejected_ref(tmp_path: Path) -> None:
+    """Push rejections that only set PushInfo flags must not look like success."""
+    err_log = tmp_path / "err.log"
+    mock_repo = mock.MagicMock()
+    push_result = mock.MagicMock()
+    push_result.raise_if_error.side_effect = GitCommandError(
+        ["git", "push", "origin"],
+        1,
+        "error: failed to push some refs",
+    )
+    mock_repo.remotes.origin.push.return_value = push_result
+    mock_repo.git.pull.return_value = ""
+
+    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
+        with pytest.raises(subprocess.CalledProcessError):
+            git.push(tmp_path, "main", retries=0, stderr_path=err_log)
+    push_result.raise_if_error.assert_called_once()
+    assert "failed to push" in err_log.read_text(encoding="utf-8")
+
+
+def test_push_raises_after_limit(tmp_path: Path) -> None:
+    """Raise `CalledProcessError` after pull/retry cycles are exhausted."""
+    err_log = tmp_path / "err.log"
+    mock_repo = mock.MagicMock()
+
+    def _fail_push(*_args: object, **_kwargs: object) -> None:
+        raise GitCommandError(["git", "push", "origin"], 1, "push failed")
+
+    mock_repo.remotes.origin.push.side_effect = _fail_push
+    mock_repo.git.pull.return_value = ""
+
+    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
+        with pytest.raises(subprocess.CalledProcessError):
+            git.push(tmp_path, "main", retries=1, stderr_path=err_log)
+    assert mock_repo.remotes.origin.push.call_count == 2
+    assert "push failed" in err_log.read_text(encoding="utf-8")
+
+
+def test_push_pull_failure_raises(tmp_path: Path) -> None:
+    """Re-raise when `pull --rebase` fails after a rejected push."""
+    log = tmp_path / "log.txt"
+    mock_repo = mock.MagicMock()
+    mock_repo.remotes.origin.push.side_effect = GitCommandError(["git", "push"], 1, "push")
+    mock_repo.git.pull.side_effect = GitCommandError(["git", "pull"], 1, "pull")
+
+    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
+        with pytest.raises(GitCommandError):
+            git.push(tmp_path, "main", retries=3, stderr_path=log)
+    assert "pull" in log.read_text(encoding="utf-8")
+
+
+def test_push_no_status_on_error(tmp_path: Path) -> None:
+    """Default to exit code 1 when GitPython omits `status` on push failure."""
+    mock_repo = mock.MagicMock()
+    err = GitCommandError(["git", "push"], 0, "push")
+    del err.status
+    mock_repo.remotes.origin.push.side_effect = err
+    mock_repo.git.pull.return_value = ""
+
+    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            git.push(tmp_path, "main", retries=0, stderr_path=None)
+    assert exc_info.value.returncode == 1

--- a/scripts/python/helpers/vcs/test_gitlab.py
+++ b/scripts/python/helpers/vcs/test_gitlab.py
@@ -1,0 +1,71 @@
+"""Tests for `vcs.gitlab`."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from . import git
+from . import gitlab
+
+
+def test_read_credentials_from_mount(tmp_path: Path) -> None:
+    secret = tmp_path / "secret"
+    secret.mkdir()
+    (secret / "gitlab_host").write_text("gitlab.example.com", encoding="utf-8")
+    (secret / "gitlab_access_token").write_text("tok", encoding="utf-8")
+    (secret / "git_author_name").write_text("Author", encoding="utf-8")
+    (secret / "git_author_email").write_text("a@example.com", encoding="utf-8")
+    (secret / "git_repo").write_text("https://gitlab.example.com/g/r.git", encoding="utf-8")
+    creds = gitlab.read_credentials_from_mount(secret)
+    assert creds.gitlab_host == "gitlab.example.com"
+    assert creds.access_token == "tok"
+    assert creds.git_repo.endswith("r.git")
+
+
+def test_export_env_for_image_helpers(tmp_path: Path) -> None:
+    secret = tmp_path / "secret"
+    secret.mkdir()
+    (secret / "gitlab_host").write_text("h", encoding="utf-8")
+    (secret / "gitlab_access_token").write_text("t", encoding="utf-8")
+    (secret / "git_author_name").write_text("n", encoding="utf-8")
+    (secret / "git_author_email").write_text("e", encoding="utf-8")
+    (secret / "git_repo").write_text("https://gitlab.example.com/g/r.git", encoding="utf-8")
+    creds = gitlab.read_credentials_from_mount(secret)
+    gitlab.export_env_for_image_helpers(creds)
+    assert os.environ["GITLAB_HOST"] == "h"
+    assert os.environ["ACCESS_TOKEN"] == "t"
+
+
+def test_raw_file_url() -> None:
+    url = gitlab.raw_file_url(
+        "https://gitlab.example.com/g/r.git",
+        "path/to/file.yaml",
+    )
+    assert url == "https://gitlab.example.com/g/r/-/raw/main/path/to/file.yaml"
+
+
+def test_configure_git_oauth2_auth_sets_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GIT_ASKPASS", raising=False)
+    gitlab.configure_git_oauth2_auth("my-token")
+    assert os.environ["GITLAB_OAUTH2_TOKEN"] == "my-token"
+    assert os.environ["GIT_TERMINAL_PROMPT"] == "0"
+    assert Path(os.environ["GIT_ASKPASS"]).is_file()
+
+
+def test_clone_project_sparse_delegates_to_git(tmp_path: Path) -> None:
+    with mock.patch.object(git, "clone", return_value=tmp_path / "repo") as m:
+        out = gitlab.clone_project_sparse(
+            "https://gitlab.example.com/g/r.git",
+            "main",
+            ["schema"],
+            parent_dir=tmp_path,
+            stderr_path=None,
+        )
+    assert out == tmp_path / "repo"
+    m.assert_called_once()
+    assert m.call_args.args[1] == "https://gitlab.example.com/g/r.git"
+    assert "oauth2:" not in m.call_args.args[1]

--- a/scripts/python/tasks/internal/check_embargoed_cves.py
+++ b/scripts/python/tasks/internal/check_embargoed_cves.py
@@ -292,9 +292,7 @@ def main(argv: list[str] | None = None) -> int:
     elif step_err is not None:
         # Exception on the way: which step and the original error; process
         # still exits 0 below.
-        rpath.write_text(
-            tekton.result_text_for_check_step_error(name, step_err), encoding="utf-8"
-        )
+        tekton.write_failure_result(rpath, name, step_err)
     # Task step must exit 0 or Tekton may not publish results; the catalog documents this.
     return 0
 

--- a/scripts/python/tasks/internal/create_advisory.py
+++ b/scripts/python/tasks/internal/create_advisory.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+"""Create advisory YAML under `data/advisories` in a Git repo (Tekton task).
+
+* Reads advisory credentials from `/mnt/advisory_secret` (or
+  `ADVISORY_SECRET_MOUNT`) and Errata credentials from `/mnt/errata_secret`
+  (or `ERRATA_SECRET_MOUNT`).
+* Reserves an Errata `live_id` when the decoded advisory JSON has no
+  `live_id`.
+* Writes task results from `RESULT_RESULT`, `RESULT_ADVISORY_URL`,
+  `RESULT_ADVISORY_INTERNAL_URL`, `RESULT_INTERNAL_REQUEST_PIPELINE_RUN_NAME`,
+  and `RESULT_INTERNAL_REQUEST_TASK_RUN_NAME`.
+* After a valid invocation with those env vars, always exits with status `0`;
+  success or failure is in the result files.
+* Missing env before result handling exits `1`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import advisory_data
+import apply_template
+import authentication
+import file
+import http_client
+import internal_request
+import requests
+import yaml
+import subprocess_cmd
+import tekton
+from jsonschema import ValidationError
+from jsonschema.validators import validator_for
+from requests_kerberos import OPTIONAL, HTTPKerberosAuth
+from vcs import git
+from vcs import gitlab
+
+PROG = "create_advisory.py"
+ADVISORY_TEMPLATE_PATH = Path("/home/templates/advisory.yaml.jinja")
+
+
+def _clone_advisory_repo(
+    credentials: gitlab.GitLabCredentials,
+    origin: str,
+    work_dir: Path,
+    *,
+    stderr_path: Path,
+) -> tuple[Path, Path]:
+    git.configure_git_global_user(
+        credentials.git_author_name,
+        credentials.git_author_email,
+    )
+    # Sparse checkout: only this tenant's advisories plus repo schema (for validation).
+    sparse_dirs = [f"data/advisories/{origin}", "schema"]
+    repo_root = gitlab.clone_project_sparse(
+        credentials.git_repo,
+        gitlab.DEFAULT_BRANCH,
+        sparse_dirs,
+        parent_dir=work_dir,
+        stderr_path=stderr_path,
+    )
+    advisory_base = repo_root / "data" / "advisories" / origin
+    return repo_root, advisory_base
+
+
+def _reserve_errata_live_id(
+    errata_api: str,
+    errata_mount: Path,
+    *,
+    stderr_path: Path | None,
+    krb5_template: Path = Path("/etc/krb5.conf"),
+    kinit_fn: Callable[..., None] = authentication.kinit_with_retry,
+) -> int:
+    """POST `reserve_live_id` with Negotiate auth after *kinit_fn*."""
+    # Errata secret mount uses `name` + `base64_keytab` keys (not the default filenames).
+    principal, keytab_bytes, _unused = authentication.load_service_account(
+        errata_mount,
+        (),
+        principal_file="name",
+        keytab_b64_file="base64_keytab",
+    )
+    # Keytab and credential cache live on disk only for the kinit + HTTP call window.
+    keytab_path = file.make_tempfile_path("keytab-", keytab_bytes)
+    ccache_fd, ccache_temp_path = tempfile.mkstemp()
+    os.close(ccache_fd)
+    ccache_path = Path(ccache_temp_path)
+    try:
+        krb5_template_source = krb5_template.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        keytab_path.unlink(missing_ok=True)
+        ccache_path.unlink(missing_ok=True)
+        raise tekton.CheckStepError("reading the Kerberos configuration", exc) from exc
+    # Pod krb5.conf may point at wrong KDC for Errata; patch before kinit.
+    krb5_config_path = file.make_tempfile_path(
+        "krb5-",
+        authentication.patch_krb5_config(krb5_template_source).encode("utf-8"),
+    )
+    kenv = {
+        "KRB5CCNAME": str(ccache_path),
+        "KRB5_CONFIG": str(krb5_config_path),
+        "KRB5_TRACE": "/dev/stderr",
+    }
+    try:
+        kinit_fn(principal, keytab_path, kenv, max_attempts=5)
+        # Propagate ccache + krb5 into the process; omit KRB5_TRACE (very noisy).
+        krb5_env_for_process = {
+            env_key: env_val for env_key, env_val in kenv.items() if env_key != "KRB5_TRACE"
+        }
+        os.environ.update(krb5_env_for_process)
+        reserve_live_id_url = f"{errata_api.rstrip('/')}/advisory/reserve_live_id"
+        session = http_client.post_session()
+        auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL)
+        try:
+            resp = session.post(reserve_live_id_url, auth=auth, timeout=120)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            if stderr_path is not None:
+                with open(
+                    stderr_path,
+                    "a",
+                    encoding="utf-8",
+                    errors="replace",
+                ) as errf:
+                    errf.write(f"\nreserve_live_id request failed: {exc!r}\n")
+            raise
+        data: dict[str, Any] = resp.json()
+        live_id_raw = data.get("live_id")
+        if live_id_raw is None:
+            msg = f"no live_id in response: {data!r}"
+            raise ValueError(msg)
+        return int(live_id_raw)
+    finally:
+        keytab_path.unlink(missing_ok=True)
+        ccache_path.unlink(missing_ok=True)
+        krb5_config_path.unlink(missing_ok=True)
+
+
+def _write_initial_content_file(
+    work_dir: Path,
+    decoded: dict[str, Any],
+    content_list_path: str,
+) -> Path:
+    # Mutable copy of spec content rows; idempotency filtering rewrites this file.
+    content_file = work_dir / "content.json"
+    decoded_content_rows = advisory_data.content_array_from_decoded(decoded, content_list_path)
+    content_file.write_text(
+        json.dumps(decoded_content_rows, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    return content_file
+
+
+def _customer_portal_url(url_prefix: str, errata_type: str, errata_name: str) -> str:
+    # Errata name is metadata.name or portal id "YYYY:NNNN" depending on caller path.
+    return f"{url_prefix}/{errata_type}-{errata_name}"
+
+
+def _write_success_results(
+    result_paths: dict[str, Path],
+    *,
+    customer_portal_url: str,
+    gitlab_raw_url: str,
+) -> None:
+    result_paths["result"].write_text("Success", encoding="utf-8")
+    result_paths["advisory_url"].write_text(customer_portal_url, encoding="utf-8")
+    result_paths["advisory_internal_url"].write_text(gitlab_raw_url, encoding="utf-8")
+
+
+def _finish_if_all_content_already_published(
+    *,
+    repo_root: Path,
+    advisory_base: Path,
+    content_file: Path,
+    content_list_path: str,
+    content_type: str,
+    git_repo: str,
+    url_prefix: str,
+    stderr_path: Path,
+    result_paths: dict[str, Path],
+) -> bool:
+    """
+    Walk existing advisories (newest first) and filter *content_file*.
+
+    Return True when every row was already published and success results were
+    written; False when a new advisory must be created.
+    """
+    # Side file holding the current advisory's content rows during each loop step.
+    existing_content = content_file.parent / "existing_content.json"
+    # Repo-relative path to the advisory that last removed rows from content_file.
+    latest_advisory_file: str | None = None
+
+    # Newest advisories first (by directory mtime). For each, drop rows already
+    # published there; stop early if nothing remains to release.
+    for year_num_subdir in advisory_data.list_existing_advisory_subdirs(advisory_base):
+        candidate_yaml = advisory_base / year_num_subdir / "advisory.yaml"
+        yaml_doc = advisory_data.load_advisory_yaml(candidate_yaml)
+        existing_rows = advisory_data.spec_content_array_from_advisory_yaml(
+            yaml_doc, content_list_path
+        )
+        existing_content.write_text(
+            json.dumps(existing_rows, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+
+        rows_before = len(json.loads(content_file.read_text(encoding="utf-8")))
+
+        # Compare row-by-row (image purl/tags, rpm nevra, etc.) via advisory_data helpers.
+        filtered = advisory_data.filter_content_by_existing(
+            content_type,
+            content_file,
+            existing_content,
+            stderr_path=stderr_path,
+        )
+        content_file.write_text(filtered + "\n", encoding="utf-8")
+
+        rows_after = len(json.loads(content_file.read_text(encoding="utf-8")))
+
+        if rows_before > rows_after and latest_advisory_file is None:
+            # Newest advisory that absorbed at least one of our rows — used for URLs
+            # when the release is a no-op (everything already shipped).
+            latest_advisory_file = str(candidate_yaml.relative_to(repo_root))
+
+        if rows_after == 0:
+            # All requested content already exists in a prior advisory; success without
+            # reserving a live_id or pushing a new directory.
+            if not latest_advisory_file:
+                msg = "all content matched but latest advisory path was not set"
+                raise RuntimeError(msg)
+            published_path = repo_root / latest_advisory_file
+            published_doc = advisory_data.load_advisory_yaml(published_path)
+            errata_type = advisory_data.get_advisory_spec_type(published_doc)
+            errata_name = advisory_data.get_advisory_metadata_name(published_doc)
+            _write_success_results(
+                result_paths,
+                customer_portal_url=_customer_portal_url(url_prefix, errata_type, errata_name),
+                gitlab_raw_url=gitlab.raw_file_url(git_repo, latest_advisory_file),
+            )
+            return True
+
+    return False
+
+
+def _build_merged_advisory_with_signing_key(
+    decoded: dict[str, Any],
+    content_file: Path,
+    content_list_path: str,
+    config_map_name: str,
+    *,
+    stderr_path: Path,
+) -> dict[str, Any]:
+    # Deep copy so we never mutate the `decoded` dict held by the caller.
+    merged = json.loads(json.dumps(decoded))
+    merged_content_rows = json.loads(content_file.read_text(encoding="utf-8"))
+    advisory_data.set_decoded_content_array(merged, content_list_path, merged_content_rows)
+    # Signing key name comes from cluster config; merged JSON is what the template sees.
+    signing_key = subprocess_cmd.run_cmd(
+        [
+            "kubectl",
+            "get",
+            "configmap",
+            config_map_name,
+            "-o",
+            "jsonpath={.data.SIG_KEY_NAME}",
+        ],
+        stderr_path=stderr_path,
+    ).stdout.strip()
+    if not signing_key:
+        msg = f"configmap {config_map_name!r} has no SIG_KEY_NAME data"
+        raise ValueError(msg)
+    # Only fill signingKey when a row does not already have one (see advisory_data).
+    advisory_data.append_signing_key_to_content(merged, content_list_path, signing_key)
+    return merged
+
+
+def _resolve_live_id_number(
+    decoded: dict[str, Any],
+    errata_mount: Path,
+    *,
+    stderr_path: Path,
+    krb5_template: Path,
+) -> int:
+    # Caller may pre-assign live_id; otherwise reserve the next number from Errata Tool.
+    live_id_param = decoded.get("live_id")
+    if live_id_param is None:
+        errata_api = authentication.read_mounted_text(errata_mount, "errata_api")
+        return _reserve_errata_live_id(
+            errata_api,
+            errata_mount,
+            stderr_path=stderr_path,
+            krb5_template=krb5_template,
+        )
+    return int(live_id_param)
+
+
+def _ensure_advisory_number_unused(
+    repo_root: Path,
+    year: str,
+    advisory_number_segment: str,
+    *,
+    stderr_path: Path,
+) -> None:
+    # Another pipeline may have pushed the same year/number.
+    # Sparse clone may not list every tenant path.
+    origin_main_tree = git.origin_ls_tree_name_only(
+        repo_root, "origin/main", stderr_path=stderr_path
+    )
+    duplicate_pattern = re.compile(rf"data/advisories/.*/{year}/{advisory_number_segment}/")
+    if any(duplicate_pattern.search(tree_line) for tree_line in origin_main_tree.splitlines()):
+        msg = f"An advisory with number {advisory_number_segment} already exists"
+        raise ValueError(msg)
+
+
+def _render_and_validate_advisory_yaml(
+    *,
+    repo_root: Path,
+    new_advisory_dir: Path,
+    merged: dict[str, Any],
+    portal_advisory_id: str,
+    ship_date: str,
+    work_dir: Path,
+    stderr_path: Path,
+) -> str:
+    """Apply the Jinja template, validate schema, return repo-relative YAML path."""
+    rendered_json_path = new_advisory_dir / "advisory.json"
+    new_advisory_yaml_path = new_advisory_dir / "advisory.yaml"
+
+    # Template expects a wrapped shape and portal id like "2025:1602" (year + live id).
+    wrapped_advisory = advisory_data.template_data_for_apply(merged)
+    template_variables = advisory_data.template_context_merge(
+        wrapped_advisory, portal_advisory_id, ship_date
+    )
+    apply_template.render_template_to_json_file(
+        rendered_json_path,
+        ADVISORY_TEMPLATE_PATH,
+        template_variables,
+        verbose=True,
+    )
+
+    # Repo stores advisory.yaml; render via JSON first so types match the template output.
+    templated_dict = json.loads(rendered_json_path.read_text(encoding="utf-8"))
+    new_advisory_yaml_path.write_text(
+        advisory_data.json_dict_to_yaml_text(templated_dict),
+        encoding="utf-8",
+    )
+
+    # Validate against schema/advisory.json (same as check-jsonschema --schemafile).
+    schema = json.loads((repo_root / "schema" / "advisory.json").read_text(encoding="utf-8"))
+    instance_doc = yaml.safe_load(new_advisory_yaml_path.read_text(encoding="utf-8"))
+    validator_cls = validator_for(schema)
+    validator_cls.check_schema(schema)
+    validator = validator_cls(schema)
+    try:
+        validator.validate(instance_doc)
+    except ValidationError as err:
+        message = f"{new_advisory_yaml_path.name}::{err.json_path}: {err.message}\n"
+        with open(stderr_path, "a", encoding="utf-8", errors="replace") as fh:
+            fh.write(message)
+        raise ValueError(f"schema validation failed for {new_advisory_yaml_path}") from err
+
+    return new_advisory_yaml_path.relative_to(repo_root).as_posix()
+
+
+def _commit_and_push_new_advisory(
+    repo_root: Path,
+    yaml_repo_path: str,
+    component_group: str,
+    *,
+    stderr_path: Path,
+) -> None:
+    git.index_add_commit(
+        repo_root,
+        [yaml_repo_path],
+        f"[Konflux Release] new advisory for {component_group}",
+        stderr_path=stderr_path,
+    )
+    # Rebase on push handles concurrent advisory commits to the same default branch.
+    git.push(
+        repo_root,
+        gitlab.DEFAULT_BRANCH,
+        retries=5,
+        stderr_path=stderr_path,
+    )
+
+
+def _create_new_advisory(
+    *,
+    credentials: gitlab.GitLabCredentials,
+    repo_root: Path,
+    advisory_base: Path,
+    merged: dict[str, Any],
+    decoded: dict[str, Any],
+    year: str,
+    advisory_number_segment: str,
+    portal_advisory_id: str,
+    ship_date: str,
+    url_prefix: str,
+    work_dir: Path,
+    stderr_path: Path,
+    result_paths: dict[str, Path],
+    params: dict[str, str],
+) -> None:
+    new_advisory_dir = advisory_base / year / advisory_number_segment
+    new_advisory_dir.mkdir(parents=True, exist_ok=True)
+
+    yaml_repo_path = _render_and_validate_advisory_yaml(
+        repo_root=repo_root,
+        new_advisory_dir=new_advisory_dir,
+        merged=merged,
+        portal_advisory_id=portal_advisory_id,
+        ship_date=ship_date,
+        work_dir=work_dir,
+        stderr_path=stderr_path,
+    )
+    _commit_and_push_new_advisory(
+        repo_root,
+        yaml_repo_path,
+        params["component_group"],
+        stderr_path=stderr_path,
+    )
+
+    advisory_type = str(decoded.get("type", ""))
+    _write_success_results(
+        result_paths,
+        customer_portal_url=_customer_portal_url(
+            url_prefix, advisory_type, portal_advisory_id
+        ),
+        gitlab_raw_url=gitlab.raw_file_url(credentials.git_repo, yaml_repo_path),
+    )
+
+
+def run_create_advisory(
+    *,
+    advisory_secret: Path,
+    errata_mount: Path,
+    stderr_path: Path,
+    result_paths: dict[str, Path],
+    params: dict[str, str],
+    decoded: dict[str, Any],
+    krb5_template: Path = Path("/etc/krb5.conf"),
+) -> None:
+    """Run the full workflow. Raises on failure; `main` maps exceptions to result files."""
+    credentials = gitlab.read_credentials_from_mount(advisory_secret)
+    # Internal-request child results are written before work begins so partial runs
+    # still expose pipeline/task run names to the parent.
+    internal_request.write_result_paths(
+        result_paths,
+        pipeline_run_name=params["internal_request_pr_name"],
+        task_run_name=params["task_run_name"],
+    )
+    gitlab.export_env_for_image_helpers(credentials)
+    gitlab.configure_git_oauth2_auth(credentials.access_token)
+
+    work_dir = Path(tempfile.mkdtemp(prefix="create-advisory-"))
+    try:
+        # Dotted path into decoded JSON / advisory YAML spec (e.g. `.content.images`).
+        content_list_path = advisory_data.spec_content_json_pointer(params["content_type"])
+        repo_root, advisory_base = _clone_advisory_repo(
+            credentials,
+            params["origin"],
+            work_dir,
+            stderr_path=stderr_path,
+        )
+        content_file = _write_initial_content_file(work_dir, decoded, content_list_path)
+
+        ship_date = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        year = ship_date.split("-", 1)[0]
+        url_prefix = advisory_data.advisory_url_prefix(credentials.git_repo)
+
+        # Idempotency: skip create when every content row is already on an advisory.
+        if _finish_if_all_content_already_published(
+            repo_root=repo_root,
+            advisory_base=advisory_base,
+            content_file=content_file,
+            content_list_path=content_list_path,
+            content_type=params["content_type"],
+            git_repo=credentials.git_repo,
+            url_prefix=url_prefix,
+            stderr_path=stderr_path,
+            result_paths=result_paths,
+        ):
+            return
+
+        merged = _build_merged_advisory_with_signing_key(
+            decoded,
+            content_file,
+            content_list_path,
+            params["config_map_name"],
+            stderr_path=stderr_path,
+        )
+        # Reserve only after idempotency check — avoids consuming Errata ids on no-ops.
+        live_num = _resolve_live_id_number(
+            decoded,
+            errata_mount,
+            stderr_path=stderr_path,
+            krb5_template=krb5_template,
+        )
+        # Directory name under data/advisories/<origin>/<year>/ (four-digit live id).
+        advisory_number_segment = f"{live_num:04d}"
+        _ensure_advisory_number_unused(
+            repo_root,
+            year,
+            advisory_number_segment,
+            stderr_path=stderr_path,
+        )
+        portal_advisory_id = f"{year}:{advisory_number_segment}"
+
+        _create_new_advisory(
+            credentials=credentials,
+            repo_root=repo_root,
+            advisory_base=advisory_base,
+            merged=merged,
+            decoded=decoded,
+            year=year,
+            advisory_number_segment=advisory_number_segment,
+            portal_advisory_id=portal_advisory_id,
+            ship_date=ship_date,
+            url_prefix=url_prefix,
+            work_dir=work_dir,
+            stderr_path=stderr_path,
+            result_paths=result_paths,
+            params=params,
+        )
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    (
+        path_step_result,
+        path_advisory_url,
+        path_advisory_internal_url,
+        path_internal_pr,
+        path_internal_task_run,
+    ) = tekton.result_paths_from_env(
+        "RESULT_RESULT",
+        "RESULT_ADVISORY_URL",
+        "RESULT_ADVISORY_INTERNAL_URL",
+        "RESULT_INTERNAL_REQUEST_PIPELINE_RUN_NAME",
+        "RESULT_INTERNAL_REQUEST_TASK_RUN_NAME",
+    )
+    result_paths = {
+        "result": path_step_result,
+        "advisory_url": path_advisory_url,
+        "advisory_internal_url": path_advisory_internal_url,
+        "internal_pr_name": path_internal_pr,
+        "internal_task_run_name": path_internal_task_run,
+    }
+
+    advisory_json = tekton.require_env("ADVISORY_JSON")
+    params = {
+        "component_group": tekton.require_env("PARAM_COMPONENT_GROUP"),
+        "origin": tekton.require_env("PARAM_ORIGIN"),
+        "config_map_name": tekton.require_env("PARAM_CONFIG_MAP_NAME"),
+        "content_type": os.environ.get("PARAM_CONTENT_TYPE", "image").strip(),
+        "internal_request_pr_name": tekton.require_env(
+            "PARAM_INTERNAL_REQUEST_PIPELINE_RUN_NAME"
+        ),
+        "task_run_name": tekton.require_env("PARAM_TASK_RUN_NAME"),
+    }
+
+    program_basename = str(Path((argv or sys.argv)[0]).name)
+    # Subprocess/git failures append here; on error the tail is copied into RESULT_RESULT.
+    command_log_path = Path("/tmp/create_advisory_command_log.txt")
+    command_log_path.write_text("", encoding="utf-8")
+
+    # Placeholders so error handlers can always overwrite URL result files.
+    path_advisory_url.write_text("", encoding="utf-8")
+    path_advisory_internal_url.write_text("", encoding="utf-8")
+
+    try:
+        # ADVISORY_JSON may be gzip+base64 from the parent pipeline (see advisory_data).
+        decoded = advisory_data.decode_advisory_param(advisory_json)
+        run_create_advisory(
+            advisory_secret=file.path_from_env_variable(
+                "ADVISORY_SECRET_MOUNT", "/mnt/advisory_secret"
+            ),
+            errata_mount=file.path_from_env_variable(
+                "ERRATA_SECRET_MOUNT", "/mnt/errata_secret"
+            ),
+            stderr_path=command_log_path,
+            result_paths=result_paths,
+            params=params,
+            decoded=decoded,
+        )
+    except Exception as e:
+        tekton.write_failure_result(
+            path_step_result,
+            program_basename,
+            e,
+            command_log_path=command_log_path,
+            workflow_action="running the advisory workflow",
+        )
+    # Tekton step succeeds; operators read failure detail from RESULT_RESULT.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/internal/test_create_advisory.py
+++ b/scripts/python/tasks/internal/test_create_advisory.py
@@ -1,0 +1,1287 @@
+"""Tests for `create_advisory`."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import requests
+import tekton
+
+import create_advisory
+from vcs import gitlab
+
+
+def _gzip_b64(obj: dict) -> str:
+    raw = json.dumps(obj).encode("utf-8")
+    return base64.standard_b64encode(gzip.compress(raw)).decode("ascii")
+
+
+def _write_errata_mount(d: Path) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "name").write_text("svc/test", encoding="utf-8")
+    (d / "base64_keytab").write_text(
+        base64.b64encode(b"x").decode("ascii"),
+        encoding="utf-8",
+    )
+    (d / "errata_api").write_text("https://errata/api/v1", encoding="utf-8")
+
+
+def _write_gitlab_secret(d: Path) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "gitlab_host").write_text("gitlab.example.com", encoding="utf-8")
+    (d / "gitlab_access_token").write_text("tok", encoding="utf-8")
+    (d / "git_author_name").write_text("Author", encoding="utf-8")
+    (d / "git_author_email").write_text("a@example.com", encoding="utf-8")
+    (d / "git_repo").write_text("https://gitlab.example.com/g/r.git", encoding="utf-8")
+
+
+def _minimal_schema() -> dict:
+    return {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["spec"],
+        "properties": {
+            "spec": {
+                "type": "object",
+                "required": ["type"],
+                "properties": {"type": {"type": "string", "enum": ["RHSA"]}},
+            }
+        },
+    }
+
+
+def _valid_advisory_yaml_dict() -> dict:
+    return {
+        "spec": {"type": "RHSA", "content": {"images": []}},
+        "metadata": {"name": "2025:0001"},
+    }
+
+
+@pytest.fixture
+def creds(tmp_path: Path) -> gitlab.GitLabCredentials:
+    secret = tmp_path / "gitlab"
+    _write_gitlab_secret(secret)
+    return gitlab.read_credentials_from_mount(secret)
+
+
+def test_reserve_errata_live_id_posts_json(tmp_path: Path) -> None:
+    mount = tmp_path / "errata"
+    _write_errata_mount(mount)
+    krb5 = tmp_path / "k5.conf"
+    krb5.write_text("[libdefaults]\n    default_realm = FOO\n", encoding="utf-8")
+
+    class _Resp:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"live_id": 42}
+
+    with mock.patch("create_advisory.http_client.post_session") as post_session:
+        sess = mock.MagicMock()
+        post_session.return_value = sess
+        sess.post.return_value = _Resp()
+        out = create_advisory._reserve_errata_live_id(
+            "https://errata/api/v1",
+            mount,
+            stderr_path=None,
+            krb5_template=krb5,
+            kinit_fn=lambda *_a, **_k: None,
+        )
+    assert out == 42
+
+
+def test_reserve_errata_live_id_krb5_read_error(tmp_path: Path) -> None:
+    mount = tmp_path / "errata"
+    _write_errata_mount(mount)
+    missing = tmp_path / "missing.conf"
+    with pytest.raises(tekton.CheckStepError, match="Kerberos"):
+        create_advisory._reserve_errata_live_id(
+            "https://errata/api/v1",
+            mount,
+            stderr_path=None,
+            krb5_template=missing,
+            kinit_fn=lambda *_a, **_k: None,
+        )
+
+
+def test_reserve_errata_live_id_request_failure_logs_stderr(tmp_path: Path) -> None:
+    mount = tmp_path / "errata"
+    _write_errata_mount(mount)
+    krb5 = tmp_path / "k5.conf"
+    krb5.write_text("[libdefaults]\n", encoding="utf-8")
+    log = tmp_path / "log.txt"
+
+    with mock.patch("create_advisory.http_client.post_session") as post_session:
+        sess = mock.MagicMock()
+        post_session.return_value = sess
+        sess.post.side_effect = requests.RequestException("net")
+        with pytest.raises(requests.RequestException):
+            create_advisory._reserve_errata_live_id(
+                "https://errata/api/v1",
+                mount,
+                stderr_path=log,
+                krb5_template=krb5,
+                kinit_fn=lambda *_a, **_k: None,
+            )
+    assert "reserve_live_id" in log.read_text(encoding="utf-8")
+
+
+def test_reserve_errata_live_id_missing_live_id(tmp_path: Path) -> None:
+    mount = tmp_path / "errata"
+    _write_errata_mount(mount)
+    krb5 = tmp_path / "k5.conf"
+    krb5.write_text("[libdefaults]\n", encoding="utf-8")
+
+    class _Resp:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {}
+
+    with mock.patch("create_advisory.http_client.post_session") as post_session:
+        sess = mock.MagicMock()
+        post_session.return_value = sess
+        sess.post.return_value = _Resp()
+        with pytest.raises(ValueError, match="no live_id"):
+            create_advisory._reserve_errata_live_id(
+                "https://errata/api/v1",
+                mount,
+                stderr_path=None,
+                krb5_template=krb5,
+                kinit_fn=lambda *_a, **_k: None,
+            )
+
+
+def test_clone_advisory_repo(tmp_path: Path, creds: gitlab.GitLabCredentials) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "data" / "advisories" / "tenant").mkdir(parents=True)
+    with mock.patch("create_advisory.gitlab.clone_project_sparse", return_value=repo):
+        root, base = create_advisory._clone_advisory_repo(
+            creds, "tenant", tmp_path, stderr_path=tmp_path / "e.log"
+        )
+    assert root == repo
+    assert base == repo / "data" / "advisories" / "tenant"
+
+
+def test_write_initial_content_file(tmp_path: Path) -> None:
+    decoded = {"content": {"images": [{"a": 1}]}}
+    path = create_advisory._write_initial_content_file(tmp_path, decoded, ".content.images")
+    assert json.loads(path.read_text(encoding="utf-8")) == [{"a": 1}]
+
+
+def test_customer_portal_url() -> None:
+    assert (
+        create_advisory._customer_portal_url(
+            "https://access.redhat.com/errata", "RHSA", "2025:1"
+        )
+        == "https://access.redhat.com/errata/RHSA-2025:1"
+    )
+
+
+def test_write_success_results(tmp_path: Path) -> None:
+    paths = {
+        "result": tmp_path / "r",
+        "advisory_url": tmp_path / "u",
+        "advisory_internal_url": tmp_path / "i",
+    }
+    create_advisory._write_success_results(
+        paths,
+        customer_portal_url="https://portal/x",
+        gitlab_raw_url="https://gitlab/raw",
+    )
+    assert paths["result"].read_text(encoding="utf-8") == "Success"
+    assert paths["advisory_url"].read_text(encoding="utf-8") == "https://portal/x"
+
+
+def test_finish_if_all_content_already_published_true(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    base = repo / "data" / "advisories" / "t" / "2025" / "0001"
+    base.mkdir(parents=True)
+    (base / "advisory.yaml").write_text(
+        "metadata:\n  name: '2025:0001'\nspec:\n  type: RHSA\n  content:\n"
+        "    images:\n      - containerImage: q.io/i\n        tags: ['t']\n"
+        "        repository: r\n",
+        encoding="utf-8",
+    )
+    work = tmp_path / "work"
+    work.mkdir()
+    content = work / "content.json"
+    content.write_text(
+        json.dumps([{"containerImage": "q.io/i", "tags": ["t"], "repository": "r"}]),
+        encoding="utf-8",
+    )
+    results = {
+        "result": tmp_path / "res",
+        "advisory_url": tmp_path / "url",
+        "advisory_internal_url": tmp_path / "internal",
+    }
+    assert create_advisory._finish_if_all_content_already_published(
+        repo_root=repo,
+        advisory_base=repo / "data" / "advisories" / "t",
+        content_file=content,
+        content_list_path=".content.images",
+        content_type="image",
+        git_repo="https://gitlab.example.com/g/r.git",
+        url_prefix="https://access.redhat.com/errata",
+        stderr_path=tmp_path / "e.log",
+        result_paths=results,
+    )
+    assert results["result"].read_text(encoding="utf-8") == "Success"
+
+
+def test_finish_if_all_content_already_published_false(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    base = repo / "data" / "advisories" / "t"
+    base.mkdir(parents=True)
+    work = tmp_path / "work"
+    work.mkdir()
+    content = work / "content.json"
+    content.write_text(json.dumps([{"containerImage": "new"}]), encoding="utf-8")
+    results = {
+        "result": tmp_path / "res",
+        "advisory_url": tmp_path / "url",
+        "advisory_internal_url": tmp_path / "internal",
+    }
+    assert not create_advisory._finish_if_all_content_already_published(
+        repo_root=repo,
+        advisory_base=base,
+        content_file=content,
+        content_list_path=".content.images",
+        content_type="image",
+        git_repo="https://gitlab.example.com/g/r.git",
+        url_prefix="https://access.redhat.com/errata",
+        stderr_path=tmp_path / "e.log",
+        result_paths=results,
+    )
+
+
+def test_finish_raises_when_no_latest_path(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    base = repo / "data" / "advisories" / "t" / "2025" / "0001"
+    base.mkdir(parents=True)
+    (base / "advisory.yaml").write_text(
+        "metadata:\n  name: n\nspec:\n  type: RHSA\n  content:\n    images: []\n",
+        encoding="utf-8",
+    )
+    work = tmp_path / "work"
+    work.mkdir()
+    content = work / "content.json"
+    content.write_text("[]", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="latest advisory path"):
+        create_advisory._finish_if_all_content_already_published(
+            repo_root=repo,
+            advisory_base=repo / "data" / "advisories" / "t",
+            content_file=content,
+            content_list_path=".content.images",
+            content_type="image",
+            git_repo="https://gitlab.example.com/g/r.git",
+            url_prefix="https://access.redhat.com/errata",
+            stderr_path=tmp_path / "e.log",
+            result_paths={
+                "result": tmp_path / "r",
+                "advisory_url": tmp_path / "u",
+                "advisory_internal_url": tmp_path / "i",
+            },
+        )
+
+
+def test_build_merged_advisory_with_signing_key(tmp_path: Path) -> None:
+    content = tmp_path / "c.json"
+    content.write_text(json.dumps([{"a": 1}]), encoding="utf-8")
+    decoded = {"type": "RHSA", "content": {"images": []}}
+    with mock.patch("create_advisory.subprocess_cmd.run_cmd") as run:
+        run.return_value = mock.MagicMock(stdout="key-name\n")
+        merged = create_advisory._build_merged_advisory_with_signing_key(
+            decoded, content, ".content.images", "cm", stderr_path=tmp_path / "e.log"
+        )
+    assert merged["content"]["images"][0]["signingKey"] == "key-name"
+
+
+def test_build_merged_advisory_with_signing_key_empty_fails(tmp_path: Path) -> None:
+    """Fail when the configmap has no SIG_KEY_NAME value."""
+    content = tmp_path / "c.json"
+    content.write_text(json.dumps([{"a": 1}]), encoding="utf-8")
+    decoded = {"type": "RHSA", "content": {"images": []}}
+    with mock.patch("create_advisory.subprocess_cmd.run_cmd") as run:
+        run.return_value = mock.MagicMock(stdout="  \n")
+        with pytest.raises(ValueError, match="SIG_KEY_NAME"):
+            create_advisory._build_merged_advisory_with_signing_key(
+                decoded, content, ".content.images", "cm", stderr_path=tmp_path / "e.log"
+            )
+
+
+def test_resolve_live_id_from_decoded() -> None:
+    assert (
+        create_advisory._resolve_live_id_number(
+            {"live_id": 7},
+            Path("/unused"),
+            stderr_path=Path("/dev/null"),
+            krb5_template=Path("/etc/krb5.conf"),
+        )
+        == 7
+    )
+
+
+def test_resolve_live_id_reserves(tmp_path: Path) -> None:
+    mount = tmp_path / "errata"
+    _write_errata_mount(mount)
+    with mock.patch("create_advisory._reserve_errata_live_id", return_value=99) as reserve:
+        out = create_advisory._resolve_live_id_number(
+            {},
+            mount,
+            stderr_path=tmp_path / "e.log",
+            krb5_template=tmp_path / "k5.conf",
+        )
+    assert out == 99
+    reserve.assert_called_once()
+
+
+def test_ensure_advisory_number_unused_raises(tmp_path: Path) -> None:
+    with mock.patch(
+        "create_advisory.git.origin_ls_tree_name_only",
+        return_value="data/advisories/t/2025/0042/advisory.yaml\n",
+    ):
+        with pytest.raises(ValueError, match="already exists"):
+            create_advisory._ensure_advisory_number_unused(
+                tmp_path, "2025", "0042", stderr_path=tmp_path / "e.log"
+            )
+
+
+def test_render_and_validate_advisory_yaml(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    schema_dir = repo / "schema"
+    schema_dir.mkdir(parents=True)
+    schema_path = schema_dir / "advisory.json"
+    schema_doc = _minimal_schema()
+    schema_doc["$id"] = schema_path.resolve().as_uri()
+    schema_path.write_text(json.dumps(schema_doc), encoding="utf-8")
+    new_dir = repo / "data" / "2025" / "0042"
+    new_dir.mkdir(parents=True)
+
+    def _fake_render(out_path: Path, _tpl: Path, _vars: dict, **_) -> None:
+        out_path.write_text(json.dumps(_valid_advisory_yaml_dict()), encoding="utf-8")
+
+    with mock.patch(
+        "create_advisory.apply_template.render_template_to_json_file",
+        side_effect=_fake_render,
+    ):
+        rel = create_advisory._render_and_validate_advisory_yaml(
+            repo_root=repo,
+            new_advisory_dir=new_dir,
+            merged={"type": "RHSA", "content": {"images": []}},
+            portal_advisory_id="2025:0042",
+            ship_date="2025-01-01T00:00:00Z",
+            work_dir=tmp_path,
+            stderr_path=tmp_path / "e.log",
+        )
+    assert rel == "data/2025/0042/advisory.yaml"
+    assert (new_dir / "advisory.yaml").is_file()
+
+
+def test_render_and_validate_schema_failure(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "schema").mkdir(parents=True)
+    (repo / "schema" / "advisory.json").write_text(
+        json.dumps(_minimal_schema()), encoding="utf-8"
+    )
+    new_dir = repo / "data" / "2025" / "0042"
+    new_dir.mkdir(parents=True)
+    log = tmp_path / "e.log"
+
+    def _bad_render(out_path: Path, _tpl: Path, _vars: dict, **_) -> None:
+        out_path.write_text(json.dumps({"spec": {"type": "WRONG"}}), encoding="utf-8")
+
+    with mock.patch(
+        "create_advisory.apply_template.render_template_to_json_file",
+        side_effect=_bad_render,
+    ):
+        with pytest.raises(ValueError, match="schema validation failed"):
+            create_advisory._render_and_validate_advisory_yaml(
+                repo_root=repo,
+                new_advisory_dir=new_dir,
+                merged={"type": "RHSA", "content": {"images": []}},
+                portal_advisory_id="2025:0042",
+                ship_date="2025-01-01T00:00:00Z",
+                work_dir=tmp_path,
+                stderr_path=log,
+            )
+    assert "advisory.yaml" in log.read_text(encoding="utf-8")
+
+
+def test_commit_and_push_new_advisory(tmp_path: Path) -> None:
+    with mock.patch("create_advisory.git.index_add_commit") as add:
+        with mock.patch("create_advisory.git.push") as push:
+            create_advisory._commit_and_push_new_advisory(
+                tmp_path, "path/y.yaml", "grp", stderr_path=tmp_path / "e.log"
+            )
+    add.assert_called_once()
+    push.assert_called_once()
+
+
+def test_create_new_advisory(tmp_path: Path, creds: gitlab.GitLabCredentials) -> None:
+    repo = tmp_path / "repo"
+    base = repo / "data" / "advisories" / "t"
+    base.mkdir(parents=True)
+    results = {
+        "result": tmp_path / "r",
+        "advisory_url": tmp_path / "u",
+        "advisory_internal_url": tmp_path / "i",
+    }
+    with mock.patch(
+        "create_advisory._render_and_validate_advisory_yaml",
+        return_value="data/2025/0042/advisory.yaml",
+    ):
+        with mock.patch("create_advisory._commit_and_push_new_advisory"):
+            create_advisory._create_new_advisory(
+                credentials=creds,
+                repo_root=repo,
+                advisory_base=base,
+                merged={"type": "RHSA", "content": {"images": []}},
+                decoded={"type": "RHSA"},
+                year="2025",
+                advisory_number_segment="0042",
+                portal_advisory_id="2025:0042",
+                ship_date="2025-01-01T00:00:00Z",
+                url_prefix="https://access.redhat.com/errata",
+                work_dir=tmp_path,
+                stderr_path=tmp_path / "e.log",
+                result_paths=results,
+                params={"component_group": "g"},
+            )
+    assert results["result"].read_text(encoding="utf-8") == "Success"
+
+
+def test_run_create_advisory_idempotent_early_return(
+    tmp_path: Path, creds: gitlab.GitLabCredentials
+) -> None:
+    secret = tmp_path / "gitlab"
+    _write_gitlab_secret(secret)
+    errata = tmp_path / "errata"
+    _write_errata_mount(errata)
+    results = {
+        "result": tmp_path / "r",
+        "advisory_url": tmp_path / "u",
+        "advisory_internal_url": tmp_path / "i",
+        "internal_pr_name": tmp_path / "pr",
+        "internal_task_run_name": tmp_path / "tr",
+    }
+    with mock.patch("create_advisory.gitlab.read_credentials_from_mount", return_value=creds):
+        with mock.patch(
+            "create_advisory._clone_advisory_repo",
+            return_value=(tmp_path / "repo", tmp_path / "repo" / "data" / "advisories" / "t"),
+        ):
+            with mock.patch(
+                "create_advisory._finish_if_all_content_already_published",
+                return_value=True,
+            ):
+                create_advisory.run_create_advisory(
+                    advisory_secret=secret,
+                    errata_mount=errata,
+                    stderr_path=tmp_path / "e.log",
+                    result_paths=results,
+                    params={
+                        "component_group": "g",
+                        "origin": "t",
+                        "config_map_name": "cm",
+                        "content_type": "image",
+                        "internal_request_pr_name": "pr",
+                        "task_run_name": "tr",
+                    },
+                    decoded={"content": {"images": [{"x": 1}]}},
+                )
+
+
+def test_run_create_advisory_full_create_path(
+    tmp_path: Path, creds: gitlab.GitLabCredentials
+) -> None:
+    secret = tmp_path / "gitlab"
+    _write_gitlab_secret(secret)
+    errata = tmp_path / "errata"
+    _write_errata_mount(errata)
+    repo = tmp_path / "repo"
+    (repo / "data" / "advisories" / "t").mkdir(parents=True)
+    results = {
+        "result": tmp_path / "r",
+        "advisory_url": tmp_path / "u",
+        "advisory_internal_url": tmp_path / "i",
+        "internal_pr_name": tmp_path / "pr",
+        "internal_task_run_name": tmp_path / "tr",
+    }
+    with mock.patch("create_advisory.gitlab.read_credentials_from_mount", return_value=creds):
+        with mock.patch(
+            "create_advisory._clone_advisory_repo",
+            return_value=(repo, repo / "data" / "advisories" / "t"),
+        ):
+            with mock.patch(
+                "create_advisory._finish_if_all_content_already_published",
+                return_value=False,
+            ):
+                with mock.patch(
+                    "create_advisory._build_merged_advisory_with_signing_key",
+                    return_value={"type": "RHSA", "content": {"images": []}},
+                ):
+                    with mock.patch(
+                        "create_advisory._resolve_live_id_number", return_value=42
+                    ):
+                        with mock.patch("create_advisory._ensure_advisory_number_unused"):
+                            with mock.patch("create_advisory._create_new_advisory") as create:
+                                create_advisory.run_create_advisory(
+                                    advisory_secret=secret,
+                                    errata_mount=errata,
+                                    stderr_path=tmp_path / "e.log",
+                                    result_paths=results,
+                                    params={
+                                        "component_group": "g",
+                                        "origin": "t",
+                                        "config_map_name": "cm",
+                                        "content_type": "image",
+                                        "internal_request_pr_name": "pr",
+                                        "task_run_name": "tr",
+                                    },
+                                    decoded={"type": "RHSA", "content": {"images": []}},
+                                )
+    create.assert_called_once()
+
+
+def _setup_main_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    paths = {
+        "RESULT_RESULT": tmp_path / "result.txt",
+        "RESULT_ADVISORY_URL": tmp_path / "url.txt",
+        "RESULT_ADVISORY_INTERNAL_URL": tmp_path / "internal.txt",
+        "RESULT_INTERNAL_REQUEST_PIPELINE_RUN_NAME": tmp_path / "pr.txt",
+        "RESULT_INTERNAL_REQUEST_TASK_RUN_NAME": tmp_path / "tr.txt",
+    }
+    for key, path in paths.items():
+        monkeypatch.setenv(key, str(path))
+        path.write_text("", encoding="utf-8")
+    monkeypatch.setenv("ADVISORY_JSON", _gzip_b64({"type": "RHSA", "content": {"images": []}}))
+    monkeypatch.setenv("PARAM_COMPONENT_GROUP", "g")
+    monkeypatch.setenv("PARAM_ORIGIN", "t")
+    monkeypatch.setenv("PARAM_CONFIG_MAP_NAME", "cm")
+    monkeypatch.setenv("PARAM_INTERNAL_REQUEST_PIPELINE_RUN_NAME", "parent-pr")
+    monkeypatch.setenv("PARAM_TASK_RUN_NAME", "task-run-1")
+    return paths
+
+
+def test_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_main_env(tmp_path, monkeypatch)
+    with mock.patch("create_advisory.run_create_advisory"):
+        assert create_advisory.main(["create_advisory.py"]) == 0
+
+
+def test_main_writes_failure_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths = _setup_main_env(tmp_path, monkeypatch)
+    with mock.patch(
+        "create_advisory.run_create_advisory",
+        side_effect=ValueError("workflow broke"),
+    ):
+        assert create_advisory.main(["create_advisory.py"]) == 0
+    text = paths["RESULT_RESULT"].read_text(encoding="utf-8")
+    assert "workflow broke" in text
+
+
+def test_main_check_step_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths = _setup_main_env(tmp_path, monkeypatch)
+    err = tekton.CheckStepError("reading secrets", OSError("no mount"))
+    with mock.patch("create_advisory.run_create_advisory", side_effect=err):
+        assert create_advisory.main(["create_advisory.py"]) == 0
+    assert "reading secrets" in paths["RESULT_RESULT"].read_text(encoding="utf-8")
+
+
+def _catalog_schema() -> dict:
+    """JSON schema matching the catalog Tekton mock (type and severity enums)."""
+    return {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["spec"],
+        "properties": {
+            "spec": {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["RHEA", "RHBA", "RHSA"],
+                    },
+                    "severity": {
+                        "type": "string",
+                        "enum": ["Critical", "Important", "Moderate", "Low"],
+                    },
+                },
+            }
+        },
+    }
+
+
+def _write_image_advisory_yaml(
+    path: Path,
+    *,
+    name: str,
+    images: list[dict],
+) -> None:
+    """Write a minimal advisory YAML with *images* under `spec.content.images`."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "metadata:\n"
+        f"  name: '{name}'\n"
+        "spec:\n"
+        "  type: RHSA\n"
+        "  content:\n"
+        "    images:\n"
+        + "".join(
+            f"      - containerImage: {row['containerImage']}\n"
+            f"        repository: {row['repository']}\n"
+            f"        tags: {json.dumps(row['tags'])}\n"
+            for row in images
+        ),
+        encoding="utf-8",
+    )
+
+
+def _idempotency_repo(tmp_path: Path, origin: str = "dev-tenant") -> tuple[Path, Path]:
+    """Build a repo tree with catalog idempotency advisories (1442, 1601, 1602)."""
+    repo = tmp_path / "repo"
+    base = repo / "data" / "advisories" / origin
+    _write_image_advisory_yaml(
+        base / "2024" / "1442" / "advisory.yaml",
+        name="2024:1442",
+        images=[
+            {
+                "containerImage": "quay.io/example/openstack@sha256:abde",
+                "repository": "quay.io/example/openstack",
+                "tags": ["v1.0", "latest"],
+            }
+        ],
+    )
+    _write_image_advisory_yaml(
+        base / "2025" / "1601" / "advisory.yaml",
+        name="2025:1601",
+        images=[
+            {
+                "containerImage": "quay.io/example/release@sha256:alpha123",
+                "repository": "example-stream/release",
+                "tags": ["v1.0", "latest"],
+            }
+        ],
+    )
+    _write_image_advisory_yaml(
+        base / "2025" / "1602" / "advisory.yaml",
+        name="2025:1602",
+        images=[
+            {
+                "containerImage": "quay.io/example/release@sha256:beta123",
+                "repository": "example-stream/release",
+                "tags": ["v2.0", "stable"],
+            }
+        ],
+    )
+    # Newest leaf mtime first (1602 > 1601 > 1442).
+    os.utime(base / "2024" / "1442", (1704012342.0, 1704012342.0))
+    os.utime(base / "2025" / "1601", (1712012344.0, 1712012344.0))
+    os.utime(base / "2025" / "1602", (1712012345.0, 1712012345.0))
+    return repo, base
+
+
+def test_finish_idempotency_single_image_returns_existing_url(tmp_path: Path) -> None:
+    """When the sole image is already published, return that advisory's portal URL."""
+    repo, base = _idempotency_repo(tmp_path)
+    work = tmp_path / "work"
+    work.mkdir()
+    content = work / "content.json"
+    content.write_text(
+        json.dumps(
+            [
+                {
+                    "containerImage": "quay.io/example/openstack@sha256:abde",
+                    "repository": "quay.io/example/openstack",
+                    "tags": ["v1.0", "latest"],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    results = {
+        "result": tmp_path / "res",
+        "advisory_url": tmp_path / "url",
+        "advisory_internal_url": tmp_path / "internal",
+    }
+    assert create_advisory._finish_if_all_content_already_published(
+        repo_root=repo,
+        advisory_base=base,
+        content_file=content,
+        content_list_path=".content.images",
+        content_type="image",
+        git_repo="https://gitlab.example.com/g/r.git",
+        url_prefix="https://access.redhat.com/errata",
+        stderr_path=tmp_path / "e.log",
+        result_paths=results,
+    )
+    assert results["advisory_url"].read_text(encoding="utf-8") == (
+        "https://access.redhat.com/errata/RHSA-2024:1442"
+    )
+
+
+def test_finish_all_images_returns_latest_advisory_url(tmp_path: Path) -> None:
+    """When all images match existing advisories, pick the newest advisory URL."""
+    repo, base = _idempotency_repo(tmp_path)
+    work = tmp_path / "work"
+    work.mkdir()
+    content = work / "content.json"
+    content.write_text(
+        json.dumps(
+            [
+                {
+                    "containerImage": "quay.io/example/release@sha256:alpha123",
+                    "repository": "example-stream/release",
+                    "tags": ["v1.0", "latest"],
+                },
+                {
+                    "containerImage": "quay.io/example/release@sha256:beta123",
+                    "repository": "example-stream/release",
+                    "tags": ["v2.0", "stable"],
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    results = {
+        "result": tmp_path / "res",
+        "advisory_url": tmp_path / "url",
+        "advisory_internal_url": tmp_path / "internal",
+    }
+    assert create_advisory._finish_if_all_content_already_published(
+        repo_root=repo,
+        advisory_base=base,
+        content_file=content,
+        content_list_path=".content.images",
+        content_type="image",
+        git_repo="https://gitlab.example.com/g/r.git",
+        url_prefix="https://access.redhat.com/errata",
+        stderr_path=tmp_path / "e.log",
+        result_paths=results,
+    )
+    assert results["advisory_url"].read_text(encoding="utf-8") == (
+        "https://access.redhat.com/errata/RHSA-2025:1602"
+    )
+
+
+def test_run_create_advisory_partial_idempotency_creates_new(
+    tmp_path: Path, creds: gitlab.GitLabCredentials
+) -> None:
+    """Filter out published images and create a new advisory for the remainder."""
+    secret = tmp_path / "gitlab"
+    _write_gitlab_secret(secret)
+    errata = tmp_path / "errata"
+    _write_errata_mount(errata)
+    repo, base = _idempotency_repo(tmp_path)
+    results = {
+        "result": tmp_path / "r",
+        "advisory_url": tmp_path / "u",
+        "advisory_internal_url": tmp_path / "i",
+        "internal_pr_name": tmp_path / "pr",
+        "internal_task_run_name": tmp_path / "tr",
+    }
+    decoded = {
+        "type": "RHSA",
+        "content": {
+            "images": [
+                {
+                    "containerImage": "quay.io/example/openstack@sha256:abde",
+                    "repository": "quay.io/example/openstack",
+                    "tags": ["v1.0", "latest"],
+                },
+                {
+                    "containerImage": "quay.io/example/release@sha256:alpha123",
+                    "repository": "example-stream/release",
+                    "tags": ["v1.0", "latest"],
+                },
+                {
+                    "containerImage": "quay.io/example/openstack@sha256:NEW",
+                    "repository": "rhosp16-rhel8/openstack",
+                    "tags": ["latest"],
+                },
+            ]
+        },
+    }
+    with mock.patch("create_advisory.gitlab.read_credentials_from_mount", return_value=creds):
+        with mock.patch(
+            "create_advisory._clone_advisory_repo",
+            return_value=(repo, base),
+        ):
+            with mock.patch(
+                "create_advisory.subprocess_cmd.run_cmd",
+                return_value=mock.MagicMock(stdout="key1\n"),
+            ):
+                with mock.patch("create_advisory._resolve_live_id_number", return_value=1234):
+                    with mock.patch("create_advisory._ensure_advisory_number_unused"):
+                        with mock.patch("create_advisory._create_new_advisory") as create:
+                            create_advisory.run_create_advisory(
+                                advisory_secret=secret,
+                                errata_mount=errata,
+                                stderr_path=tmp_path / "e.log",
+                                result_paths=results,
+                                params={
+                                    "component_group": "g",
+                                    "origin": "dev-tenant",
+                                    "config_map_name": "cm",
+                                    "content_type": "image",
+                                    "internal_request_pr_name": "pr",
+                                    "task_run_name": "tr",
+                                },
+                                decoded=decoded,
+                            )
+    merged_arg = create.call_args.kwargs["merged"]
+    assert len(merged_arg["content"]["images"]) == 1
+    assert "NEW" in merged_arg["content"]["images"][0]["containerImage"]
+    create.assert_called_once()
+
+
+def test_run_create_advisory_clone_failure(
+    tmp_path: Path, creds: gitlab.GitLabCredentials
+) -> None:
+    """A sparse-clone failure propagates from `run_create_advisory`."""
+    secret = tmp_path / "gitlab"
+    _write_gitlab_secret(secret)
+    errata = tmp_path / "errata"
+    _write_errata_mount(errata)
+    import git as gitpython
+
+    with mock.patch("create_advisory.gitlab.read_credentials_from_mount", return_value=creds):
+        with mock.patch(
+            "create_advisory._clone_advisory_repo",
+            side_effect=gitpython.exc.GitCommandError("clone", "failing-tenant"),
+        ):
+            with pytest.raises(gitpython.exc.GitCommandError):
+                create_advisory.run_create_advisory(
+                    advisory_secret=secret,
+                    errata_mount=errata,
+                    stderr_path=tmp_path / "e.log",
+                    result_paths={
+                        "result": tmp_path / "r",
+                        "advisory_url": tmp_path / "u",
+                        "advisory_internal_url": tmp_path / "i",
+                        "internal_pr_name": tmp_path / "pr",
+                        "internal_task_run_name": tmp_path / "tr",
+                    },
+                    params={
+                        "component_group": "g",
+                        "origin": "failing-tenant",
+                        "config_map_name": "cm",
+                        "content_type": "image",
+                        "internal_request_pr_name": "pr",
+                        "task_run_name": "tr",
+                    },
+                    decoded={"type": "RHSA", "content": {"images": []}},
+                )
+
+
+def test_render_schema_failure_wrong_type_and_severity(tmp_path: Path) -> None:
+    """Invalid `type` / `severity` values fail schema validation with stderr detail."""
+    repo = tmp_path / "repo"
+    schema_path = repo / "schema" / "advisory.json"
+    schema_path.parent.mkdir(parents=True)
+    schema_doc = _catalog_schema()
+    schema_doc["$id"] = schema_path.resolve().as_uri()
+    schema_path.write_text(json.dumps(schema_doc), encoding="utf-8")
+    new_dir = repo / "data" / "2025" / "0042"
+    new_dir.mkdir(parents=True)
+    log = tmp_path / "e.log"
+
+    def _bad_render(out_path: Path, _tpl: Path, _vars: dict, **_) -> None:
+        out_path.write_text(
+            json.dumps({"spec": {"type": "wrongType", "severity": "wrongSeverity"}}),
+            encoding="utf-8",
+        )
+
+    with mock.patch(
+        "create_advisory.apply_template.render_template_to_json_file",
+        side_effect=_bad_render,
+    ):
+        with pytest.raises(ValueError, match="schema validation failed"):
+            create_advisory._render_and_validate_advisory_yaml(
+                repo_root=repo,
+                new_advisory_dir=new_dir,
+                merged={"type": "RHSA", "content": {"images": []}},
+                portal_advisory_id="2025:0042",
+                ship_date="2025-01-01T00:00:00Z",
+                work_dir=tmp_path,
+                stderr_path=log,
+            )
+    log_text = log.read_text(encoding="utf-8")
+    assert "wrongType" in log_text or "type" in log_text
+
+
+def test_create_new_advisory_stage_portal_url(
+    tmp_path: Path,
+) -> None:
+    """`rhtap-release` repos use the staging customer portal errata URL prefix."""
+    secret = tmp_path / "gitlab"
+    _write_gitlab_secret(secret)
+    secret.joinpath("git_repo").write_text(
+        "https://gitlab.com/rhtap-release/repo.git",
+        encoding="utf-8",
+    )
+    creds = gitlab.read_credentials_from_mount(secret)
+    repo = tmp_path / "repo"
+    base = repo / "data" / "advisories" / "t"
+    base.mkdir(parents=True)
+    results = {
+        "result": tmp_path / "r",
+        "advisory_url": tmp_path / "u",
+        "advisory_internal_url": tmp_path / "i",
+    }
+    with mock.patch(
+        "create_advisory._render_and_validate_advisory_yaml",
+        return_value="data/2025/0042/advisory.yaml",
+    ):
+        with mock.patch("create_advisory._commit_and_push_new_advisory"):
+            create_advisory._create_new_advisory(
+                credentials=creds,
+                repo_root=repo,
+                advisory_base=base,
+                merged={"type": "RHSA", "content": {"images": []}},
+                decoded={"type": "RHSA"},
+                year="2025",
+                advisory_number_segment="0042",
+                portal_advisory_id="2025:0042",
+                ship_date="2025-01-01T00:00:00Z",
+                url_prefix="https://access.stage.redhat.com/errata",
+                work_dir=tmp_path,
+                stderr_path=tmp_path / "e.log",
+                result_paths=results,
+                params={"component_group": "g"},
+            )
+    assert results["advisory_url"].read_text(encoding="utf-8") == (
+        "https://access.stage.redhat.com/errata/RHSA-2025:0042"
+    )
+
+
+def test_create_new_advisory_custom_live_id_portal_url(
+    tmp_path: Path, creds: gitlab.GitLabCredentials
+) -> None:
+    """A pre-assigned `live_id` is reflected in the portal URL (e.g. `:0999`)."""
+    repo = tmp_path / "repo"
+    base = repo / "data" / "advisories" / "t"
+    base.mkdir(parents=True)
+    results = {
+        "result": tmp_path / "r",
+        "advisory_url": tmp_path / "u",
+        "advisory_internal_url": tmp_path / "i",
+    }
+    with mock.patch(
+        "create_advisory._render_and_validate_advisory_yaml",
+        return_value="data/2025/0999/advisory.yaml",
+    ):
+        with mock.patch("create_advisory._commit_and_push_new_advisory"):
+            create_advisory._create_new_advisory(
+                credentials=creds,
+                repo_root=repo,
+                advisory_base=base,
+                merged={"type": "RHSA", "content": {"images": []}},
+                decoded={"type": "RHSA", "live_id": 999},
+                year="2025",
+                advisory_number_segment="0999",
+                portal_advisory_id="2025:0999",
+                ship_date="2025-01-01T00:00:00Z",
+                url_prefix="https://access.redhat.com/errata",
+                work_dir=tmp_path,
+                stderr_path=tmp_path / "e.log",
+                result_paths=results,
+                params={"component_group": "g"},
+            )
+    assert results["advisory_url"].read_text(encoding="utf-8") == (
+        "https://access.redhat.com/errata/RHSA-2025:0999"
+    )
+
+
+def test_render_preserves_tags_and_product_version(tmp_path: Path) -> None:
+    """JSON-to-YAML keeps string tags and `product_version` like `1.20` intact."""
+    repo = tmp_path / "repo"
+    schema_path = repo / "schema" / "advisory.json"
+    schema_path.parent.mkdir(parents=True)
+    schema_doc = _catalog_schema()
+    schema_doc["$id"] = schema_path.resolve().as_uri()
+    schema_path.write_text(json.dumps(schema_doc), encoding="utf-8")
+    new_dir = repo / "data" / "2025" / "0001"
+    new_dir.mkdir(parents=True)
+    template = Path(__file__).resolve().parents[4] / "templates" / "advisory.yaml.jinja"
+    merged = {
+        "product_id": 123,
+        "product_name": "preserves data",
+        "product_version": "1.20",
+        "product_stream": "preserver-data-1.20",
+        "cpe": "cpe:/a:test:product",
+        "type": "RHEA",
+        "synopsis": "Test synopsis",
+        "topic": "Test topic",
+        "description": "Test description",
+        "solution": "Test solution",
+        "references": ["https://example.com"],
+        "content": {
+            "images": [
+                {
+                    "containerImage": "quay.io/example/image@sha256:abc123",
+                    "repository": "example/repo",
+                    "tags": ["33158e1", "1.0.0", "latest", "v2.0e10"],
+                }
+            ]
+        },
+    }
+    with mock.patch.object(create_advisory, "ADVISORY_TEMPLATE_PATH", template):
+        create_advisory._render_and_validate_advisory_yaml(
+            repo_root=repo,
+            new_advisory_dir=new_dir,
+            merged=merged,
+            portal_advisory_id="2025:0001",
+            ship_date="2025-01-01T00:00:00Z",
+            work_dir=tmp_path,
+            stderr_path=tmp_path / "e.log",
+        )
+    import yaml
+
+    doc = yaml.safe_load((new_dir / "advisory.yaml").read_text(encoding="utf-8"))
+    assert doc["spec"]["product_version"] == "1.20"
+    assert doc["spec"]["product_stream"] == "preserver-data-1.20"
+    assert doc["spec"]["content"]["images"][0]["tags"] == [
+        "33158e1",
+        "1.0.0",
+        "latest",
+        "v2.0e10",
+    ]
+
+
+def test_render_jinja_cross_field_references(tmp_path: Path) -> None:
+    """Jinja in synopsis/topic/description resolves other `advisory.spec` fields."""
+    repo = tmp_path / "repo"
+    schema_path = repo / "schema" / "advisory.json"
+    schema_path.parent.mkdir(parents=True)
+    schema_doc = _catalog_schema()
+    schema_doc["$id"] = schema_path.resolve().as_uri()
+    schema_path.write_text(json.dumps(schema_doc), encoding="utf-8")
+    new_dir = repo / "data" / "2025" / "0001"
+    new_dir.mkdir(parents=True)
+    template = Path(__file__).resolve().parents[4] / "templates" / "advisory.yaml.jinja"
+    merged = {
+        "product_id": 123,
+        "product_name": "Red Hat Product",
+        "product_version": "9.0.1",
+        "product_stream": "tp1",
+        "cpe": "cpe:/a:example:product:el8",
+        "type": "RHSA",
+        "severity": "Moderate",
+        "synopsis": (
+            "{% set version_str = advisory.spec.product_version | string() %}"
+            "{% set major = version_str.split('.')[0] %}"
+            "{% if advisory.spec.type == 'RHSA' %}"
+            "{{ advisory.spec.severity }}: RHEL {{ major }} security update"
+            "{% else %}RHEL {{ major }} bug fix update{% endif %}"
+        ),
+        "topic": (
+            "Updated {{ advisory.spec.product_name }} "
+            "{{ advisory.spec.product_version }} available"
+        ),
+        "description": (
+            "Security update for {{ advisory.spec.product_name }} "
+            "for advisory {{ advisory_name }}"
+        ),
+        "solution": "Update your containers",
+        "references": ["https://docs.example.com/notes"],
+        "content": {"images": [{"containerImage": "q.io/i", "tags": ["latest"]}]},
+    }
+    with mock.patch.object(create_advisory, "ADVISORY_TEMPLATE_PATH", template):
+        create_advisory._render_and_validate_advisory_yaml(
+            repo_root=repo,
+            new_advisory_dir=new_dir,
+            merged=merged,
+            portal_advisory_id="2025:0001",
+            ship_date="2025-01-01T00:00:00Z",
+            work_dir=tmp_path,
+            stderr_path=tmp_path / "e.log",
+        )
+    import yaml
+
+    doc = yaml.safe_load((new_dir / "advisory.yaml").read_text(encoding="utf-8"))
+    assert doc["spec"]["synopsis"] == "Moderate: RHEL 9 security update"
+    assert doc["spec"]["topic"] == "Updated Red Hat Product 9.0.1 available"
+    assert "Red Hat Product" in doc["spec"]["description"]
+    assert "2025:0001" in doc["spec"]["description"]
+
+
+def test_run_create_advisory_generic_content_type(
+    tmp_path: Path, creds: gitlab.GitLabCredentials
+) -> None:
+    """`content_type=generic` uses the `.content.artifacts` content list path."""
+    secret = tmp_path / "gitlab"
+    _write_gitlab_secret(secret)
+    errata = tmp_path / "errata"
+    _write_errata_mount(errata)
+    repo = tmp_path / "repo"
+    (repo / "data" / "advisories" / "t").mkdir(parents=True)
+    results = {
+        "result": tmp_path / "r",
+        "advisory_url": tmp_path / "u",
+        "advisory_internal_url": tmp_path / "i",
+        "internal_pr_name": tmp_path / "pr",
+        "internal_task_run_name": tmp_path / "tr",
+    }
+    decoded = {
+        "type": "RHSA",
+        "content": {"artifacts": [{"purl": "pkg:generic/example@1"}]},
+    }
+    with mock.patch("create_advisory.gitlab.read_credentials_from_mount", return_value=creds):
+        with mock.patch(
+            "create_advisory._clone_advisory_repo",
+            return_value=(repo, repo / "data" / "advisories" / "t"),
+        ):
+            with mock.patch(
+                "create_advisory._finish_if_all_content_already_published",
+                return_value=False,
+            ):
+                with mock.patch(
+                    "create_advisory._build_merged_advisory_with_signing_key",
+                    return_value=decoded,
+                ) as build:
+                    with mock.patch(
+                        "create_advisory._resolve_live_id_number", return_value=1234
+                    ):
+                        with mock.patch("create_advisory._ensure_advisory_number_unused"):
+                            with mock.patch("create_advisory._create_new_advisory"):
+                                create_advisory.run_create_advisory(
+                                    advisory_secret=secret,
+                                    errata_mount=errata,
+                                    stderr_path=tmp_path / "e.log",
+                                    result_paths=results,
+                                    params={
+                                        "component_group": "g",
+                                        "origin": "t",
+                                        "config_map_name": "cm",
+                                        "content_type": "generic",
+                                        "internal_request_pr_name": "pr",
+                                        "task_run_name": "tr",
+                                    },
+                                    decoded=decoded,
+                                )
+    assert build.call_args[0][2] == ".content.artifacts"
+
+
+def test_run_create_advisory_happy_path_writes_portal_url(
+    tmp_path: Path, creds: gitlab.GitLabCredentials
+) -> None:
+    """End-to-end create path writes Success and an `RHSA-*:1234` portal URL."""
+    secret = tmp_path / "gitlab"
+    _write_gitlab_secret(secret)
+    errata = tmp_path / "errata"
+    _write_errata_mount(errata)
+    repo = tmp_path / "repo"
+    schema_dir = repo / "schema"
+    schema_dir.mkdir(parents=True)
+    schema_path = schema_dir / "advisory.json"
+    schema_doc = _catalog_schema()
+    schema_doc["$id"] = schema_path.resolve().as_uri()
+    schema_path.write_text(json.dumps(schema_doc), encoding="utf-8")
+    base = repo / "data" / "advisories" / "not-existing-origin"
+    base.mkdir(parents=True)
+    template = Path(__file__).resolve().parents[4] / "templates" / "advisory.yaml.jinja"
+    results = {
+        "result": tmp_path / "r",
+        "advisory_url": tmp_path / "u",
+        "advisory_internal_url": tmp_path / "i",
+        "internal_pr_name": tmp_path / "pr",
+        "internal_task_run_name": tmp_path / "tr",
+    }
+    decoded = {
+        "product_id": 123,
+        "product_name": "Red Hat Product",
+        "product_version": "1.2.3",
+        "product_stream": "tp1",
+        "cpe": "cpe:/a:example:product:el8",
+        "type": "RHSA",
+        "synopsis": "test synopsis",
+        "topic": "test topic",
+        "description": "test description",
+        "solution": "test solution",
+        "references": ["https://docs.example.com/notes"],
+        "content": {
+            "images": [
+                {
+                    "containerImage": "quay.io/example/openstack@sha256:abdeNEW",
+                    "repository": "rhosp16-rhel8/openstack",
+                    "tags": ["latest"],
+                }
+            ]
+        },
+    }
+    with mock.patch("create_advisory.gitlab.read_credentials_from_mount", return_value=creds):
+        with mock.patch(
+            "create_advisory._clone_advisory_repo",
+            return_value=(repo, base),
+        ):
+            with mock.patch(
+                "create_advisory._finish_if_all_content_already_published",
+                return_value=False,
+            ):
+                with mock.patch(
+                    "create_advisory.subprocess_cmd.run_cmd",
+                    return_value=mock.MagicMock(stdout="key1\n"),
+                ):
+                    with mock.patch(
+                        "create_advisory._reserve_errata_live_id", return_value=1234
+                    ):
+                        with mock.patch(
+                            "create_advisory.git.origin_ls_tree_name_only",
+                            return_value="",
+                        ):
+                            with mock.patch.object(
+                                create_advisory, "ADVISORY_TEMPLATE_PATH", template
+                            ):
+                                with mock.patch("create_advisory.git.index_add_commit"):
+                                    with mock.patch("create_advisory.git" ".push"):
+                                        create_advisory.run_create_advisory(
+                                            advisory_secret=secret,
+                                            errata_mount=errata,
+                                            stderr_path=tmp_path / "e.log",
+                                            result_paths=results,
+                                            params={
+                                                "component_group": "test-app",
+                                                "origin": "not-existing-origin",
+                                                "config_map_name": "cm",
+                                                "content_type": "image",
+                                                "internal_request_pr_name": "pr",
+                                                "task_run_name": "tr",
+                                            },
+                                            decoded=decoded,
+                                        )
+    assert results["result"].read_text(encoding="utf-8") == "Success"
+    url = results["advisory_url"].read_text(encoding="utf-8")
+    assert url.startswith("https://access.redhat.com/errata/RHSA-")
+    assert url.endswith(":1234")
+
+
+def test_main_uses_secret_mount_env_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`ADVISORY_SECRET_MOUNT` and `ERRATA_SECRET_MOUNT` override default paths."""
+    _setup_main_env(tmp_path, monkeypatch)
+    advisory_mount = tmp_path / "adv"
+    errata_mount = tmp_path / "err"
+    advisory_mount.mkdir()
+    errata_mount.mkdir()
+    monkeypatch.setenv("ADVISORY_SECRET_MOUNT", str(advisory_mount))
+    monkeypatch.setenv("ERRATA_SECRET_MOUNT", str(errata_mount))
+    seen: list[tuple[Path, Path]] = []
+
+    def _capture(**kwargs) -> None:
+        seen.append((kwargs["advisory_secret"], kwargs["errata_mount"]))
+
+    with mock.patch("create_advisory.run_create_advisory", side_effect=_capture):
+        assert create_advisory.main(["create_advisory.py"]) == 0
+    assert seen == [(advisory_mount, errata_mount)]

--- a/utils/apply_template.py
+++ b/utils/apply_template.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import traceback
 
 import yaml
@@ -8,6 +10,7 @@ import argparse
 import json
 import logging
 import sys
+from pathlib import Path
 from typing import Any
 
 LOGGER = logging.getLogger("apply_template")
@@ -47,25 +50,30 @@ def setup_argparser() -> argparse.Namespace:  # pragma: no cover
     return parser.parse_args()
 
 
-def main():  # pragma: no cover
-    """Main func"""
+def render_template_to_json_file(
+    output_path: str | Path,
+    template_path: str | Path,
+    template_data: dict[str, Any],
+    *,
+    verbose: bool = False,
+) -> None:
+    """
+    Two-pass Jinja render of *template_path* with *template_data*; write JSON to
+    *output_path*.
 
-    args = setup_argparser()
-    log_level = logging.DEBUG if args.verbose else logging.INFO
+    YAML is used as an intermediate representation; output is JSON so values like
+    version strings are not corrupted by YAML type coercion.
+    """
+    log_level = logging.DEBUG if verbose else logging.INFO
     setup_logger(level=log_level)
 
-    # Load JSON data from either --data argument or --data-file
-    if args.data:
-        template_data = json.loads(args.data)
-    else:  # args.data_file
-        with open(args.data_file, "r") as f:
-            template_data = json.loads(f.read())
-
-    with open(args.template) as t:
+    with open(template_path, encoding="utf-8") as template_file:
         # DebugUndefined renders undefined variables as empty strings
         # instead of raising errors.
         template = Template(
-            t.read(), extensions=[AnsibleCoreFiltersExtension], undefined=DebugUndefined
+            template_file.read(),
+            extensions=[AnsibleCoreFiltersExtension],
+            undefined=DebugUndefined,
         )
     LOGGER.info("Rendering 1st pass")
     try:
@@ -112,11 +120,27 @@ def main():  # pragma: no cover
     # Convert to JSON for safer parsing. Jinja works cleaner with YAML syntax
     # but YAML type conversion can corrupt data e.g. "33158e1" to 331580 JSON
     # output prevents this.
-    filename = args.output
     data = yaml.safe_load(content)
-    with open(filename, mode="w", encoding="utf-8") as data_file:
+    out = Path(output_path)
+    with open(out, mode="w", encoding="utf-8") as data_file:
         json.dump(data, data_file, indent=2)
-        LOGGER.info(f"Wrote {filename}")
+        LOGGER.info("Wrote %s", out)
+
+
+def main():  # pragma: no cover
+    """CLI entrypoint."""
+    args = setup_argparser()
+    if args.data:
+        template_data = json.loads(args.data)
+    else:
+        with open(args.data_file, encoding="utf-8") as data_file:
+            template_data = json.loads(data_file.read())
+    render_template_to_json_file(
+        args.output,
+        args.template,
+        template_data,
+        verbose=args.verbose,
+    )
 
 
 def setup_logger(level: int = logging.INFO, log_format: Any = None):

--- a/uv.lock
+++ b/uv.lock
@@ -574,6 +574,30 @@ wheels = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.50"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1640,8 +1664,10 @@ dependencies = [
     { name = "check-jsonschema" },
     { name = "confluent-kafka" },
     { name = "diffused-lib" },
+    { name = "gitpython" },
     { name = "jinja2" },
     { name = "jinja2-ansible-filters" },
+    { name = "jsonschema" },
     { name = "packageurl-python" },
     { name = "packaging" },
     { name = "pubtools-content-gateway" },
@@ -1651,6 +1677,7 @@ dependencies = [
     { name = "pubtools-pyxis" },
     { name = "pubtools-sign" },
     { name = "pulp-cli" },
+    { name = "pyyaml" },
     { name = "requests" },
     { name = "requests-kerberos" },
 ]
@@ -1667,8 +1694,10 @@ requires-dist = [
     { name = "check-jsonschema" },
     { name = "confluent-kafka" },
     { name = "diffused-lib", specifier = "==0.3.0" },
+    { name = "gitpython", specifier = ">=3.1.40" },
     { name = "jinja2" },
     { name = "jinja2-ansible-filters" },
+    { name = "jsonschema", specifier = ">=4.23" },
     { name = "packageurl-python" },
     { name = "packaging" },
     { name = "pubtools-content-gateway", specifier = "==0.5.4" },
@@ -1678,6 +1707,7 @@ requires-dist = [
     { name = "pubtools-pyxis", specifier = "==1.3.8" },
     { name = "pubtools-sign", specifier = "==1.0.6" },
     { name = "pulp-cli", specifier = "==0.36.3" },
+    { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "requests" },
     { name = "requests-kerberos" },
 ]
@@ -1879,6 +1909,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This commit adds a python script to replicate the functionality of the inline bash script in the create-advisory internal task in the catalog repo. The task will be updated to use this python module instead.

It also updates some helper modules so that future converted tasks can use them instead of it being inside the create_advisory module. Finally, it reworks apply_template.py a bit from the utils dir so that the create_advisory python script can call it natively instead of using subprocess to call apply_template.py.

Assisted-By: Cursor