### PR TITLE
feat(RELEASE-2419): add --append-tags to create_container_image

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-Python script to create a Container Image object in Pyxis
+"""Python script to create a Container Image object in Pyxis.
 
 NOTE: Any change to this file that changes functionality should be posted for review in
 #forum-metadata-guild on slack. No PR changing functionality should be removed without
@@ -64,11 +63,10 @@ MANIFEST_LIST_TYPES = [
 
 
 def setup_argparser() -> Any:  # pragma: no cover
-    """Setup argument parser
+    """Set up argument parser.
 
     :return: Initialized argument parser
     """
-
     parser = argparse.ArgumentParser(description="ContainerImage resource creator.")
 
     parser.add_argument(
@@ -174,11 +172,10 @@ def proxymap(repository: str) -> str:
 
 
 def find_image(pyxis_url, digest: str) -> Any:
-    """Function to find a containerImage with the given digest.
+    """Find a containerImage with the given digest.
 
     :return: the image, if one exists, else None if none found
     """
-
     raw_filter = f'repositories.manifest_schema2_digest=="{digest}";not(deleted==true)'
     # quote is needed to urlparse the quotation marks
     filter_str = quote(raw_filter)
@@ -202,7 +199,7 @@ def find_image(pyxis_url, digest: str) -> Any:
 
 
 def find_repo_in_image(repository_str: str, image: Dict[str, Any]) -> Optional[int]:
-    """Check if a repository already exists in the ContainerImage
+    """Check if a repository already exists in the ContainerImage.
 
     :return: index of repository if repository_str string is found in the ContainerImage
         repositories, None otherwise
@@ -214,16 +211,16 @@ def find_repo_in_image(repository_str: str, image: Dict[str, Any]) -> Optional[i
 
 
 def prepare_parsed_data(args) -> Dict[str, Any]:
-    """Function to extract the data this script needs to create parsed_data.
-       Processes data from:
-        - Architecture from args
-        - ORAS manifest fetch output
-        - Dockerfile content (if provided)
-        - Metadata file with env_variables and labels (if provided)
+    """Extract the data this script needs to create parsed_data.
+
+    Processes data from:
+     - Architecture from args
+     - ORAS manifest fetch output
+     - Dockerfile content (if provided)
+     - Metadata file with env_variables and labels (if provided)
 
     :return: Dict containing processed data from parsed sources
     """
-
     with open(args.oras_manifest_fetch) as json_file:
         oras_manifest_fetch = json.load(json_file)
 
@@ -276,7 +273,7 @@ def prepare_parsed_data(args) -> Dict[str, Any]:
 
 
 def pyxis_tags(tags, date_now):
-    """Return list of tags formatted for pyxis"""
+    """Return list of tags formatted for pyxis."""
     return [
         {
             "added_date": date_now,
@@ -319,7 +316,7 @@ def construct_tags(
 
 
 def repository_digest_values(args):
-    """Return digest values for the repository entry in the image entity"""
+    """Return digest values for the repository entry in the image entity."""
     result = {"manifest_schema2_digest": args.architecture_digest}
     if args.media_type in MANIFEST_LIST_TYPES:
         result["manifest_list_digest"] = args.digest
@@ -327,8 +324,7 @@ def repository_digest_values(args):
 
 
 def create_container_image(args, parsed_data: Dict[str, Any], tags: List[str]):
-    """Function to create a new containerImage entry in a pyxis instance"""
-
+    """Create a new containerImage entry in a pyxis instance."""
     LOGGER.info("Creating new container image")
 
     constructed_tags = construct_tags(tags)
@@ -372,6 +368,7 @@ def create_container_image(args, parsed_data: Dict[str, Any], tags: List[str]):
 def update_container_image_repositories(
     pyxis_url, image_id: str, repositories: List[Dict[str, Any]]
 ):
+    """Update repositories for a container image."""
     LOGGER.info(f"Updating repositories for container image {image_id}")
 
     patch_url = urljoin(pyxis_url, f"v1/images/id/{image_id}")
@@ -444,8 +441,7 @@ def construct_repository(args, tag_dicts):
 
 
 def main():  # pragma: no cover
-    """Main func"""
-
+    """Execute main function."""
     parser = setup_argparser()
     args = parser.parse_args()
     log_level = logging.DEBUG if args.verbose else logging.INFO

--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -145,6 +145,13 @@ def setup_argparser() -> Any:  # pragma: no cover
         help="Path to the Dockerfile to be included in the ContainerImage.parsed_data field",
         default="",
     )
+    parser.add_argument(
+        "--append-tags",
+        help="If set to true, when an image with the given repository already exists, "
+        "missing tags will be added to the existing tags instead of replacing them. "
+        "This preserves existing tags while adding new ones.",
+        default="false",
+    )
     parser.add_argument("--verbose", action="store_true", help="Verbose output")
     return parser
 
@@ -279,6 +286,38 @@ def pyxis_tags(tags, date_now):
     ]
 
 
+def construct_tags(
+    tag_names: List[str], existing_tags: List[Dict[str, str]] = None
+) -> List[Dict[str, str]]:
+    """Construct tags structure for Pyxis, optionally preserving existing tags.
+
+    :param tag_names: List of tag names to include
+    :param existing_tags: Optional list of existing tag dicts with 'name' and
+                          'added_date'. If provided, dates will be preserved for
+                          tags that were not re-applied.
+    :return: List of tag dicts with 'name' and 'added_date'
+    """
+    date_now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
+
+    if existing_tags is None:
+        # Normal mode: create all tags with current date
+        return pyxis_tags(tag_names, date_now)
+
+    # Append mode: new/re-applied tags get current date, other existing tags keep their dates
+    new_tag_names_set = set(tag_names)
+    result = []
+
+    # Add all new tags with current date
+    result.extend(pyxis_tags(tag_names, date_now))
+
+    # Add existing tags that aren't in the new tags (preserve their original dates)
+    for tag in existing_tags:
+        if tag["name"] not in new_tag_names_set:
+            result.append(tag)
+
+    return result
+
+
 def repository_digest_values(args):
     """Return digest values for the repository entry in the image entity"""
     result = {"manifest_schema2_digest": args.architecture_digest}
@@ -292,7 +331,8 @@ def create_container_image(args, parsed_data: Dict[str, Any], tags: List[str]):
 
     LOGGER.info("Creating new container image")
 
-    repository = construct_repository(args, tags)
+    constructed_tags = construct_tags(tags)
+    repository = construct_repository(args, constructed_tags)
 
     # sum_layer_size_bytes isn't accepted in the parsed_data payload to pyxis
     sum_layer_size_bytes = parsed_data.pop("sum_layer_size_bytes", 0)
@@ -361,7 +401,7 @@ def _rh_push_registry(image_name: str) -> str:
     return "registry.access.redhat.com"
 
 
-def construct_repository(args, tags):
+def construct_repository(args, tag_dicts):
     """Build the repository dict for the Container Image.
 
     When rh_push is true, the repository entry it adds will be for Red Hat
@@ -370,6 +410,9 @@ def construct_repository(args, tags):
     flatpaks.registry.redhat.io (for flatpak images quay.io/rh-flatpaks-prod/*,
     quay.io/rh-flatpaks-stage/*). The repository path is derived via proxymap
     (e.g. product----image -> product/image).
+
+    :param args: Command line arguments
+    :param tag_dicts: List of tag dicts with 'name' and 'added_date'
     """
     image_name = args.name
     date_now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
@@ -382,7 +425,7 @@ def construct_repository(args, tags):
             "registry": registry,
             "repository": proxymap(image_name),
             "push_date": date_now,
-            "tags": pyxis_tags(tags, date_now),
+            "tags": tag_dicts,
         }
     else:
         image_registry = image_name.split("/")[0]
@@ -392,7 +435,7 @@ def construct_repository(args, tags):
             "registry": image_registry,
             "repository": image_repo,
             "push_date": date_now,
-            "tags": pyxis_tags(tags, date_now),
+            "tags": tag_dicts,
         }
 
     repo.update(repository_digest_values(args))
