### PR TITLE
chore: don't run e2e on draft PRs

### DIFF
--- a/.tekton/release-service-utils-standalone-pull-request.yaml
+++ b/.tekton/release-service-utils-standalone-pull-request.yaml
@@ -7,7 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main") || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      (event == "pull_request"
+      && target_branch == "main"
+      && (!has(body.pull_request) || !body.pull_request.draft))
+      || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: release-service-utils


### PR DESCRIPTION
This commit updates the build pr pipeline to not automatically run if the PR is a draft. This is done in the same way the release-service-catalog does it - via cel expression. E2E should still be able to be triggered via a /retest comment, so this should just prevent unintended additional runs.