### PR TITLE
chore: rename result_paths python function

### DIFF
--- a/scripts/python/helpers/tekton.py
+++ b/scripts/python/helpers/tekton.py
@@ -88,7 +88,7 @@ def _join_var_names(names: list[str]) -> str:
     return f"{', '.join(names[:-1])}, and {names[-1]}"
 
 
-def result_paths(*env_var_names: str, file: TextIO = sys.stderr) -> tuple[Path, ...]:
+def result_paths_from_env(*env_var_names: str, file: TextIO = sys.stderr) -> tuple[Path, ...]:
     """
     Return pathlib Paths for the given environment variable names, in order.
 

--- a/scripts/python/helpers/test_tekton.py
+++ b/scripts/python/helpers/test_tekton.py
@@ -52,7 +52,7 @@ def test_subprocess_cmd_preview_for_string_cmd() -> None:
     assert s == "echo hi"
 
 
-def test_result_paths_returns_in_order(
+def test_result_paths_from_env_returns_in_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Each set env var yields a ``Path`` in the same order as the arguments."""
@@ -62,36 +62,40 @@ def test_result_paths_returns_in_order(
     b.write_text("y", encoding="utf-8")
     monkeypatch.setenv("RESULT_RESULT", str(a))
     monkeypatch.setenv("RESULT_EMBARGOED_CVES", str(b))
-    one, two = tekton.result_paths("RESULT_RESULT", "RESULT_EMBARGOED_CVES")
+    one, two = tekton.result_paths_from_env("RESULT_RESULT", "RESULT_EMBARGOED_CVES")
     assert (one, two) == (a, b)
 
 
-def test_result_paths_missing_exits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_result_paths_from_env_missing_exits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Unset or empty env values print which names are missing and exit with code 1."""
     p = tmp_path / "a"
     p.write_text("x", encoding="utf-8")
     buf = io.StringIO()
     monkeypatch.setenv("A_ONLY", str(p))
     with pytest.raises(SystemExit) as ex:
-        tekton.result_paths("A_ONLY", "B_MISSING", file=buf)
+        tekton.result_paths_from_env("A_ONLY", "B_MISSING", file=buf)
     assert ex.value.code == 1
     s = buf.getvalue()
     assert "B_MISSING" in s
     assert "must be set" in s
 
 
-def test_result_paths_three_missing_names_message(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_result_paths_from_env_three_missing_names_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Three missing names are joined in the error with an Oxford-comma style list."""
     buf = io.StringIO()
     for name in ("A", "B", "C"):
         monkeypatch.delenv(name, raising=False)
     with pytest.raises(SystemExit) as ex:
-        tekton.result_paths("A", "B", "C", file=buf)
+        tekton.result_paths_from_env("A", "B", "C", file=buf)
     assert ex.value.code == 1
     assert buf.getvalue().strip() == "A, B, and C must be set"
 
 
-def test_result_paths_no_names() -> None:
-    """Calling ``result_paths`` with no var names is a programming error."""
+def test_result_paths_from_env_no_names() -> None:
+    """Calling `result_paths_from_env` with no var names is a programming error."""
     with pytest.raises(ValueError, match="at least one"):
-        tekton.result_paths()
+        tekton.result_paths_from_env()

--- a/scripts/python/tasks/internal/check_embargoed_cves.py
+++ b/scripts/python/tasks/internal/check_embargoed_cves.py
@@ -258,7 +258,7 @@ def main(argv: list[str] | None = None) -> int:
     if not cve_list:
         return 1
 
-    rpath, epath = tekton.result_paths("RESULT_RESULT", "RESULT_EMBARGOED_CVES")
+    rpath, epath = tekton.result_paths_from_env("RESULT_RESULT", "RESULT_EMBARGOED_CVES")
     # Clear both files up front: if run_check throws, the embargoed list
     # stays empty and we still fill result.
     epath.write_text("", encoding="utf-8")

--- a/scripts/python/tasks/internal/check_fbc_opt_in.py
+++ b/scripts/python/tasks/internal/check_fbc_opt_in.py
@@ -161,7 +161,7 @@ def run_check(
 def main() -> int:
     """Write `RESULT_OPT_IN_RESULTS` and return exit code `0` on success."""
     # `RESULT_OPT_IN_RESULTS` is the path of the JSON file this step writes.
-    rpath = tekton.result_paths("RESULT_OPT_IN_RESULTS")[0]
+    rpath = tekton.result_paths_from_env("RESULT_OPT_IN_RESULTS")[0]
     raw_images = os.environ.get("CONTAINER_IMAGES", "")
 
     try:


### PR DESCRIPTION
This function renames the tekton python helper result_paths to result_paths_from_env for better clarity.