@@ -436,18 +479,25 @@ def main():  # pragma: no cover
             f"Image with given docker_image_digest exists as {identifier}, but "
             f"is not yet associated with repository {args.name}."
         )
-        repositories.append(construct_repository(args, tags))
+        constructed_tags = construct_tags(tags)
+        repositories.append(construct_repository(args, constructed_tags))
         update_container_image_repositories(args.pyxis_url, identifier, repositories)
         return
 
     # Then, check if the tags are different. If they are, update them
-    existing_tags = [tag["name"] for tag in repositories[repo_index].get("tags") or []]
+    existing_tags = [tag["name"] for tag in repositories[repo_index].get("tags", [])]
     if existing_tags != tags:
         LOGGER.info(
             f"Image with given docker_image_digest exists as {identifier} and "
             f"is associated with repository {args.name}, but the tags differ."
         )
-        repositories[repo_index] = construct_repository(args, tags)
+        if args.append_tags == "true":
+            LOGGER.info("--append-tags is true. Merging new tags with existing tags.")
+            existing_tag_dicts = repositories[repo_index].get("tags", [])
+            constructed_tags = construct_tags(tags, existing_tag_dicts)
+        else:
+            constructed_tags = construct_tags(tags)
+        repositories[repo_index] = construct_repository(args, constructed_tags)
         update_container_image_repositories(args.pyxis_url, identifier, repositories)
         return
 

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -9,11 +9,13 @@ from create_container_image import (
     find_repo_in_image,
     prepare_parsed_data,
     pyxis_tags,
+    construct_tags,
     repository_digest_values,
     create_container_image,
     update_container_image_repositories,
     construct_repository,
     _rh_push_registry,
+    main,
 )
 
 PYXIS_URL = "https://catalog.redhat.com/api/containers/"
