### PR TITLE
feat(RELEASE-1986): filter-already-released-advisory-images script

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -22,6 +22,9 @@ jobs:
         run: |
           sudo apt-get -y update
           sudo apt-get install -y libkrb5-dev
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_amd64 \
+            -o /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
       - name: Check out repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:

--- a/integration-tests/lib/tests/test_run_single_catalog_e2e_suite.py
+++ b/integration-tests/lib/tests/test_run_single_catalog_e2e_suite.py
@@ -422,6 +422,7 @@ def test_fetch_run_test_task_output_json_invalid_json_in_value(
 
 
 def test_require_test_output_success_none_exits() -> None:
+    """Missing TEST_OUTPUT JSON exits with code 1."""
     with pytest.raises(SystemExit) as ei:
         rs._require_test_output_success(None)
     assert ei.value.code == 1
@@ -430,6 +431,7 @@ def test_require_test_output_success_none_exits() -> None:
 def test_require_test_output_success_failure_exits(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """A FAILURE TEST_OUTPUT result exits with code 1."""
     with pytest.raises(SystemExit) as ei:
         rs._require_test_output_success({"result": "FAILURE"})
     assert ei.value.code == 1
@@ -437,12 +439,14 @@ def test_require_test_output_success_failure_exits(
 
 
 def test_require_test_output_success_ok() -> None:
+    """A SUCCESS TEST_OUTPUT result is accepted."""
     rs._require_test_output_success({"result": "SUCCESS"})
 
 
 def test_require_test_output_success_skipped_prints(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """A SKIPPED TEST_OUTPUT result is printed and accepted."""
     rs._require_test_output_success({"result": "SKIPPED"})
     assert "SKIPPED" in capsys.readouterr().out
 
@@ -450,6 +454,7 @@ def test_require_test_output_success_skipped_prints(
 def test_require_test_output_success_unexpected_exits(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """An unexpected TEST_OUTPUT result exits with code 1."""
     with pytest.raises(SystemExit) as ei:
         rs._require_test_output_success({"result": "WAT"})
     assert ei.value.code == 1
@@ -457,6 +462,7 @@ def test_require_test_output_success_unexpected_exits(
 
 
 def test_build_snapshot_shape() -> None:
+    """``_build_snapshot`` returns the expected application and component fields."""
     snap = rs._build_snapshot(
         runner="quay.io/img:v1",
         url="https://github.com/o/r.git",
@@ -470,6 +476,7 @@ def test_build_snapshot_shape() -> None:
 
 
 def test_build_catalog_e2e_pipelinerun_shape() -> None:
+    """``_build_catalog_e2e_pipelinerun`` wires snapshot and parent metadata."""
     snap = rs._build_snapshot(runner="r", url="u", rev="v")
     m = rs._build_catalog_e2e_pipelinerun(
         ns="rhtap-release-2-tenant",

--- a/scripts/python/helpers/subprocess_cmd.py
+++ b/scripts/python/helpers/subprocess_cmd.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
+
+import tekton
+
+RunCmd = Callable[..., str]
 
 
 def run_cmd(
@@ -57,3 +62,45 @@ def run_cmd(
     finally:
         if fh is not None:
             fh.close()
+
+
+def run_cmd_text(
+    cmd: Sequence[str | Path],
+    *,
+    cwd: Path | None = None,
+) -> str:
+    """Run *cmd*, return captured stdout as text, and raise on non-zero exit.
+
+    Uses a Tekton-friendly command preview in ``CalledProcessError.cmd``.
+    """
+    argv = [str(x) for x in cmd]
+    proc = subprocess.run(
+        argv,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        preview = tekton.subprocess_cmd_preview_for_tekton_result(argv)
+        err = (proc.stderr or proc.stdout or "").strip()
+        raise subprocess.CalledProcessError(
+            proc.returncode,
+            preview,
+            output=err,
+        )
+    return proc.stdout or ""
+
+
+def run_yq_json(
+    path: Path,
+    expression: str,
+    *,
+    run_cmd: RunCmd | None = None,
+) -> Any:
+    """Evaluate a ``yq`` expression against ``path`` and parse JSON output."""
+    runner = run_cmd or run_cmd_text
+    out = runner(["yq", "-o=json", expression, str(path)])
+    if not str(out).strip():
+        return []
+    return json.loads(out)

--- a/scripts/python/helpers/tekton.py
+++ b/scripts/python/helpers/tekton.py
@@ -1,23 +1,29 @@
-"""Shared helpers for Tekton `result`-file and step-error conventions in task scripts.
+"""Shared helpers for Tekton task scripts: results, step errors, and CLI parsing.
 
 The catalog passes result file locations via environment variables
 (`env.value: $(results.foo.path)` on the task step). Tasks that require those
 paths should fail fast in the same way: print to stderr and exit 1, since
 downstream can only interpret `result` bodies when the step was intended to
 write them.
+
+CLI entrypoints use the same contract: short usage on stderr and exit 1 for
+``--help`` or missing required flags (not argparse's default stdout help or
+exit codes).
 """
 
 from __future__ import annotations
 
+import argparse
 import os
 import re
 import sys
 from pathlib import Path
-from typing import TextIO
+from typing import NoReturn, TextIO
 
 
 class CheckStepError(Exception):
-    """
+    """Attach a human task action to an underlying exception for Tekton results.
+
     Pairs a short *human* description of what the task was doing (the first
     argument) with the real exception, for the Tekton one-line result file.
     The standard library and `requests` only know about the underlying failure
@@ -26,14 +32,14 @@ class CheckStepError(Exception):
     """
 
     def __init__(self, action: str, cause: BaseException) -> None:
+        """Store *action* and *cause* on the exception instance."""
         self.action = action
         self.cause = cause
         super().__init__(f"{action}: {cause}")
 
 
 def result_text_from_exception(exc: BaseException, *, max_len: int = 500) -> str:
-    """
-    `str(exc)` in a form suitable for a Tekton `result` value.
+    """`str(exc)` in a form suitable for a Tekton `result` value.
 
     Reuses each exception’s normal string (no custom wording per type).
     Newlines are flattened and the text is cut at *max_len* so the value
@@ -74,8 +80,7 @@ def write_failure_result(
     max_log_lines: int = 20,
     max_total_len: int = 8192,
 ) -> None:
-    """
-    Write Tekton `result` text for a failed step.
+    """Write Tekton `result` text for a failed step.
 
     Includes a one-line summary (`CheckStepError` uses its *action*; other
     exceptions use *workflow_action*) and, when *command_log_path* is set, the
@@ -106,8 +111,7 @@ def subprocess_cmd_preview_for_tekton_result(
     *,
     max_len: int = 200,
 ) -> str:
-    """
-    One-line description of a subprocess *cmd* for Tekton `result` files.
+    """One-line description of a subprocess *cmd* for Tekton `result` files.
 
     `CalledProcessError` (and some APIs) expose *cmd* as a string, a list of
     argv pieces, or another object. Result lines stay short, so the joined or
@@ -121,10 +125,7 @@ def subprocess_cmd_preview_for_tekton_result(
 
 
 def _join_var_names(names: list[str]) -> str:
-    """
-    Build a small English list for a one-line error message, for example
-    "A and B" or "A, B, and C".
-    """
+    """Format names as an English list, for example ``A and B`` or ``A, B, and C``."""
     if len(names) == 1:
         return names[0]
     if len(names) == 2:
@@ -133,8 +134,7 @@ def _join_var_names(names: list[str]) -> str:
 
 
 def require_env(name: str, *, file: TextIO = sys.stderr) -> str:
-    """
-    Return the non-empty string value of an environment variable.
+    """Return the non-empty string value of an environment variable.
 
     If *name* is unset or only whitespace, print `{name} must be set` to
     *file* and raise `SystemExit(1)`.
@@ -147,8 +147,7 @@ def require_env(name: str, *, file: TextIO = sys.stderr) -> str:
 
 
 def result_paths_from_env(*env_var_names: str, file: TextIO = sys.stderr) -> tuple[Path, ...]:
-    """
-    Return pathlib Paths for the given environment variable names, in order.
+    """Return pathlib Paths for the given environment variable names, in order.
 
     In Tekton, each result file is often wired as an env var whose value is the
     path the step must write. For every name you pass, the value in `os.environ`
@@ -173,3 +172,24 @@ def result_paths_from_env(*env_var_names: str, file: TextIO = sys.stderr) -> tup
         print(f"{label} must be set", file=file)
         raise SystemExit(1)
     return tuple(out)
+
+
+def tekton_argument_parser(prog: str) -> argparse.ArgumentParser:
+    """Return an ``ArgumentParser`` for Tekton task entrypoints.
+
+    Disables argparse's default help and usage strings so callers can print a
+    short, task-specific usage summary to stderr and exit with code ``1``.
+    Unknown or extra arguments still make ``parse_args`` exit with code ``2``.
+    """
+    return argparse.ArgumentParser(prog=prog, add_help=False, usage=argparse.SUPPRESS)
+
+
+def exit_with_usage(usage: str, code: int = 1) -> NoReturn:
+    """Print *usage* to stderr and terminate with *code*."""
+    print(usage, file=sys.stderr, end="")
+    raise SystemExit(code)
+
+
+def missing_blank_option_values(*options: tuple[str, str | None]) -> list[str]:
+    """Return flag names whose values are missing or whitespace-only."""
+    return [name for name, val in options if not val or not str(val).strip()]

--- a/scripts/python/helpers/test_subprocess_cmd.py
+++ b/scripts/python/helpers/test_subprocess_cmd.py
@@ -2,23 +2,30 @@
 
 from __future__ import annotations
 
+import json
+import shutil
 import subprocess
+from pathlib import Path
+from unittest import mock
 
 import pytest
 import subprocess_cmd
 
 
 def test_run_cmd_captures_stdout() -> None:
+    """``run_cmd`` returns captured stdout from a successful subprocess."""
     out = subprocess_cmd.run_cmd(["echo", "hi"], check=True).stdout.strip()
     assert out == "hi"
 
 
 def test_run_cmd_check_false(tmp_path) -> None:
+    """``run_cmd`` with ``check=False`` returns a non-zero exit code without raising."""
     r = subprocess_cmd.run_cmd(["false"], cwd=tmp_path, check=False)
     assert r.returncode != 0
 
 
 def test_run_cmd_stderr_path_logs_failed_command(tmp_path) -> None:
+    """Failed commands append a failure line to *stderr_path*."""
     log = tmp_path / "log.txt"
     with pytest.raises(subprocess.CalledProcessError):
         subprocess_cmd.run_cmd(["false"], stderr_path=log, check=True)
@@ -28,6 +35,80 @@ def test_run_cmd_stderr_path_logs_failed_command(tmp_path) -> None:
 
 
 def test_run_cmd_stderr_path_on_success(tmp_path) -> None:
+    """Successful commands leave *stderr_path* empty."""
     log = tmp_path / "log.txt"
     subprocess_cmd.run_cmd(["echo", "ok"], stderr_path=log, check=True)
     assert log.read_text(encoding="utf-8") == ""
+
+
+def test_run_cmd_text_success() -> None:
+    """``run_cmd_text`` returns stdout from a successful subprocess."""
+    with mock.patch("subprocess_cmd.subprocess.run") as run:
+        run.return_value = mock.Mock(returncode=0, stdout="ok", stderr="")
+        assert subprocess_cmd.run_cmd_text(["echo", "ok"]) == "ok"
+
+
+def test_run_cmd_text_failure() -> None:
+    """``run_cmd_text`` raises ``CalledProcessError`` on non-zero exit."""
+    with mock.patch("subprocess_cmd.subprocess.run") as run:
+        run.return_value = mock.Mock(returncode=1, stdout="", stderr="bad")
+        with pytest.raises(subprocess.CalledProcessError):
+            subprocess_cmd.run_cmd_text(["false"])
+
+
+def test_run_yq_json_empty_output(tmp_path: Path) -> None:
+    """Blank ``yq`` output is treated as an empty list."""
+    path = tmp_path / "advisory.yaml"
+    path.write_text("x: 1\n", encoding="utf-8")
+    assert (
+        subprocess_cmd.run_yq_json(
+            path, ".spec.content.images // []", run_cmd=lambda *_a, **_k: ""
+        )
+        == []
+    )
+
+
+def test_run_yq_json_uses_runner(tmp_path: Path) -> None:
+    """Injected ``run_cmd`` is used instead of subprocess."""
+    path = tmp_path / "advisory.yaml"
+    path.write_text("x: 1\n", encoding="utf-8")
+
+    def _runner(args: list[str], *, cwd: Path | None = None) -> str:
+        assert args[0] == "yq"
+        return json.dumps([{"containerImage": "a"}])
+
+    assert subprocess_cmd.run_yq_json(path, ".spec.content.images // []", run_cmd=_runner) == [
+        {"containerImage": "a"}
+    ]
+
+
+def test_run_yq_json_reads_yaml_with_yq(tmp_path: Path) -> None:
+    """``run_yq_json`` runs ``yq -o=json`` against advisory YAML and parses JSON."""
+    if shutil.which("yq") is None:
+        pytest.skip("yq is not installed")
+
+    path = tmp_path / "advisory.yaml"
+    path.write_text(
+        """\
+spec:
+  type: RHBA
+  content:
+    images:
+      - containerImage: registry.example.com/app@sha256:abc
+        tags: ["v1"]
+        repository: registry.example.com/app
+metadata:
+  name: "2025:1"
+""",
+        encoding="utf-8",
+    )
+
+    assert subprocess_cmd.run_yq_json(path, ".spec.content.images // []") == [
+        {
+            "containerImage": "registry.example.com/app@sha256:abc",
+            "tags": ["v1"],
+            "repository": "registry.example.com/app",
+        }
+    ]
+    assert subprocess_cmd.run_yq_json(path, ".spec.type") == "RHBA"
+    assert subprocess_cmd.run_yq_json(path, ".metadata.name") == "2025:1"

--- a/scripts/python/helpers/test_tekton.py
+++ b/scripts/python/helpers/test_tekton.py
@@ -9,6 +9,32 @@ import pytest
 import tekton
 
 
+def test_tekton_argument_parser_suppresses_default_help() -> None:
+    """Built-in help is disabled; unknown args still exit with code 2."""
+    p = tekton.tekton_argument_parser("prog.py")
+    p.add_argument("--foo")
+    with pytest.raises(SystemExit) as exc:
+        p.parse_args(["--help"])
+    assert exc.value.code == 2
+
+
+def test_exit_with_usage() -> None:
+    """Usage text is printed to stderr and the process exits with the given code."""
+    with pytest.raises(SystemExit) as exc:
+        tekton.exit_with_usage("usage: prog\n", code=1)
+    assert exc.value.code == 1
+
+
+def test_missing_blank_option_values() -> None:
+    """Missing, empty, and whitespace-only values are reported by flag name."""
+    assert tekton.missing_blank_option_values(
+        ("--a", None),
+        ("--b", ""),
+        ("--c", "  "),
+        ("--d", "ok"),
+    ) == ["--a", "--b", "--c"]
+
+
 def test_check_step_error() -> None:
     """`CheckStepError` stores the human *action* and the underlying *cause*."""
     inner = KeyError("k")

--- a/scripts/python/tasks/internal/check_embargoed_cves.py
+++ b/scripts/python/tasks/internal/check_embargoed_cves.py
@@ -40,6 +40,10 @@ import osidb
 import tekton
 
 PROG = "check_embargoed_cves.py"
+USAGE = (
+    f"usage: {PROG} [--cves 'CVE-1 CVE-2']\n"
+    f"  --cves  The CVEs to check (space-separated, quote if you pass several)\n"
+)
 
 
 def parse_cve_list(value: str) -> list[str]:
@@ -48,8 +52,7 @@ def parse_cve_list(value: str) -> list[str]:
 
 
 def is_embargoed_flaw_response(data: dict[str, Any]) -> bool:
-    """
-    Return True if the first flaw in the list response is not clearly not embargoed.
+    """Return True if the first flaw in the list response is not clearly not embargoed.
 
     Only ``results[0].embargoed`` with JSON value ``false`` is treated as
     not embargoed. Empty ``results``, a missing first row, a non-dict first row,
@@ -68,10 +71,7 @@ def is_embargoed_flaw_response(data: dict[str, Any]) -> bool:
 
 
 def _embargo_finding_result_text(program_name: str) -> str:
-    """
-    Text to write to ``RESULT_RESULT`` when the run finished without a Python
-    exception but the OSIDB API indicates at least one listed CVE is embargoed
-    or not clearly public.
+    """Build ``RESULT_RESULT`` text when listed CVEs are not clearly public.
 
     CVE ids are written to ``RESULT_EMBARGOED_CVES``; this string in
     ``RESULT_RESULT`` points readers there.
@@ -83,12 +83,11 @@ def _embargo_finding_result_text(program_name: str) -> str:
 
 
 def fetch_flaw_state(osidb_url: str, token: str, cve_id: str) -> dict[str, Any]:
-    """
-    GET the v2 flaw list for one CVE, asking only for ``cve_id`` and
-    ``embargoed`` fields, using the bearer token.
+    """GET the v2 flaw list for one CVE using the bearer token.
 
-    Returns a parsed JSON object, or an empty dict if the response body is
-    empty (treated as no visible flaw for embargo decisions).
+    Requests only ``cve_id`` and ``embargoed`` fields. Returns a parsed JSON
+    object, or an empty dict if the response body is empty (treated as no
+    visible flaw for embargo decisions).
     """
     q = urllib.parse.urlencode([("cve_id", cve_id), ("include_fields", "cve_id,embargoed")])
     u = f"{osidb_url.rstrip('/')}/osidb/api/v2/flaws?{q}"
@@ -104,33 +103,20 @@ def fetch_flaw_state(osidb_url: str, token: str, cve_id: str) -> dict[str, Any]:
     return json.loads(body)
 
 
-def _usage_text() -> str:
-    """Return the short usage summary printed to stderr on bad CLI usage."""
-    return (
-        f"usage: {PROG} [--cves 'CVE-1 CVE-2']\n"
-        f"  --cves  The CVEs to check (space-separated, quote if you pass several)\n"
-    )
-
-
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
-    """
-    Parse CLI arguments: ``--cves`` (required) and ``-h`` / ``--help``.
+    """Parse CLI arguments: ``--cves`` (required) and ``-h`` / ``--help``.
 
     The Tekton task uses a fixed argv shape; this uses strict parsing (extra
     arguments are rejected by ``argparse`` with exit 2). Help, or missing/blank
     ``--cves``, print our usage to stderr and exit 1. Returns a namespace
     with a ``cves`` string.
     """
-    p = argparse.ArgumentParser(prog=PROG, add_help=False, usage=argparse.SUPPRESS)
+    p = tekton.tekton_argument_parser(PROG)
     p.add_argument("-h", "--help", action="store_true")
     p.add_argument("--cves", metavar="CVES")
     ns = p.parse_args(argv or [])
-    if ns.help:
-        print(_usage_text(), file=sys.stderr, end="")
-        raise SystemExit(1)
-    if not ns.cves or not str(ns.cves).strip():
-        print(_usage_text(), file=sys.stderr, end="")
-        raise SystemExit(1)
+    if ns.help or tekton.missing_blank_option_values(("--cves", ns.cves)):
+        tekton.exit_with_usage(USAGE)
     return ns
 
 
@@ -143,8 +129,7 @@ def run_check(
     get_flaw: Any = fetch_flaw_state,
     krb5_template: Path = Path("/etc/krb5.conf"),
 ) -> tuple[list[str], int]:
-    """
-    Core check: kinit, then for each CVE fetch token + flaw JSON and test embargo.
+    """Core check: kinit, then for each CVE fetch token + flaw JSON and test embargo.
 
     Writes the keytab and a patched KRB5_CONFIG to temp files, runs ``kinit``,
     then for each id obtains a token and queries flaws. Injected callables
@@ -235,8 +220,7 @@ def run_check(
 
 
 def main(argv: list[str] | None = None) -> int:
-    """
-    CLI entry: bad args return 1; a normal run writes result files and returns 0.
+    """CLI entry: bad args return 1; a normal run writes result files and returns 0.
 
     Normal runs (with ``RESULT_RESULT`` and ``RESULT_EMBARGOED_CVES``) always
     exit 0 at the process level; logical success is ``Success`` in the first

--- a/scripts/python/tasks/internal/filter_already_released_advisory_images.py
+++ b/scripts/python/tasks/internal/filter_already_released_advisory_images.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Filter snapshot images already published in GitLab-stored advisories.
+
+Reads advisory repository metadata from a mounted secret, sparse-clones the
+advisory Git repository, and progressively removes arch-specific snapshot rows
+that match ``spec.content.images`` entries in existing advisories.
+
+Writes Tekton result files from ``RESULT_*`` environment variables.
+The process exits with status ``0`` even on logical failure so callers can
+read ``RESULT_RESULT``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import gzip
+import json
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from git.exc import GitCommandError
+
+import file
+import internal_request
+import subprocess_cmd
+import tekton
+from logger import logger
+from vcs import gitlab
+
+PROG = "filter_already_released_advisory_images.py"
+USAGE = (
+    f"usage: {PROG} --transformed-snapshot B64 --origin ORIGIN "
+    f"--internal-request-pipeline-run-name NAME "
+    f"--internal-request-task-run-name NAME\n"
+    f"  --transformed-snapshot  Gzip+base64 JSON array of arch-specific images\n"
+    f"  --origin                Release origin workspace (advisories subdir)\n"
+)
+ADVISORY_SECRET_MOUNT_DEFAULT = Path("/mnt/advisory_secret")
+
+
+@dataclass(frozen=True)
+class FilterOutput:
+    """Values written to Tekton result files."""
+
+    result: str
+    unreleased_components_b64: str
+    advisory_url: str
+    advisory_internal_url: str
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse required CLI flags for Tekton parameters."""
+    p = tekton.tekton_argument_parser(PROG)
+    p.add_argument("-h", "--help", action="store_true")
+    p.add_argument("--transformed-snapshot", metavar="B64")
+    p.add_argument("--origin", metavar="ORIGIN")
+    p.add_argument("--internal-request-pipeline-run-name", metavar="NAME")
+    p.add_argument("--internal-request-task-run-name", metavar="NAME")
+    ns = p.parse_args(argv or [])
+    if ns.help or tekton.missing_blank_option_values(
+        ("--transformed-snapshot", ns.transformed_snapshot),
+        ("--origin", ns.origin),
+        (
+            "--internal-request-pipeline-run-name",
+            ns.internal_request_pipeline_run_name,
+        ),
+        ("--internal-request-task-run-name", ns.internal_request_task_run_name),
+    ):
+        tekton.exit_with_usage(USAGE)
+    return ns
+
+
+def decode_transformed_snapshot(value: str) -> list[dict[str, Any]]:
+    """Decode a gzip+base64 JSON array of arch-specific snapshot rows."""
+    try:
+        raw = base64.b64decode(value, validate=True)
+        text = gzip.decompress(raw).decode("utf-8")
+        data = json.loads(text)
+    except (OSError, ValueError, json.JSONDecodeError) as e:
+        raise ValueError("invalid transformed snapshot payload") from e
+    if not isinstance(data, list):
+        raise ValueError("transformed snapshot must be a JSON array")
+    return data
+
+
+def unique_component_names(arch_images: list[dict[str, Any]]) -> list[str]:
+    """Return unique ``name`` values from ``arch_images`` in first-seen order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for row in arch_images:
+        name = row.get("name")
+        if not isinstance(name, str) or not name or name in seen:
+            continue
+        seen.add(name)
+        out.append(name)
+    return out
+
+
+def encode_gzipped_base64_json(value: Any) -> str:
+    """Return ``gzip(JSON)`` encoded as base64 without trailing newline."""
+    payload = json.dumps(value, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return base64.b64encode(gzip.compress(payload)).decode("ascii")
+
+
+def filter_arch_images(
+    arch_images: list[dict[str, Any]],
+    existing_images: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Drop snapshot rows whose image triple exists in ``existing_images``."""
+    kept: list[dict[str, Any]] = []
+    for row in arch_images:
+        ci = row.get("containerImage")
+        tags = row.get("tags")
+        repo = row.get("repository")
+        if any(
+            ex.get("containerImage") == ci
+            and ex.get("tags") == tags
+            and ex.get("repository") == repo
+            for ex in existing_images
+        ):
+            continue
+        kept.append(row)
+    return kept
+
+
+def list_advisory_subdirs(advisory_base_dir: Path) -> list[str]:
+    """Return advisory subdirectories relative to ``advisory_base_dir``, newest first."""
+    if not advisory_base_dir.is_dir():
+        return []
+    newest: dict[str, float] = {}
+    for advisory_file in advisory_base_dir.rglob("advisory.yaml"):
+        subdir = advisory_file.parent
+        rel = subdir.relative_to(advisory_base_dir)
+        if len(rel.parts) < 2:
+            continue
+        key = rel.as_posix()
+        mtime = subdir.stat().st_mtime
+        newest[key] = max(newest.get(key, 0.0), mtime)
+    return [name for name, _ in sorted(newest.items(), key=lambda item: item[1], reverse=True)]
+
+
+def advisory_errata_url_prefix(git_repo: str) -> str:
+    """Return the public errata URL prefix for production or stage advisories."""
+    if "/rhtap-release/" in git_repo:
+        return "https://access.stage.redhat.com/errata"
+    return "https://access.redhat.com/errata"
+
+
+def build_advisory_urls(
+    git_repo: str,
+    advisory_file: Path,
+    advisory_type: str,
+    advisory_name: str,
+) -> tuple[str, str]:
+    """Build public and GitLab raw URLs for a matching advisory."""
+    prefix = advisory_errata_url_prefix(git_repo)
+    public_url = f"{prefix}/{advisory_type}-{advisory_name}"
+    internal_url = gitlab.raw_file_url(git_repo, advisory_file.as_posix())
+    return public_url, internal_url
+
+
+def run_filter(
+    transformed_snapshot_b64: str,
+    origin: str,
+    secret_mount: Path,
+    *,
+    work_dir: Path | None = None,
+    clone_sparse: Callable[[], Path] | None = None,
+    run_cmd: Callable[..., str] | None = None,
+) -> FilterOutput:
+    """Filter arch-specific snapshot rows against advisories stored in GitLab."""
+    arch_images = decode_transformed_snapshot(transformed_snapshot_b64)
+    logger.info("Transformed Snapshot JSON (arch-specific): %s", json.dumps(arch_images))
+
+    try:
+        credentials = gitlab.read_credentials_from_mount(secret_mount)
+    except OSError as e:
+        raise tekton.CheckStepError("reading the mounted advisory secret", e) from e
+    gitlab.export_env_for_image_helpers(credentials)
+    gitlab.configure_git_oauth2_auth(credentials.access_token)
+
+    advisory_base_dir = f"data/advisories/{origin.strip()}"
+    tmp_root = work_dir or Path("/tmp")
+    try:
+        if clone_sparse is not None:
+            repo_dir = clone_sparse()
+        else:
+            repo_dir = gitlab.clone_project_sparse(
+                credentials.git_repo,
+                gitlab.DEFAULT_BRANCH,
+                [advisory_base_dir],
+                parent_dir=tmp_root,
+                stderr_path=None,
+            )
+    except GitCommandError as e:
+        raise tekton.CheckStepError("cloning the advisory Git repository", e) from e
+
+    advisory_root = repo_dir / advisory_base_dir
+
+    existing = list_advisory_subdirs(advisory_root)
+    if not existing:
+        logger.info("No existing advisories found. No components have been released yet.")
+        names = unique_component_names(arch_images)
+        return FilterOutput(
+            result="Success",
+            unreleased_components_b64=encode_gzipped_base64_json(names),
+            advisory_url="",
+            advisory_internal_url="",
+        )
+
+    latest_advisory_file = ""
+    working = arch_images
+    for subdir in existing:
+        advisory_file = advisory_root / subdir / "advisory.yaml"
+        existing_images = subprocess_cmd.run_yq_json(
+            advisory_file,
+            ".spec.content.images // []",
+            run_cmd=run_cmd,
+        )
+        if not isinstance(existing_images, list):
+            existing_images = []
+
+        logger.info("Comparing against: %s", advisory_file)
+        before = working
+        working = filter_arch_images(working, existing_images)
+
+        if len(before) > len(working) and not latest_advisory_file:
+            latest_advisory_file = str(advisory_file.relative_to(repo_dir))
+            logger.info(
+                "Tracked latest advisory: %s (filtered %s items)",
+                latest_advisory_file,
+                len(before) - len(working),
+            )
+
+        if not working:
+            logger.info(
+                "All arch images in the snapshot have already been released in advisories. "
+                "Stopping pipeline."
+            )
+            latest_path = repo_dir / latest_advisory_file
+            adv_type = str(
+                subprocess_cmd.run_yq_json(latest_path, ".spec.type", run_cmd=run_cmd)
+            ).strip()
+            adv_name = str(
+                subprocess_cmd.run_yq_json(latest_path, ".metadata.name", run_cmd=run_cmd)
+            ).strip()
+            public_url, internal_url = build_advisory_urls(
+                credentials.git_repo,
+                Path(latest_advisory_file),
+                adv_type,
+                adv_name,
+            )
+            return FilterOutput(
+                result="Success",
+                unreleased_components_b64=encode_gzipped_base64_json([]),
+                advisory_url=public_url,
+                advisory_internal_url=internal_url,
+            )
+
+    original_count = len(arch_images)
+    remaining_count = len(working)
+    logger.info(
+        "Filtered out %s arch-specific image(s) already in advisories",
+        original_count - remaining_count,
+    )
+    logger.info("Remaining unpublished arch images: %s", json.dumps(working))
+    names = unique_component_names(working)
+    return FilterOutput(
+        result="Success",
+        unreleased_components_b64=encode_gzipped_base64_json(names),
+        advisory_url="",
+        advisory_internal_url="",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse CLI args, write Tekton results, and always return ``0`` on normal runs."""
+    raw_argv = sys.argv if argv is None else argv
+    try:
+        args = parse_args(raw_argv[1:])
+    except SystemExit as e:
+        code = e.code
+        return code if isinstance(code, int) else 1
+
+    (
+        path_step_result,
+        path_advisory_url,
+        path_advisory_internal_url,
+        path_internal_pr,
+        path_internal_task_run,
+        path_unreleased,
+    ) = tekton.result_paths_from_env(
+        "RESULT_RESULT",
+        "RESULT_ADVISORY_URL",
+        "RESULT_ADVISORY_INTERNAL_URL",
+        "RESULT_INTERNAL_REQUEST_PIPELINE_RUN_NAME",
+        "RESULT_INTERNAL_REQUEST_TASK_RUN_NAME",
+        "RESULT_UNRELEASED_COMPONENTS",
+    )
+    result_paths = {
+        "result": path_step_result,
+        "advisory_url": path_advisory_url,
+        "advisory_internal_url": path_advisory_internal_url,
+        "internal_pr_name": path_internal_pr,
+        "internal_task_run_name": path_internal_task_run,
+        "unreleased_components": path_unreleased,
+    }
+    program_basename = str(Path(raw_argv[0]).name)
+
+    path_advisory_url.write_text("", encoding="utf-8")
+    path_advisory_internal_url.write_text("", encoding="utf-8")
+    path_unreleased.write_text("", encoding="utf-8")
+
+    mount = file.path_from_env_variable(
+        "ADVISORY_SECRET_MOUNT",
+        ADVISORY_SECRET_MOUNT_DEFAULT,
+    )
+    try:
+        internal_request.write_result_paths(
+            result_paths,
+            pipeline_run_name=args.internal_request_pipeline_run_name,
+            task_run_name=args.internal_request_task_run_name,
+        )
+        output = run_filter(
+            args.transformed_snapshot,
+            args.origin,
+            mount,
+        )
+        result_paths["result"].write_text(output.result, encoding="utf-8")
+        result_paths["unreleased_components"].write_text(
+            output.unreleased_components_b64,
+            encoding="utf-8",
+        )
+        result_paths["advisory_url"].write_text(output.advisory_url, encoding="utf-8")
+        result_paths["advisory_internal_url"].write_text(
+            output.advisory_internal_url,
+            encoding="utf-8",
+        )
+    except Exception as e:
+        tekton.write_failure_result(
+            path_step_result,
+            program_basename,
+            e,
+            workflow_action="filtering already released advisory images",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/internal/test_filter_already_released_advisory_images.py
+++ b/scripts/python/tasks/internal/test_filter_already_released_advisory_images.py
@@ -1,0 +1,754 @@
+"""Tests for `filter_already_released_advisory_images`."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest import mock
+
+import filter_already_released_advisory_images as filt
+import pytest
+import tekton
+from git.exc import GitCommandError
+
+
+def _encode_snapshot(rows: list[dict[str, object]] | dict[str, object]) -> str:
+    payload = json.dumps(rows, separators=(",", ":")).encode("utf-8")
+    return base64.b64encode(gzip.compress(payload)).decode("ascii")
+
+
+def _decode_components(value: str) -> list[str]:
+    raw = base64.b64decode(value)
+    return json.loads(gzip.decompress(raw).decode("utf-8"))
+
+
+def _write_secret(mount: Path, *, git_repo: str = "https://gitlab.com/org/repo.git") -> None:
+    mount.mkdir(parents=True, exist_ok=True)
+    (mount / "git_repo").write_text(git_repo, encoding="utf-8")
+    (mount / "gitlab_host").write_text("gitlab.example.com", encoding="utf-8")
+    (mount / "gitlab_access_token").write_text("token", encoding="utf-8")
+    (mount / "git_author_name").write_text("tester", encoding="utf-8")
+    (mount / "git_author_email").write_text("tester@tester", encoding="utf-8")
+
+
+def _advisory_images_by_num(advisory_num: str) -> list[dict[str, object]]:
+    """Mirror catalog ``tests/mocks.sh`` advisory image payloads."""
+    mapping: dict[str, list[dict[str, object]]] = {
+        "1601": [
+            {
+                "containerImage": "registry.redhat.io/test@sha256:releasedarch123",
+                "tags": ["v1.0"],
+                "repository": "registry.redhat.io/test",
+            },
+            {
+                "containerImage": "registry.redhat.io/test@sha256:amd64digest123",
+                "tags": ["v1.0"],
+                "repository": "registry.redhat.io/test",
+            },
+            {
+                "containerImage": "registry.redhat.io/test@sha256:arm64digest456",
+                "tags": ["v1.0"],
+                "repository": "registry.redhat.io/test",
+            },
+        ],
+        "1602": [
+            {
+                "containerImage": "quay.io/test/other-image:1.0.0",
+                "tags": ["stable"],
+                "repository": "quay.io/test",
+            }
+        ],
+        "1452": [
+            {
+                "containerImage": "quay.io/test/legacy-image:2.0.0",
+                "tags": ["old"],
+                "repository": "quay.io/legacy",
+            }
+        ],
+    }
+    return mapping.get(advisory_num, [])
+
+
+def _catalog_yq_fake(args: list[str], *, cwd: Path | None = None) -> str:
+    """Return mock ``yq`` JSON for advisory paths under ``test-origin``."""
+    if args[0] != "yq":
+        return ""
+    expression = args[2]
+    advisory_path = args[3]
+    advisory_num = Path(advisory_path).parent.name
+    if expression == ".spec.type":
+        return json.dumps("RHBA")
+    if expression == ".metadata.name":
+        year = Path(advisory_path).parent.parent.name
+        return json.dumps(f"{year}:{advisory_num}")
+    if expression == ".spec.content.images // []":
+        return json.dumps(_advisory_images_by_num(advisory_num))
+    return ""
+
+
+def _setup_repo_tree(repo: Path, origin: str, advisory_nums: list[str]) -> None:
+    """Create advisory layout under ``repo/data/advisories/<origin>/``."""
+    base = repo / "data" / "advisories" / origin
+    if not advisory_nums:
+        base.mkdir(parents=True, exist_ok=True)
+        return
+    for sub in advisory_nums:
+        (base / sub).mkdir(parents=True, exist_ok=True)
+        (base / sub / "advisory.yaml").write_text(
+            "spec: {}\nmetadata: {}\n",
+            encoding="utf-8",
+        )
+
+
+def _make_clone_sparse(
+    tmp_path: Path,
+    *,
+    origin: str = "test-origin",
+    advisory_nums: list[str] | None = None,
+) -> object:
+    """Return a ``clone_sparse`` callable that materializes a fake advisory repo tree."""
+    repo = tmp_path / "work" / "repo"
+    nums = advisory_nums if advisory_nums is not None else ["2025/1601"]
+
+    def _clone() -> Path:
+        _setup_repo_tree(repo, origin, nums)
+        return repo
+
+    return _clone
+
+
+def _make_yq_run_cmd(*, fail: bool = False) -> object:
+    """Return a ``run_cmd`` fake for ``yq`` invocations."""
+
+    def _run_cmd(args: list[str], *, cwd: Path | None = None) -> str:
+        if fail:
+            raise subprocess.CalledProcessError(1, "yq", output="yq failed")
+        if args[:1] == ["yq"]:
+            return _catalog_yq_fake(args, cwd=cwd)
+        return ""
+
+    return _run_cmd
+
+
+def _result_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, Path]:
+    paths = {
+        "RESULT_RESULT": tmp_path / "result",
+        "RESULT_INTERNAL_REQUEST_PIPELINE_RUN_NAME": tmp_path / "pr",
+        "RESULT_INTERNAL_REQUEST_TASK_RUN_NAME": tmp_path / "tr",
+        "RESULT_UNRELEASED_COMPONENTS": tmp_path / "unreleased",
+        "RESULT_ADVISORY_URL": tmp_path / "url",
+        "RESULT_ADVISORY_INTERNAL_URL": tmp_path / "iurl",
+    }
+    for key, path in paths.items():
+        monkeypatch.setenv(key, str(path))
+    return paths
+
+
+def test_parse_args_ok() -> None:
+    """Required flags parse into a namespace."""
+    ns = filt.parse_args(
+        [
+            "--transformed-snapshot",
+            "abc",
+            "--origin",
+            "org",
+            "--internal-request-pipeline-run-name",
+            "pr",
+            "--internal-request-task-run-name",
+            "tr",
+        ]
+    )
+    assert ns.transformed_snapshot == "abc"
+    assert ns.origin == "org"
+
+
+def test_parse_args_help_exits() -> None:
+    """``--help`` prints usage and exits with code 1."""
+    with pytest.raises(SystemExit) as exc:
+        filt.parse_args(["--help"])
+    assert exc.value.code == 1
+
+
+def test_parse_args_missing_required_exits() -> None:
+    """Missing required flags print usage and exit with code 1."""
+    with pytest.raises(SystemExit) as exc:
+        filt.parse_args(["--origin", "only-origin"])
+    assert exc.value.code == 1
+
+
+def test_main_rejects_extra_argv(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Extra positional arguments are rejected with exit code 2."""
+    _result_env(monkeypatch, tmp_path)
+    rc = filt.main(
+        [
+            "prog",
+            "--transformed-snapshot",
+            "x",
+            "--origin",
+            "o",
+            "--internal-request-pipeline-run-name",
+            "pr",
+            "--internal-request-task-run-name",
+            "tr",
+            "extra",
+        ]
+    )
+    assert rc == 2
+
+
+def test_decode_transformed_snapshot_ok() -> None:
+    """Round-trip gzip+base64 snapshot encoding decodes to the original rows."""
+    rows = [
+        {
+            "name": "a",
+            "containerImage": "r.io/i:1",
+            "tags": ["v1"],
+            "repository": "r.io",
+        }
+    ]
+    assert filt.decode_transformed_snapshot(_encode_snapshot(rows)) == rows
+
+
+def test_decode_transformed_snapshot_invalid_payload() -> None:
+    """Malformed snapshot payloads raise `ValueError`."""
+    with pytest.raises(ValueError, match="invalid transformed snapshot"):
+        filt.decode_transformed_snapshot("not-valid")
+
+
+def test_decode_transformed_snapshot_not_array() -> None:
+    """Non-array JSON raises `ValueError`."""
+    with pytest.raises(ValueError, match="must be a JSON array"):
+        filt.decode_transformed_snapshot(_encode_snapshot({"x": 1}))
+
+
+def test_encode_gzipped_base64_json_roundtrip() -> None:
+    """Encoded component lists decode back to the same JSON value."""
+    value = ["a", "b"]
+    encoded = filt.encode_gzipped_base64_json(value)
+    assert _decode_components(encoded) == value
+
+
+def test_unique_component_names_dedupes_and_skips_blank() -> None:
+    """Duplicate and blank names are skipped; order is first-seen."""
+    rows = [
+        {"name": "a"},
+        {"name": "a"},
+        {"name": ""},
+        {"name": 1},
+        {"name": "b"},
+    ]
+    assert filt.unique_component_names(rows) == ["a", "b"]
+
+
+def test_filter_arch_images_triple_match() -> None:
+    """Rows matching containerImage/tags/repository triples are removed."""
+    existing = [
+        {
+            "containerImage": "registry.redhat.io/test@sha256:abc",
+            "tags": ["v1.0"],
+            "repository": "registry.redhat.io/test",
+        }
+    ]
+    rows = [
+        {
+            "name": "released",
+            "containerImage": "registry.redhat.io/test@sha256:abc",
+            "tags": ["v1.0"],
+            "repository": "registry.redhat.io/test",
+        },
+        {
+            "name": "new",
+            "containerImage": "registry.redhat.io/test@sha256:new",
+            "tags": ["v1.0"],
+            "repository": "registry.redhat.io/test",
+        },
+    ]
+    out = filt.filter_arch_images(rows, existing)
+    assert [row["name"] for row in out] == ["new"]
+
+
+def test_filter_arch_images_tag_mismatch_keeps_row() -> None:
+    """Different tags prevent a triple match."""
+    existing = [
+        {
+            "containerImage": "r.io/i@sha256:abc",
+            "tags": ["v1.0"],
+            "repository": "r.io/i",
+        }
+    ]
+    row = {
+        "name": "x",
+        "containerImage": "r.io/i@sha256:abc",
+        "tags": ["v2.0"],
+        "repository": "r.io/i",
+    }
+    assert filt.filter_arch_images([row], existing) == [row]
+
+
+def test_list_advisory_subdirs_newest_first(tmp_path: Path) -> None:
+    """Advisories are listed by directory mtime, newest first."""
+    base = tmp_path / "data/advisories/origin"
+    old = base / "2024" / "100"
+    new = base / "2025" / "200"
+    old.mkdir(parents=True)
+    new.mkdir(parents=True)
+    (old / "advisory.yaml").write_text("old: true\n", encoding="utf-8")
+    (new / "advisory.yaml").write_text("new: true\n", encoding="utf-8")
+    old_time = time.time() - 100
+    new_time = time.time()
+    os.utime(old, (old_time, old_time))
+    os.utime(new, (new_time, new_time))
+    assert filt.list_advisory_subdirs(base) == ["2025/200", "2024/100"]
+
+
+def test_list_advisory_subdirs_missing_dir() -> None:
+    """A missing advisory base directory yields an empty list."""
+    assert filt.list_advisory_subdirs(Path("/does/not/exist")) == []
+
+
+def test_list_advisory_subdirs_skips_shallow_paths(tmp_path: Path) -> None:
+    """Advisory paths with fewer than two relative segments are ignored."""
+    base = tmp_path / "data/advisories/origin"
+    shallow = base / "2025"
+    shallow.mkdir(parents=True)
+    (shallow / "advisory.yaml").write_text("x: 1\n", encoding="utf-8")
+    assert filt.list_advisory_subdirs(base) == []
+
+
+def test_advisory_errata_url_prefixes() -> None:
+    """Production and stage errata prefixes are selected from the repo URL."""
+    assert "access.redhat.com" in filt.advisory_errata_url_prefix(
+        "https://gitlab.com/org/repo.git"
+    )
+    assert "access.stage.redhat.com" in filt.advisory_errata_url_prefix(
+        "https://gitlab.com/rhtap-release/advisories.git"
+    )
+
+
+def test_build_advisory_urls_stage_and_prod() -> None:
+    """Public and internal advisory URLs are built for stage and production repos."""
+    stage_public, stage_internal = filt.build_advisory_urls(
+        "https://gitlab.com/rhtap-release/advisories.git",
+        Path("data/advisories/x/2025/1/advisory.yaml"),
+        "RHBA",
+        "2025:1",
+    )
+    assert stage_public == "https://access.stage.redhat.com/errata/RHBA-2025:1"
+    assert stage_internal == (
+        "https://gitlab.com/rhtap-release/advisories/-/raw/main/"
+        "data/advisories/x/2025/1/advisory.yaml"
+    )
+
+    prod_public, _ = filt.build_advisory_urls(
+        "https://gitlab.com/org/advisories.git",
+        Path("data/advisories/x/2025/1/advisory.yaml"),
+        "RHBA",
+        "2025:1",
+    )
+    assert prod_public == "https://access.redhat.com/errata/RHBA-2025:1"
+
+
+def test_run_filter_empty_advisory_directory(tmp_path: Path) -> None:
+    """An existing but empty advisory tree returns all component names."""
+    secret = tmp_path / "secret"
+    _write_secret(secret)
+    out = filt.run_filter(
+        _encode_snapshot([{"name": "c1"}, {"name": "c2"}]),
+        "test-origin",
+        secret,
+        work_dir=tmp_path / "work",
+        clone_sparse=_make_clone_sparse(tmp_path, advisory_nums=[]),
+    )
+    assert _decode_components(out.unreleased_components_b64) == ["c1", "c2"]
+
+
+def test_run_filter_partial_release(tmp_path: Path) -> None:
+    """Released triples are filtered out and unreleased component names remain."""
+    secret = tmp_path / "secret"
+    _write_secret(secret)
+    rows = [
+        {
+            "name": "released-component",
+            "containerImage": "registry.redhat.io/test@sha256:releasedarch123",
+            "tags": ["v1.0"],
+            "repository": "registry.redhat.io/test",
+        },
+        {
+            "name": "new-component",
+            "containerImage": "registry.redhat.io/test@sha256:newarch456",
+            "tags": ["v1.0"],
+            "repository": "registry.redhat.io/test",
+        },
+    ]
+    out = filt.run_filter(
+        _encode_snapshot(rows),
+        "test-origin",
+        secret,
+        work_dir=tmp_path / "work",
+        clone_sparse=_make_clone_sparse(tmp_path),
+        run_cmd=_make_yq_run_cmd(),
+    )
+    assert out.result == "Success"
+    assert _decode_components(out.unreleased_components_b64) == ["new-component"]
+    assert out.advisory_url == ""
+
+
+def test_run_filter_all_released(tmp_path: Path) -> None:
+    """When every row is filtered out, advisory URLs are returned."""
+    secret = tmp_path / "secret"
+    _write_secret(secret)
+    rows = [
+        {
+            "name": "released-component",
+            "containerImage": "registry.redhat.io/test@sha256:releasedarch123",
+            "tags": ["v1.0"],
+            "repository": "registry.redhat.io/test",
+        }
+    ]
+    out = filt.run_filter(
+        _encode_snapshot(rows),
+        "test-origin",
+        secret,
+        work_dir=tmp_path / "work",
+        clone_sparse=_make_clone_sparse(tmp_path),
+        run_cmd=_make_yq_run_cmd(),
+    )
+    assert out.result == "Success"
+    assert _decode_components(out.unreleased_components_b64) == []
+    assert out.advisory_url == "https://access.redhat.com/errata/RHBA-2025:1601"
+    assert "2025/1601/advisory.yaml" in out.advisory_internal_url
+
+
+def test_run_filter_multi_arch_all_released(tmp_path: Path) -> None:
+    """Both arch-specific rows matching advisory 1601 yield empty unreleased output."""
+    secret = tmp_path / "secret"
+    _write_secret(secret)
+    rows = [
+        {
+            "name": "multi-arch-component",
+            "containerImage": "registry.redhat.io/test@sha256:amd64digest123",
+            "tags": ["v1.0"],
+            "repository": "registry.redhat.io/test",
+        },
+        {
+            "name": "multi-arch-component",
+            "containerImage": "registry.redhat.io/test@sha256:arm64digest456",
+            "tags": ["v1.0"],
+            "repository": "registry.redhat.io/test",
+        },
+    ]
+    out = filt.run_filter(
+        _encode_snapshot(rows),
+        "test-origin",
+        secret,
+        work_dir=tmp_path / "work",
+        clone_sparse=_make_clone_sparse(tmp_path),
+        run_cmd=_make_yq_run_cmd(),
+    )
+    assert _decode_components(out.unreleased_components_b64) == []
+    assert out.advisory_url.endswith("RHBA-2025:1601")
+
+
+def test_run_filter_multi_advisory_progressive(tmp_path: Path) -> None:
+    """Filtering continues across multiple advisories until rows remain."""
+    secret = tmp_path / "secret"
+    _write_secret(secret)
+    rows = [
+        {
+            "name": "released-component",
+            "containerImage": "registry.redhat.io/test@sha256:releasedarch123",
+            "tags": ["v1.0"],
+            "repository": "registry.redhat.io/test",
+        },
+        {
+            "name": "other-component",
+            "containerImage": "quay.io/test/other-image:1.0.0",
+            "tags": ["stable"],
+            "repository": "quay.io/test",
+        },
+        {
+            "name": "still-new",
+            "containerImage": "quay.io/test/brand-new:9.9.9",
+            "tags": ["latest"],
+            "repository": "quay.io/test",
+        },
+    ]
+    out = filt.run_filter(
+        _encode_snapshot(rows),
+        "test-origin",
+        secret,
+        work_dir=tmp_path / "work",
+        clone_sparse=_make_clone_sparse(tmp_path, advisory_nums=["2025/1601", "2025/1602"]),
+        run_cmd=_make_yq_run_cmd(),
+    )
+    assert _decode_components(out.unreleased_components_b64) == ["still-new"]
+
+
+def test_run_filter_yq_non_list_images_coerced(tmp_path: Path) -> None:
+    """Non-list ``yq`` image payloads are treated as empty advisory content."""
+
+    def _bad_yq(args: list[str], *, cwd: Path | None = None) -> str:
+        if args[:1] == ["yq"] and ".spec.content.images" in args[2]:
+            return json.dumps({"bad": True})
+        return _catalog_yq_fake(args, cwd=cwd)
+
+    secret = tmp_path / "secret"
+    _write_secret(secret)
+    rows = [
+        {
+            "name": "only-one",
+            "containerImage": "r.io/i:1",
+            "tags": [],
+            "repository": "r.io",
+        }
+    ]
+    out = filt.run_filter(
+        _encode_snapshot(rows),
+        "test-origin",
+        secret,
+        work_dir=tmp_path / "work",
+        clone_sparse=_make_clone_sparse(tmp_path),
+        run_cmd=_bad_yq,
+    )
+    assert _decode_components(out.unreleased_components_b64) == ["only-one"]
+
+
+def test_run_filter_secret_read_failure(tmp_path: Path) -> None:
+    """Mounted secret read errors are wrapped as ``CheckStepError``."""
+    with (
+        mock.patch.object(
+            filt.gitlab,
+            "read_credentials_from_mount",
+            side_effect=OSError("permission denied"),
+        ),
+        pytest.raises(tekton.CheckStepError, match="reading the mounted advisory secret"),
+    ):
+        filt.run_filter(
+            _encode_snapshot([{"name": "x"}]),
+            "test-origin",
+            tmp_path / "secret",
+        )
+
+
+def test_run_filter_uses_gitlab_clone_sparse(tmp_path: Path) -> None:
+    """Default path delegates sparse clone to ``gitlab.clone_project_sparse``."""
+    secret = tmp_path / "secret"
+    _write_secret(secret)
+    repo = tmp_path / "work" / "repo"
+    _setup_repo_tree(repo, "test-origin", [])
+
+    with (
+        mock.patch.object(filt.gitlab, "configure_git_oauth2_auth"),
+        mock.patch.object(filt.gitlab, "clone_project_sparse", return_value=repo) as clone,
+    ):
+        out = filt.run_filter(
+            _encode_snapshot([{"name": "c1"}]),
+            "test-origin",
+            secret,
+            work_dir=tmp_path / "work",
+            run_cmd=_make_yq_run_cmd(),
+        )
+    clone.assert_called_once()
+    assert _decode_components(out.unreleased_components_b64) == ["c1"]
+
+
+def test_run_filter_git_failure(tmp_path: Path) -> None:
+    """Git clone failures are wrapped as ``CheckStepError``."""
+    secret = tmp_path / "secret"
+    _write_secret(secret)
+    with (
+        mock.patch.object(
+            filt.gitlab,
+            "clone_project_sparse",
+            side_effect=GitCommandError(["git"], 1, "clone failed"),
+        ),
+        pytest.raises(tekton.CheckStepError, match="cloning the advisory Git repository"),
+    ):
+        filt.run_filter(
+            _encode_snapshot([{"name": "x"}]),
+            "test-origin",
+            secret,
+            work_dir=tmp_path / "work",
+        )
+
+
+def test_run_filter_yq_failure(tmp_path: Path) -> None:
+    """``yq`` failures propagate as ``CalledProcessError``."""
+    secret = tmp_path / "secret"
+    _write_secret(secret)
+    with pytest.raises(subprocess.CalledProcessError):
+        filt.run_filter(
+            _encode_snapshot([{"name": "x"}]),
+            "test-origin",
+            secret,
+            work_dir=tmp_path / "work",
+            clone_sparse=_make_clone_sparse(tmp_path),
+            run_cmd=_make_yq_run_cmd(fail=True),
+        )
+
+
+def test_main_writes_results(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``main`` writes all Tekton result files and returns 0."""
+    paths = _result_env(monkeypatch, tmp_path)
+    expected = filt.FilterOutput(
+        result="Success",
+        unreleased_components_b64="abc",
+        advisory_url="pub",
+        advisory_internal_url="int",
+    )
+    with mock.patch.object(filt, "run_filter", return_value=expected):
+        rc = filt.main(
+            [
+                "filter_already_released_advisory_images.py",
+                "--transformed-snapshot",
+                "x",
+                "--origin",
+                "o",
+                "--internal-request-pipeline-run-name",
+                "pr-1",
+                "--internal-request-task-run-name",
+                "tr-1",
+            ]
+        )
+    assert rc == 0
+    assert paths["RESULT_RESULT"].read_text(encoding="utf-8") == "Success"
+    assert (
+        paths["RESULT_INTERNAL_REQUEST_PIPELINE_RUN_NAME"].read_text(encoding="utf-8")
+        == "pr-1"
+    )
+    assert paths["RESULT_UNRELEASED_COMPONENTS"].read_text(encoding="utf-8") == "abc"
+    assert paths["RESULT_ADVISORY_URL"].read_text(encoding="utf-8") == "pub"
+    assert paths["RESULT_ADVISORY_INTERNAL_URL"].read_text(encoding="utf-8") == "int"
+
+
+def test_main_failure_still_exits_zero(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Operational failures are written to ``RESULT_RESULT`` and exit code stays 0."""
+    paths = _result_env(monkeypatch, tmp_path)
+    with mock.patch.object(
+        filt,
+        "run_filter",
+        side_effect=tekton.CheckStepError(
+            "reading the mounted advisory secret", OSError("boom")
+        ),
+    ):
+        rc = filt.main(
+            [
+                "filter_already_released_advisory_images.py",
+                "--transformed-snapshot",
+                "x",
+                "--origin",
+                "o",
+                "--internal-request-pipeline-run-name",
+                "pr-1",
+                "--internal-request-task-run-name",
+                "tr-1",
+            ]
+        )
+    assert rc == 0
+    assert "Failed while reading the mounted advisory secret" in paths[
+        "RESULT_RESULT"
+    ].read_text(encoding="utf-8")
+
+
+def test_main_unexpected_exception(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Unexpected exceptions are wrapped and written to ``RESULT_RESULT``."""
+    paths = _result_env(monkeypatch, tmp_path)
+    with mock.patch.object(filt, "run_filter", side_effect=RuntimeError("kaboom")):
+        rc = filt.main(
+            [
+                "filter_already_released_advisory_images.py",
+                "--transformed-snapshot",
+                "x",
+                "--origin",
+                "o",
+                "--internal-request-pipeline-run-name",
+                "pr-1",
+                "--internal-request-task-run-name",
+                "tr-1",
+            ]
+        )
+    assert rc == 0
+    text = paths["RESULT_RESULT"].read_text(encoding="utf-8")
+    assert "Failed while filtering already released advisory images" in text
+
+
+def test_main_subprocess_failure_still_exits_zero(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Subprocess failures from ``run_filter`` are written to ``RESULT_RESULT``."""
+    paths = _result_env(monkeypatch, tmp_path)
+    with mock.patch.object(
+        filt,
+        "run_filter",
+        side_effect=subprocess.CalledProcessError(1, "git clone", output="clone failed"),
+    ):
+        rc = filt.main(
+            [
+                "filter_already_released_advisory_images.py",
+                "--transformed-snapshot",
+                "x",
+                "--origin",
+                "o",
+                "--internal-request-pipeline-run-name",
+                "pr-1",
+                "--internal-request-task-run-name",
+                "tr-1",
+            ]
+        )
+    assert rc == 0
+    assert "Failed while filtering already released advisory images" in paths[
+        "RESULT_RESULT"
+    ].read_text(encoding="utf-8")
+
+
+def test_main_missing_required_flags_returns_one() -> None:
+    """Bad CLI usage returns 1 before result env is required."""
+    assert filt.main(["filter_already_released_advisory_images.py", "--origin", "o"]) == 1
+
+
+def test_script_help_via_subprocess() -> None:
+    """The script entrypoint handles ``--help`` when invoked as ``__main__``."""
+    script = Path(__file__).with_name("filter_already_released_advisory_images.py")
+    proc = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(
+                [
+                    str(Path(__file__).resolve().parents[2] / "helpers"),
+                    str(Path(__file__).resolve().parent),
+                ]
+            ),
+        },
+    )
+    assert proc.returncode == 1
+    assert "--transformed-snapshot" in proc.stderr
+
+
+def test_main_missing_result_env_raises_system_exit() -> None:
+    """Missing ``RESULT_*`` env vars fail fast via ``tekton.result_paths_from_env``."""
+    with pytest.raises(SystemExit):
+        filt.main(
+            [
+                "filter_already_released_advisory_images.py",
+                "--transformed-snapshot",
+                "x",
+                "--origin",
+                "o",
+                "--internal-request-pipeline-run-name",
+                "pr-1",
+                "--internal-request-task-run-name",
+                "tr-1",
+            ]
+        )


### PR DESCRIPTION
## Describe your changes
Adds a standalone Python script for the `filter-already-released-advisory-images` internal task so its logic runs from the utils image instead of inline bash in the catalog.

## Relevant Jira
[RELEASE-1986](https://redhat.atlassian.net/browse/RELEASE-1986)

[RELEASE-1986]: https://redhat.atlassian.net/browse/RELEASE-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