### PR TITLE
feat(RELEASE-1993): convert update-fbc-catalog internal task

### DIFF
--- a/scripts/python/helpers/authentication.py
+++ b/scripts/python/helpers/authentication.py
@@ -10,12 +10,16 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import subprocess
 import tempfile
-from collections.abc import Sequence
+from collections.abc import Callable, Generator, Sequence
+from contextlib import contextmanager
 from pathlib import Path
 
+import file
 import retry
+from logger import logger
 
 
 def read_mounted_text(mount: Path, filename: str) -> str:
@@ -177,3 +181,79 @@ def setup_docker_config(
             raise ValueError(f"No valid JSON object found in {path}")
         raw = json.dumps(json.loads(raw[first : last + 1]))
     write_docker_config(raw)
+
+
+@contextmanager
+def kerberos_login(
+    principal: str,
+    keytab_bytes: bytes,
+    krb5_config: str,
+    *,
+    kinit_fn: Callable[..., None] = kinit_with_retry,
+) -> Generator[None, None, None]:
+    """Set up Kerberos auth with ephemeral temp files and clean up on exit.
+
+    Create temporary files for the keytab, krb5 config, and credential
+    cache, run ``kinit``, and update ``os.environ`` so that
+    ``requests-kerberos`` can use the credentials.  All temp files are
+    removed when the context exits.
+    """
+    keytab_path = file.make_tempfile_path("keytab-", keytab_bytes)
+    krb5_path = file.make_tempfile_path("krb5-", krb5_config.encode("utf-8"))
+    ccache_fd, ccache_name = tempfile.mkstemp()
+    os.close(ccache_fd)
+    ccache_path = Path(ccache_name)
+
+    try:
+        kenv = {
+            "KRB5_CONFIG": str(krb5_path),
+            "KRB5CCNAME": str(ccache_path),
+            "KRB5_TRACE": "/dev/stderr",
+        }
+        logger.info("Logging in with Kerberos (kinit)...")
+        kinit_fn(principal, keytab_path, kenv, max_attempts=5)
+        os.environ.update(kenv)
+        yield
+    finally:
+        for key in kenv:
+            os.environ.pop(key, None)
+        for p in (keytab_path, krb5_path, ccache_path):
+            p.unlink(missing_ok=True)
+
+
+def create_container_auth_config(
+    from_index: str,
+    publishing_credential: str,
+) -> None:
+    """Create ``~/.config/containers/auth.json`` for skopeo.
+
+    For ``registry-proxy.engineering.redhat.com``, remove any existing auth
+    entry (that registry uses Kerberos, not token auth).  For other
+    registries, write base64-encoded publishing credentials.
+    """
+    auth_dir = Path.home() / ".config" / "containers"
+    auth_dir.mkdir(parents=True, exist_ok=True)
+    auth_file = auth_dir / "auth.json"
+
+    auth_name = from_index.rsplit(":", 1)[0]
+
+    if re.match(r"^registry-proxy(-stage)?\.engineering\.redhat\.com", auth_name):
+        if auth_file.exists():
+            try:
+                data = json.loads(auth_file.read_text(encoding="utf-8"))
+                data.get("auths", {}).pop(auth_name, None)
+                auth_file.write_text(json.dumps(data), encoding="utf-8")
+            except (json.JSONDecodeError, OSError):
+                auth_file.write_text("{}", encoding="utf-8")
+        else:
+            auth_file.write_text("{}", encoding="utf-8")
+        return
+
+    if not publishing_credential:
+        logger.warning("No publishing credentials available for %s", auth_name)
+        auth_file.write_text("{}", encoding="utf-8")
+        return
+
+    token = base64.b64encode(publishing_credential.encode()).decode("ascii")
+    auth_data = {"auths": {auth_name: {"auth": token}}}
+    auth_file.write_text(json.dumps(auth_data), encoding="utf-8")

--- a/scripts/python/helpers/iib.py
+++ b/scripts/python/helpers/iib.py
@@ -1,0 +1,158 @@
+"""IIB (Index Image Build) REST API client helpers.
+
+Provide functions for querying, submitting, and monitoring IIB builds,
+plus gzip/base64 compression for Tekton result files (4 KB limit).
+"""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+from datetime import datetime
+from typing import TypedDict
+from urllib.parse import urlencode
+
+import requests
+from requests.auth import AuthBase
+
+import http_client
+from logger import logger
+
+
+class IIBBuildLogs(TypedDict, total=False):
+    """Log URLs attached to an IIB build."""
+
+    url: str
+
+
+class IIBBuild(TypedDict, total=False):
+    """Subset of fields returned by the IIB builds endpoint."""
+
+    id: int
+    state: str
+    state_reason: str | None
+    from_index: str | None
+    from_index_resolved: str | None
+    index_image: str | None
+    index_image_resolved: str | None
+    internal_index_image_copy: str | None
+    fbc_fragments: list[str] | None
+    build_tags: list[str] | None
+    distribution_scope: str | None
+    updated: str | None
+    created: str | None
+    logs: IIBBuildLogs
+    state_history: list[dict[str, str]]
+
+
+class IIBQueryResponse(TypedDict):
+    """Paginated response from ``GET /builds``."""
+
+    items: list[IIBBuild]
+
+
+class FBCOperationPayload(TypedDict, total=False):
+    """JSON body for ``POST /builds/fbc-operations``."""
+
+    fbc_fragments: list[str]
+    from_index: str
+    build_tags: list[str]
+    add_arches: list[str]
+    overwrite_from_index: bool
+    overwrite_from_index_token: str
+
+
+def query_builds(
+    iib_url: str,
+    *,
+    user: str,
+    from_index: str,
+    state: str,
+) -> IIBQueryResponse:
+    """Query IIB for builds matching *user*, *from_index*, and *state*.
+
+    Return the parsed JSON response body (contains an ``items`` list).
+    The IIB read endpoint is unauthenticated.
+    """
+    params = urlencode({"user": user, "from_index": from_index, "state": state})
+    url = f"{iib_url}/builds?{params}"
+    body = http_client.get_text(url)
+    return json.loads(body)
+
+
+def get_build(
+    iib_url: str,
+    build_id: int,
+) -> IIBBuild:
+    """Fetch a single IIB build by *build_id*.
+
+    Return the parsed JSON response body.  The endpoint is unauthenticated.
+    """
+    url = f"{iib_url}/builds/{build_id}"
+    body = http_client.get_text(url)
+    return json.loads(body)
+
+
+def submit_fbc_operation(
+    iib_url: str,
+    payload: FBCOperationPayload,
+    *,
+    auth: AuthBase,
+    verify_ssl: bool = False,
+) -> IIBBuild:
+    """POST an FBC operation to IIB with Kerberos negotiate auth.
+
+    *verify_ssl* defaults to ``False`` to match the original bash behaviour
+    (``curl --insecure``).  Raise ``requests.HTTPError`` on non-2xx or
+    ``ValueError`` when the IIB response body contains an ``error`` field.
+    """
+    url = f"{iib_url}/builds/fbc-operations"
+    logger.info("Submitting FBC operation to %s", url)
+
+    session = requests.Session()
+    resp = session.post(
+        url,
+        json=payload,
+        auth=auth,
+        verify=verify_ssl,
+        timeout=120,
+    )
+    resp.raise_for_status()
+
+    data: IIBBuild = resp.json()
+    error = data.get("error")  # type: ignore[call-overload]
+    if error is not None:
+        raise ValueError(f"IIB service error: {error}")
+    return data
+
+
+def parse_date_to_epoch(date_str: str) -> int:
+    """Parse an ISO 8601 date string to a Unix epoch integer."""
+    return int(datetime.fromisoformat(date_str).timestamp())
+
+
+def extract_log_url(build_info: IIBBuild) -> str:
+    """Extract the IIB log URL from build info, or return empty string."""
+    logs = build_info.get("logs")
+    if logs and isinstance(logs, dict):
+        return logs.get("url", "")
+    return ""
+
+
+def compress_build_info(data: IIBBuild) -> str:
+    """Serialize, gzip-compress, and base64-encode build info.
+
+    Return an ASCII string suitable for writing to a Tekton result file.
+    """
+    raw = json.dumps(data, separators=(",", ":")).encode("utf-8")
+    return base64.b64encode(gzip.compress(raw)).decode("ascii")
+
+
+def decompress_build_info(compressed: str) -> IIBBuild:
+    """Reverse of ``compress_build_info``.
+
+    Decode base64, gunzip, and parse JSON.
+    """
+    raw = gzip.decompress(base64.b64decode(compressed))
+    return json.loads(raw)

--- a/scripts/python/helpers/skopeo.py
+++ b/scripts/python/helpers/skopeo.py
@@ -1,0 +1,22 @@
+"""Skopeo CLI wrapper helpers."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def inspect(
+    image_ref: str,
+    *,
+    config: bool = False,
+    raw: bool = False,
+    retry_times: int = 3,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``skopeo inspect`` on a container image reference."""
+    cmd = ["skopeo", "inspect", "--retry-times", str(retry_times)]
+    if config:
+        cmd.append("--config")
+    if raw:
+        cmd.append("--raw")
+    cmd.append(f"docker://{image_ref}")
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)

--- a/scripts/python/helpers/test_authentication.py
+++ b/scripts/python/helpers/test_authentication.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import os
 import subprocess
 from pathlib import Path
 from unittest import mock
@@ -197,3 +198,116 @@ def test_setup_docker_config_required_missing_raises(tmp_path: Path) -> None:
     missing = tmp_path / ".dockerconfigjson"
     with pytest.raises(FileNotFoundError):
         authentication.setup_docker_config(missing)
+
+
+# ---------------------------------------------------------------------------
+# kerberos_login
+# ---------------------------------------------------------------------------
+
+
+def _no_kinit(*_a: object, **_k: object) -> None:
+    return None
+
+
+def test_kerberos_login_creates_and_cleans_temp_files(
+    tmp_path: Path,
+) -> None:
+    """Temp files exist inside the context and are removed after."""
+    created_files: list[Path] = []
+
+    def _track_kinit(
+        _princ: str,
+        keytab: Path,
+        env: dict[str, str],
+        **_kw: object,
+    ) -> None:
+        created_files.append(keytab)
+        created_files.append(Path(env["KRB5_CONFIG"]))
+        created_files.append(Path(env["KRB5CCNAME"]))
+        for f in created_files:
+            assert f.exists()
+
+    with authentication.kerberos_login(
+        "user@REALM",
+        b"keytab-data",
+        "[libdefaults]\n",
+        kinit_fn=_track_kinit,
+    ):
+        for f in created_files:
+            assert f.exists()
+
+    for f in created_files:
+        assert not f.exists()
+
+
+def test_kerberos_login_updates_and_cleans_environ() -> None:
+    """KRB5 env vars are set inside the context and removed after."""
+    with authentication.kerberos_login(
+        "user@REALM",
+        b"kt",
+        "[libdefaults]\n",
+        kinit_fn=_no_kinit,
+    ):
+        assert "KRB5_CONFIG" in os.environ
+        assert "KRB5CCNAME" in os.environ
+        assert os.environ["KRB5_TRACE"] == "/dev/stderr"
+
+    assert "KRB5_CONFIG" not in os.environ
+    assert "KRB5CCNAME" not in os.environ
+    assert "KRB5_TRACE" not in os.environ
+
+
+def test_kerberos_login_calls_kinit_with_correct_args() -> None:
+    """``kinit_fn`` is called with the principal, keytab path, and env."""
+    calls: list[tuple[str, bytes, dict[str, str]]] = []
+
+    def _spy(
+        princ: str,
+        keytab: Path,
+        env: dict[str, str],
+        **_kw: object,
+    ) -> None:
+        calls.append((princ, keytab.read_bytes(), dict(env)))
+
+    with authentication.kerberos_login(
+        "bot@REALM",
+        b"kt-bytes",
+        "[libdefaults]\n",
+        kinit_fn=_spy,
+    ):
+        pass
+
+    assert len(calls) == 1
+    princ, keytab_data, env = calls[0]
+    assert princ == "bot@REALM"
+    assert keytab_data == b"kt-bytes"
+    assert "KRB5_CONFIG" in env
+    assert "KRB5CCNAME" in env
+
+
+def test_kerberos_login_cleans_up_on_kinit_failure() -> None:
+    """Temp files are removed even when kinit raises."""
+    created_files: list[Path] = []
+
+    def _fail_kinit(
+        _princ: str,
+        keytab: Path,
+        env: dict[str, str],
+        **_kw: object,
+    ) -> None:
+        created_files.append(keytab)
+        created_files.append(Path(env["KRB5_CONFIG"]))
+        created_files.append(Path(env["KRB5CCNAME"]))
+        raise subprocess.CalledProcessError(1, "kinit")
+
+    with pytest.raises(subprocess.CalledProcessError):
+        with authentication.kerberos_login(
+            "user@REALM",
+            b"kt",
+            "[libdefaults]\n",
+            kinit_fn=_fail_kinit,
+        ):
+            pass
+
+    for f in created_files:
+        assert not f.exists()