@@ -640,9 +642,10 @@ def test_construct_repository__rh_push_true(mock_datetime):
     args.digest = "some_digest"
     args.rh_push = "true"
     args.name = "quay.io/redhat-pending/some-product----some-image"
-    tags = ["tagprefix", "tagprefix-timestamp"]
+    tag_names = ["tagprefix", "tagprefix-timestamp"]
+    tag_dicts = construct_tags(tag_names)
 
-    repo = construct_repository(args, tags)
+    repo = construct_repository(args, tag_dicts)
 
     assert repo == {
         "published": True,
@@ -673,9 +676,10 @@ def test_construct_repository__rh_push_true_flatpak_prod(mock_datetime):
     args.digest = "sha256:top"
     args.rh_push = "true"
     args.name = "quay.io/rh-flatpaks-prod/myapp----myflatpak"
-    tags = ["latest"]
+    tag_names = ["latest"]
+    tag_dicts = construct_tags(tag_names)
 
-    repo = construct_repository(args, tags)
+    repo = construct_repository(args, tag_dicts)
 
     assert repo["registry"] == "flatpaks.registry.redhat.io"
     assert repo["repository"] == "myapp/myflatpak"
@@ -691,9 +695,10 @@ def test_construct_repository__rh_push_true_flatpak_stage(mock_datetime):
     args.digest = "sha256:top2"
     args.rh_push = "true"
     args.name = "quay.io/rh-flatpaks-stage/namespace----another-flatpak"
-    tags = ["1.0"]
+    tag_names = ["1.0"]
+    tag_dicts = construct_tags(tag_names)
 
-    repo = construct_repository(args, tags)
+    repo = construct_repository(args, tag_dicts)
 
     assert repo["registry"] == "flatpaks.registry.redhat.io"
     assert repo["repository"] == "namespace/another-flatpak"  # proxymap: ---- -> /
@@ -709,9 +714,10 @@ def test_construct_repository__rh_push_false(mock_datetime):
     args.digest = "some_digest"
     args.rh_push = "false"
     args.name = "quay.io/some-org/some-image"
-    tags = ["tagprefix", "tagprefix-timestamp", "latest"]
+    tag_names = ["tagprefix", "tagprefix-timestamp", "latest"]
+    tag_dicts = construct_tags(tag_names)
 
-    repo = construct_repository(args, tags)
+    repo = construct_repository(args, tag_dicts)
 
     assert repo == {
         "published": False,
@@ -735,3 +741,307 @@ def test_construct_repository__rh_push_false(mock_datetime):
         "manifest_list_digest": "some_digest",
         "manifest_schema2_digest": "arch specific digest",
     }
+
+
+@patch("create_container_image.datetime")
+def test_construct_tags__normal_mode(mock_datetime):
+    """Test construct_tags without existing tags (normal mode)"""
+    mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 10, 10, 10))
+    tag_names = ["v1.0", "latest"]
+
+    result = construct_tags(tag_names)
+
+    assert result == [
+        {"added_date": "2026-05-21T10:10:10.000000+00:00", "name": "v1.0"},
+        {"added_date": "2026-05-21T10:10:10.000000+00:00", "name": "latest"},
+    ]
+
+
+@patch("create_container_image.datetime")
+def test_construct_tags__append_mode_all_new(mock_datetime):
+    """Test construct_tags with existing tags, but all new tags are different"""
+    mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
+    tag_names = ["v2.0", "v2.1"]
+    existing_tags = [
+        {"added_date": "2026-05-20T10:00:00.000000+00:00", "name": "v1.0"},
+        {"added_date": "2026-05-20T11:00:00.000000+00:00", "name": "v1.1"},
+    ]
+
+    result = construct_tags(tag_names, existing_tags)
+
+    assert result == [
+        {"added_date": "2026-05-21T12:00:00.000000+00:00", "name": "v2.0"},
+        {"added_date": "2026-05-21T12:00:00.000000+00:00", "name": "v2.1"},
+        {"added_date": "2026-05-20T10:00:00.000000+00:00", "name": "v1.0"},
+        {"added_date": "2026-05-20T11:00:00.000000+00:00", "name": "v1.1"},
+    ]
+
+
+@patch("create_container_image.datetime")
+def test_construct_tags__append_mode_overlapping(mock_datetime):
+    """Test construct_tags with existing tags where some tags overlap"""
+    mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
+    tag_names = ["v1.0", "v2.0"]
+    existing_tags = [
+        {"added_date": "2026-05-20T10:00:00.000000+00:00", "name": "v1.0"},
+        {"added_date": "2026-05-20T11:00:00.000000+00:00", "name": "latest"},
+    ]
+
+    result = construct_tags(tag_names, existing_tags)
+
+    # v1.0 gets updated date, v2.0 is new, latest is preserved
+    assert result == [
+        {"added_date": "2026-05-21T12:00:00.000000+00:00", "name": "v1.0"},
+        {"added_date": "2026-05-21T12:00:00.000000+00:00", "name": "v2.0"},
+        {"added_date": "2026-05-20T11:00:00.000000+00:00", "name": "latest"},
+    ]
+
+
+@patch("create_container_image.datetime")
+def test_construct_tags__append_mode_empty_existing(mock_datetime):
+    """Test construct_tags with empty existing tags list"""
+    mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
+    tag_names = ["v1.0"]
+    existing_tags = []
+
+    result = construct_tags(tag_names, existing_tags)
+
+    assert result == [
+        {"added_date": "2026-05-21T12:00:00.000000+00:00", "name": "v1.0"},
+    ]
+
+
+@patch("create_container_image.update_container_image_repositories")
+@patch("create_container_image.find_image")
+@patch("create_container_image.prepare_parsed_data")
+@patch("create_container_image.pyxis.setup_logger")
+@patch("create_container_image.datetime")
+def test_main__append_tags_false_replaces_tags(
+    mock_datetime,
+    mock_setup_logger,
+    mock_prepare_parsed_data,
+    mock_find_image,
+    mock_update,
+):
+    """Test that without --append-tags, tags are replaced (existing behavior)"""
+    mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
+    mock_prepare_parsed_data.return_value = {"architecture": "amd64"}
+
+    # Existing image with v1.0 and v1.1 tags
+    existing_image = {
+        "_id": "12345",
+        "repositories": [
+            {
+                "registry": "quay.io",
+                "repository": "myorg/myimage",
+                "tags": [
+                    {"added_date": "2026-05-20T10:00:00.000000+00:00", "name": "v1.0"},
+                    {"added_date": "2026-05-20T11:00:00.000000+00:00", "name": "v1.1"},
+                ],
+            }
+        ],
+    }
+    mock_find_image.return_value = existing_image
+
+    # Simulate running with new tags v2.0
+    test_args = [
+        "create_container_image.py",
+        "--pyxis-url",
+        "https://pyxis.test.com",
+        "--certified",
+        "false",
+        "--tags",
+        "v2.0",
+        "--oras-manifest-fetch",
+        "/dev/null",
+        "--is-latest",
+        "false",
+        "--name",
+        "quay.io/myorg/myimage",
+        "--digest",
+        "sha256:abc",
+        "--architecture-digest",
+        "sha256:def",
+        "--architecture",
+        "amd64",
+        "--media-type",
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "--append-tags",
+        "false",
+    ]
+
+    with patch("sys.argv", test_args), patch("builtins.open", create=True):
+        main()
+
+    # Verify update was called with only the new tag (old tags replaced)
+    assert mock_update.called
+    updated_repos = mock_update.call_args[0][2]
+    updated_tags = updated_repos[0]["tags"]
+    tag_names = [tag["name"] for tag in updated_tags]
+
+    assert tag_names == ["v2.0"]
+    assert len(updated_tags) == 1
+
+
+@patch("create_container_image.update_container_image_repositories")
+@patch("create_container_image.find_image")
+@patch("create_container_image.prepare_parsed_data")
+@patch("create_container_image.pyxis.setup_logger")
+@patch("create_container_image.datetime")
+def test_main__append_tags_true_preserves_tags(
+    mock_datetime,
+    mock_setup_logger,
+    mock_prepare_parsed_data,
+    mock_find_image,
+    mock_update,
+):
+    """Test that with --append-tags true, existing tags are preserved"""
+    mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
+    mock_prepare_parsed_data.return_value = {"architecture": "amd64"}
+
+    # Existing image with v1.0 and v1.1 tags
+    existing_image = {
+        "_id": "12345",
+        "repositories": [
+            {
+                "registry": "quay.io",
+                "repository": "myorg/myimage",
+                "tags": [
+                    {"added_date": "2026-05-20T10:00:00.000000+00:00", "name": "v1.0"},
+                    {"added_date": "2026-05-20T11:00:00.000000+00:00", "name": "v1.1"},
+                ],
+            }
+        ],
+    }
+    mock_find_image.return_value = existing_image
+
+    # Simulate running with new tags v2.0
+    test_args = [
+        "create_container_image.py",
+        "--pyxis-url",
+        "https://pyxis.test.com",
+        "--certified",
+        "false",
+        "--tags",
+        "v2.0",
+        "--oras-manifest-fetch",
+        "/dev/null",
+        "--is-latest",
+        "false",
+        "--name",
+        "quay.io/myorg/myimage",
+        "--digest",
+        "sha256:abc",
+        "--architecture-digest",
+        "sha256:def",
+        "--architecture",
+        "amd64",
+        "--media-type",
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "--append-tags",
+        "true",
+    ]
+
+    with patch("sys.argv", test_args), patch("builtins.open", create=True):
+        main()
+
+    # Verify update was called with all tags (new + existing)
+    assert mock_update.called
+    updated_repos = mock_update.call_args[0][2]
+    updated_tags = updated_repos[0]["tags"]
+    tag_names = [tag["name"] for tag in updated_tags]
+
+    # Should have v2.0 (new) and v1.0, v1.1 (existing preserved)
+    assert set(tag_names) == {"v2.0", "v1.0", "v1.1"}
+    assert len(updated_tags) == 3
+
+    # Check that existing tags kept their original dates
+    for tag in updated_tags:
+        if tag["name"] == "v1.0":
+            assert tag["added_date"] == "2026-05-20T10:00:00.000000+00:00"
+        elif tag["name"] == "v1.1":
+            assert tag["added_date"] == "2026-05-20T11:00:00.000000+00:00"
+        elif tag["name"] == "v2.0":
+            # New tag gets current date
+            assert tag["added_date"] == "2026-05-21T12:00:00.000000+00:00"
+
+
+@patch("create_container_image.update_container_image_repositories")
+@patch("create_container_image.find_image")
+@patch("create_container_image.prepare_parsed_data")
+@patch("create_container_image.pyxis.setup_logger")
+@patch("create_container_image.datetime")
+def test_main__append_tags_true_updates_reapplied_tag_date(
+    mock_datetime,
+    mock_setup_logger,
+    mock_prepare_parsed_data,
+    mock_find_image,
+    mock_update,
+):
+    """Test that with --append-tags true, re-applied tags get updated dates"""
+    mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
+    mock_prepare_parsed_data.return_value = {"architecture": "amd64"}
+
+    # Existing image with v1.0 and latest tags
+    existing_image = {
+        "_id": "12345",
+        "repositories": [
+            {
+                "registry": "quay.io",
+                "repository": "myorg/myimage",
+                "tags": [
+                    {"added_date": "2026-05-20T10:00:00.000000+00:00", "name": "v1.0"},
+                    {"added_date": "2026-05-20T11:00:00.000000+00:00", "name": "latest"},
+                ],
+            }
+        ],
+    }
+    mock_find_image.return_value = existing_image
+
+    # Simulate running with v1.0 and v2.0 (v1.0 is re-applied)
+    test_args = [
+        "create_container_image.py",
+        "--pyxis-url",
+        "https://pyxis.test.com",
+        "--certified",
+        "false",
+        "--tags",
+        "v1.0 v2.0",
+        "--oras-manifest-fetch",
+        "/dev/null",
+        "--is-latest",
+        "false",
+        "--name",
+        "quay.io/myorg/myimage",
+        "--digest",
+        "sha256:abc",
+        "--architecture-digest",
+        "sha256:def",
+        "--architecture",
+        "amd64",
+        "--media-type",
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "--append-tags",
+        "true",
+    ]
+
+    with patch("sys.argv", test_args), patch("builtins.open", create=True):
+        main()
+
+    # Verify update was called
+    assert mock_update.called
+    updated_repos = mock_update.call_args[0][2]
+    updated_tags = updated_repos[0]["tags"]
+
+    # Should have v1.0 (updated date), v2.0 (new), latest (preserved)
+    assert len(updated_tags) == 3
+    tag_dict = {tag["name"]: tag for tag in updated_tags}
+
+    # v1.0 was re-applied, should have updated date
+    assert tag_dict["v1.0"]["added_date"] == "2026-05-21T12:00:00.000000+00:00"
+
+    # v2.0 is new, should have current date
+    assert tag_dict["v2.0"]["added_date"] == "2026-05-21T12:00:00.000000+00:00"
+
+    # latest was not re-applied, should have original date
+    assert tag_dict["latest"]["added_date"] == "2026-05-20T11:00:00.000000+00:00"

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -1,3 +1,5 @@
+"""Tests for create_container_image module."""
+
 import pytest
 from datetime import datetime
 import json
