### PR TITLE
chore: print failing e2e test logs

### DIFF
--- a/integration-tests/lib/run_single_catalog_e2e_suite.py
+++ b/integration-tests/lib/run_single_catalog_e2e_suite.py
@@ -137,6 +137,46 @@ def _taskrun_name_for_pipeline_task(pr_name: str, ns: str, pipeline_task: str) -
     return None
 
 
+def _print_run_test_step_logs(pr_name: str, ns: str) -> None:
+    """Print run-test TaskRun logs to stderr."""
+    tr_name = _taskrun_name_for_pipeline_task(pr_name, ns, "run-test")
+    if not tr_name:
+        print(
+            "NOTE: could not resolve run-test TaskRun for "
+            f"pipelinerun/{pr_name} in {ns}; skipping log dump",
+            file=sys.stderr,
+        )
+        return
+
+    print(
+        f"--- run-test logs (TaskRun {tr_name}, pipelinerun/{pr_name} in {ns}) ---",
+        file=sys.stderr,
+        flush=True,
+    )
+
+    result = subprocess.run(
+        [
+            "kubectl",
+            "logs",
+            "-n",
+            ns,
+            "-l",
+            f"tekton.dev/taskRun={tr_name}",
+            "--tail=-1",
+            "--all-containers",
+        ],
+        stdout=sys.stderr,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        err = (result.stderr or "empty").rstrip("\n")
+        print(f"NOTE: could not fetch run-test logs: {err}", file=sys.stderr)
+
+    print("--- end run-test logs ---", file=sys.stderr, flush=True)
+
+
 def _fetch_run_test_task_output_json(pr_name: str, ns: str) -> dict | None:
     """Load JSON from TaskRun ``run-test`` result TEST_OUTPUT."""
     tr_name = _taskrun_name_for_pipeline_task(pr_name, ns, "run-test")
@@ -326,9 +366,14 @@ def main() -> None:
         # Do not use kubectl wait --for=condition=Succeeded: on failure Succeeded
         # stays False, so the step would hang until timeout and delay finally cleanup.
         if not _wait_pipelinerun_terminal(name=name, ns=ns, timeout_seconds=wait_seconds):
+            _print_run_test_step_logs(name, ns)
             sys.exit(1)
         # Catalog run-test exits 0 even on test failure; status is task TEST_OUTPUT.
-        _require_test_output_success(_fetch_run_test_task_output_json(name, ns))
+        test_output = _fetch_run_test_task_output_json(name, ns)
+        outcome = str((test_output or {}).get("result", "")).strip().upper()
+        if test_output is None or outcome not in ("SUCCESS", "SKIPPED"):
+            _print_run_test_step_logs(name, ns)
+        _require_test_output_success(test_output)
         print(f"PipelineRun {name} succeeded (TEST_OUTPUT ok)", flush=True)
     finally:
         if path is not None:

--- a/integration-tests/lib/tests/test_run_single_catalog_e2e_suite.py
+++ b/integration-tests/lib/tests/test_run_single_catalog_e2e_suite.py
@@ -193,6 +193,55 @@ def test_wait_pipelinerun_terminal_failed_prints_to_stderr(
     assert "step foo died" in capsys.readouterr().err
 
 
+def test_print_run_test_step_logs_no_taskrun(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Skip log dump when run-test TaskRun cannot be resolved."""
+    monkeypatch.setattr(rs, "_taskrun_name_for_pipeline_task", lambda *a, **k: None)
+    rs._print_run_test_step_logs("pr1", "ns1")
+    err = capsys.readouterr().err
+    assert "skipping log dump" in err
+    assert "end run-test logs" not in err
+
+
+def test_print_run_test_step_logs_via_kubectl(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Stream kubectl logs directly to stderr."""
+
+    def fake_run(cmd: list, **kwargs):
+        if cmd[:3] == ["kubectl", "logs", "-n"]:
+            assert kwargs.get("stdout") is sys.stderr
+            sys.stderr.write("line1\nline2\n")
+            return subprocess.CompletedProcess(cmd, 0, None, "")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(rs, "_taskrun_name_for_pipeline_task", lambda *a, **k: "tr-run-test")
+    monkeypatch.setattr(rs.subprocess, "run", fake_run)
+    rs._print_run_test_step_logs("pr1", "ns1")
+    err = capsys.readouterr().err
+    assert "run-test logs" in err
+    assert "line1" in err
+    assert "end run-test logs" in err
+
+
+def test_print_run_test_step_logs_kubectl_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Print kubectl stderr when log fetch fails."""
+
+    def fake_run(cmd: list, **kwargs):
+        if cmd[:3] == ["kubectl", "logs", "-n"]:
+            return subprocess.CompletedProcess(cmd, 1, None, "pods not found\n")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(rs, "_taskrun_name_for_pipeline_task", lambda *a, **k: "tr-run-test")
+    monkeypatch.setattr(rs.subprocess, "run", fake_run)
+    rs._print_run_test_step_logs("pr1", "ns1")
+    err = capsys.readouterr().err
+    assert "could not fetch run-test logs: pods not found" in err
+
+
 def test_taskrun_name_for_pipeline_task_found(monkeypatch: pytest.MonkeyPatch) -> None:
     """Resolve TaskRun name from childReferences."""
     body = json.dumps(
@@ -492,8 +541,8 @@ def test_main_happy_path(monkeypatch: pytest.MonkeyPatch, tmp_path, capsys) -> N
     assert manifests[0]["metadata"]["name"] == "utils-e2e-catalog-abc-123"
 
 
-def test_main_wait_failure_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-    """Exit 1 when _wait_pipelinerun_terminal returns False."""
+def test_main_wait_failure_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path, capsys) -> None:
+    """Exit 1 when _wait_pipelinerun_terminal returns False and dump run-test logs."""
     monkeypatch.setenv("KUBECONFIG", "/k")
     monkeypatch.setenv("CATALOG_GIT_URL", "u")
     monkeypatch.setenv("CATALOG_GIT_REVISION", "r")
@@ -514,10 +563,114 @@ def test_main_wait_failure_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path) ->
         lambda cmd, **kw: "n\n",
     )
     monkeypatch.setattr(rs, "_wait_pipelinerun_terminal", lambda **kw: False)
+    log_calls: list[tuple[str, str]] = []
+
+    def fake_logs(pr: str, ns: str) -> None:
+        log_calls.append((pr, ns))
+        print("dumped run-test logs", file=sys.stderr)
+
+    monkeypatch.setattr(rs, "_print_run_test_step_logs", fake_logs)
 
     with pytest.raises(SystemExit) as ei:
         rs.main()
     assert ei.value.code == 1
+    assert log_calls == [("n", rs.CATALOG_E2E_NAMESPACE)]
+    assert "dumped run-test logs" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "test_output",
+    [
+        {"result": "FAILURE"},
+        {"result": "WAT"},
+        {},
+    ],
+)
+def test_main_bad_test_output_dumps_logs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys,
+    test_output: dict,
+) -> None:
+    """Dump run-test logs for any TEST_OUTPUT outcome that is not SUCCESS or SKIPPED."""
+    monkeypatch.setenv("KUBECONFIG", "/tmp/k")
+    monkeypatch.setenv("CATALOG_GIT_URL", "https://github.com/o/c.git")
+    monkeypatch.setenv("CATALOG_GIT_REVISION", "dev")
+    monkeypatch.setenv("CATALOG_E2E_RUNNER_IMAGE", "quay.io/runner:v1")
+    monkeypatch.setenv("PIPELINE_TEST_SUITE", "suite1")
+    monkeypatch.setenv("PIPELINE_USED", "pipe1")
+    monkeypatch.setenv("ORCHESTRATOR_PIPELINE_RUN_UID", "abc-123")
+
+    def fake_mkstemp(suffix: str = "", **kw):
+        path = tmp_path / "plr3.json"
+        fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+        return (fd, str(path))
+
+    monkeypatch.setattr(rs.tempfile, "mkstemp", fake_mkstemp)
+    monkeypatch.setattr(
+        rs.subprocess,
+        "check_output",
+        lambda cmd, **kw: "child-plr\n",
+    )
+    monkeypatch.setattr(rs, "_wait_pipelinerun_terminal", lambda **kw: True)
+    monkeypatch.setattr(
+        rs,
+        "_fetch_run_test_task_output_json",
+        lambda pr, ns: test_output,
+    )
+    log_calls: list[tuple[str, str]] = []
+
+    def fake_logs(pr: str, ns: str) -> None:
+        log_calls.append((pr, ns))
+        print("bad outcome log dump", file=sys.stderr)
+
+    monkeypatch.setattr(rs, "_print_run_test_step_logs", fake_logs)
+
+    with pytest.raises(SystemExit) as ei:
+        rs.main()
+    assert ei.value.code == 1
+    assert log_calls == [("child-plr", rs.CATALOG_E2E_NAMESPACE)]
+    assert "bad outcome log dump" in capsys.readouterr().err
+
+
+def test_main_missing_test_output_dumps_logs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
+) -> None:
+    """Dump run-test logs when TEST_OUTPUT could not be loaded."""
+    monkeypatch.setenv("KUBECONFIG", "/tmp/k")
+    monkeypatch.setenv("CATALOG_GIT_URL", "https://github.com/o/c.git")
+    monkeypatch.setenv("CATALOG_GIT_REVISION", "dev")
+    monkeypatch.setenv("CATALOG_E2E_RUNNER_IMAGE", "quay.io/runner:v1")
+    monkeypatch.setenv("PIPELINE_TEST_SUITE", "suite1")
+    monkeypatch.setenv("PIPELINE_USED", "pipe1")
+    monkeypatch.setenv("ORCHESTRATOR_PIPELINE_RUN_UID", "abc-123")
+
+    def fake_mkstemp(suffix: str = "", **kw):
+        path = tmp_path / "plr4.json"
+        fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+        return (fd, str(path))
+
+    monkeypatch.setattr(rs.tempfile, "mkstemp", fake_mkstemp)
+    monkeypatch.setattr(
+        rs.subprocess,
+        "check_output",
+        lambda cmd, **kw: "child-plr\n",
+    )
+    monkeypatch.setattr(rs, "_wait_pipelinerun_terminal", lambda **kw: True)
+    monkeypatch.setattr(rs, "_fetch_run_test_task_output_json", lambda pr, ns: None)
+    log_calls: list[tuple[str, str]] = []
+
+    def fake_logs(pr: str, ns: str) -> None:
+        log_calls.append((pr, ns))
+        print("missing test output log dump", file=sys.stderr)
+
+    monkeypatch.setattr(rs, "_print_run_test_step_logs", fake_logs)
+
+    with pytest.raises(SystemExit) as ei:
+        rs.main()
+    assert ei.value.code == 1
+    assert log_calls == [("child-plr", rs.CATALOG_E2E_NAMESPACE)]
+    assert "missing test output log dump" in capsys.readouterr().err
 
 
 def test_script_main_guard_exits_when_kubeconfig_missing() -> None:


### PR DESCRIPTION
Currently, if the e2e test fails, all you will see in the pipelineRun for the run-catalog-e2e step is Waiting on pipelinerun ... and then ERROR that it failed. It tells you the pipelineRun name so you can go look at it to see why it failed, but it would be much easier if the logs just showed the run-test step output directly so we didn't have to navigate to the executor pipelineRun. This commit adds that.

Assisted-By: Cursor