--- a/scripts/python/helpers/test_iib.py
+++ b/scripts/python/helpers/test_iib.py
@@ -1,0 +1,294 @@
+"""Tests for the ``iib`` helper module."""
+
+from __future__ import annotations
+
+import json
+import unittest.mock as mock
+
+import pytest
+import requests
+
+import iib
+
+# ---------------------------------------------------------------------------
+# compress / decompress round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_compress_decompress_roundtrip() -> None:
+    """Compressed data decompresses back to the original dict."""
+    data: iib.IIBBuild = {
+        "id": 42,
+        "state": "complete",
+        "from_index": "registry.example.com/idx:v4.12",
+        "fbc_fragments": ["frag-a", "frag-b"],
+    }
+    compressed = iib.compress_build_info(data)
+    assert isinstance(compressed, str)
+    assert iib.decompress_build_info(compressed) == data
+
+
+def test_compress_returns_ascii_string() -> None:
+    """The compressed string contains only base64-safe ASCII characters."""
+    data: iib.IIBBuild = {"id": 1, "state": "in_progress"}
+    compressed = iib.compress_build_info(data)
+    compressed.encode("ascii")
+
+
+def test_decompress_invalid_base64_raises() -> None:
+    """Invalid base64 input raises an error."""
+    with pytest.raises(Exception):
+        iib.decompress_build_info("not-valid-base64!!!")
+
+
+# ---------------------------------------------------------------------------
+# query_builds
+# ---------------------------------------------------------------------------
+
+
+def test_query_builds_constructs_url_and_parses_response() -> None:
+    """``query_builds`` encodes query parameters and parses the JSON body."""
+    response_body: iib.IIBQueryResponse = {
+        "items": [
+            {"id": 10, "state": "complete", "fbc_fragments": ["a"]},
+        ],
+    }
+    with mock.patch(
+        "http_client.get_text",
+        return_value=json.dumps(response_body),
+    ) as get_mock:
+        result = iib.query_builds(
+            "https://iib.example.com",
+            user="bot@REALM",
+            from_index="registry/idx:v4.12",
+            state="complete",
+        )
+
+    assert result == response_body
+    url = get_mock.call_args[0][0]
+    assert "user=bot%40REALM" in url
+    assert "from_index=registry%2Fidx%3Av4.12" in url
+    assert "state=complete" in url
+    assert url.startswith("https://iib.example.com/builds?")
+
+
+def test_query_builds_propagates_http_error() -> None:
+    """HTTP errors from ``get_text`` propagate unchanged."""
+    with mock.patch(
+        "http_client.get_text",
+        side_effect=requests.HTTPError("500"),
+    ):
+        with pytest.raises(requests.HTTPError):
+            iib.query_builds(
+                "https://iib",
+                user="u",
+                from_index="i",
+                state="complete",
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_build
+# ---------------------------------------------------------------------------
+
+
+def test_get_build_fetches_by_id() -> None:
+    """``get_build`` hits ``/builds/{id}`` and parses JSON."""
+    build: iib.IIBBuild = {"id": 55, "state": "complete"}
+    with mock.patch(
+        "http_client.get_text",
+        return_value=json.dumps(build),
+    ) as get_mock:
+        result = iib.get_build("https://iib.example.com", 55)
+
+    assert result == build
+    assert get_mock.call_args[0][0] == "https://iib.example.com/builds/55"
+
+
+# ---------------------------------------------------------------------------
+# submit_fbc_operation
+# ---------------------------------------------------------------------------
+
+
+def test_submit_fbc_operation_posts_with_auth() -> None:
+    """``submit_fbc_operation`` POSTs JSON with the supplied auth object."""
+    build: iib.IIBBuild = {"id": 99, "state": "in_progress"}
+    payload: iib.FBCOperationPayload = {
+        "fbc_fragments": ["frag-1"],
+        "from_index": "registry/idx:v4.12",
+    }
+    fake_auth = mock.MagicMock()
+
+    resp = mock.MagicMock()
+    resp.json.return_value = build
+    resp.raise_for_status = mock.MagicMock()
+
+    with mock.patch("requests.Session") as session_cls:
+        session_cls.return_value.post.return_value = resp
+        result = iib.submit_fbc_operation(
+            "https://iib",
+            payload,
+            auth=fake_auth,
+        )
+
+    assert result == build
+    call_kwargs = session_cls.return_value.post.call_args[1]
+    assert call_kwargs["json"] == payload
+    assert call_kwargs["auth"] is fake_auth
+    assert call_kwargs["verify"] is False
+
+
+def test_submit_fbc_operation_raises_on_iib_error() -> None:
+    """An ``error`` field in the response body raises ``ValueError``."""
+    resp = mock.MagicMock()
+    resp.json.return_value = {"error": "something went wrong"}
+    resp.raise_for_status = mock.MagicMock()
+
+    with mock.patch("requests.Session") as session_cls:
+        session_cls.return_value.post.return_value = resp
+        with pytest.raises(ValueError, match="something went wrong"):
+            iib.submit_fbc_operation(
+                "https://iib",
+                {"fbc_fragments": ["x"], "from_index": "y"},
+                auth=mock.MagicMock(),
+            )
+
+
+def test_submit_fbc_operation_raises_on_http_error() -> None:
+    """Non-2xx responses raise ``requests.HTTPError``."""
+    resp = mock.MagicMock()
+    resp.raise_for_status.side_effect = requests.HTTPError("403")
+
+    with mock.patch("requests.Session") as session_cls:
+        session_cls.return_value.post.return_value = resp
+        with pytest.raises(requests.HTTPError):
+            iib.submit_fbc_operation(
+                "https://iib",
+                {"fbc_fragments": ["x"], "from_index": "y"},
+                auth=mock.MagicMock(),
+            )
+
+
+def test_submit_fbc_operation_verify_ssl_passthrough() -> None:
+    """``verify_ssl=True`` is forwarded to the session POST call."""
+    resp = mock.MagicMock()
+    resp.json.return_value = {"id": 1, "state": "in_progress"}
+    resp.raise_for_status = mock.MagicMock()
+
+    with mock.patch("requests.Session") as session_cls:
+        session_cls.return_value.post.return_value = resp
+        iib.submit_fbc_operation(
+            "https://iib",
+            {"fbc_fragments": ["x"], "from_index": "y"},
+            auth=mock.MagicMock(),
+            verify_ssl=True,
+        )
+
+    assert session_cls.return_value.post.call_args[1]["verify"] is True
+
+
+# ---------------------------------------------------------------------------
+# parse_date_to_epoch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "date_str",
+    [
+        "2026-05-26T15:32:23.47548548Z",  # 8 fractional digits
+        "2026-04-15T20:01:40.139676757Z",  # 9 fractional digits (nanoseconds)
+        "2024-01-01T00:00:00.123456Z",  # 6 fractional digits (microseconds)
+        "2024-01-01T00:00:00Z",  # no fractional seconds
+        "2024-06-15T12:30:00+00:00",  # explicit UTC offset
+        "2024-06-15T14:30:00+02:00",  # non-UTC offset
+        "2024-01-01T00:00:00",  # no timezone
+    ],
+)
+def test_parse_date_to_epoch_valid(date_str: str) -> None:
+    """Valid ISO 8601 dates parse to a positive integer epoch."""
+    result = iib.parse_date_to_epoch(date_str)
+    assert isinstance(result, int)
+    assert result > 0
+
+
+def test_parse_date_to_epoch_known_value() -> None:
+    """A known UTC timestamp produces the expected epoch value."""
+    assert iib.parse_date_to_epoch("2024-01-01T00:00:00Z") == 1704067200
+
+
+def test_parse_date_to_epoch_preserves_timezone() -> None:
+    """The same instant in different timezones produces the same epoch."""
+    utc = iib.parse_date_to_epoch("2024-06-15T12:00:00+00:00")
+    plus2 = iib.parse_date_to_epoch("2024-06-15T14:00:00+02:00")
+    assert utc == plus2
+
+
+def test_parse_date_to_epoch_nanoseconds_match_microseconds() -> None:
+    """Nanosecond and microsecond variants of the same date produce the same epoch."""
+    micro = iib.parse_date_to_epoch("2026-05-26T15:32:23.475485Z")
+    nano = iib.parse_date_to_epoch("2026-05-26T15:32:23.47548548Z")
+    assert micro == nano
+
+
+@pytest.mark.parametrize(
+    "bad_date",
+    [
+        "",
+        "not-a-date",
+        "2024-13-01T00:00:00Z",  # invalid month
+        "2024-01-32T00:00:00Z",  # invalid day
+        "15/06/2024",  # wrong format
+        "1234567890",  # bare epoch string
+    ],
+)
+def test_parse_date_to_epoch_invalid_raises(bad_date: str) -> None:
+    """Invalid date strings raise ``ValueError``."""
+    with pytest.raises(ValueError):
+        iib.parse_date_to_epoch(bad_date)
+
+
+# ---------------------------------------------------------------------------
+# extract_log_url
+# ---------------------------------------------------------------------------
+
+
+def test_extract_log_url_present() -> None:
+    """Return the URL when the ``logs`` dict has a ``url`` key."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "logs": {"url": "https://iib.example.com/logs/42"},
+    }
+    assert iib.extract_log_url(build) == "https://iib.example.com/logs/42"
+
+
+def test_extract_log_url_missing_logs_key() -> None:
+    """Return empty string when ``logs`` is absent."""
+    build: iib.IIBBuild = {"id": 1, "state": "complete"}
+    assert iib.extract_log_url(build) == ""
+
+
+def test_extract_log_url_empty_logs() -> None:
+    """Return empty string when ``logs`` is an empty dict."""
+    build: iib.IIBBuild = {"id": 1, "state": "complete", "logs": {}}
+    assert iib.extract_log_url(build) == ""
+
+
+def test_extract_log_url_logs_missing_url_key() -> None:
+    """Return empty string when ``logs`` dict has no ``url`` key."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "logs": {"other": "value"},  # type: ignore[typeddict-item]
+    }
+    assert iib.extract_log_url(build) == ""
+
+
+def test_extract_log_url_logs_none() -> None:
+    """Return empty string when ``logs`` is explicitly ``None``."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "logs": None,  # type: ignore[typeddict-item]
+    }
+    assert iib.extract_log_url(build) == ""

--- a/scripts/python/helpers/test_skopeo.py
+++ b/scripts/python/helpers/test_skopeo.py
@@ -1,0 +1,135 @@
+"""Tests for the ``skopeo`` helper module."""
+
+from __future__ import annotations
+
+import subprocess
+import unittest.mock as mock
+
+import skopeo
+
+
+def _completed(
+    stdout: str = "",
+    returncode: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+# ---------------------------------------------------------------------------
+# inspect
+# ---------------------------------------------------------------------------
+
+
+def test_inspect_basic_command() -> None:
+    """Default inspect builds the correct command."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_completed(),
+    ) as run_mock:
+        skopeo.inspect("registry.example.com/repo:tag")
+
+    cmd = run_mock.call_args[0][0]
+    assert cmd == [
+        "skopeo",
+        "inspect",
+        "--retry-times",
+        "3",
+        "docker://registry.example.com/repo:tag",
+    ]
+    assert run_mock.call_args[1]["capture_output"] is True
+    assert run_mock.call_args[1]["text"] is True
+    assert run_mock.call_args[1]["check"] is False
+
+
+def test_inspect_config_flag() -> None:
+    """``config=True`` adds ``--config`` to the command."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_completed(),
+    ) as run_mock:
+        skopeo.inspect("img:v1", config=True)
+
+    cmd = run_mock.call_args[0][0]
+    assert "--config" in cmd
+    assert "--raw" not in cmd
+
+
+def test_inspect_raw_flag() -> None:
+    """``raw=True`` adds ``--raw`` to the command."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_completed(),
+    ) as run_mock:
+        skopeo.inspect("img:v1", raw=True)
+
+    cmd = run_mock.call_args[0][0]
+    assert "--raw" in cmd
+    assert "--config" not in cmd
+
+
+def test_inspect_custom_retry_times() -> None:
+    """``retry_times`` overrides the default retry count."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_completed(),
+    ) as run_mock:
+        skopeo.inspect("img:v1", retry_times=5)
+
+    cmd = run_mock.call_args[0][0]
+    assert "--retry-times" in cmd
+    idx = cmd.index("--retry-times")
+    assert cmd[idx + 1] == "5"
+
+
+def test_inspect_returns_completed_process() -> None:
+    """The raw ``CompletedProcess`` is returned to the caller."""
+    expected = _completed(stdout='{"created": "2024-01-01T00:00:00Z"}')
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=expected,
+    ):
+        result = skopeo.inspect("img:v1", config=True)
+
+    assert result is expected
+    assert result.stdout == '{"created": "2024-01-01T00:00:00Z"}'
+
+
+def test_inspect_nonzero_exit_code() -> None:
+    """A non-zero exit code is returned, not raised."""
+    expected = _completed(returncode=1)
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=expected,
+    ):
+        result = skopeo.inspect("img:v1")
+
+    assert result.returncode == 1
+
+
+def test_inspect_config_and_raw_together() -> None:
+    """Both flags can be set simultaneously."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_completed(),
+    ) as run_mock:
+        skopeo.inspect("img:v1", config=True, raw=True)
+
+    cmd = run_mock.call_args[0][0]
+    assert "--config" in cmd
+    assert "--raw" in cmd
+
+
+def test_inspect_image_ref_with_digest() -> None:
+    """Digest references are passed through correctly."""
+    digest = "sha256:abc123"
+    ref = f"registry.example.com/repo@{digest}"
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_completed(),
+    ) as run_mock:
+        skopeo.inspect(ref)
+
+    cmd = run_mock.call_args[0][0]
+    assert cmd[-1] == f"docker://{ref}"