@@ -22,6 +24,7 @@ PYXIS_URL = "https://catalog.redhat.com/api/containers/"
 
 
 def test_proxymap():
+    """Test proxymap function."""
     repository = "quay.io/redhat-pending/foo----bar"
 
     mapped = proxymap(repository)
@@ -31,6 +34,7 @@ def test_proxymap():
 
 @patch("create_container_image.pyxis.get")
 def test_find_image__image_does_exist(mock_get):
+    """Test find image  image does exist."""
     # Arrange
     mock_rsp = MagicMock()
     mock_get.return_value = mock_rsp
@@ -55,6 +59,7 @@ def test_find_image__image_does_exist(mock_get):
 
 @patch("create_container_image.pyxis.get")
 def test_find_image__image_does_not_exist(mock_get):
+    """Test find image  image does not exist."""
     # Arrange
     mock_rsp = MagicMock()
     mock_get.return_value = mock_rsp
@@ -72,6 +77,7 @@ def test_find_image__image_does_not_exist(mock_get):
 
 @patch("create_container_image.pyxis.get")
 def test_find_image__no_id_in_image(mock_get):
+    """Test find image  no id in image."""
     # Arrange
     mock_rsp = MagicMock()
     mock_get.return_value = mock_rsp
@@ -87,6 +93,7 @@ def test_find_image__no_id_in_image(mock_get):
 
 # scenario where repo is present in the image
 def test_find_repo_in_image__found():
+    """Test find repo in image  found."""
     image = {"repositories": [{"repository": "my/repo"}, {"repository": "foo/bar"}]}
 
     result = find_repo_in_image("foo/bar", image)
@@ -96,6 +103,7 @@ def test_find_repo_in_image__found():
 
 # scenario where repo is not present in the image
 def test_find_repo_in_image__not_found():
+    """Test find repo in image  not found."""
     image = {"repositories": [{"repository": "my/repo"}, {"repository": "foo/bar"}]}
 
     result = find_repo_in_image("something/missing", image)
@@ -106,6 +114,7 @@ def test_find_repo_in_image__not_found():
 @patch("create_container_image.pyxis.post")
 @patch("create_container_image.datetime")
 def test_create_container_image(mock_datetime, mock_post):
+    """Test create container image."""
     # Mock an _id in the response for logger check
     mock_post.return_value.json.return_value = {"_id": 0}
 
@@ -161,7 +170,7 @@ def test_create_container_image(mock_datetime, mock_post):
 @patch("create_container_image.pyxis.post")
 @patch("create_container_image.datetime")
 def test_create_container_image__top_layer_id(mock_datetime, mock_post):
-    """Scenario where top_layer_id and uncompressed_top_layer_id are defined in parsed_data"""
+    """Scenario where top_layer_id and uncompressed_top_layer_id are defined in parsed_data."""
     # Mock an _id in the response for logger check
     mock_post.return_value.json.return_value = {"_id": 0}
 