--- a/scripts/python/tasks/internal/test_update_fbc_catalog.py
+++ b/scripts/python/tasks/internal/test_update_fbc_catalog.py
@@ -1,0 +1,1660 @@
+"""Tests for ``update_fbc_catalog``."""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import requests
+
+import authentication
+import iib
+import tekton
+import update_fbc_catalog
+
+# ---------------------------------------------------------------------------
+# parse_fbc_fragments
+# ---------------------------------------------------------------------------
+
+
+def test_parse_fbc_fragments_valid() -> None:
+    """A valid JSON array is parsed and sorted."""
+    assert update_fbc_catalog.parse_fbc_fragments('["b", "a", "c"]') == ["a", "b", "c"]
+
+
+def test_parse_fbc_fragments_not_array() -> None:
+    """Non-array JSON raises ``ValueError``."""
+    with pytest.raises(ValueError, match="JSON array"):
+        update_fbc_catalog.parse_fbc_fragments('{"a": 1}')
+
+
+def test_parse_fbc_fragments_empty_array() -> None:
+    """An empty array raises ``ValueError``."""
+    with pytest.raises(ValueError, match="empty"):
+        update_fbc_catalog.parse_fbc_fragments("[]")
+
+
+def test_parse_fbc_fragments_non_string_item() -> None:
+    """Non-string items raise ``ValueError``."""
+    with pytest.raises(ValueError, match="non-empty strings"):
+        update_fbc_catalog.parse_fbc_fragments("[1, 2]")
+
+
+def test_parse_fbc_fragments_blank_item() -> None:
+    """Whitespace-only items raise ``ValueError``."""
+    with pytest.raises(ValueError, match="non-empty strings"):
+        update_fbc_catalog.parse_fbc_fragments('["ok", "  "]')
+
+
+def test_parse_fbc_fragments_invalid_json() -> None:
+    """Invalid JSON raises ``JSONDecodeError``."""
+    with pytest.raises(json.JSONDecodeError):
+        update_fbc_catalog.parse_fbc_fragments("not json")
+
+
+# ---------------------------------------------------------------------------
+# create_container_auth_config
+# ---------------------------------------------------------------------------
+
+
+def test_create_auth_config_normal_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Auth entry is written with base64-encoded credentials."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    authentication.create_container_auth_config("registry.example.com/repo:v1", "user:pass")
+    auth_file = tmp_path / ".config" / "containers" / "auth.json"
+    data = json.loads(auth_file.read_text(encoding="utf-8"))
+    expected_token = base64.b64encode(b"user:pass").decode("ascii")
+    assert data["auths"]["registry.example.com/repo"]["auth"] == expected_token
+
+
+def test_create_auth_config_no_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Empty credentials produce an empty auth.json."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    authentication.create_container_auth_config("registry.example.com/repo:v1", "")
+    auth_file = tmp_path / ".config" / "containers" / "auth.json"
+    assert json.loads(auth_file.read_text(encoding="utf-8")) == {}
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "registry-proxy.engineering.redhat.com",
+        "registry-proxy-stage.engineering.redhat.com",
+    ],
+)
+def test_create_auth_config_registry_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    host: str,
+) -> None:
+    """registry-proxy hosts get empty auth (Kerberos, not token auth)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    authentication.create_container_auth_config(
+        f"{host}/rh-osbs/iib:v4.12",
+        "some-cred",
+    )
+    auth_file = tmp_path / ".config" / "containers" / "auth.json"
+    assert json.loads(auth_file.read_text(encoding="utf-8")) == {}
+
+
+def test_create_auth_config_registry_proxy_removes_existing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Existing auth entry for registry-proxy is removed."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    auth_dir = tmp_path / ".config" / "containers"
+    auth_dir.mkdir(parents=True)
+    auth_file = auth_dir / "auth.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "auths": {
+                    "registry-proxy.engineering.redhat.com/rh-osbs/iib": {"auth": "old-token"},
+                    "other-registry.com/repo": {"auth": "keep-me"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    authentication.create_container_auth_config(
+        "registry-proxy.engineering.redhat.com/rh-osbs/iib:v4.12",
+        "some-cred",
+    )
+    data = json.loads(auth_file.read_text(encoding="utf-8"))
+    assert "registry-proxy.engineering.redhat.com/rh-osbs/iib" not in data["auths"]
+    assert data["auths"]["other-registry.com/repo"]["auth"] == "keep-me"
+
+
+# ---------------------------------------------------------------------------
+# inspect_image_created
+# ---------------------------------------------------------------------------
+
+
+def _skopeo_result(
+    stdout: str = "",
+    returncode: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+def test_inspect_image_created_success() -> None:
+    """A valid skopeo response returns the created date string."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_skopeo_result('{"created": "2024-01-15T10:30:00Z"}'),
+    ):
+        assert update_fbc_catalog.inspect_image_created("img:v1") == "2024-01-15T10:30:00Z"
+
+
+def test_inspect_image_created_skopeo_failure() -> None:
+    """Non-zero skopeo exit returns ``None``."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_skopeo_result(returncode=1),
+    ):
+        assert update_fbc_catalog.inspect_image_created("img:v1") is None
+
+
+def test_inspect_image_created_no_created_field() -> None:
+    """Missing ``created`` field returns ``None``."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_skopeo_result("{}"),
+    ):
+        assert update_fbc_catalog.inspect_image_created("img:v1") is None
+
+
+def test_inspect_image_created_invalid_json() -> None:
+    """Invalid JSON stdout returns ``None``."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_skopeo_result("not json"),
+    ):
+        assert update_fbc_catalog.inspect_image_created("img:v1") is None
+
+
+# ---------------------------------------------------------------------------
+# is_build_newer_than_index
+# ---------------------------------------------------------------------------
+
+
+def test_is_build_newer_than_index_newer() -> None:
+    """Return ``True`` when the build is newer than from_index."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "index_image_resolved": "registry/idx@sha256:new",
+    }
+    with mock.patch(
+        "update_fbc_catalog.inspect_image_created",
+        side_effect=[
+            "2024-06-01T00:00:00Z",
+            "2024-01-01T00:00:00Z",
+        ],
+    ):
+        assert update_fbc_catalog.is_build_newer_than_index(
+            build, "registry/idx:v4.12", "https://iib", "user"
+        )
+
+
+def test_is_build_newer_than_index_older() -> None:
+    """Return ``False`` when the build is older than from_index."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "index_image_resolved": "registry/idx@sha256:old",
+    }
+    with mock.patch(
+        "update_fbc_catalog.inspect_image_created",
+        side_effect=[
+            "2024-01-01T00:00:00Z",
+            "2024-06-01T00:00:00Z",
+        ],
+    ):
+        assert not update_fbc_catalog.is_build_newer_than_index(
+            build, "registry/idx:v4.12", "https://iib", "user"
+        )
+
+
+def test_is_build_newer_than_index_no_resolved() -> None:
+    """Return ``False`` when ``index_image_resolved`` is missing."""
+    build: iib.IIBBuild = {"id": 1, "state": "complete"}
+    assert not update_fbc_catalog.is_build_newer_than_index(
+        build, "registry/idx:v4.12", "https://iib", "user"
+    )
+
+
+def test_is_build_newer_than_index_falls_back_to_resolved() -> None:
+    """Use ``from_index_resolved`` when direct from_index inspect fails."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "index_image_resolved": "registry/idx@sha256:new",
+        "from_index_resolved": "registry/idx@sha256:old-resolved",
+    }
+    with mock.patch(
+        "update_fbc_catalog.inspect_image_created",
+        side_effect=[
+            "2024-06-01T00:00:00Z",
+            None,
+            "2024-01-01T00:00:00Z",
+        ],
+    ):
+        assert update_fbc_catalog.is_build_newer_than_index(
+            build, "registry/idx:v4.12", "https://iib", "user"
+        )
+
+
+def test_is_build_newer_than_index_skopeo_fails_uses_iib() -> None:
+    """Fall back to IIB query when skopeo fails for both images."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "index_image_resolved": "registry/idx@sha256:x",
+        "from_index": "registry/idx:v4.12",
+        "updated": "2024-06-01T00:00:00Z",
+    }
+    with (
+        mock.patch(
+            "update_fbc_catalog.inspect_image_created",
+            return_value=None,
+        ),
+        mock.patch(
+            "iib.query_builds",
+            return_value={"items": []},
+        ),
+    ):
+        assert not update_fbc_catalog.is_build_newer_than_index(
+            build, "registry/idx:v4.12", "https://iib", "user"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _is_build_newer_via_iib
+# ---------------------------------------------------------------------------
+
+
+def test_is_build_newer_via_iib_no_newer_builds() -> None:
+    """Return ``True`` when no newer build exists in IIB."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "from_index": "registry/idx:v4.12",
+        "updated": "2024-06-01T00:00:00Z",
+    }
+    with mock.patch(
+        "iib.query_builds",
+        return_value={
+            "items": [
+                {
+                    "id": 1,
+                    "distribution_scope": "prod",
+                    "updated": "2024-06-01T00:00:00Z",
+                }
+            ],
+        },
+    ):
+        assert update_fbc_catalog._is_build_newer_via_iib(
+            build, "registry/idx:v4.12", "https://iib", "user"
+        )
+
+
+def test_is_build_newer_via_iib_newer_build_exists() -> None:
+    """Return ``False`` when a newer build exists for the same from_index."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "from_index": "registry/idx:v4.12",
+        "updated": "2024-01-01T00:00:00Z",
+    }
+    with mock.patch(
+        "iib.query_builds",
+        return_value={
+            "items": [
+                {
+                    "id": 2,
+                    "distribution_scope": "prod",
+                    "updated": "2024-06-01T00:00:00Z",
+                }
+            ],
+        },
+    ):
+        assert not update_fbc_catalog._is_build_newer_via_iib(
+            build, "registry/idx:v4.12", "https://iib", "user"
+        )
+
+
+def test_is_build_newer_via_iib_query_fails() -> None:
+    """Return ``False`` when the IIB query fails."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "from_index": "registry/idx:v4.12",
+        "updated": "2024-06-01T00:00:00Z",
+    }
+    with mock.patch(
+        "iib.query_builds",
+        side_effect=requests.ConnectionError("timeout"),
+    ):
+        assert not update_fbc_catalog._is_build_newer_via_iib(
+            build, "registry/idx:v4.12", "https://iib", "user"
+        )
+
+
+def test_is_build_newer_via_iib_mismatched_from_index() -> None:
+    """Return ``False`` when the build's from_index doesn't match."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "from_index": "registry/idx:v4.11",
+        "updated": "2024-06-01T00:00:00Z",
+    }
+    assert not update_fbc_catalog._is_build_newer_via_iib(
+        build, "registry/idx:v4.12", "https://iib", "user"
+    )
+
+
+# ---------------------------------------------------------------------------
+# check_previous_build
+# ---------------------------------------------------------------------------
+
+
+def test_check_previous_build_finds_fresh_complete() -> None:
+    """Return a fresh completed build when one exists."""
+    complete_build: iib.IIBBuild = {
+        "id": 10,
+        "state": "complete",
+        "fbc_fragments": ["b", "a"],
+        "distribution_scope": "prod",
+        "updated": "2024-06-01T00:00:00Z",
+    }
+    with (
+        mock.patch(
+            "iib.query_builds",
+            return_value={"items": [complete_build]},
+        ),
+        mock.patch(
+            "update_fbc_catalog.is_build_newer_than_index",
+            return_value=True,
+        ),
+    ):
+        result = update_fbc_catalog.check_previous_build(
+            "https://iib",
+            "user",
+            "idx:v4.12",
+            ["a", "b"],
+            [],
+        )
+    assert result == complete_build
+
+
+def test_check_previous_build_stale_complete_finds_in_progress() -> None:
+    """Fall through to in-progress when completed build is stale."""
+    ip_build: iib.IIBBuild = {
+        "id": 20,
+        "state": "in_progress",
+        "fbc_fragments": ["a", "b"],
+        "distribution_scope": "prod",
+        "updated": "2024-06-01T00:00:00Z",
+    }
+    with (
+        mock.patch(
+            "iib.query_builds",
+            side_effect=[
+                {
+                    "items": [
+                        {
+                            "id": 10,
+                            "state": "complete",
+                            "fbc_fragments": ["a", "b"],
+                            "distribution_scope": "prod",
+                            "updated": "2024-01-01T00:00:00Z",
+                        }
+                    ]
+                },
+                {"items": [ip_build]},
+            ],
+        ),
+        mock.patch(
+            "update_fbc_catalog.is_build_newer_than_index",
+            return_value=False,
+        ),
+    ):
+        result = update_fbc_catalog.check_previous_build(
+            "https://iib",
+            "user",
+            "idx:v4.12",
+            ["a", "b"],
+            [],
+        )
+    assert result == ip_build
+
+
+def test_check_previous_build_filters_by_build_tags() -> None:
+    """In-progress builds are filtered by build_tags when provided."""
+    with mock.patch(
+        "iib.query_builds",
+        side_effect=[
+            {"items": []},
+            {
+                "items": [
+                    {
+                        "id": 1,
+                        "state": "in_progress",
+                        "fbc_fragments": ["a"],
+                        "distribution_scope": "prod",
+                        "updated": "2024-01-01T00:00:00Z",
+                        "build_tags": ["other-plr"],
+                    },
+                    {
+                        "id": 2,
+                        "state": "in_progress",
+                        "fbc_fragments": ["a"],
+                        "distribution_scope": "prod",
+                        "updated": "2024-06-01T00:00:00Z",
+                        "build_tags": ["my-plr"],
+                    },
+                ]
+            },
+        ],
+    ):
+        result = update_fbc_catalog.check_previous_build(
+            "https://iib",
+            "user",
+            "idx:v4.12",
+            ["a"],
+            ["my-plr"],
+        )
+    assert result is not None
+    assert result["id"] == 2
+
+
+def test_check_previous_build_no_match() -> None:
+    """Return ``None`` when no builds match."""
+    with mock.patch(
+        "iib.query_builds",
+        return_value={"items": []},
+    ):
+        result = update_fbc_catalog.check_previous_build(
+            "https://iib",
+            "user",
+            "idx:v4.12",
+            ["a"],
+            [],
+        )
+    assert result is None
+
+
+def test_check_previous_build_query_error() -> None:
+    """Return ``None`` when the IIB query fails."""
+    with mock.patch(
+        "iib.query_builds",
+        side_effect=requests.ConnectionError("timeout"),
+    ):
+        result = update_fbc_catalog.check_previous_build(
+            "https://iib",
+            "user",
+            "idx:v4.12",
+            ["a"],
+            [],
+        )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# poll_build_status
+# ---------------------------------------------------------------------------
+
+
+def test_poll_build_status_immediate_complete() -> None:
+    """Return immediately when the build is already complete."""
+    build: iib.IIBBuild = {"id": 1, "state": "complete"}
+    with mock.patch("iib.get_build", return_value=build):
+        result = update_fbc_catalog.poll_build_status(
+            "https://iib",
+            1,
+            3600,
+            sleep_fn=lambda _: None,
+            clock_fn=mock.MagicMock(side_effect=[0.0, 0.0, 0.0]),
+        )
+    assert result["state"] == "complete"
+
+
+def test_poll_build_status_polls_until_complete() -> None:
+    """Poll multiple times before the build completes."""
+    builds = [
+        {"id": 1, "state": "in_progress"},
+        {"id": 1, "state": "in_progress"},
+        {"id": 1, "state": "complete"},
+    ]
+    clock_values = [0.0, 0.0, 0.0, 30.0, 30.0, 60.0, 60.0]
+    with mock.patch("iib.get_build", side_effect=builds):
+        result = update_fbc_catalog.poll_build_status(
+            "https://iib",
+            1,
+            3600,
+            sleep_fn=lambda _: None,
+            clock_fn=mock.MagicMock(side_effect=clock_values),
+        )
+    assert result["state"] == "complete"
+
+
+def test_poll_build_status_timeout() -> None:
+    """Raise ``TimeoutError`` when timeout is exceeded."""
+    with mock.patch(
+        "iib.get_build",
+        return_value={"id": 1, "state": "in_progress"},
+    ):
+        with pytest.raises(TimeoutError, match="Timeout after"):
+            update_fbc_catalog.poll_build_status(
+                "https://iib",
+                1,
+                60,
+                sleep_fn=lambda _: None,
+                clock_fn=mock.MagicMock(side_effect=[0.0, 0.0, 0.0, 61.0]),
+            )
+
+
+def test_poll_build_status_failed_state() -> None:
+    """Return build info when the build fails."""
+    build: iib.IIBBuild = {"id": 1, "state": "failed", "state_reason": "oops"}
+    with mock.patch("iib.get_build", return_value=build):
+        result = update_fbc_catalog.poll_build_status(
+            "https://iib",
+            1,
+            3600,
+            sleep_fn=lambda _: None,
+            clock_fn=mock.MagicMock(side_effect=[0.0, 0.0, 0.0]),
+        )
+    assert result["state"] == "failed"
+
+
+def test_poll_build_status_removes_state_history() -> None:
+    """``state_history`` is removed from the returned build info."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "state_history": [{"state": "in_progress"}],
+    }
+    with mock.patch("iib.get_build", return_value=build):
+        result = update_fbc_catalog.poll_build_status(
+            "https://iib",
+            1,
+            3600,
+            sleep_fn=lambda _: None,
+            clock_fn=mock.MagicMock(side_effect=[0.0, 0.0, 0.0]),
+        )
+    assert "state_history" not in result
+
+
+def test_poll_build_status_retries_on_fetch_error() -> None:
+    """Transient fetch errors are retried."""
+    builds = [
+        requests.ConnectionError("fail"),
+        {"id": 1, "state": "complete"},
+    ]
+    clock_values = [0.0, 0.0, 0.0, 30.0, 30.0, 30.0]
+
+    def _get_build(_url: str, _id: int) -> iib.IIBBuild:
+        val = builds.pop(0)
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+    with mock.patch("iib.get_build", side_effect=_get_build):
+        result = update_fbc_catalog.poll_build_status(
+            "https://iib",
+            1,
+            3600,
+            sleep_fn=lambda _: None,
+            clock_fn=mock.MagicMock(side_effect=clock_values),
+        )
+    assert result["state"] == "complete"
+
+
+# ---------------------------------------------------------------------------
+# validate_index_image
+# ---------------------------------------------------------------------------
+
+
+def test_validate_index_image_overwrite_and_publish_match() -> None:
+    """No error when index_image matches from_index."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "index_image": "registry/idx:v4.12",
+        "from_index": "registry/idx:v4.12",
+    }
+    update_fbc_catalog.validate_index_image(build, True, True)
+
+
+def test_validate_index_image_overwrite_and_publish_mismatch() -> None:
+    """Raise ``ValueError`` when index_image doesn't match from_index."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "index_image": "registry/idx:wrong",
+        "from_index": "registry/idx:v4.12",
+    }
+    with pytest.raises(ValueError, match="Index image mismatch"):
+        update_fbc_catalog.validate_index_image(build, True, True)
+
+
+def test_validate_index_image_overwrite_without_publish() -> None:
+    """Raise ``ValueError`` for invalid overwrite+no-publish combination."""
+    build: iib.IIBBuild = {"id": 1, "state": "complete"}
+    with pytest.raises(ValueError, match="Invalid combination"):
+        update_fbc_catalog.validate_index_image(build, True, False)
+
+
+def test_validate_index_image_no_overwrite_passes() -> None:
+    """No error for non-overwrite strategies."""
+    build: iib.IIBBuild = {"id": 1, "state": "complete"}
+    update_fbc_catalog.validate_index_image(build, False, True)
+    update_fbc_catalog.validate_index_image(build, False, False)
+
+
+# ---------------------------------------------------------------------------
+# get_manifest_digests
+# ---------------------------------------------------------------------------
+
+
+def test_get_manifest_digests_success() -> None:
+    """Return space-separated digests from a manifest list."""
+    manifest = {
+        "manifests": [
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "digest": "sha256:aaa",
+            },
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "digest": "sha256:bbb",
+            },
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": "sha256:ccc",
+            },
+        ],
+    }
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_skopeo_result(json.dumps(manifest)),
+    ):
+        result = update_fbc_catalog.get_manifest_digests("img:v1")
+    assert result == "sha256:aaa sha256:bbb"
+
+
+def test_get_manifest_digests_not_multiarch() -> None:
+    """Raise ``RuntimeError`` when no v2 manifests are found."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_skopeo_result('{"manifests": []}'),
+    ):
+        with pytest.raises(RuntimeError, match="not multi-arch"):
+            update_fbc_catalog.get_manifest_digests("img:v1")
+
+
+def test_get_manifest_digests_skopeo_failure() -> None:
+    """Raise ``RuntimeError`` when skopeo fails."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_skopeo_result(returncode=1),
+    ):
+        with pytest.raises(RuntimeError, match="skopeo inspect --raw failed"):
+            update_fbc_catalog.get_manifest_digests("img:v1")
+
+
+# ---------------------------------------------------------------------------
+# _poll_and_collect
+# ---------------------------------------------------------------------------
+
+
+def test_poll_and_collect_complete_success() -> None:
+    """Successful complete build returns exit_code=0 with digests."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "internal_index_image_copy": "internal/img:v1",
+        "index_image": "registry/idx:v4.12",
+        "from_index": "registry/idx:v4.12",
+        "logs": {"url": "https://logs/1"},
+    }
+    manifest = {
+        "manifests": [
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "digest": "sha256:abc",
+            }
+        ],
+    }
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_skopeo_result(json.dumps(manifest)),
+    ):
+        result = update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            build,
+            3600,
+            True,
+            True,
+        )
+    assert result.exit_code == 0
+    assert result.state == "complete"
+    assert result.index_image_digests == "sha256:abc"
+    assert result.iib_log_url == "https://logs/1"
+
+
+def test_poll_and_collect_failed_build() -> None:
+    """Failed build returns exit_code=1."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "failed",
+        "state_reason": "something broke",
+    }
+    result = update_fbc_catalog._poll_and_collect(
+        "https://iib",
+        build,
+        3600,
+        False,
+        False,
+    )
+    assert result.exit_code == 1
+    assert result.state == "failed"
+
+
+def test_poll_and_collect_timeout() -> None:
+    """Timeout returns exit_code=124."""
+    build: iib.IIBBuild = {"id": 1, "state": "in_progress"}
+    with mock.patch(
+        "update_fbc_catalog.poll_build_status",
+        side_effect=TimeoutError("timed out"),
+    ):
+        result = update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            build,
+            60,
+            False,
+            False,
+        )
+    assert result.exit_code == 124
+    assert result.state == "failed"
+    assert result.state_reason == "Build timeout"
+
+
+def test_poll_and_collect_missing_id() -> None:
+    """Raise ``ValueError`` when build has no id."""
+    build: iib.IIBBuild = {"state": "complete"}
+    with pytest.raises(ValueError, match="missing 'id'"):
+        update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            build,
+            3600,
+            False,
+            False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def _setup_result_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> dict[str, Path]:
+    """Set up Tekton result env vars and return paths."""
+    paths = {
+        "RESULT_JSON_BUILD_INFO": tmp_path / "json_build_info",
+        "RESULT_BUILD_STATE": tmp_path / "build_state",
+        "RESULT_INDEX_IMAGE_DIGESTS": tmp_path / "digests",
+        "RESULT_IIB_LOG": tmp_path / "iib_log",
+        "RESULT_EXIT_CODE": tmp_path / "exit_code",
+    }
+    for name, path in paths.items():
+        monkeypatch.setenv(name, str(path))
+    return paths
+
+
+def test_main_invalid_fbc_fragments(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Invalid fbc_fragments writes failure and exits."""
+    paths = _setup_result_env(monkeypatch, tmp_path)
+    with pytest.raises(SystemExit, match="update_fbc_catalog.py"):
+        update_fbc_catalog.main(
+            [
+                "--fbc-fragments",
+                "not-json",
+                "--from-index",
+                "idx:v1",
+            ]
+        )
+    state = json.loads(paths["RESULT_BUILD_STATE"].read_text(encoding="utf-8"))
+    assert state["state"] == "failed"
+    assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "1"
+
+
+def test_main_empty_fbc_fragments(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Empty fbc_fragments array writes failure and exits."""
+    paths = _setup_result_env(monkeypatch, tmp_path)
+    with pytest.raises(SystemExit, match="empty"):
+        update_fbc_catalog.main(
+            [
+                "--fbc-fragments",
+                "[]",
+                "--from-index",
+                "idx:v1",
+            ]
+        )
+    assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "1"
+
+
+def test_main_writes_results_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Successful run writes all result files and returns 0."""
+    paths = _setup_result_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("IIB_SERVICE_ACCOUNT_MOUNT", str(tmp_path / "sa"))
+    monkeypatch.setenv("IIB_SERVICES_CONFIG_MOUNT", str(tmp_path / "cfg"))
+    monkeypatch.setenv(
+        "IIB_OVERWRITE_FROMIMAGE_CREDENTIALS_MOUNT",
+        str(tmp_path / "ow"),
+    )
+    monkeypatch.setenv(
+        "PUBLISHING_CREDENTIALS_MOUNT",
+        str(tmp_path / "pub"),
+    )
+
+    fake_result = update_fbc_catalog.RunResult(
+        build_info={"id": 1, "state": "complete"},
+        state="complete",
+        state_reason="",
+        index_image_digests="sha256:abc sha256:def",
+        iib_log_url="https://logs/1",
+        exit_code=0,
+    )
+    with mock.patch(
+        "update_fbc_catalog.run",
+        return_value=fake_result,
+    ):
+        rc = update_fbc_catalog.main(
+            [
+                "--fbc-fragments",
+                '["frag-a"]',
+                "--from-index",
+                "idx:v1",
+            ]
+        )
+
+    assert rc == 0
+    assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "0"
+    assert (
+        paths["RESULT_INDEX_IMAGE_DIGESTS"].read_text(encoding="utf-8")
+        == "sha256:abc sha256:def"
+    )
+    state = json.loads(paths["RESULT_BUILD_STATE"].read_text(encoding="utf-8"))
+    assert state["state"] == "complete"
+    compressed = paths["RESULT_JSON_BUILD_INFO"].read_text(encoding="utf-8")
+    assert iib.decompress_build_info(compressed) == {
+        "id": 1,
+        "state": "complete",
+    }
+    assert (
+        paths["RESULT_IIB_LOG"].read_text(encoding="utf-8") == "IIB log url is: https://logs/1"
+    )
+
+
+def test_main_check_step_error_writes_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``CheckStepError`` from ``run`` writes failure and exits."""
+    paths = _setup_result_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("IIB_SERVICE_ACCOUNT_MOUNT", str(tmp_path / "sa"))
+    monkeypatch.setenv("IIB_SERVICES_CONFIG_MOUNT", str(tmp_path / "cfg"))
+    monkeypatch.setenv(
+        "IIB_OVERWRITE_FROMIMAGE_CREDENTIALS_MOUNT",
+        str(tmp_path / "ow"),
+    )
+    monkeypatch.setenv(
+        "PUBLISHING_CREDENTIALS_MOUNT",
+        str(tmp_path / "pub"),
+    )
+
+    with mock.patch(
+        "update_fbc_catalog.run",
+        side_effect=tekton.CheckStepError(
+            "kinit",
+            subprocess.CalledProcessError(1, "kinit"),
+        ),
+    ):
+        with pytest.raises(SystemExit, match="update_fbc_catalog.py"):
+            update_fbc_catalog.main(
+                [
+                    "--fbc-fragments",
+                    '["frag-a"]',
+                    "--from-index",
+                    "idx:v1",
+                ]
+            )
+
+    assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "1"
+    state = json.loads(paths["RESULT_BUILD_STATE"].read_text(encoding="utf-8"))
+    assert state["state"] == "failed"
+
+
+def test_main_missing_result_env_exits() -> None:
+    """Missing result env vars raise ``SystemExit``."""
+    with pytest.raises(SystemExit):
+        update_fbc_catalog.main(
+            [
+                "--fbc-fragments",
+                '["a"]',
+                "--from-index",
+                "idx:v1",
+            ]
+        )
+
+
+def test_main_invalid_build_tags_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Invalid build-tags JSON writes failure and exits."""
+    paths = _setup_result_env(monkeypatch, tmp_path)
+    with pytest.raises(SystemExit, match="Invalid JSON"):
+        update_fbc_catalog.main(
+            [
+                "--fbc-fragments",
+                '["a"]',
+                "--from-index",
+                "idx:v1",
+                "--build-tags",
+                "not-json",
+            ]
+        )
+    assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "1"
+
+
+def test_main_returns_nonzero_on_failed_build(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Failed build result returns non-zero exit code from main."""
+    paths = _setup_result_env(monkeypatch, tmp_path)
+    _setup_mount_env(monkeypatch, tmp_path)
+
+    fake_result = update_fbc_catalog.RunResult(
+        build_info={"id": 1, "state": "failed"},
+        state="failed",
+        state_reason="Build failed with exit code 1",
+        index_image_digests="",
+        iib_log_url="",
+        exit_code=1,
+    )
+    with mock.patch(
+        "update_fbc_catalog.run",
+        return_value=fake_result,
+    ):
+        rc = update_fbc_catalog.main(
+            [
+                "--fbc-fragments",
+                '["a"]',
+                "--from-index",
+                "idx:v1",
+            ]
+        )
+
+    assert rc == 1
+    assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "1"
+    state = json.loads(paths["RESULT_BUILD_STATE"].read_text(encoding="utf-8"))
+    assert state["state"] == "failed"
+    assert state["state_reason"] == "Build failed with exit code 1"
+
+
+def test_main_timeout_returns_124(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Timeout result returns exit code 124 from main."""
+    paths = _setup_result_env(monkeypatch, tmp_path)
+    _setup_mount_env(monkeypatch, tmp_path)
+
+    fake_result = update_fbc_catalog.RunResult(
+        build_info={"id": 1, "state": "in_progress"},
+        state="failed",
+        state_reason="Build timeout",
+        index_image_digests="",
+        iib_log_url="",
+        exit_code=124,
+    )
+    with mock.patch(
+        "update_fbc_catalog.run",
+        return_value=fake_result,
+    ):
+        rc = update_fbc_catalog.main(
+            [
+                "--fbc-fragments",
+                '["a"]',
+                "--from-index",
+                "idx:v1",
+            ]
+        )
+
+    assert rc == 124
+    assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "124"
+
+
+def _setup_mount_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Set up mount path env vars."""
+    monkeypatch.setenv("IIB_SERVICE_ACCOUNT_MOUNT", str(tmp_path / "sa"))
+    monkeypatch.setenv("IIB_SERVICES_CONFIG_MOUNT", str(tmp_path / "cfg"))
+    monkeypatch.setenv(
+        "IIB_OVERWRITE_FROMIMAGE_CREDENTIALS_MOUNT",
+        str(tmp_path / "ow"),
+    )
+    monkeypatch.setenv(
+        "PUBLISHING_CREDENTIALS_MOUNT",
+        str(tmp_path / "pub"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# poll_build_status — new behavior tests
+# ---------------------------------------------------------------------------
+
+
+def test_poll_build_status_skips_error_responses() -> None:
+    """Responses with an ``error`` field are retried."""
+    responses = [
+        {"error": "service unavailable"},
+        {"id": 1, "state": "complete"},
+    ]
+    clock_values = [0.0, 0.0, 30.0, 30.0, 30.0]
+
+    def _get_build(_url: str, _id: int) -> iib.IIBBuild:
+        return responses.pop(0)
+
+    with mock.patch("iib.get_build", side_effect=_get_build):
+        result = update_fbc_catalog.poll_build_status(
+            "https://iib",
+            1,
+            3600,
+            sleep_fn=lambda _: None,
+            clock_fn=mock.MagicMock(side_effect=clock_values),
+        )
+    assert result["state"] == "complete"
+
+
+def test_poll_build_status_writes_log_url(tmp_path: Path) -> None:
+    """Log URL is written to iib_log_path each iteration."""
+    builds = [
+        {"id": 1, "state": "in_progress", "logs": {"url": "https://logs/1"}},
+        {"id": 1, "state": "complete", "logs": {"url": "https://logs/2"}},
+    ]
+    clock_values = [0.0, 0.0, 0.0, 30.0, 30.0, 30.0]
+    log_path = tmp_path / "iib_log"
+
+    with mock.patch("iib.get_build", side_effect=builds):
+        update_fbc_catalog.poll_build_status(
+            "https://iib",
+            1,
+            3600,
+            iib_log_path=log_path,
+            sleep_fn=lambda _: None,
+            clock_fn=mock.MagicMock(side_effect=clock_values),
+        )
+
+    assert log_path.read_text(encoding="utf-8") == "IIB log url is: https://logs/2"
+
+
+# ---------------------------------------------------------------------------
+# _poll_and_collect — additional paths
+# ---------------------------------------------------------------------------
+
+
+def test_poll_and_collect_validation_error() -> None:
+    """Index image validation failure returns exit_code=1."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "index_image": "registry/idx:wrong",
+        "from_index": "registry/idx:v4.12",
+    }
+    result = update_fbc_catalog._poll_and_collect(
+        "https://iib",
+        build,
+        3600,
+        True,
+        True,
+    )
+    assert result.exit_code == 1
+    assert result.state == "failed"
+    assert "Index image mismatch" in result.state_reason
+
+
+def test_poll_and_collect_missing_internal_copy() -> None:
+    """Missing internal_index_image_copy returns exit_code=1."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "index_image": "registry/idx:v4.12",
+        "from_index": "registry/idx:v4.12",
+    }
+    result = update_fbc_catalog._poll_and_collect(
+        "https://iib",
+        build,
+        3600,
+        True,
+        True,
+    )
+    assert result.exit_code == 1
+    assert "Missing internal_index_image_copy" in result.state_reason
+
+
+def test_poll_and_collect_digest_extraction_fails() -> None:
+    """Failed manifest digest extraction returns exit_code=1."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "internal_index_image_copy": "internal/img:v1",
+    }
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_skopeo_result(returncode=1),
+    ):
+        result = update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            build,
+            3600,
+            False,
+            False,
+        )
+    assert result.exit_code == 1
+    assert "Failed to get manifest digests" in result.state_reason
+
+
+def test_poll_and_collect_polls_in_progress_build() -> None:
+    """In-progress build is polled until complete."""
+    ip_build: iib.IIBBuild = {"id": 1, "state": "in_progress"}
+    complete_build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "internal_index_image_copy": "internal/img:v1",
+    }
+    manifest = {
+        "manifests": [
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "digest": "sha256:abc",
+            }
+        ],
+    }
+    with (
+        mock.patch(
+            "update_fbc_catalog.poll_build_status",
+            return_value=complete_build,
+        ),
+        mock.patch(
+            "skopeo.subprocess.run",
+            return_value=_skopeo_result(json.dumps(manifest)),
+        ),
+    ):
+        result = update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            ip_build,
+            3600,
+            False,
+            False,
+        )
+    assert result.exit_code == 0
+    assert result.index_image_digests == "sha256:abc"
+
+
+def test_poll_and_collect_failed_state_reason() -> None:
+    """Failed build uses state_reason from IIB or fallback message."""
+    build_with_reason: iib.IIBBuild = {
+        "id": 1,
+        "state": "failed",
+        "state_reason": "IIB internal error",
+    }
+    result = update_fbc_catalog._poll_and_collect(
+        "https://iib",
+        build_with_reason,
+        3600,
+        False,
+        False,
+    )
+    assert result.state_reason == "IIB internal error"
+
+    build_no_reason: iib.IIBBuild = {
+        "id": 2,
+        "state": "failed",
+    }
+    result2 = update_fbc_catalog._poll_and_collect(
+        "https://iib",
+        build_no_reason,
+        3600,
+        False,
+        False,
+    )
+    assert result2.state_reason == "Build failed with exit code 1"
+
+
+# ---------------------------------------------------------------------------
+# _is_build_newer_via_iib — additional paths
+# ---------------------------------------------------------------------------
+
+
+def test_is_build_newer_via_iib_empty_items() -> None:
+    """Return ``False`` when IIB returns empty items list."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "from_index": "registry/idx:v4.12",
+        "updated": "2024-06-01T00:00:00Z",
+    }
+    with mock.patch(
+        "iib.query_builds",
+        return_value={"items": []},
+    ):
+        assert not update_fbc_catalog._is_build_newer_via_iib(
+            build, "registry/idx:v4.12", "https://iib", "user"
+        )
+
+
+def test_is_build_newer_via_iib_no_updated_field() -> None:
+    """Return ``False`` when the build has no updated timestamp."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "from_index": "registry/idx:v4.12",
+    }
+    assert not update_fbc_catalog._is_build_newer_via_iib(
+        build, "registry/idx:v4.12", "https://iib", "user"
+    )
+
+
+def test_is_build_newer_via_iib_unparseable_timestamps() -> None:
+    """Unparseable timestamps default to 0 (matching bash behavior)."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "from_index": "registry/idx:v4.12",
+        "updated": "not-a-date",
+    }
+    with mock.patch(
+        "iib.query_builds",
+        return_value={
+            "items": [
+                {
+                    "id": 2,
+                    "distribution_scope": "prod",
+                    "updated": "also-not-a-date",
+                }
+            ],
+        },
+    ):
+        assert update_fbc_catalog._is_build_newer_via_iib(
+            build, "registry/idx:v4.12", "https://iib", "user"
+        )
+
+
+def test_is_build_newer_via_iib_filters_invalid_scope() -> None:
+    """Builds with non-valid distribution_scope are excluded."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "from_index": "registry/idx:v4.12",
+        "updated": "2024-06-01T00:00:00Z",
+    }
+    with mock.patch(
+        "iib.query_builds",
+        return_value={
+            "items": [
+                {
+                    "id": 2,
+                    "distribution_scope": "dev",
+                    "updated": "2024-12-01T00:00:00Z",
+                }
+            ],
+        },
+    ):
+        assert not update_fbc_catalog._is_build_newer_via_iib(
+            build, "registry/idx:v4.12", "https://iib", "user"
+        )
+
+
+# ---------------------------------------------------------------------------
+# check_previous_build — additional paths
+# ---------------------------------------------------------------------------
+
+
+def test_check_previous_build_ignores_non_matching_fragments() -> None:
+    """Builds with different fbc_fragments are not returned."""
+    with mock.patch(
+        "iib.query_builds",
+        side_effect=[
+            {
+                "items": [
+                    {
+                        "id": 1,
+                        "state": "complete",
+                        "fbc_fragments": ["x", "y"],
+                        "distribution_scope": "prod",
+                        "updated": "2024-06-01T00:00:00Z",
+                    }
+                ]
+            },
+            {"items": []},
+        ],
+    ):
+        result = update_fbc_catalog.check_previous_build(
+            "https://iib",
+            "user",
+            "idx:v4.12",
+            ["a", "b"],
+            [],
+        )
+    assert result is None
+
+
+def test_check_previous_build_ignores_null_fragments() -> None:
+    """Builds with null fbc_fragments are skipped."""
+    with mock.patch(
+        "iib.query_builds",
+        side_effect=[
+            {
+                "items": [
+                    {
+                        "id": 1,
+                        "state": "complete",
+                        "fbc_fragments": None,
+                        "distribution_scope": "prod",
+                        "updated": "2024-06-01T00:00:00Z",
+                    }
+                ]
+            },
+            {"items": []},
+        ],
+    ):
+        result = update_fbc_catalog.check_previous_build(
+            "https://iib",
+            "user",
+            "idx:v4.12",
+            ["a"],
+            [],
+        )
+    assert result is None
+
+
+def test_check_previous_build_ignores_dev_scope() -> None:
+    """Builds with distribution_scope 'dev' are excluded."""
+    with mock.patch(
+        "iib.query_builds",
+        side_effect=[
+            {
+                "items": [
+                    {
+                        "id": 1,
+                        "state": "complete",
+                        "fbc_fragments": ["a"],
+                        "distribution_scope": "dev",
+                        "updated": "2024-06-01T00:00:00Z",
+                    }
+                ]
+            },
+            {"items": []},
+        ],
+    ):
+        result = update_fbc_catalog.check_previous_build(
+            "https://iib",
+            "user",
+            "idx:v4.12",
+            ["a"],
+            [],
+        )
+    assert result is None
+
+
+def test_check_previous_build_picks_latest_completed() -> None:
+    """When multiple completed builds match, the latest is picked."""
+    with (
+        mock.patch(
+            "iib.query_builds",
+            return_value={
+                "items": [
+                    {
+                        "id": 1,
+                        "state": "complete",
+                        "fbc_fragments": ["a"],
+                        "distribution_scope": "prod",
+                        "updated": "2024-01-01T00:00:00Z",
+                    },
+                    {
+                        "id": 2,
+                        "state": "complete",
+                        "fbc_fragments": ["a"],
+                        "distribution_scope": "prod",
+                        "updated": "2024-06-01T00:00:00Z",
+                    },
+                ]
+            },
+        ),
+        mock.patch(
+            "update_fbc_catalog.is_build_newer_than_index",
+            return_value=True,
+        ),
+    ):
+        result = update_fbc_catalog.check_previous_build(
+            "https://iib",
+            "user",
+            "idx:v4.12",
+            ["a"],
+            [],
+        )
+    assert result is not None
+    assert result["id"] == 2
+
+
+def test_check_previous_build_no_build_tags_matches_all_ip() -> None:
+    """Without build_tags, any in-progress build with matching fragments is returned."""
+    with mock.patch(
+        "iib.query_builds",
+        side_effect=[
+            {"items": []},
+            {
+                "items": [
+                    {
+                        "id": 1,
+                        "state": "in_progress",
+                        "fbc_fragments": ["a"],
+                        "distribution_scope": "prod",
+                        "updated": "2024-06-01T00:00:00Z",
+                        "build_tags": ["some-plr"],
+                    }
+                ]
+            },
+        ],
+    ):
+        result = update_fbc_catalog.check_previous_build(
+            "https://iib",
+            "user",
+            "idx:v4.12",
+            ["a"],
+            [],
+        )
+    assert result is not None
+    assert result["id"] == 1
+
+
+def test_check_previous_build_in_progress_query_error() -> None:
+    """Return ``None`` when the in-progress query fails."""
+    with mock.patch(
+        "iib.query_builds",
+        side_effect=[
+            {"items": []},
+            requests.ConnectionError("timeout"),
+        ],
+    ):
+        result = update_fbc_catalog.check_previous_build(
+            "https://iib",
+            "user",
+            "idx:v4.12",
+            ["a"],
+            [],
+        )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# is_build_newer_than_index — additional paths
+# ---------------------------------------------------------------------------
+
+
+def test_is_build_newer_catalog_date_unparseable() -> None:
+    """Unparseable catalog date falls through to IIB check."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "index_image_resolved": "registry/idx@sha256:x",
+        "from_index": "registry/idx:v4.12",
+        "updated": "2024-06-01T00:00:00Z",
+    }
+    with (
+        mock.patch(
+            "update_fbc_catalog.inspect_image_created",
+            side_effect=["bad-date", "2024-01-01T00:00:00Z"],
+        ),
+        mock.patch(
+            "update_fbc_catalog._is_build_newer_via_iib",
+            return_value=True,
+        ) as iib_mock,
+    ):
+        assert update_fbc_catalog.is_build_newer_than_index(
+            build, "registry/idx:v4.12", "https://iib", "user"
+        )
+    iib_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# inspect_image_created — additional paths
+# ---------------------------------------------------------------------------
+
+
+def test_inspect_image_created_null_string() -> None:
+    """A ``created`` value of literal ``"null"`` returns ``None``."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_skopeo_result('{"created": "null"}'),
+    ):
+        assert update_fbc_catalog.inspect_image_created("img:v1") is None
+
+
+# ---------------------------------------------------------------------------
+# Scenarios from bash test suite
+# ---------------------------------------------------------------------------
+
+
+def test_auth_failure_falls_back_to_iib_and_reuses() -> None:
+    """When skopeo fails for both images, IIB fallback confirms reuse."""
+    build: iib.IIBBuild = {
+        "id": 10,
+        "state": "complete",
+        "index_image_resolved": "registry/idx@sha256:resolved",
+        "from_index": "registry/idx:v4.12",
+        "updated": "2024-06-01T00:00:00Z",
+    }
+    with (
+        mock.patch(
+            "update_fbc_catalog.inspect_image_created",
+            return_value=None,
+        ),
+        mock.patch(
+            "iib.query_builds",
+            return_value={
+                "items": [
+                    {
+                        "id": 10,
+                        "distribution_scope": "prod",
+                        "updated": "2024-06-01T00:00:00Z",
+                    }
+                ],
+            },
+        ),
+    ):
+        assert update_fbc_catalog.is_build_newer_than_index(
+            build, "registry/idx:v4.12", "https://iib", "user"
+        )
+
+
+def test_main_empty_from_index(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Empty ``--from-index`` writes failure and exits."""
+    paths = _setup_result_env(monkeypatch, tmp_path)
+    with pytest.raises(SystemExit, match="from-index is required"):
+        update_fbc_catalog.main(
+            [
+                "--fbc-fragments",
+                '["a"]',
+                "--from-index",
+                "",
+            ]
+        )
+    assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "1"
+
+
+def test_poll_and_collect_removes_state_history_without_polling() -> None:
+    """``state_history`` is removed even when polling is skipped."""
+    build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "internal_index_image_copy": "internal/img:v1",
+        "state_history": [{"state": "in_progress"}],
+    }
+    manifest = {
+        "manifests": [
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "digest": "sha256:abc",
+            }
+        ],
+    }
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_skopeo_result(json.dumps(manifest)),
+    ):
+        result = update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            build,
+            3600,
+            False,
+            False,
+        )
+    assert result.exit_code == 0
+    assert "state_history" not in result.build_info