@@ -228,6 +237,7 @@ def test_create_container_image__top_layer_id(mock_datetime, mock_post):
 @patch("create_container_image.pyxis.post")
 @patch("create_container_image.datetime")
 def test_create_container_image__rh_push_multiple_tags(mock_datetime, mock_post):
+    """Test create container image  rh push multiple tags."""
     # Mock an _id in the response for logger check
     mock_post.return_value.json.return_value = {"_id": 0}
 
@@ -288,6 +298,7 @@ def test_create_container_image__rh_push_multiple_tags(mock_datetime, mock_post)
 
 
 def test_create_container_image__no_digest():
+    """Test create container image  no digest."""
     args = MagicMock()
 
     with pytest.raises(Exception):
@@ -302,6 +313,7 @@ def test_create_container_image__no_digest():
 
 
 def test_create_container_image__no_name():
+    """Test create container image  no name."""
     args = MagicMock()
 
     with pytest.raises(Exception):
@@ -317,6 +329,7 @@ def test_create_container_image__no_name():
 
 @patch("create_container_image.pyxis.patch")
 def test_update_container_image_repositories(mock_patch):
+    """Test update container image repositories."""
     image_id = "0000"
     # Mock an _id in the response for logger check
     mock_patch.return_value.json.return_value = {"_id": image_id}
@@ -357,6 +370,7 @@ def test_update_container_image_repositories(mock_patch):
 
 @patch("builtins.open")
 def test_prepare_parsed_data__success(mock_open):
+    """Test prepare parsed data  success."""
     args = MagicMock()
     args.architecture = "test"
     args.dockerfile = "mydockerfile"
@@ -416,6 +430,7 @@ def test_prepare_parsed_data__success(mock_open):
 
 @patch("builtins.open")
 def test_prepare_parsed_data__success_no_dockerfile(mock_open):
+    """Test prepare parsed data  success no dockerfile."""
     args = MagicMock()
     args.architecture = "test"
     args.dockerfile = ""
@@ -443,6 +458,7 @@ def test_prepare_parsed_data__success_no_dockerfile(mock_open):
 
 @patch("builtins.open")
 def test_prepare_parsed_data__with_layer_sizes(mock_open):
+    """Test prepare parsed data  with layer sizes."""
     args = MagicMock()
     args.architecture = "test"
     args.dockerfile = "mydockerfile"
@@ -486,6 +502,7 @@ def test_prepare_parsed_data__with_layer_sizes(mock_open):
 
 @patch("builtins.open")
 def test_prepare_parsed_data__metadata_empty_json(mock_open):
+    """Test prepare parsed data  metadata empty json."""
     args = MagicMock()
     args.architecture = "test"
     args.dockerfile = ""
@@ -506,6 +523,7 @@ def test_prepare_parsed_data__metadata_empty_json(mock_open):
 
 @patch("builtins.open")
 def test_prepare_parsed_data__metadata_empty_object(mock_open):
+    """Test prepare parsed data  metadata empty object."""
     args = MagicMock()
     args.architecture = "test"
     args.dockerfile = ""
@@ -532,6 +550,7 @@ def test_prepare_parsed_data__metadata_empty_object(mock_open):
 
 @patch("builtins.open")
 def test_prepare_parsed_data__metadata_env_only(mock_open):
+    """Test prepare parsed data  metadata env only."""
     args = MagicMock()
     args.architecture = "test"
     args.dockerfile = ""
@@ -555,6 +574,7 @@ def test_prepare_parsed_data__metadata_env_only(mock_open):
 
 @patch("builtins.open")
 def test_prepare_parsed_data__metadata_labels_only(mock_open):
+    """Test prepare parsed data  metadata labels only."""
     args = MagicMock()
     args.architecture = "test"
     args.dockerfile = ""
@@ -577,6 +597,7 @@ def test_prepare_parsed_data__metadata_labels_only(mock_open):
 
 
 def test_pyxis_tags():
+    """Test pyxis tags."""
     tags = ["tag1", "tag2"]
     now = "now"
 
@@ -589,6 +610,7 @@ def test_pyxis_tags():
 
 
 def test_repository_digest_values__single_arch():
+    """Test repository digest values  single arch."""
     args = MagicMock()
     args.media_type = "application/vnd.docker.distribution.manifest.v2+json"
     args.architecture_digest = "mydigest"
@@ -599,6 +621,7 @@ def test_repository_digest_values__single_arch():
 
 
 def test_repository_digest_values__multi_arch():
+    """Test repository digest values  multi arch."""
     args = MagicMock()
     args.media_type = "application/vnd.docker.distribution.manifest.list.v2+json"
     args.architecture_digest = "mydigest"
@@ -613,9 +636,7 @@ def test_repository_digest_values__multi_arch():
 
 
 def test_rh_push_registry():
-    """Flatpak namespaces use flatpaks.registry.redhat.io;
-    others use registry.access.redhat.com.
-    """
+    """Test registry selection for flatpak vs standard namespaces."""
     assert (
         _rh_push_registry("quay.io/rh-flatpaks-prod/foo/bar") == "flatpaks.registry.redhat.io"
     )
@@ -635,6 +656,7 @@ def test_rh_push_registry():
 
 @patch("create_container_image.datetime")
 def test_construct_repository__rh_push_true(mock_datetime):
+    """Test construct repository  rh push true."""
     mock_datetime.now = MagicMock(return_value=datetime(1970, 10, 10, 10, 10, 10))
     args = MagicMock()
     args.media_type = "application/vnd.docker.distribution.manifest.list.v2+json"
@@ -669,6 +691,7 @@ def test_construct_repository__rh_push_true(mock_datetime):
 
 @patch("create_container_image.datetime")
 def test_construct_repository__rh_push_true_flatpak_prod(mock_datetime):