--- a/scripts/python/tasks/internal/update_fbc_catalog.py
+++ b/scripts/python/tasks/internal/update_fbc_catalog.py
@@ -1,0 +1,828 @@
+#!/usr/bin/env python3
+"""Submit and monitor IIB FBC catalog update builds.
+
+Authenticate with Kerberos, check for reusable previous builds, submit a
+new FBC operation to IIB if needed, poll for completion, validate the
+resulting index image, and retrieve manifest digests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import binascii
+import json
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+from requests_kerberos import HTTPKerberosAuth, OPTIONAL
+
+import authentication
+import file
+import http_client
+import iib
+import skopeo
+import tekton
+from logger import logger
+
+PROG = "update_fbc_catalog.py"
+POLL_INTERVAL_SECONDS = 30
+LOG_INTERVAL_SECONDS = 300
+
+
+@dataclass
+class FBCCatalogInput:
+    """Parsed CLI inputs for the update-fbc-catalog flow."""
+
+    fbc_fragments: list[str]
+    from_index: str
+    build_tags: list[str]
+    add_arches: list[str]
+    must_overwrite: bool
+    must_publish: bool
+    build_timeout_seconds: int
+
+
+@dataclass
+class RunResult:
+    """Outcome of a full update-fbc-catalog run."""
+
+    build_info: iib.IIBBuild
+    state: str
+    state_reason: str
+    index_image_digests: str
+    iib_log_url: str
+    exit_code: int
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse CLI arguments for the update FBC catalog task."""
+    parser = argparse.ArgumentParser(prog=PROG)
+    parser.add_argument(
+        "--fbc-fragments",
+        required=True,
+        help="FBC fragments as JSON array",
+    )
+    parser.add_argument(
+        "--from-index",
+        required=True,
+        help="Index image the FBC fragment will be added to",
+    )
+    parser.add_argument(
+        "--build-tags",
+        default="[]",
+        help="Additional tags for the internal index image copy (JSON array)",
+    )
+    parser.add_argument(
+        "--add-arches",
+        default="[]",
+        help="Architectures to build the index image for (JSON array)",
+    )
+    parser.add_argument(
+        "--must-publish-index-image",
+        default="false",
+        help="Whether the index image should be published",
+    )
+    parser.add_argument(
+        "--must-overwrite-from-index-image",
+        default="false",
+        help="Whether to overwrite the from index image",
+    )
+    parser.add_argument(
+        "--build-timeout-seconds",
+        type=int,
+        default=3600,
+        help="Timeout in seconds for the IIB build",
+    )
+    return parser.parse_args(argv)
+
+
+def parse_fbc_fragments(raw: str) -> list[str]:
+    """Parse *raw* as a sorted JSON array of non-empty strings."""
+    data = json.loads(raw)
+    if not isinstance(data, list):
+        raise ValueError("fbcFragments must be a JSON array")
+    if len(data) == 0:
+        raise ValueError("fbcFragments array is empty")
+    for item in data:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError("fbcFragments items must be non-empty strings")
+    return sorted(data)
+
+
+def inspect_image_created(image_ref: str) -> str | None:
+    """Return the creation date from ``skopeo inspect --config``.
+
+    Return ``None`` on any failure.
+    """
+    result = skopeo.inspect(image_ref, config=True)
+    if result.returncode != 0:
+        return None
+    try:
+        created = json.loads(result.stdout).get("created")
+        if not created or created == "null":
+            return None
+        return str(created)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def is_build_newer_than_index(
+    build: iib.IIBBuild,
+    from_index: str,
+    iib_url: str,
+    user: str,
+) -> bool:
+    """Check whether a completed build's index image is newer than from_index.
+
+    Compare creation dates via skopeo.  Fall back to IIB build history
+    when skopeo cannot determine the answer.  Return ``True`` if the
+    build is newer.
+    """
+    index_image_resolved = build.get("index_image_resolved")
+    if not index_image_resolved:
+        logger.warning("No index_image_resolved in build, skipping reuse")
+        return False
+
+    new_catalog_created = inspect_image_created(index_image_resolved)
+    new_catalog_ts: int | None = None
+    if new_catalog_created:
+        try:
+            new_catalog_ts = iib.parse_date_to_epoch(new_catalog_created)
+        except (ValueError, OSError) as e:
+            logger.warning("Could not parse index_image_resolved date: %s", e)
+
+    # Try direct tag inspection of from_index
+    from_index_created = inspect_image_created(from_index)
+
+    # Fallback: try from_index_resolved stored in the build
+    if not from_index_created:
+        resolved = build.get("from_index_resolved")
+        if resolved:
+            from_index_created = inspect_image_created(resolved)
+
+    if from_index_created and new_catalog_ts is not None:
+        try:
+            upstream_ts = iib.parse_date_to_epoch(from_index_created)
+            if new_catalog_ts < upstream_ts:
+                logger.warning("Completed build is older than from_index, " "skipping reuse")
+                return False
+            return True
+        except (ValueError, OSError) as e:
+            logger.warning("Could not parse from_index date: %s", e)
+
+    return _is_build_newer_via_iib(
+        build,
+        from_index,
+        iib_url,
+        user,
+    )
+
+
+def _is_build_newer_via_iib(
+    build: iib.IIBBuild,
+    from_index: str,
+    iib_url: str,
+    user: str,
+) -> bool:
+    """Fall-back check using IIB build history.
+
+    If a newer build exists for the same ``from_index``, the candidate is
+    stale (another product may have updated the catalog concurrently).
+    """
+    completed_from_index = build.get("from_index")
+    build_updated = build.get("updated")
+
+    if completed_from_index != from_index or not build_updated:
+        logger.error(
+            "Could not verify from_index via skopeo, and cannot "
+            "validate via IIB (missing from_index or updated "
+            "timestamp). Skipping reuse for safety."
+        )
+        return False
+
+    try:
+        all_data = iib.query_builds(
+            iib_url,
+            user=user,
+            from_index=from_index,
+            state="complete",
+        )
+    except (
+        requests.RequestException,
+        OSError,
+        json.JSONDecodeError,
+    ) as e:
+        logger.error(
+            "Could not verify from_index via skopeo, and IIB query "
+            "failed: %s. Skipping reuse for safety.",
+            e,
+        )
+        return False
+
+    items = all_data.get("items", [])
+    if not items:
+        logger.error(
+            "Could not verify from_index via skopeo, and IIB query "
+            "returned empty. Skipping reuse for safety."
+        )
+        return False
+
+    valid = [
+        b
+        for b in items
+        if b.get("distribution_scope") in ("prod", "stage", None) and b.get("updated")
+    ]
+    if not valid:
+        logger.error("No valid builds in IIB response, skipping reuse")
+        return False
+
+    valid.sort(key=lambda b: b.get("updated", ""), reverse=True)
+    last_updated = valid[0].get("updated", "")
+
+    if last_updated and last_updated != build_updated:
+        build_ts = 0
+        last_ts = 0
+        try:
+            build_ts = iib.parse_date_to_epoch(build_updated)
+            last_ts = iib.parse_date_to_epoch(last_updated)
+        except (ValueError, OSError) as e:
+            logger.warning("Could not parse build timestamps: %s", e)
+
+        if last_ts > build_ts:
+            logger.error(
+                "A newer build exists for this from_index "
+                "(last: %s, candidate: %s). Skipping reuse to "
+                "avoid race condition.",
+                last_updated,
+                build_updated,
+            )
+            return False
+
+    logger.warning(
+        "Could not verify from_index via skopeo, but IIB confirms "
+        "no newer builds exist. Proceeding with reuse."
+    )
+    return True
+
+
+def check_previous_build(
+    iib_url: str,
+    user: str,
+    from_index: str,
+    fbc_fragments: list[str],
+    build_tags: list[str],
+) -> iib.IIBBuild | None:
+    """Check for a reusable completed or in-progress IIB build.
+
+    Search for completed builds first; if a fresh one is found, return it.
+    Otherwise search for in-progress builds (optionally filtered by
+    *build_tags* for PLR collision prevention).
+    """
+    sorted_frags = sorted(fbc_fragments)
+
+    try:
+        completed = iib.query_builds(
+            iib_url,
+            user=user,
+            from_index=from_index,
+            state="complete",
+        )
+    except (
+        requests.RequestException,
+        OSError,
+        json.JSONDecodeError,
+    ) as e:
+        logger.warning("Failed to query IIB for completed builds: %s", e)
+        return None
+
+    # Find builds whose fbc_fragments match the requested fragments
+    # (compared sorted so order is irrelevant) and whose
+    # distribution_scope is prod, stage, or unset.  Builds with null
+    # fbc_fragments or other scopes (e.g. "dev") are excluded.
+    matching = [
+        b
+        for b in completed.get("items", [])
+        if b.get("fbc_fragments") is not None
+        and sorted(b["fbc_fragments"]) == sorted_frags
+        and b.get("distribution_scope") in ("prod", "stage", None)
+    ]
+    if matching:
+        matching.sort(key=lambda b: b.get("updated", ""))
+        candidate = matching[-1]
+        if is_build_newer_than_index(
+            candidate,
+            from_index,
+            iib_url,
+            user,
+        ):
+            return candidate
+
+    try:
+        in_progress = iib.query_builds(
+            iib_url,
+            user=user,
+            from_index=from_index,
+            state="in_progress",
+        )
+    except (
+        requests.RequestException,
+        OSError,
+        json.JSONDecodeError,
+    ) as e:
+        logger.warning("Failed to query IIB for in-progress builds: %s", e)
+        return None
+
+    candidates = [
+        b
+        for b in in_progress.get("items", [])
+        if b.get("fbc_fragments") is not None
+        and sorted(b["fbc_fragments"]) == sorted_frags
+        and b.get("distribution_scope") in ("prod", "stage", None)
+    ]
+    if build_tags:
+        candidates = [
+            b
+            for b in candidates
+            if b.get("build_tags") and any(t in b["build_tags"] for t in build_tags)
+        ]
+
+    if candidates:
+        candidates.sort(key=lambda b: b.get("updated", ""))
+        return candidates[-1]
+
+    return None
+
+
+def poll_build_status(
+    iib_url: str,
+    build_id: int,
+    timeout_seconds: int,
+    iib_log_path: Path | None = None,
+    *,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    clock_fn: Callable[[], float] = time.monotonic,
+) -> iib.IIBBuild:
+    """Poll IIB build status until a terminal state or timeout.
+
+    Poll every 30 s, log a status line every 5 min.  Raise
+    ``TimeoutError`` when *timeout_seconds* elapses before the build
+    reaches a terminal state.
+    """
+    logger.info("Monitoring IIB build %d", build_id)
+    logger.info("IIB service URL: %s", iib_url)
+    start = clock_fn()
+    last_log = start
+    poll_count = 0
+
+    while True:
+        elapsed = clock_fn() - start
+        if elapsed >= timeout_seconds:
+            raise TimeoutError(
+                f"Timeout after {timeout_seconds}s waiting for " f"build {build_id}"
+            )
+
+        now = clock_fn()
+
+        try:
+            build_info = iib.get_build(iib_url, build_id)
+        except (
+            requests.RequestException,
+            OSError,
+            json.JSONDecodeError,
+        ) as e:
+            logger.warning("Failed to fetch build info: %s", e)
+            poll_count += 1
+            sleep_fn(POLL_INTERVAL_SECONDS)
+            continue
+
+        if build_info.get("error") is not None:
+            logger.warning(
+                "IIB service returned error: %s",
+                build_info.get("error"),
+            )
+            sleep_fn(POLL_INTERVAL_SECONDS)
+            continue
+
+        state = build_info.get("state", "")
+        poll_count += 1
+
+        if now - last_log >= LOG_INTERVAL_SECONDS:
+            logger.info(
+                "Build status check #%d (elapsed: %.0fs): "
+                "state=%s, reason=%s, created=%s, updated=%s",
+                poll_count,
+                elapsed,
+                state,
+                build_info.get("state_reason", "none"),
+                build_info.get("created", ""),
+                build_info.get("updated", ""),
+            )
+            last_log = now
+
+        build_info.pop("state_history", None)  # type: ignore[misc]
+
+        log_url = iib.extract_log_url(build_info)
+        if iib_log_path and log_url:
+            try:
+                iib_log_path.write_text(f"IIB log url is: {log_url}", encoding="utf-8")
+            except OSError as e:
+                logger.warning("Failed to write IIB log URL: %s", e)
+
+        if state in ("complete", "failed"):
+            return build_info
+
+        sleep_fn(POLL_INTERVAL_SECONDS)
+
+
+def validate_index_image(
+    build_info: iib.IIBBuild,
+    must_overwrite: bool,
+    must_publish: bool,
+) -> None:
+    """Validate the index image based on the release strategy.
+
+    Raise ``ValueError`` on invalid strategy combinations or when the
+    expected image field is missing.
+    """
+    if must_overwrite and must_publish:
+        index_image = build_info.get("index_image", "")
+        expected = build_info.get("from_index", "")
+        if index_image != expected:
+            raise ValueError(
+                f"Index image mismatch: expected {expected}, got "
+                f"{index_image}. The from index was not properly "
+                "overwritten."
+            )
+    elif must_overwrite and not must_publish:
+        raise ValueError(
+            "Invalid combination: mustOverwriteFromIndexImage=true "
+            "and mustPublishIndexImage=false. This could be caused "
+            "by multiple pipelines releasing to production running "
+            "in parallel."
+        )
+
+
+def get_manifest_digests(image_ref: str) -> str:
+    """Return space-separated v2 manifest digests from a multi-arch image.
+
+    Raise ``RuntimeError`` if the image is not a manifest list.
+    """
+    result = skopeo.inspect(image_ref, raw=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"skopeo inspect --raw failed for {image_ref}: " f"{result.stderr}")
+    raw = json.loads(result.stdout)
+    media = "application/vnd.docker.distribution.manifest.v2+json"
+    digests = [m["digest"] for m in raw.get("manifests", []) if m.get("mediaType") == media]
+    if not digests:
+        raise RuntimeError("Index image produced is not multi-arch with a manifest " "list")
+    return " ".join(digests)
+
+
+def run(
+    input: FBCCatalogInput,
+    service_account_mount: Path,
+    iib_config_mount: Path,
+    overwrite_creds_mount: Path,
+    publishing_creds_mount: Path,
+    build_state_path: Path | None = None,
+    iib_log_path: Path | None = None,
+) -> RunResult:
+    """Execute the full update-fbc-catalog flow.
+
+    Authenticate, check for previous builds, submit if needed, poll for
+    completion, validate, and retrieve manifest digests.
+    """
+    try:
+        iib_url = authentication.read_mounted_text(iib_config_mount, "url")
+        krb5_source = (iib_config_mount / "krb5.conf").read_text(
+            encoding="utf-8", errors="replace"
+        )
+
+        overwrite_username = authentication.read_mounted_text(
+            overwrite_creds_mount, "username"
+        )
+        overwrite_token = authentication.read_mounted_text(overwrite_creds_mount, "token")
+    except OSError as e:
+        raise tekton.CheckStepError("reading mounted secrets", e) from e
+
+    pub_cred_path = publishing_creds_mount / "targetIndexCredential"
+    publishing_credential = ""
+    if pub_cred_path.is_file() and pub_cred_path.stat().st_size > 0:
+        publishing_credential = pub_cred_path.read_text(encoding="utf-8").strip()
+
+    try:
+        principal, keytab_bytes = authentication.load_keytab_from_mount(
+            service_account_mount,
+            principal_file="principal",
+            keytab_b64_file="keytab",
+        )
+    except (OSError, ValueError, binascii.Error) as e:
+        raise tekton.CheckStepError("reading the mounted IIB service account", e) from e
+
+    try:
+        with authentication.kerberos_login(
+            principal,
+            keytab_bytes,
+            krb5_source,
+        ):
+            return _authenticated_run(
+                input,
+                iib_url,
+                principal,
+                publishing_credential,
+                overwrite_username,
+                overwrite_token,
+                build_state_path=build_state_path,
+                iib_log_path=iib_log_path,
+            )
+    except subprocess.CalledProcessError as e:
+        raise tekton.CheckStepError("logging in with Kerberos (kinit)", e) from e
+
+
+def _authenticated_run(
+    input: FBCCatalogInput,
+    iib_url: str,
+    principal: str,
+    publishing_credential: str,
+    overwrite_username: str,
+    overwrite_token: str,
+    build_state_path: Path | None = None,
+    iib_log_path: Path | None = None,
+) -> RunResult:
+    """Run the IIB flow after Kerberos auth is established."""
+    authentication.create_container_auth_config(input.from_index, publishing_credential)
+
+    logger.info("Processing fragments: %s", json.dumps(input.fbc_fragments))
+    logger.info(
+        "Publishing decisions: mustOverwrite=%s, mustPublish=%s",
+        input.must_overwrite,
+        input.must_publish,
+    )
+
+    previous = check_previous_build(
+        iib_url,
+        principal,
+        input.from_index,
+        input.fbc_fragments,
+        input.build_tags,
+    )
+
+    if previous:
+        logger.info("=== A previous build for this fragment was found ===")
+        build_info = previous
+    else:
+        payload: iib.FBCOperationPayload = {
+            "fbc_fragments": input.fbc_fragments,
+            "from_index": input.from_index,
+        }
+        if input.must_overwrite:
+            payload["overwrite_from_index"] = True
+            payload["overwrite_from_index_token"] = f"{overwrite_username}:{overwrite_token}"
+        if input.build_tags:
+            payload["build_tags"] = input.build_tags
+        if input.add_arches:
+            payload["add_arches"] = input.add_arches
+
+        if build_state_path:
+            build_state_path.write_text(
+                json.dumps(
+                    {
+                        "state": "in_progress",
+                        "state_reason": "Calling IIB endpoint",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+        auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL)
+        try:
+            build_info = iib.submit_fbc_operation(
+                iib_url,
+                payload,
+                auth=auth,
+            )
+        except (requests.RequestException, ValueError) as e:
+            raise tekton.CheckStepError("submitting IIB build", e) from e
+
+    return _poll_and_collect(
+        iib_url,
+        build_info,
+        input.build_timeout_seconds,
+        input.must_overwrite,
+        input.must_publish,
+        iib_log_path=iib_log_path,
+    )
+
+
+def _poll_and_collect(
+    iib_url: str,
+    build_info: iib.IIBBuild,
+    timeout_seconds: int,
+    must_overwrite: bool,
+    must_publish: bool,
+    iib_log_path: Path | None = None,
+) -> RunResult:
+    """Poll for completion, validate, and collect manifest digests."""
+    build_id = build_info.get("id")
+    if not build_id:
+        raise ValueError("Build response missing 'id' field")
+
+    build_info.pop("state_history", None)  # type: ignore[misc]
+
+    state = build_info.get("state", "")
+    if state not in ("complete", "failed"):
+        try:
+            build_info = poll_build_status(
+                iib_url,
+                build_id,
+                timeout_seconds,
+                iib_log_path=iib_log_path,
+            )
+        except TimeoutError:
+            return RunResult(
+                build_info=build_info,
+                state="failed",
+                state_reason="Build timeout",
+                index_image_digests="",
+                iib_log_url=iib.extract_log_url(build_info),
+                exit_code=124,
+            )
+        state = build_info.get("state", "")
+
+    log_url = iib.extract_log_url(build_info)
+    state_reason = build_info.get("state_reason", "")
+
+    if state != "complete":
+        return RunResult(
+            build_info=build_info,
+            state=state,
+            state_reason=state_reason or "Build failed with exit code 1",
+            index_image_digests="",
+            iib_log_url=log_url,
+            exit_code=1,
+        )
+
+    try:
+        validate_index_image(build_info, must_overwrite, must_publish)
+    except ValueError as e:
+        return RunResult(
+            build_info=build_info,
+            state="failed",
+            state_reason=str(e),
+            index_image_digests="",
+            iib_log_url=log_url,
+            exit_code=1,
+        )
+
+    internal_copy = build_info.get("internal_index_image_copy", "")
+    if not internal_copy:
+        return RunResult(
+            build_info=build_info,
+            state="failed",
+            state_reason="Missing internal_index_image_copy",
+            index_image_digests="",
+            iib_log_url=log_url,
+            exit_code=1,
+        )
+
+    try:
+        digests = get_manifest_digests(internal_copy)
+    except (RuntimeError, json.JSONDecodeError) as e:
+        return RunResult(
+            build_info=build_info,
+            state="failed",
+            state_reason=f"Failed to get manifest digests: {e}",
+            index_image_digests="",
+            iib_log_url=log_url,
+            exit_code=1,
+        )
+
+    return RunResult(
+        build_info=build_info,
+        state=state,
+        state_reason=state_reason,
+        index_image_digests=digests,
+        iib_log_url=log_url,
+        exit_code=0,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments, run the full flow, and write Tekton result files."""
+    args = parse_args(argv)
+
+    (
+        json_build_info_path,
+        build_state_path,
+        index_image_digests_path,
+        iib_log_path,
+        exit_code_path,
+    ) = tekton.result_paths_from_env(
+        "RESULT_JSON_BUILD_INFO",
+        "RESULT_BUILD_STATE",
+        "RESULT_INDEX_IMAGE_DIGESTS",
+        "RESULT_IIB_LOG",
+        "RESULT_EXIT_CODE",
+    )
+
+    if not args.from_index.strip():
+        _write_failure(build_state_path, exit_code_path, "from-index is required")
+        raise SystemExit(f"{PROG}: from-index is required")
+
+    try:
+        fbc_fragments = parse_fbc_fragments(args.fbc_fragments)
+    except (json.JSONDecodeError, ValueError) as e:
+        _write_failure(build_state_path, exit_code_path, str(e))
+        raise SystemExit(f"{PROG}: {e}") from e
+
+    try:
+        build_tags: list[str] = json.loads(args.build_tags)
+        add_arches: list[str] = json.loads(args.add_arches)
+    except json.JSONDecodeError as e:
+        _write_failure(build_state_path, exit_code_path, str(e))
+        raise SystemExit(f"{PROG}: Invalid JSON: {e}") from e
+
+    input = FBCCatalogInput(
+        fbc_fragments=fbc_fragments,
+        from_index=args.from_index,
+        build_tags=build_tags,
+        add_arches=add_arches,
+        must_overwrite=(args.must_overwrite_from_index_image.lower() == "true"),
+        must_publish=args.must_publish_index_image.lower() == "true",
+        build_timeout_seconds=args.build_timeout_seconds,
+    )
+
+    sa_mount = file.path_from_env_variable(
+        "IIB_SERVICE_ACCOUNT_MOUNT", "/mnt/service-account-secret"
+    )
+    iib_cfg_mount = file.path_from_env_variable(
+        "IIB_SERVICES_CONFIG_MOUNT", "/mnt/iib-services-config"
+    )
+    overwrite_mount = file.path_from_env_variable(
+        "IIB_OVERWRITE_FROMIMAGE_CREDENTIALS_MOUNT",
+        "/mnt/iib-overwrite-fromimage-credentials",
+    )
+    pub_mount = file.path_from_env_variable(
+        "PUBLISHING_CREDENTIALS_MOUNT", "/mnt/publishing-credentials"
+    )
+
+    try:
+        result = run(
+            input,
+            sa_mount,
+            iib_cfg_mount,
+            overwrite_mount,
+            pub_mount,
+            build_state_path=build_state_path,
+            iib_log_path=iib_log_path,
+        )
+    except tekton.CheckStepError as e:
+        _write_failure(build_state_path, exit_code_path, str(e))
+        raise SystemExit(f"{PROG}: {e}") from e
+
+    json_build_info_path.write_text(
+        iib.compress_build_info(result.build_info), encoding="utf-8"
+    )
+    build_state_path.write_text(
+        json.dumps(
+            {
+                "state": result.state,
+                "state_reason": result.state_reason,
+            }
+        ),
+        encoding="utf-8",
+    )
+    index_image_digests_path.write_text(result.index_image_digests, encoding="utf-8")
+    if result.iib_log_url:
+        iib_log_path.write_text(f"IIB log url is: {result.iib_log_url}", encoding="utf-8")
+    exit_code_path.write_text(str(result.exit_code), encoding="utf-8")
+
+    if result.iib_log_url:
+        try:
+            log_content = http_client.get_text(result.iib_log_url)
+            logger.info("IIB build log:\n%s", log_content)
+        except (requests.RequestException, OSError):
+            logger.warning("Could not fetch IIB log from %s", result.iib_log_url)
+
+    return result.exit_code
+
+
+def _write_failure(
+    build_state_path: Path,
+    exit_code_path: Path,
+    reason: str,
+) -> None:
+    """Write failure state to Tekton result files."""
+    build_state_path.write_text(
+        json.dumps({"state": "failed", "state_reason": reason}),
+        encoding="utf-8",
+    )
+    exit_code_path.write_text("1", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Convert the inline bash scripts from the internal update-fbc-catalog-task Tekton task into a standalone Python script.

New shared helpers were added for IIB REST API interaction, container image inspection via skopeo, and a kerberos_login context manager that extracts the common Kerberos temp-file setup pattern.

Assisted-by: Claude Code