+    """Test construct repository  rh push true flatpak prod."""
     mock_datetime.now = MagicMock(return_value=datetime(1970, 10, 10, 10, 10, 10))
     args = MagicMock()
     args.media_type = "application/vnd.oci.image.manifest.v1+json"
@@ -688,6 +711,7 @@ def test_construct_repository__rh_push_true_flatpak_prod(mock_datetime):
 
 @patch("create_container_image.datetime")
 def test_construct_repository__rh_push_true_flatpak_stage(mock_datetime):
+    """Test construct repository  rh push true flatpak stage."""
     mock_datetime.now = MagicMock(return_value=datetime(1970, 10, 10, 10, 10, 10))
     args = MagicMock()
     args.media_type = "application/vnd.oci.image.manifest.v1+json"
@@ -707,6 +731,7 @@ def test_construct_repository__rh_push_true_flatpak_stage(mock_datetime):
 
 @patch("create_container_image.datetime")
 def test_construct_repository__rh_push_false(mock_datetime):
+    """Test construct repository  rh push false."""
     mock_datetime.now = MagicMock(return_value=datetime(1970, 10, 10, 10, 10, 10))
     args = MagicMock()
     args.media_type = "application/vnd.docker.distribution.manifest.list.v2+json"
@@ -745,7 +770,7 @@ def test_construct_repository__rh_push_false(mock_datetime):
 
 @patch("create_container_image.datetime")
 def test_construct_tags__normal_mode(mock_datetime):
-    """Test construct_tags without existing tags (normal mode)"""
+    """Test construct_tags without existing tags (normal mode)."""
     mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 10, 10, 10))
     tag_names = ["v1.0", "latest"]
 
@@ -759,7 +784,7 @@ def test_construct_tags__normal_mode(mock_datetime):
 
 @patch("create_container_image.datetime")
 def test_construct_tags__append_mode_all_new(mock_datetime):
-    """Test construct_tags with existing tags, but all new tags are different"""
+    """Test construct_tags with existing tags, but all new tags are different."""
     mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
     tag_names = ["v2.0", "v2.1"]
     existing_tags = [
@@ -779,7 +804,7 @@ def test_construct_tags__append_mode_all_new(mock_datetime):
 
 @patch("create_container_image.datetime")
 def test_construct_tags__append_mode_overlapping(mock_datetime):
-    """Test construct_tags with existing tags where some tags overlap"""
+    """Test construct_tags with existing tags where some tags overlap."""
     mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
     tag_names = ["v1.0", "v2.0"]
     existing_tags = [
@@ -799,7 +824,7 @@ def test_construct_tags__append_mode_overlapping(mock_datetime):
 
 @patch("create_container_image.datetime")
 def test_construct_tags__append_mode_empty_existing(mock_datetime):
-    """Test construct_tags with empty existing tags list"""
+    """Test construct_tags with empty existing tags list."""
     mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
     tag_names = ["v1.0"]
     existing_tags = []
@@ -823,7 +848,7 @@ def test_main__append_tags_false_replaces_tags(
     mock_find_image,
     mock_update,
 ):
-    """Test that without --append-tags, tags are replaced (existing behavior)"""
+    """Test that without --append-tags, tags are replaced (existing behavior)."""
     mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
     mock_prepare_parsed_data.return_value = {"architecture": "amd64"}
 
@@ -895,7 +920,7 @@ def test_main__append_tags_true_preserves_tags(
     mock_find_image,
     mock_update,
 ):
-    """Test that with --append-tags true, existing tags are preserved"""
+    """Test that with --append-tags true, existing tags are preserved."""
     mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
     mock_prepare_parsed_data.return_value = {"architecture": "amd64"}
 
@@ -978,7 +1003,7 @@ def test_main__append_tags_true_updates_reapplied_tag_date(
     mock_find_image,
     mock_update,
 ):
-    """Test that with --append-tags true, re-applied tags get updated dates"""
+    """Test that with --append-tags true, re-applied tags get updated dates."""
     mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
     mock_prepare_parsed_data.return_value = {"architecture": "amd64"}
 


### PR DESCRIPTION
Add --append-tags parameter to create_container_image script. When set to true, the script preserves existing tags in Pyxis and adds new ones instead of replacing them. This enables releasing the same image for multiple product versions while maintaining all version tags.

- Add construct_tags() function to handle both normal and append modes
- Modify construct_repository() to accept pre-constructed tag dicts
- In append mode, new/re-applied tags get current date, existing-only tags preserve their original dates
- Add comprehensive unit and integration tests

Assisted-by: Claude Code