### PR TITLE
feat(RELEASE-2533): add update_infra_deployments.py script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,7 +160,7 @@ ENV PATH="$PATH:/home/publish-to-cgw-wrapper"
 # Flat imports: helpers and task scripts must be importable.
 # Tests use the same layout via pyproject [tool.pytest.ini_options] pythonpath.
 # Keep /home for other modules (e.g. pyxis, sbom) that expect it.
-ENV PYTHONPATH="/home:/home/utils:/home/scripts/python/helpers:/home/scripts/python/tasks/internal:/home/pubtools-pulp-wrapper:/home/publish-to-cgw-wrapper"
+ENV PYTHONPATH="/home:/home/utils:/home/scripts/python/helpers:/home/scripts/python/tasks/internal:/home/scripts/python/tasks/managed:/home/pubtools-pulp-wrapper:/home/publish-to-cgw-wrapper"
 
 # uv installs newer requests and certifi which don't use the system CA like the one installed via
 # dnf. So we need to point requests to the system CA bundle explicitly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pythonpath = [
   "integration-tests/lib",
   "scripts/python/helpers",
   "scripts/python/tasks/internal",
+  "scripts/python/tasks/managed",
   "utils",
   "pubtools-pulp-wrapper",
   "publish-to-cgw-wrapper",

--- a/scripts/python/helpers/file.py
+++ b/scripts/python/helpers/file.py
@@ -3,9 +3,21 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import tempfile
 from pathlib import Path
+from typing import Any
+
+
+def load_json_dict(path: Path) -> dict[str, Any]:
+    """Load a JSON file whose root value must be an object."""
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        msg = f"JSON root must be an object: {path}"
+        raise TypeError(msg)
+    return data
 
 
 def sha256(path: Path) -> str:
@@ -21,14 +33,14 @@ def path_from_env_variable(
     name: str,
     default: str | Path,
 ) -> Path:
-    """Return a filesystem path from the named environment variable, or *default*.
+    """Return a filesystem path from an environment variable, or a default.
 
-    The value of *name* in ``os.environ`` (if set and non-blank after
-    ``str.strip``) is interpreted as a path; this function does not open or
-    stat paths.
+    The value of name in `os.environ` (if set and not blank after
+    `str.strip`) is interpreted as a path; it is not a path to a file whose
+    contents you read, and this function does not open or stat paths.
 
-    If the variable is missing or only whitespace, *default* is returned (a
-    str or an existing ``Path``).
+    If the variable is missing or only whitespace, default is returned (a str
+    or an existing `Path`).
 
     Typical use: a Tekton or pod env var that holds a mount directory path, with
     tests setting the same variable to a temp directory. Existence of the path
@@ -46,13 +58,13 @@ def make_tempfile_path(
 ) -> Path:
     """Create a secure private temp file and return a pathlib.Path to it.
 
-    Uses the standard library ``tempfile.mkstemp``, which creates a new file and
-    returns a file handle (a safe pattern). We never use the old ``mktemp`` API
-    (unsafe under concurrency; deprecated in Python 3.12). If ``data`` is given,
+    Uses the standard library `tempfile.mkstemp`, which creates a new file and
+    returns a file handle (a safe pattern). We never use the old `mktemp` API
+    (unsafe under concurrency; deprecated in Python 3.12). If `data` is given,
     those bytes are written into the new file; otherwise the file is empty. The
     file is closed before returning; the caller is responsible for deleting the
-    path when done. ``prefix`` is the filename prefix in the system temp
-    directory, same as the ``prefix`` argument to ``mkstemp``.
+    path when done. `prefix` is the filename prefix in the system temp
+    directory, same as the `prefix` argument to `mkstemp`.
     """
     fd, name = tempfile.mkstemp(prefix=prefix)
     try:

--- a/scripts/python/helpers/image_ref.py
+++ b/scripts/python/helpers/image_ref.py
@@ -2,10 +2,56 @@
 
 from __future__ import annotations
 
+import json
+import re
+
+import http_client
+import requests
+
+_QUAY_SHA_TAG = re.compile(r"^[0-9a-f]{40}$")
+_MAX_QUAY_TAG_PAGES = 50
+
+
+def resolve_quay_digest_to_git_sha(digest: str, container_image: str) -> str | None:
+    """Resolve an image digest to a git commit SHA via the Quay public API.
+
+    Returns `None` when resolution fails (non-quay image, no matching tag, etc).
+    """
+    try:
+        repo_url = container_image.split("@", 1)[0]
+        if not repo_url.startswith("quay.io/"):
+            print("Not a quay.io image, skipping digest resolution")
+            return None
+        repo_path = repo_url.removeprefix("quay.io/")
+        page = 1
+        while page <= _MAX_QUAY_TAG_PAGES:
+            url = (
+                f"https://quay.io/api/v1/repository/{repo_path}/tag/" f"?limit=100&page={page}"
+            )
+            try:
+                body = http_client.get_text(url, timeout=10)
+            except requests.HTTPError as exc:
+                code = exc.response.status_code if exc.response is not None else "?"
+                print(f"Quay API returned {code}, skipping digest resolution")
+                return None
+            data = json.loads(body)
+            for tag in data.get("tags", []):
+                name = tag.get("name", "")
+                if tag.get("manifest_digest") == digest and _QUAY_SHA_TAG.fullmatch(name):
+                    print(f"Resolved {digest[:19]}... to git SHA {name}")
+                    return str(name)
+            if not data.get("has_additional", False):
+                break
+            page += 1
+        print(f"No git SHA tag found for digest {digest[:19]}...")
+        return None
+    except Exception as exc:
+        print(f"Failed to resolve digest to git SHA: {exc}")
+        return None
+
 
 def pyxis_url_for_pull_spec(pyxis_url: str, pull_spec: str) -> str:
-    """
-    Build the Pyxis repository/tag API URL for `pull_spec`.
+    """Build the Pyxis repository/tag API URL for `pull_spec`.
 
     `registry.redhat.io` is rewritten to `registry.access.redhat.com` to
     match Pyxis lookups.

--- a/scripts/python/helpers/snapshot.py
+++ b/scripts/python/helpers/snapshot.py
@@ -1,0 +1,40 @@
+"""Helpers for reading Konflux snapshot JSON documents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import file
+
+
+def first_component(snapshot_path: Path) -> dict[str, str]:
+    """Return fields from the first snapshot `components` entry.
+
+    Keys: `revision`, `origin_repo` (`source.git.url` without `.git`),
+    and `container_image`.
+    """
+    snapshot = file.load_json_dict(snapshot_path)
+    components = snapshot.get("components")
+    if not isinstance(components, list) or not components:
+        msg = f"snapshot has no components: {snapshot_path}"
+        raise ValueError(msg)
+    first = components[0]
+    if not isinstance(first, dict):
+        msg = f"snapshot component[0] must be an object: {snapshot_path}"
+        raise TypeError(msg)
+    source = first.get("source")
+    if not isinstance(source, dict):
+        msg = f"snapshot component[0].source must be an object: {snapshot_path}"
+        raise TypeError(msg)
+    git_info = source.get("git")
+    if not isinstance(git_info, dict):
+        msg = f"snapshot component[0].source.git must be an object: {snapshot_path}"
+        raise TypeError(msg)
+    revision = str(git_info.get("revision", "")).strip()
+    origin_repo = str(git_info.get("url", "")).strip().removesuffix(".git")
+    container_image = str(first.get("containerImage", "")).strip()
+    return {
+        "revision": revision,
+        "origin_repo": origin_repo,
+        "container_image": container_image,
+    }

--- a/scripts/python/helpers/test_file.py
+++ b/scripts/python/helpers/test_file.py
@@ -1,7 +1,8 @@
-"""Tests for the ``file`` helper module."""
+"""Tests for the `file` helper module."""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import file
@@ -11,7 +12,7 @@ import pytest
 def test_path_from_env_variable_uses_set_value(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A non-empty env value (after trim) is returned as a ``Path``."""
+    """A non-empty env value (after trim) is returned as a `Path`."""
     p = tmp_path / "m"
     monkeypatch.setenv("MOUNT", str(p))
     assert file.path_from_env_variable("MOUNT", "/d/e/f") == p
@@ -29,7 +30,7 @@ def test_path_from_env_variable_strips_value(
 def test_path_from_env_variable_uses_default_when_unset(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Unset or all-whitespace *name* yields *default* (``Path`` or str)."""
+    """Unset or all-whitespace *name* yields *default* (`Path` or str)."""
     default = str(tmp_path / "default")
     monkeypatch.delenv("MOUNT", raising=False)
     assert file.path_from_env_variable("MOUNT", default) == tmp_path / "default"
@@ -40,14 +41,29 @@ def test_path_from_env_variable_uses_default_when_unset(
 def test_path_from_env_variable_path_default(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """*default* may be a ``Path`` object, returned unchanged when the env is unset."""
+    """*default* may be a `Path` object, returned unchanged when the env is unset."""
     d = tmp_path / "d"
     monkeypatch.delenv("MOUNTX", raising=False)
     assert file.path_from_env_variable("MOUNTX", d) == d
 
 
+def test_load_json_dict(tmp_path: Path) -> None:
+    """A JSON object file is parsed and returned as a dict."""
+    path = tmp_path / "data.json"
+    path.write_text(json.dumps({"a": 1}), encoding="utf-8")
+    assert file.load_json_dict(path) == {"a": 1}
+
+
+def test_load_json_dict_rejects_non_object(tmp_path: Path) -> None:
+    """A JSON array (non-object root) raises `TypeError`."""
+    path = tmp_path / "data.json"
+    path.write_text("[1]", encoding="utf-8")
+    with pytest.raises(TypeError, match="object"):
+        file.load_json_dict(path)
+
+
 def test_make_tempfile_path_empty_file() -> None:
-    """A ``None`` payload leaves the created file with zero length."""
+    """A `None` payload leaves the created file with zero length."""
     p = file.make_tempfile_path("t-", None)
     try:
         assert p.read_bytes() == b""
@@ -56,7 +72,7 @@ def test_make_tempfile_path_empty_file() -> None:
 
 
 def test_make_tempfile_path_with_bytes() -> None:
-    """If ``data`` is set, the file on disk has exactly those bytes."""
+    """If `data` is set, the file on disk has exactly those bytes."""
     p = file.make_tempfile_path("t-", b"hello")
     try:
         assert p.read_bytes() == b"hello"

--- a/scripts/python/helpers/test_image_ref.py
+++ b/scripts/python/helpers/test_image_ref.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import json
+from unittest import mock
+
 import image_ref
 import pytest
+import requests
 
 
 def test_pyxis_url_for_pull_spec_with_tag_and_registry_rewrite() -> None:
@@ -28,3 +32,103 @@ def test_pyxis_url_for_pull_spec_invalid() -> None:
     """Invalid pull specs raise `ValueError`."""
     with pytest.raises(ValueError, match="invalid pull spec"):
         image_ref.pyxis_url_for_pull_spec("https://pyxis/v1", "not/a-pullspec")
+
+
+def test_resolve_quay_digest_skips_non_quay() -> None:
+    """Non-quay.io images return `None` without calling the Quay API."""
+    assert (
+        image_ref.resolve_quay_digest_to_git_sha(
+            "sha256:abc",
+            "registry.io/org/repo@sha256:abc",
+        )
+        is None
+    )
+
+
+def test_resolve_quay_digest_finds_sha_tag() -> None:
+    """A 40-char hex tag matching the digest is returned from the first API page."""
+    digest = "sha256:" + "a" * 64
+    sha = "b" * 40
+    payload = json.dumps(
+        {
+            "tags": [{"name": sha, "manifest_digest": digest}],
+            "has_additional": False,
+        }
+    )
+    with mock.patch("image_ref.http_client.get_text", return_value=payload):
+        out = image_ref.resolve_quay_digest_to_git_sha(
+            digest,
+            f"quay.io/org/repo@{digest}",
+        )
+    assert out == sha
+
+
+def test_resolve_quay_digest_non_200_response() -> None:
+    """Quay API errors return `None` instead of raising."""
+    digest = "sha256:" + "a" * 64
+    response = mock.MagicMock(status_code=503)
+    with mock.patch(
+        "image_ref.http_client.get_text",
+        side_effect=requests.HTTPError(response=response),
+    ):
+        out = image_ref.resolve_quay_digest_to_git_sha(
+            digest,
+            f"quay.io/org/repo@{digest}",
+        )
+    assert out is None
+
+
+def test_resolve_quay_digest_paginates() -> None:
+    """Resolution follows `has_additional` across multiple tag-list pages."""
+    digest = "sha256:" + "a" * 64
+    sha = "c" * 40
+    page_one = json.dumps({"tags": [], "has_additional": True})
+    page_two = json.dumps(
+        {
+            "tags": [{"name": sha, "manifest_digest": digest}],
+            "has_additional": False,
+        }
+    )
+    with mock.patch(
+        "image_ref.http_client.get_text",
+        side_effect=[page_one, page_two],
+    ) as get_text:
+        out = image_ref.resolve_quay_digest_to_git_sha(
+            digest,
+            f"quay.io/org/repo@{digest}",
+        )
+    assert out == sha
+    assert get_text.call_count == 2
+
+
+def test_resolve_quay_digest_no_matching_tag() -> None:
+    """Return `None` when no tag has both the digest and a 40-char hex name."""
+    digest = "sha256:" + "a" * 64
+    payload = json.dumps(
+        {
+            "tags": [
+                {"name": "not-a-sha", "manifest_digest": digest},
+                {"name": "b" * 40, "manifest_digest": "sha256:other"},
+            ],
+            "has_additional": False,
+        }
+    )
+    with mock.patch("image_ref.http_client.get_text", return_value=payload):
+        out = image_ref.resolve_quay_digest_to_git_sha(
+            digest,
+            f"quay.io/org/repo@{digest}",
+        )
+    assert out is None
+
+
+def test_resolve_quay_digest_handles_exception() -> None:
+    """Unexpected failures are swallowed and return `None`."""
+    with mock.patch(
+        "image_ref.http_client.get_text",
+        side_effect=RuntimeError("network down"),
+    ):
+        out = image_ref.resolve_quay_digest_to_git_sha(
+            "sha256:abc",
+            "quay.io/org/repo@sha256:abc",
+        )
+    assert out is None

--- a/scripts/python/helpers/test_snapshot.py
+++ b/scripts/python/helpers/test_snapshot.py
@@ -1,0 +1,67 @@
+"""Tests for `snapshot` helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import snapshot
+
+
+def test_first_component_missing_components(tmp_path: Path) -> None:
+    """Reject snapshots with no `components` list."""
+    path = tmp_path / "snapshot.json"
+    path.write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError, match="no components"):
+        snapshot.first_component(path)
+
+
+def test_first_component_invalid_component(tmp_path: Path) -> None:
+    """Reject when the first component is not a JSON object."""
+    path = tmp_path / "snapshot.json"
+    path.write_text(json.dumps({"components": ["bad"]}), encoding="utf-8")
+    with pytest.raises(TypeError, match="component\\[0\\] must be an object"):
+        snapshot.first_component(path)
+
+
+def test_first_component_invalid_source(tmp_path: Path) -> None:
+    """Reject when `component[0].source` is not a JSON object."""
+    path = tmp_path / "snapshot.json"
+    path.write_text(json.dumps({"components": [{}]}), encoding="utf-8")
+    with pytest.raises(TypeError, match="source must be an object"):
+        snapshot.first_component(path)
+
+
+def test_first_component_invalid_git(tmp_path: Path) -> None:
+    """Reject when `component[0].source.git` is not a JSON object."""
+    path = tmp_path / "snapshot.json"
+    path.write_text(
+        json.dumps({"components": [{"source": {"git": "bad"}}]}),
+        encoding="utf-8",
+    )
+    with pytest.raises(TypeError, match="source.git must be an object"):
+        snapshot.first_component(path)
+
+
+def test_first_component(tmp_path: Path) -> None:
+    """Return revision, origin repo URL, and container image from the first component."""
+    snap = {
+        "components": [
+            {
+                "containerImage": "quay.io/org/img@sha256:abc",
+                "source": {
+                    "git": {
+                        "revision": "deadbeef" * 5,
+                        "url": "https://github.com/org/repo.git",
+                    }
+                },
+            }
+        ]
+    }
+    path = tmp_path / "snapshot.json"
+    path.write_text(json.dumps(snap), encoding="utf-8")
+    out = snapshot.first_component(path)
+    assert out["revision"] == "deadbeef" * 5
+    assert out["origin_repo"] == "https://github.com/org/repo"
+    assert "quay.io" in out["container_image"]

--- a/scripts/python/helpers/vcs/__init__.py
+++ b/scripts/python/helpers/vcs/__init__.py
@@ -1,1 +1,1 @@
-"""Version-control helpers (`git` and `gitlab` submodules)."""
+"""Version-control helpers: `git`, `gitlab`, and `github` submodules."""

--- a/scripts/python/helpers/vcs/git.py
+++ b/scripts/python/helpers/vcs/git.py
@@ -21,7 +21,7 @@ def repository_workdir_name(repository_url: str) -> str:
 
 
 def _redact_credential_urls(text: str) -> str:
-    # Git errors often echo clone URLs with embedded oauth2 / token credentials.
+    """Redact oauth2/token credentials embedded in HTTPS URLs in *text*."""
     return re.sub(
         r"https://([^/@\s:]+):([^@\s]+)@",
         r"https://\1:[REDACTED]@",
@@ -31,7 +31,7 @@ def _redact_credential_urls(text: str) -> str:
 
 
 def _append_cmd_stderr(stderr_path: Path | None, message: str) -> None:
-    # CLI git stderr is captured on failure and written here (redacted).
+    """Append redacted *message* to *stderr_path* when configured."""
     if stderr_path is None or not message.strip():
         return
     safe_text = _redact_credential_urls(str(message))
@@ -97,43 +97,207 @@ def clone(
     clone_url: str,
     *,
     directory_name: str | None = None,
-    revision: str,
-    sparse_dirs: Sequence[str],
+    revision: str | None = None,
+    sparse_dirs: Sequence[str] | None = None,
+    shallow: bool = False,
     stderr_path: Path | None = None,
 ) -> Path:
-    """Shallow clone *clone_url* with sparse checkout of *sparse_dirs* at *revision*.
+    """Clone *clone_url* into *parent_dir*.
 
-    Returns the repository root directory.
+    When *shallow* is true, perform a blob-filtered shallow clone and optional
+    sparse checkout of *sparse_dirs* at *revision*.
+
+    Creates *parent_dir* when it does not exist yet.
     """
+    parent_dir.mkdir(parents=True, exist_ok=True)
     dir_name = directory_name or repository_workdir_name(clone_url)
     repo_dir = parent_dir / dir_name
-    _run_git_cmd(
-        [
-            "git",
-            "clone",
-            "--filter=blob:none",
-            "--no-checkout",
-            "--depth",
-            "1",
-            "--branch",
-            revision,
-            clone_url,
-            str(repo_dir),
-        ],
-        cwd=parent_dir,
-        stderr_path=stderr_path,
-    )
-    _run_git_cmd(
-        ["git", "sparse-checkout", "set", *sparse_dirs],
-        cwd=repo_dir,
-        stderr_path=stderr_path,
-    )
-    _run_git_cmd(
-        ["git", "checkout", revision],
-        cwd=repo_dir,
-        stderr_path=stderr_path,
-    )
+    if repo_dir.exists():
+        msg = f"clone destination already exists: {repo_dir}"
+        raise FileExistsError(msg)
+    if shallow:
+        if revision is None:
+            msg = "revision is required for a shallow clone"
+            raise ValueError(msg)
+        if not sparse_dirs:
+            msg = "sparse_dirs is required for a shallow clone"
+            raise ValueError(msg)
+        _run_git_cmd(
+            [
+                "git",
+                "clone",
+                "--filter=blob:none",
+                "--no-checkout",
+                "--depth",
+                "1",
+                "--branch",
+                revision,
+                clone_url,
+                str(repo_dir),
+            ],
+            cwd=parent_dir,
+            stderr_path=stderr_path,
+        )
+        _run_git_cmd(
+            ["git", "sparse-checkout", "set", *sparse_dirs],
+            cwd=repo_dir,
+            stderr_path=stderr_path,
+        )
+        _run_git_cmd(
+            ["git", "checkout", revision],
+            cwd=repo_dir,
+            stderr_path=stderr_path,
+        )
+    else:
+        _run_git_cmd(
+            ["git", "clone", clone_url, str(repo_dir)],
+            cwd=parent_dir,
+            stderr_path=stderr_path,
+        )
     return repo_dir
+
+
+def fetch(
+    repo_dir: Path,
+    remote: str,
+    *refs: str,
+    stderr_path: Path | None = None,
+) -> None:
+    """Fetch *refs* from *remote*."""
+    for ref in refs:
+        _run_git_cmd(
+            ["git", "fetch", remote, ref],
+            cwd=repo_dir,
+            stderr_path=stderr_path,
+        )
+
+
+def _local_branch_exists(
+    repo_dir: Path,
+    branch: str,
+    *,
+    stderr_path: Path | None = None,
+) -> bool:
+    """Return True when a local branch named *branch* exists in *repo_dir*."""
+    result = _run_git_cmd(
+        ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+        cwd=repo_dir,
+        stderr_path=stderr_path,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def checkout(
+    repo_dir: Path,
+    branch: str,
+    *,
+    start_point: str | None = None,
+    reset: bool = False,
+    stderr_path: Path | None = None,
+) -> None:
+    """Check out *branch*.
+
+    By default, use an existing local branch or create it when missing.
+    With *reset* true, run `checkout -B` from *start_point* (required).
+    """
+    if reset:
+        if start_point is None:
+            msg = "start_point is required when reset is true"
+            raise ValueError(msg)
+        _run_git_cmd(
+            ["git", "checkout", "-B", branch, start_point],
+            cwd=repo_dir,
+            stderr_path=stderr_path,
+        )
+        return
+    if _local_branch_exists(repo_dir, branch, stderr_path=stderr_path):
+        _run_git_cmd(
+            ["git", "checkout", branch],
+            cwd=repo_dir,
+            stderr_path=stderr_path,
+        )
+        return
+    if start_point is not None:
+        _run_git_cmd(
+            ["git", "checkout", "-b", branch, start_point],
+            cwd=repo_dir,
+            stderr_path=stderr_path,
+        )
+        return
+    _run_git_cmd(
+        ["git", "checkout", "-b", branch],
+        cwd=repo_dir,
+        stderr_path=stderr_path,
+    )
+
+
+def sync_to_origin_main(
+    repo_dir: Path,
+    *,
+    remote: str = "origin",
+    base_branch: str = "main",
+    stderr_path: Path | None = None,
+) -> None:
+    """Fetch *base_branch* and reset the working tree to *remote*/*base_branch*."""
+    fetch(repo_dir, remote, base_branch, stderr_path=stderr_path)
+    _run_git_cmd(
+        ["git", "checkout", base_branch],
+        cwd=repo_dir,
+        stderr_path=stderr_path,
+    )
+    _run_git_cmd(
+        ["git", "reset", "--hard", f"{remote}/{base_branch}"],
+        cwd=repo_dir,
+        stderr_path=stderr_path,
+    )
+
+
+def working_tree_diff(
+    repo_dir: Path,
+    *,
+    stderr_path: Path | None = None,
+) -> str:
+    """Return unstaged working-tree diff text for *repo_dir*."""
+    return _run_git_cmd(
+        ["git", "diff"],
+        cwd=repo_dir,
+        stderr_path=stderr_path,
+    ).stdout
+
+
+def changed_paths_from_status(
+    repo_dir: Path,
+    *,
+    stderr_path: Path | None = None,
+) -> list[str]:
+    """Return repo-relative paths with local modifications (porcelain)."""
+    status = _run_git_cmd(
+        ["git", "status", "-s", "--porcelain"],
+        cwd=repo_dir,
+        stderr_path=stderr_path,
+    ).stdout
+    paths: list[str] = []
+    for line in status.splitlines():
+        if len(line) < 4:
+            continue
+        paths.append(line[3:].strip())
+    return paths
+
+
+def set_remote_url(
+    repo_dir: Path,
+    remote_name: str,
+    url: str,
+    *,
+    stderr_path: Path | None = None,
+) -> None:
+    """Point *remote_name* at *url*."""
+    _run_git_cmd(
+        ["git", "remote", "set-url", remote_name, url],
+        cwd=repo_dir,
+        stderr_path=stderr_path,
+    )
 
 
 def origin_main_has_path_matching(
@@ -172,7 +336,10 @@ def index_add_commit(
     *,
     stderr_path: Path | None = None,
 ) -> None:
-    """Stage *relative_paths* and commit with *message* via the git CLI."""
+    """Stage *relative_paths* and commit with *message* via the git CLI.
+
+    Call `configure_git_global_user` first so git can identify the committer.
+    """
     _run_git_cmd(
         ["git", "add", *relative_paths],
         cwd=repo_root,
@@ -207,46 +374,80 @@ def commit_and_push(
         branch,
         remote=remote,
         retries=retries,
+        rebase_branch=branch,
         stderr_path=stderr_path,
     )
 
 
+def _push_argv(
+    remote: str,
+    branch: str | None,
+    *,
+    force: bool,
+) -> list[str]:
+    """Build the `git push` argv for *remote* and optional *branch*."""
+    argv = ["git", "push", remote]
+    if force:
+        argv.append("--force")
+    if branch is not None:
+        argv.append(branch)
+    return argv
+
+
 def push(
-    repo_root: Path,
-    branch: str,
+    repo_dir: Path,
+    branch: str | None = None,
     *,
     remote: str = "origin",
+    force: bool = False,
     retries: int = 0,
+    rebase_branch: str | None = None,
     stderr_path: Path | None = None,
 ) -> None:
-    """Push *branch* to *remote* via the git CLI.
+    """Push to *remote* via the git CLI.
 
-    On rejection, run `pull --rebase` and retry with exponential backoff until
-    *retries* recovery cycles are exhausted, then raise `CalledProcessError`.
+    When *branch* is set, push that ref; otherwise push the current branch.
+    With *rebase_branch* set and *retries* > 0, run `pull --rebase` after each
+    rejected push and retry with exponential backoff.
     """
+    if retries > 0 and rebase_branch is None:
+        msg = "rebase_branch is required when retries > 0"
+        raise ValueError(msg)
+    if retries == 0 and rebase_branch is None:
+        _run_git_cmd(
+            _push_argv(remote, branch, force=force),
+            cwd=repo_dir,
+            stderr_path=stderr_path,
+        )
+        return
+
+    rebase_ref = rebase_branch if rebase_branch is not None else branch
+    if rebase_ref is None:
+        msg = "rebase_branch or branch is required when retries > 0"
+        raise ValueError(msg)
+
     max_attempts = retries + 1
     attempt = 0
 
     def _push_with_rebase() -> None:
+        """Push once, rebasing from *remote* when the push is rejected."""
         nonlocal attempt
         attempt += 1
         current_attempt = attempt
         try:
             _run_git_cmd(
-                ["git", "push", remote, branch],
-                cwd=repo_root,
+                _push_argv(remote, branch, force=force),
+                cwd=repo_dir,
                 stderr_path=stderr_path,
             )
         except subprocess.CalledProcessError as push_error:
             if current_attempt >= max_attempts:
                 raise
-            # Pull failure is a CalledProcessError too; let it propagate as-is.
             _run_git_cmd(
-                ["git", "pull", "--rebase", remote, branch],
-                cwd=repo_root,
+                ["git", "pull", "--rebase", remote, rebase_ref],
+                cwd=repo_dir,
                 stderr_path=stderr_path,
             )
-            # Signal retry without using CalledProcessError (pull uses that too).
             raise RuntimeError("git push rejected") from push_error
 
     try:

--- a/scripts/python/helpers/vcs/github.py
+++ b/scripts/python/helpers/vcs/github.py
@@ -1,0 +1,311 @@
+"""GitHub.com hosting helpers (App auth, REST API, PR workflow)."""
+
+from __future__ import annotations
+
+import atexit
+import base64
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import http_client
+import requests
+
+from . import git
+
+
+@dataclass(frozen=True)
+class GitHubAppSession:
+    """Installation access token and API base URL."""
+
+    api_url: str
+    token: str
+
+
+def _jwt_json_segment(data: dict[str, Any]) -> bytes:
+    """Encode a dict as compact JSON and base64url without padding (JWT segment)."""
+    raw = json.dumps(data, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).rstrip(b"=")
+
+
+def app_jwt(
+    private_key_path: Path,
+    app_id: str,
+    *,
+    expire_seconds: int = 600,
+) -> str:
+    """Build a GitHub App JWT signed with the app private key."""
+    now = int(time.time())
+    header = _jwt_json_segment({"typ": "JWT", "alg": "RS256"})
+    payload = _jwt_json_segment({"iat": now, "exp": now + expire_seconds, "iss": app_id})
+    header_payload = header + b"." + payload
+    proc = subprocess.run(
+        ["openssl", "dgst", "-sha256", "-sign", str(private_key_path)],
+        input=header_payload,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    signature = base64.urlsafe_b64encode(proc.stdout).rstrip(b"=")
+    return (header_payload + b"." + signature).decode()
+
+
+def open_session(
+    *,
+    api_url: str,
+    private_key_path: Path,
+    app_id: str,
+    installation_id: str,
+) -> GitHubAppSession:
+    """Exchange an app JWT for an installation access token."""
+    jwt_token = app_jwt(private_key_path, app_id)
+    url = f"{api_url.rstrip('/')}/app/installations/{installation_id}/access_tokens"
+    response = requests.post(
+        url,
+        headers={
+            "Authorization": f"Bearer {jwt_token}",
+            "Accept": "application/vnd.github.machine-man-preview+json",
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    body = response.json()
+    token = body.get("token")
+    if not token:
+        msg = f"GitHub App authentication failed: {body!r}"
+        raise RuntimeError(msg)
+    return GitHubAppSession(api_url=api_url.rstrip("/"), token=str(token))
+
+
+def _api_url(session: GitHubAppSession, path: str) -> str:
+    """Return an absolute GitHub REST URL for *path*."""
+    return path if path.startswith("http") else f"{session.api_url}{path}"
+
+
+def _auth_headers(
+    session: GitHubAppSession,
+    extra_headers: dict[str, str] | None,
+) -> dict[str, str]:
+    """Build Authorization headers for *session*, merging *extra_headers*."""
+    headers = {"Authorization": f"Bearer {session.token}"}
+    if extra_headers:
+        headers.update(extra_headers)
+    return headers
+
+
+def _get_json(
+    session: GitHubAppSession,
+    path: str,
+    *,
+    extra_headers: dict[str, str] | None = None,
+) -> Any:
+    """Perform a GitHub REST GET via `http_client.get_text` and parse JSON."""
+    text = http_client.get_text(
+        _api_url(session, path),
+        headers=_auth_headers(session, extra_headers),
+        timeout=60,
+    )
+    return json.loads(text)
+
+
+def api_request(
+    session: GitHubAppSession,
+    method: str,
+    path: str,
+    *,
+    json_body: dict[str, Any] | None = None,
+    extra_headers: dict[str, str] | None = None,
+) -> requests.Response:
+    """Call the GitHub REST API for POST/PATCH relative to *session.api_url*."""
+    return requests.request(
+        method,
+        _api_url(session, path),
+        headers=_auth_headers(session, extra_headers),
+        json=json_body,
+        timeout=60,
+    )
+
+
+def configure_git_askpass_auth(access_token: str) -> None:
+    """Set process env so git HTTPS uses a token via GIT_ASKPASS, not embedded URLs.
+
+    Keeps credentials out of remote URLs so git stderr and config dumps cannot
+    leak the installation token.
+    """
+    fd, path = tempfile.mkstemp(prefix="git-askpass-", suffix=".sh")
+    askpass = Path(path)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write('#!/bin/sh\nexec echo "$GITHUB_ACCESS_TOKEN"\n')
+    askpass.chmod(askpass.stat().st_mode | stat.S_IXUSR)
+    atexit.register(lambda: askpass.unlink(missing_ok=True))
+    os.environ["GIT_TERMINAL_PROMPT"] = "0"
+    os.environ["GIT_ASKPASS"] = str(askpass)
+    os.environ["GITHUB_ACCESS_TOKEN"] = access_token
+
+
+def owner_repo_from_url(repo_url: str) -> str:
+    """Return `owner/repo` from a GitHub HTTPS URL."""
+    return "/".join(repo_url.rstrip("/").split("/")[-2:])
+
+
+def branch_name_from_origin_repo(origin_repo: str) -> str:
+    """Derive a branch name from the last path segment of a repository URL."""
+    return origin_repo.rstrip("/").split("/")[-1]
+
+
+def force_push_updated_files(
+    session: GitHubAppSession,
+    *,
+    clone_dir: Path,
+    target_repo: str,
+    branch: str,
+    relative_paths: Sequence[str],
+    commit_email: str = "release-service@redhat.com",
+    commit_name: str = "release-service",
+) -> None:
+    """Commit listed paths in *clone_dir* and force-push *branch* to *target_repo*.
+
+    Recreates *branch* at the current HEAD (the base already synced by the
+    caller) before committing, so each run produces one commit on the PR
+    without re-fetching `origin/main` or resetting the remote ref first
+    (which can close the open pull request).
+    """
+    configure_git_askpass_auth(session.token)
+    git.configure_git_global_user(commit_name, commit_email)
+    repo_url = f"https://github.com/{target_repo}.git"
+    git.set_remote_url(clone_dir, "origin", repo_url)
+    git.checkout(clone_dir, branch, reset=True, start_point="HEAD")
+    git.index_add_commit(
+        clone_dir,
+        relative_paths,
+        "Update from release-service",
+        stderr_path=None,
+    )
+    git.push(clone_dir, remote="origin", branch=branch, force=True)
+
+
+def create_pull_request(
+    session: GitHubAppSession,
+    target_repo: str,
+    *,
+    head_branch: str,
+    base_branch: str = "main",
+    title: str,
+) -> dict[str, Any]:
+    """Open a pull request and return the JSON body.
+
+    On 422 (for example pull request already exists), return the error JSON
+    without raising so callers can look up the existing PR.
+    """
+    response = api_request(
+        session,
+        "POST",
+        f"/repos/{target_repo}/pulls",
+        json_body={
+            "head": head_branch,
+            "base": base_branch,
+            "title": title,
+            "maintainer_can_modify": False,
+        },
+        extra_headers={"Accept": "application/vnd.github.v3+json"},
+    )
+    if response.status_code in (201, 422):
+        return response.json()
+    response.raise_for_status()
+    return response.json()
+
+
+def find_open_pull_request_by_branch(
+    session: GitHubAppSession,
+    target_repo: str,
+    branch: str,
+) -> dict[str, Any] | None:
+    """Return the open pull request for *branch*, if any."""
+    owner = target_repo.split("/", 1)[0]
+    items = _get_json(
+        session,
+        f"/repos/{target_repo}/pulls?head={owner}:{branch}&state=open",
+        extra_headers={"Accept": "application/vnd.github.v3+json"},
+    )
+    if not items:
+        return None
+    return items[0]
+
+
+def pull_request_url_for_commit_sha(session: GitHubAppSession, sha: str) -> str:
+    """Search for a PR link associated with *sha*."""
+    data = _get_json(
+        session,
+        f"/search/issues?q={sha}",
+        extra_headers={"Accept": "application/vnd.github.v3+json"},
+    )
+    items = data.get("items") or []
+    if not items:
+        msg = f"no pull request found for commit {sha}"
+        raise RuntimeError(msg)
+    pull_request = items[0].get("pull_request") or {}
+    url = pull_request.get("html_url")
+    if not url:
+        msg = f"search result missing pull_request html_url for {sha}"
+        raise RuntimeError(msg)
+    return str(url)
+
+
+def compare_changelog(
+    session: GitHubAppSession,
+    source_repo_url: str,
+    old_rev: str,
+    new_rev: str,
+) -> str:
+    """Return a markdown changelog section for `old_rev...new_rev`."""
+    owner_repo = owner_repo_from_url(source_repo_url)
+    path = f"/repos/{owner_repo}/compare/{old_rev}...{new_rev}"
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    try:
+        data = _get_json(session, path, extra_headers=headers)
+        commits = data.get("commits") or []
+        if not commits:
+            return ""
+        lines = ["## Changelog"]
+        for commit_info in commits:
+            sha = commit_info["sha"][:7]
+            url = commit_info["html_url"]
+            message = commit_info["commit"]["message"].split("\n", 1)[0]
+            author = commit_info.get("author")
+            login = author.get("login") if isinstance(author, dict) else None
+            if login:
+                lines.append(f"- [`{sha}`]({url}) {message} - @{login}")
+            else:
+                author_name = commit_info["commit"]["author"]["name"]
+                lines.append(f"- [`{sha}`]({url}) {message} - {author_name}")
+        return "\n".join(lines)
+    except requests.HTTPError as exc:
+        status = exc.response.status_code if exc.response is not None else 0
+        print(f"Compare API returned {status}, skipping changelog")
+        return ""
+    except Exception as exc:
+        print(f"Compare changelog failed, skipping: {exc}")
+        return ""
+
+
+def update_pull_request_body(
+    session: GitHubAppSession,
+    pr_api_url: str,
+    body: str,
+) -> dict[str, Any]:
+    """PATCH the pull request description at *pr_api_url*."""
+    response = api_request(
+        session,
+        "PATCH",
+        pr_api_url,
+        json_body={"body": body},
+        extra_headers={"Accept": "application/vnd.github.v3+json"},
+    )
+    response.raise_for_status()
+    return response.json()

--- a/scripts/python/helpers/vcs/gitlab.py
+++ b/scripts/python/helpers/vcs/gitlab.py
@@ -99,5 +99,6 @@ def clone_project_sparse(
         directory_name=git.repository_workdir_name(repository),
         revision=revision,
         sparse_dirs=sparse_dirs,
+        shallow=True,
         stderr_path=stderr_path,
     )

--- a/scripts/python/helpers/vcs/test_git.py
+++ b/scripts/python/helpers/vcs/test_git.py
@@ -79,6 +79,26 @@ def test_run_git_cmd_redacts_clone_failure_log(tmp_path: Path) -> None:
     assert "command exited with failure" in text
 
 
+def test_run_git_cmd_success(tmp_path: Path) -> None:
+    """Return the subprocess result when the git command succeeds."""
+
+    def _fake_run(
+        argv: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout="ok\n",
+            stderr="",
+        )
+
+    with mock.patch("vcs.git.subprocess.run", side_effect=_fake_run):
+        result = git._run_git_cmd(["git", "status"], cwd=tmp_path)
+    assert result.returncode == 0
+    assert result.stdout == "ok\n"
+
+
 def test_configure_git_global_user() -> None:
     """Set global `user.name` and `user.email` via the git CLI."""
     with mock.patch.object(git, "_run_git_cmd") as run_cmd:
@@ -86,8 +106,38 @@ def test_configure_git_global_user() -> None:
     assert run_cmd.call_count == 2
 
 
+def test_clone_full(tmp_path: Path) -> None:
+    """Clone a repository into a named directory under *parent_dir*."""
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
+        out = git.clone(
+            tmp_path,
+            "https://github.com/o/r.git",
+            directory_name="cloned",
+        )
+    run_cmd.assert_called_once()
+    assert run_cmd.call_args.args[0][:2] == ["git", "clone"]
+    assert out == tmp_path / "cloned"
+
+
+def test_clone_creates_parent_dir(tmp_path: Path) -> None:
+    """Create *parent_dir* when it is missing before running `git clone`."""
+    parent_dir = tmp_path / "nested" / "work"
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
+        out = git.clone(parent_dir, "https://github.com/o/r.git", directory_name="cloned")
+    assert parent_dir.is_dir()
+    run_cmd.assert_called_once()
+    assert out == parent_dir / "cloned"
+
+
+def test_clone_rejects_existing_destination(tmp_path: Path) -> None:
+    """Raise when the clone target directory already exists."""
+    (tmp_path / "cloned").mkdir()
+    with pytest.raises(FileExistsError, match="clone destination already exists"):
+        git.clone(tmp_path, "https://github.com/o/r.git", directory_name="cloned")
+
+
 def test_clone_shallow_sparse(tmp_path: Path) -> None:
-    """Sparse-checkout clone returns the repository root path."""
+    """Shallow sparse clone checks out the requested revision."""
     repo_dir = tmp_path / "proj"
     with mock.patch.object(git, "_run_git_cmd") as run_cmd:
         out = git.clone(
@@ -96,9 +146,16 @@ def test_clone_shallow_sparse(tmp_path: Path) -> None:
             directory_name="proj",
             revision="main",
             sparse_dirs=["schema"],
+            shallow=True,
         )
     assert out == repo_dir
     assert run_cmd.call_count == 3
+
+
+def test_clone_shallow_requires_revision(tmp_path: Path) -> None:
+    """Shallow clones require a revision."""
+    with pytest.raises(ValueError, match="revision"):
+        git.clone(tmp_path, "https://x/p.git", shallow=True, sparse_dirs=["a"])
 
 
 def test_clone_appends_stderr(tmp_path: Path) -> None:
@@ -110,13 +167,154 @@ def test_clone_appends_stderr(tmp_path: Path) -> None:
         side_effect=subprocess.CalledProcessError(1, "git clone"),
     ):
         with pytest.raises(subprocess.CalledProcessError):
-            git.clone(
+            git.clone(tmp_path, "https://x/p.git", stderr_path=log)
+
+
+def test_fetch(tmp_path: Path) -> None:
+    """Fetch one or more refs from a remote."""
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
+        git.fetch(tmp_path, "origin", "main", "my-app")
+    assert run_cmd.call_args_list == [
+        mock.call(
+            ["git", "fetch", "origin", "main"],
+            cwd=tmp_path,
+            stderr_path=None,
+        ),
+        mock.call(
+            ["git", "fetch", "origin", "my-app"],
+            cwd=tmp_path,
+            stderr_path=None,
+        ),
+    ]
+
+
+def test_checkout_existing_branch(tmp_path: Path) -> None:
+    """Check out a branch that already exists locally."""
+    with (
+        mock.patch.object(git, "_local_branch_exists", return_value=True),
+        mock.patch.object(git, "_run_git_cmd") as run_cmd,
+    ):
+        git.checkout(tmp_path, "my-app")
+    run_cmd.assert_called_once_with(
+        ["git", "checkout", "my-app"],
+        cwd=tmp_path,
+        stderr_path=None,
+    )
+
+
+def test_checkout_creates_when_missing(tmp_path: Path) -> None:
+    """Create and check out a branch when it is not present locally."""
+    with (
+        mock.patch.object(git, "_local_branch_exists", return_value=False),
+        mock.patch.object(git, "_run_git_cmd") as run_cmd,
+    ):
+        git.checkout(tmp_path, "my-app", start_point="origin/main")
+    run_cmd.assert_called_once_with(
+        ["git", "checkout", "-b", "my-app", "origin/main"],
+        cwd=tmp_path,
+        stderr_path=None,
+    )
+
+
+def test_checkout_reset_requires_start_point(tmp_path: Path) -> None:
+    """Reset checkout requires a start ref."""
+    with pytest.raises(ValueError, match="start_point"):
+        git.checkout(tmp_path, "my-app", reset=True)
+
+
+def test_checkout_reset(tmp_path: Path) -> None:
+    """Reset checkout recreates the branch from a start ref."""
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
+        git.checkout(tmp_path, "my-app", reset=True, start_point="origin/main")
+    run_cmd.assert_called_once_with(
+        ["git", "checkout", "-B", "my-app", "origin/main"],
+        cwd=tmp_path,
+        stderr_path=None,
+    )
+
+
+def test_sync_to_origin_main(tmp_path: Path) -> None:
+    """Fetch and hard-reset to the remote default branch."""
+    with (
+        mock.patch.object(git, "fetch") as fetch,
+        mock.patch.object(git, "_run_git_cmd") as run_cmd,
+    ):
+        git.sync_to_origin_main(tmp_path)
+    fetch.assert_called_once_with(tmp_path, "origin", "main", stderr_path=None)
+    assert run_cmd.call_args_list[0].args[0] == ["git", "checkout", "main"]
+    assert run_cmd.call_args_list[1].args[0] == ["git", "reset", "--hard", "origin/main"]
+
+
+def test_push_force_branch(tmp_path: Path) -> None:
+    """Force-push a named branch via the git CLI."""
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
+        git.push(tmp_path, branch="my-branch", force=True)
+    run_cmd.assert_called_once_with(
+        ["git", "push", "origin", "--force", "my-branch"],
+        cwd=tmp_path,
+        stderr_path=None,
+    )
+
+
+def test_push_retries_success_first_try(tmp_path: Path) -> None:
+    """Return immediately when the first push succeeds."""
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
+        git.push(
+            tmp_path,
+            branch="main",
+            retries=2,
+            rebase_branch="main",
+            stderr_path=None,
+        )
+    run_cmd.assert_called_once()
+
+
+def test_push_retries_raises_after_limit(tmp_path: Path) -> None:
+    """Raise `CalledProcessError` after pull/retry cycles are exhausted."""
+    err_log = tmp_path / "err.log"
+
+    def _cmd_side_effect(cmd: list[str], **_kwargs: object) -> mock.MagicMock:
+        if "pull" in cmd:
+            return mock.MagicMock()
+        raise subprocess.CalledProcessError(1, "git push")
+
+    with mock.patch.object(git, "_run_git_cmd", side_effect=_cmd_side_effect):
+        with pytest.raises(subprocess.CalledProcessError):
+            git.push(
                 tmp_path,
-                "https://x/p.git",
-                revision="main",
-                sparse_dirs=["a"],
+                branch="main",
+                retries=1,
+                rebase_branch="main",
+                stderr_path=err_log,
+            )
+
+
+def test_push_pull_failure_raises(tmp_path: Path) -> None:
+    """Re-raise when CLI `pull --rebase` fails after a rejected push."""
+    log = tmp_path / "log.txt"
+    push_error = subprocess.CalledProcessError(1, "git push")
+    pull_error = subprocess.CalledProcessError(1, "git pull")
+
+    def _cmd_side_effect(cmd: list[str], **_kwargs: object) -> mock.MagicMock:
+        if "pull" in cmd:
+            raise pull_error
+        raise push_error
+
+    with mock.patch.object(git, "_run_git_cmd", side_effect=_cmd_side_effect):
+        with pytest.raises(subprocess.CalledProcessError):
+            git.push(
+                tmp_path,
+                branch="main",
+                retries=3,
+                rebase_branch="main",
                 stderr_path=log,
             )
+
+
+def test_push_retries_requires_rebase_branch(tmp_path: Path) -> None:
+    """Raise when retries are requested without a rebase branch."""
+    with pytest.raises(ValueError, match="rebase_branch"):
+        git.push(tmp_path, retries=1)
 
 
 def test_origin_main_has_path_matching_found(tmp_path: Path) -> None:
@@ -136,14 +334,6 @@ def test_origin_main_has_path_matching_found(tmp_path: Path) -> None:
             listing,
         )
     run_cmd.assert_called_once()
-    assert run_cmd.call_args.args[0] == [
-        "git",
-        "ls-tree",
-        "-r",
-        "--name-only",
-        "origin/main",
-    ]
-    assert run_cmd.call_args.kwargs["stdout"] is not None
 
 
 def test_origin_main_has_path_matching_not_found(tmp_path: Path) -> None:
@@ -169,6 +359,7 @@ def test_index_add_commit(tmp_path: Path) -> None:
     with mock.patch.object(git, "_run_git_cmd") as run_cmd:
         git.index_add_commit(tmp_path, ["a.yaml"], "msg", stderr_path=None)
     assert run_cmd.call_count == 2
+    assert run_cmd.call_args_list[1].args[0] == ["git", "commit", "-m", "msg"]
 
 
 def test_commit_and_push(tmp_path: Path) -> None:
@@ -189,86 +380,42 @@ def test_commit_and_push(tmp_path: Path) -> None:
         "main",
         remote="origin",
         retries=2,
+        rebase_branch="main",
         stderr_path=None,
     )
 
 
-def test_push_success_first_try(tmp_path: Path) -> None:
-    """Return immediately when the first CLI push succeeds."""
+def test_working_tree_diff(tmp_path: Path) -> None:
+    """Return `git diff` output for the working tree."""
     with mock.patch.object(git, "_run_git_cmd") as run_cmd:
-        git.push(tmp_path, "main", retries=2, stderr_path=None)
-    run_cmd.assert_called_once()
+        run_cmd.return_value = mock.MagicMock(stdout="-    newTag: old\n")
+        assert git.working_tree_diff(tmp_path) == "-    newTag: old\n"
 
 
-def test_push_retries_after_rejection_with_backoff(tmp_path: Path) -> None:
-    """Retry push after `pull --rebase` with exponential backoff between attempts."""
-    sleeps: list[float] = []
-    push_calls = {"n": 0}
-    pull_calls = {"n": 0}
-
-    def _cmd_side_effect(cmd: list[str], **_kwargs: object) -> mock.MagicMock:
-        if "pull" in cmd:
-            pull_calls["n"] += 1
-            return mock.MagicMock()
-        push_calls["n"] += 1
-        raise subprocess.CalledProcessError(1, "git push")
-
-    with mock.patch("retry.time.sleep", side_effect=sleeps.append):
-        with mock.patch.object(
-            git,
-            "_run_git_cmd",
-            side_effect=_cmd_side_effect,
-        ):
-            with pytest.raises(subprocess.CalledProcessError):
-                git.push(tmp_path, "main", retries=1, stderr_path=None)
-    assert push_calls["n"] == 2
-    assert pull_calls["n"] == 1
-    assert sleeps == [5]
+def test_changed_paths_from_status(tmp_path: Path) -> None:
+    """Parse porcelain status lines into repo-relative paths."""
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
+        run_cmd.return_value = mock.MagicMock(
+            stdout=" M path/a.yaml\n?? path/b.yaml\n",
+        )
+        out = git.changed_paths_from_status(tmp_path)
+    assert out == ["path/a.yaml", "path/b.yaml"]
 
 
-def test_push_zero_retries_skips_pull(tmp_path: Path) -> None:
-    """Do not pull when push fails and no recovery retries are configured."""
-    pull_calls = {"n": 0}
-
-    def _cmd_side_effect(cmd: list[str], **_kwargs: object) -> mock.MagicMock:
-        if "pull" in cmd:
-            pull_calls["n"] += 1
-            return mock.MagicMock()
-        raise subprocess.CalledProcessError(1, "git push")
-
-    with mock.patch.object(git, "_run_git_cmd", side_effect=_cmd_side_effect):
-        with pytest.raises(subprocess.CalledProcessError):
-            git.push(tmp_path, "main", retries=0, stderr_path=None)
-    assert pull_calls["n"] == 0
+def test_changed_paths_from_status_skips_short_lines(tmp_path: Path) -> None:
+    """Ignore malformed porcelain lines shorter than four characters."""
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
+        run_cmd.return_value = mock.MagicMock(stdout="??\n M ok.yaml\n")
+        out = git.changed_paths_from_status(tmp_path)
+    assert out == ["ok.yaml"]
 
 
-def test_push_raises_after_limit(tmp_path: Path) -> None:
-    """Raise `CalledProcessError` after pull/retry cycles are exhausted."""
-    err_log = tmp_path / "err.log"
-
-    def _always_fail(*_args: object, **_kwargs: object) -> None:
-        raise subprocess.CalledProcessError(1, "git push")
-
-    with mock.patch.object(git, "_run_git_cmd", side_effect=_always_fail):
-        with pytest.raises(subprocess.CalledProcessError):
-            git.push(tmp_path, "main", retries=1, stderr_path=err_log)
-
-
-def test_push_pull_failure_raises(tmp_path: Path) -> None:
-    """Re-raise when CLI `pull --rebase` fails after a rejected push."""
-    log = tmp_path / "log.txt"
-    push_error = subprocess.CalledProcessError(1, "git push")
-    pull_error = subprocess.CalledProcessError(1, "git pull")
-
-    def _cmd_side_effect(cmd: list[str], **_kwargs: object) -> mock.MagicMock:
-        if "pull" in cmd:
-            raise pull_error
-        raise push_error
-
-    with mock.patch.object(
-        git,
-        "_run_git_cmd",
-        side_effect=_cmd_side_effect,
-    ):
-        with pytest.raises(subprocess.CalledProcessError):
-            git.push(tmp_path, "main", retries=3, stderr_path=log)
+def test_set_remote_url(tmp_path: Path) -> None:
+    """Update the URL for a named remote."""
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
+        git.set_remote_url(tmp_path, "origin", "https://example/repo.git")
+    run_cmd.assert_called_once_with(
+        ["git", "remote", "set-url", "origin", "https://example/repo.git"],
+        cwd=tmp_path,
+        stderr_path=None,
+    )

--- a/scripts/python/helpers/vcs/test_github.py
+++ b/scripts/python/helpers/vcs/test_github.py
@@ -1,0 +1,392 @@
+"""Tests for `vcs.github`."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import requests
+
+from . import github
+
+
+def _session() -> github.GitHubAppSession:
+    return github.GitHubAppSession(api_url="https://api.github.com", token="tok")
+
+
+def test_owner_repo_from_url() -> None:
+    """Extract `owner/repo` from GitHub HTTPS URLs."""
+    assert github.owner_repo_from_url("https://github.com/org/repo") == "org/repo"
+    assert github.owner_repo_from_url("https://github.com/org/repo/") == "org/repo"
+
+
+def test_branch_name_from_origin_repo() -> None:
+    """Use the last path segment of the origin repo URL as the branch name."""
+    assert github.branch_name_from_origin_repo("https://github.com/org/my-app") == "my-app"
+
+
+def test_app_jwt_builds_token(tmp_path: Path) -> None:
+    """Build a three-part JWT signed with the app private key."""
+    key = tmp_path / "key.pem"
+    key.write_text("fake-key", encoding="utf-8")
+    with mock.patch("vcs.github.subprocess.run") as run:
+        run.return_value = mock.MagicMock(stdout=b"signature-bytes")
+        token = github.app_jwt(key, "12345", expire_seconds=60)
+    assert token.count(".") == 2
+    run.assert_called_once()
+
+
+def test_open_session(tmp_path: Path) -> None:
+    """Exchange an app JWT for an installation access token."""
+    key = tmp_path / "key.pem"
+    key.write_text("fake", encoding="utf-8")
+    with mock.patch.object(github, "app_jwt", return_value="jwt"):
+        with mock.patch("vcs.github.requests.post") as post:
+            post.return_value = mock.MagicMock(
+                status_code=201,
+                json=lambda: {"token": "inst-token"},
+            )
+            post.return_value.raise_for_status = mock.MagicMock()
+            session = github.open_session(
+                api_url="https://api.github.com",
+                private_key_path=key,
+                app_id="1",
+                installation_id="2",
+            )
+    assert session.token == "inst-token"
+
+
+def test_open_session_missing_token_raises(tmp_path: Path) -> None:
+    """Raise when the installation token response omits `token`."""
+    key = tmp_path / "key.pem"
+    key.write_text("fake", encoding="utf-8")
+    with mock.patch.object(github, "app_jwt", return_value="jwt"):
+        with mock.patch("vcs.github.requests.post") as post:
+            post.return_value = mock.MagicMock(
+                status_code=201,
+                json=lambda: {},
+            )
+            post.return_value.raise_for_status = mock.MagicMock()
+            with pytest.raises(RuntimeError, match="authentication failed"):
+                github.open_session(
+                    api_url="https://api.github.com",
+                    private_key_path=key,
+                    app_id="1",
+                    installation_id="2",
+                )
+
+
+def test_api_request_absolute_url_and_json_body() -> None:
+    """Pass JSON bodies and extra headers through to `requests.request`."""
+    session = _session()
+    response = mock.MagicMock()
+    with mock.patch("vcs.github.requests.request", return_value=response) as req:
+        out = github.api_request(
+            session,
+            "PATCH",
+            "https://api.github.com/repos/o/r/pulls/1",
+            json_body={"body": "x"},
+            extra_headers={"Accept": "application/vnd.github.v3+json"},
+        )
+    assert out is response
+    _, kwargs = req.call_args
+    assert kwargs["json"] == {"body": "x"}
+    assert "Accept" in kwargs["headers"]
+
+
+def test_get_json_uses_http_client() -> None:
+    """GitHub GET helpers delegate to `http_client.get_text`."""
+    session = _session()
+    payload = {"items": []}
+    with mock.patch.object(
+        github.http_client,
+        "get_text",
+        return_value=json.dumps(payload),
+    ) as get_text:
+        out = github._get_json(session, "/search/issues?q=abc")
+    assert out == payload
+    get_text.assert_called_once()
+    assert "Authorization" in get_text.call_args.kwargs["headers"]
+
+
+def test_configure_git_askpass_auth(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write an askpass script and configure git HTTPS token env vars."""
+    askpass_path = tmp_path / "git-askpass.sh"
+    fd = os.open(askpass_path, os.O_WRONLY | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR)
+    monkeypatch.delenv("GIT_TERMINAL_PROMPT", raising=False)
+    monkeypatch.delenv("GIT_ASKPASS", raising=False)
+    monkeypatch.delenv("GITHUB_ACCESS_TOKEN", raising=False)
+
+    with (
+        mock.patch("vcs.github.tempfile.mkstemp", return_value=(fd, str(askpass_path))),
+        mock.patch("vcs.github.atexit.register") as register,
+    ):
+        github.configure_git_askpass_auth("inst-token")
+
+    assert askpass_path.read_text(encoding="utf-8") == (
+        '#!/bin/sh\nexec echo "$GITHUB_ACCESS_TOKEN"\n'
+    )
+    assert os.access(askpass_path, os.X_OK)
+    assert os.environ["GIT_TERMINAL_PROMPT"] == "0"
+    assert os.environ["GIT_ASKPASS"] == str(askpass_path)
+    assert os.environ["GITHUB_ACCESS_TOKEN"] == "inst-token"
+    register.assert_called_once()
+
+
+def test_force_push_updated_files(tmp_path: Path) -> None:
+    """Recreate the branch at HEAD, commit, and force-push to GitHub."""
+    session = _session()
+    with (
+        mock.patch.object(github, "configure_git_askpass_auth") as askpass,
+        mock.patch.object(github.git, "configure_git_global_user") as git_user,
+        mock.patch.object(github.git, "set_remote_url") as set_url,
+        mock.patch.object(github.git, "checkout") as checkout,
+        mock.patch.object(github.git, "fetch") as fetch,
+        mock.patch.object(github.git, "index_add_commit") as commit,
+        mock.patch.object(github.git, "push") as push,
+    ):
+        github.force_push_updated_files(
+            session,
+            clone_dir=tmp_path,
+            target_repo="org/infra",
+            branch="my-app",
+            relative_paths=["a.yaml"],
+        )
+    askpass.assert_called_once_with("tok")
+    git_user.assert_called_once_with("release-service", "release-service@redhat.com")
+    set_url.assert_called_once_with(
+        tmp_path,
+        "origin",
+        "https://github.com/org/infra.git",
+    )
+    checkout.assert_called_once_with(
+        tmp_path,
+        "my-app",
+        reset=True,
+        start_point="HEAD",
+    )
+    fetch.assert_not_called()
+    commit.assert_called_once()
+    push.assert_called_once_with(
+        tmp_path,
+        remote="origin",
+        branch="my-app",
+        force=True,
+    )
+
+
+def test_create_pull_request() -> None:
+    """Open a pull request and return the JSON response body."""
+    session = _session()
+    response = mock.MagicMock(status_code=201)
+    response.json.return_value = {"url": "https://github.com/o/r/pull/1"}
+    with mock.patch.object(github, "api_request", return_value=response):
+        out = github.create_pull_request(
+            session,
+            "org/infra",
+            head_branch="my-app",
+            title="my-app update",
+        )
+    assert out["url"].endswith("/pull/1")
+
+
+def test_create_pull_request_returns_422_json() -> None:
+    """Return the error JSON on 422 without raising."""
+    session = _session()
+    response = mock.MagicMock(status_code=422)
+    response.json.return_value = {"message": "A pull request already exists."}
+    with mock.patch.object(github, "api_request", return_value=response):
+        out = github.create_pull_request(
+            session,
+            "org/infra",
+            head_branch="my-app",
+            title="my-app update",
+        )
+    assert "already exists" in out["message"]
+
+
+def test_find_open_pull_request_by_branch_found() -> None:
+    """Return the open PR whose head ref matches the branch."""
+    session = _session()
+    payload = [
+        {
+            "head": {"ref": "my-app"},
+            "url": "https://api.github.com/repos/o/i/pulls/9",
+        }
+    ]
+    with mock.patch.object(github, "_get_json", return_value=payload) as get_json:
+        out = github.find_open_pull_request_by_branch(session, "org/infra", "my-app")
+    assert out is not None
+    assert out["head"]["ref"] == "my-app"
+    assert "head=org:my-app" in get_json.call_args[0][1]
+
+
+def test_find_open_pull_request_by_branch_not_found() -> None:
+    """Return `None` when no open PR matches the branch."""
+    session = _session()
+    with mock.patch.object(github, "_get_json", return_value=[]):
+        assert github.find_open_pull_request_by_branch(session, "org/infra", "my-app") is None
+
+
+def test_pull_request_url_for_commit_sha() -> None:
+    """Resolve a commit SHA to its pull request HTML URL via search."""
+    session = _session()
+    payload = {"items": [{"pull_request": {"html_url": "https://github.com/o/r/pull/2"}}]}
+    with mock.patch.object(github, "_get_json", return_value=payload):
+        url = github.pull_request_url_for_commit_sha(session, "abc123")
+    assert url.endswith("/pull/2")
+
+
+def test_pull_request_url_for_commit_sha_no_items() -> None:
+    """Raise when the search API returns no matching issues."""
+    session = _session()
+    with mock.patch.object(github, "_get_json", return_value={"items": []}):
+        with pytest.raises(RuntimeError, match="no pull request found"):
+            github.pull_request_url_for_commit_sha(session, "abc123")
+
+
+def test_pull_request_url_for_commit_sha_missing_html_url() -> None:
+    """Raise when the search hit has no `pull_request.html_url`."""
+    session = _session()
+    with mock.patch.object(
+        github,
+        "_get_json",
+        return_value={"items": [{"pull_request": {}}]},
+    ):
+        with pytest.raises(RuntimeError, match="missing pull_request html_url"):
+            github.pull_request_url_for_commit_sha(session, "abc123")
+
+
+def test_compare_changelog_non_200() -> None:
+    """Return an empty string when the compare API is not successful."""
+    session = _session()
+    http_response = mock.MagicMock(status_code=404)
+    with mock.patch.object(
+        github,
+        "_get_json",
+        side_effect=requests.HTTPError(response=http_response),
+    ):
+        assert (
+            github.compare_changelog(
+                session,
+                "https://github.com/org/repo",
+                "old",
+                "new",
+            )
+            == ""
+        )
+
+
+def test_compare_changelog_empty_commits() -> None:
+    """Return an empty string when the compare response has no commits."""
+    session = _session()
+    with mock.patch.object(github, "_get_json", return_value={"commits": []}):
+        assert (
+            github.compare_changelog(
+                session,
+                "https://github.com/org/repo",
+                "old",
+                "new",
+            )
+            == ""
+        )
+
+
+def test_compare_changelog_malformed_response() -> None:
+    """Return an empty string when the compare payload cannot be parsed."""
+    session = _session()
+    with mock.patch.object(github, "_get_json", return_value={"commits": [{}]}):
+        assert (
+            github.compare_changelog(
+                session,
+                "https://github.com/org/repo",
+                "old",
+                "new",
+            )
+            == ""
+        )
+
+
+def test_compare_changelog_get_json_failure() -> None:
+    """Return an empty string when the compare GET or JSON decode fails."""
+    session = _session()
+    with mock.patch.object(
+        github,
+        "_get_json",
+        side_effect=ValueError("invalid JSON"),
+    ):
+        assert (
+            github.compare_changelog(
+                session,
+                "https://github.com/org/repo",
+                "old",
+                "new",
+            )
+            == ""
+        )
+
+
+def test_compare_changelog_with_github_login() -> None:
+    """Format changelog entries with `@login` when GitHub author metadata exists."""
+    session = _session()
+    payload = {
+        "commits": [
+            {
+                "sha": "a" * 40,
+                "html_url": "https://github.com/o/r/commit/aaa",
+                "commit": {"message": "fix things\n\nbody", "author": {"name": "A"}},
+                "author": {"login": "dev"},
+            }
+        ]
+    }
+    with mock.patch.object(github, "_get_json", return_value=payload):
+        out = github.compare_changelog(
+            session,
+            "https://github.com/org/repo",
+            "old",
+            "new",
+        )
+    assert "## Changelog" in out
+    assert "@dev" in out
+
+
+def test_compare_changelog_without_github_login() -> None:
+    """Fall back to the commit author name when GitHub login is absent."""
+    session = _session()
+    payload = {
+        "commits": [
+            {
+                "sha": "b" * 40,
+                "html_url": "https://github.com/o/r/commit/bbb",
+                "commit": {"message": "feat", "author": {"name": "Release Bot"}},
+                "author": None,
+            }
+        ]
+    }
+    with mock.patch.object(github, "_get_json", return_value=payload):
+        out = github.compare_changelog(
+            session,
+            "https://github.com/org/repo",
+            "old",
+            "new",
+        )
+    assert "Release Bot" in out
+    assert "@" not in out.split("\n", 1)[1]
+
+
+def test_update_pull_request_body() -> None:
+    """PATCH the pull request description and return the updated JSON."""
+    session = _session()
+    response = mock.MagicMock()
+    response.json.return_value = {"body": "updated"}
+    with mock.patch.object(github, "api_request", return_value=response):
+        out = github.update_pull_request_body(
+            session,
+            "https://api.github.com/repos/o/i/pulls/1",
+            "new body",
+        )
+    assert out["body"] == "updated"

--- a/scripts/python/helpers/vcs/test_gitlab.py
+++ b/scripts/python/helpers/vcs/test_gitlab.py
@@ -74,4 +74,5 @@ def test_clone_project_sparse_delegates_to_git(tmp_path: Path) -> None:
     assert out is repo_root
     m.assert_called_once()
     assert m.call_args.args[1] == "https://gitlab.example.com/g/r.git"
+    assert m.call_args.kwargs["shallow"] is True
     assert "oauth2:" not in m.call_args.args[1]

--- a/scripts/python/tasks/managed/test_update_infra_deployments.py
+++ b/scripts/python/tasks/managed/test_update_infra_deployments.py
@@ -1,0 +1,524 @@
+"""Tests for `update_infra_deployments`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import update_infra_deployments as task
+from vcs import github
+
+
+def _write_snapshot(data_dir: Path) -> None:
+    snap = {
+        "components": [
+            {
+                "containerImage": "quay.io/org/img@sha256:abc",
+                "source": {
+                    "git": {
+                        "revision": "rev123",
+                        "url": "https://github.com/org/my-app.git",
+                    }
+                },
+            }
+        ]
+    }
+    (data_dir / "snap.json").write_text(json.dumps(snap), encoding="utf-8")
+
+
+def _task_params(tmp_path: Path, data_dir: Path) -> task.TaskParams:
+    return task.TaskParams(
+        work_dir=tmp_path / "work",
+        data_dir=data_dir,
+        data_json_path=Path("data.json"),
+        snapshot_path=Path("snap.json"),
+        default_target_repo="org/infra",
+        default_app_id="1",
+        default_installation_id="2",
+        github_api_url="https://api.github.com",
+        github_app_key_path=tmp_path / "key",
+    )
+
+
+def test_extract_old_revision_new_tag() -> None:
+    """Read the removed `newTag` or `digest` value from a unified diff."""
+    diff = " context\n-    newTag: abc123\n+    newTag: def456\n"
+    assert task._extract_old_revision_from_diff(diff) == "abc123"
+
+
+def test_extract_old_revision_ignores_version() -> None:
+    """Ignore `version` field changes when extracting the old revision."""
+    diff = "-    version: 1.2.3\n+    version: 1.3.0\n"
+    assert task._extract_old_revision_from_diff(diff) == ""
+
+
+def test_update_script_from_data_empty() -> None:
+    """Return `None` when the update script key is missing or blank."""
+    assert task._update_script_from_data({}) is None
+    assert task._update_script_from_data({"infra-deployment-update-script": ""}) is None
+
+
+def test_github_app_ids() -> None:
+    """Read GitHub App ID and installation ID from data JSON."""
+    data = {
+        "githubAppID": 9,
+        "githubAppInstallationID": 8,
+    }
+    assert task._github_app_ids(
+        data,
+        default_app_id="1",
+        default_installation_id="2",
+    ) == ("9", "8")
+
+
+def test_run_update_script_prints_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Forward bash stdout from the update script to the process stdout."""
+    task._run_update_script("echo hello\n", tmp_path)
+    assert "hello" in capsys.readouterr().out
+
+
+def test_run_update_script_prints_stderr(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Forward bash stderr from the update script to the process stderr."""
+    task._run_update_script("echo err 1>&2\n", tmp_path)
+    assert "err" in capsys.readouterr().err
+
+
+def test_collect_apply_result() -> None:
+    """Collect old revision and changed paths from the clone after the script."""
+    snap = task.SnapshotContext("rev", "https://github.com/org/app", "img")
+    with (
+        mock.patch(
+            "update_infra_deployments.git.working_tree_diff",
+            return_value="-    newTag: x\n",
+        ),
+        mock.patch(
+            "update_infra_deployments.git.changed_paths_from_status",
+            return_value=["a.yaml"],
+        ),
+    ):
+        result = task._collect_apply_result(snap, Path("/repo"))
+    assert result.snap is snap
+    assert result.old_revision == "x"
+    assert result.changed_paths == ["a.yaml"]
+
+
+def test_build_pr_description_appends_changelog() -> None:
+    """Keep prior changelog entries and append new commits plus the PR link."""
+    session = github.GitHubAppSession(api_url="https://api.github.com", token="t")
+    with (
+        mock.patch(
+            "update_infra_deployments.github.pull_request_url_for_commit_sha",
+            return_value="https://github.com/o/r/pull/1",
+        ),
+        mock.patch(
+            "update_infra_deployments.github.compare_changelog",
+            return_value="## Changelog\n- new item",
+        ),
+        mock.patch(
+            "update_infra_deployments.image_ref.resolve_quay_digest_to_git_sha",
+            return_value="oldrev",
+        ),
+    ):
+        body = task._build_pr_description(
+            session,
+            existing_body="Included PRs:\r\n- old\r\n\r\n## Changelog\r\n- stale",
+            origin_repo="https://github.com/org/repo",
+            revision="newrev",
+            old_revision="sha256:abc",
+            container_image="quay.io/org/img",
+        )
+    assert "stale" in body
+    assert "new item" in body
+    assert "## Changelog" in body
+    assert "pull/1" in body
+
+
+def test_merge_changelog_section_dedupes_lines() -> None:
+    """Do not duplicate changelog list lines already in the PR body."""
+    body = "Links\n\n## Changelog\n- same"
+    merged = task._merge_changelog_section(body, "## Changelog\n- same\n- other")
+    assert merged.count("- same") == 1
+    assert "- other" in merged
+
+
+def test_merge_changelog_section_finds_lf_only_marker() -> None:
+    """Detect an existing LF-only changelog section in a CRLF PR body."""
+    body = "Links\r\n\r\n## Changelog\r\n- stale"
+    merged = task._merge_changelog_section(body, "## Changelog\n- new")
+    assert merged.count("## Changelog") == 1
+    assert "- stale" in merged
+    assert "- new" in merged
+
+
+def test_build_pr_description_without_changelog_rev() -> None:
+    """Omit the changelog block when there is no resolvable old revision."""
+    session = github.GitHubAppSession(api_url="https://api.github.com", token="t")
+    with mock.patch(
+        "update_infra_deployments.github.pull_request_url_for_commit_sha",
+        return_value="https://github.com/o/r/pull/2",
+    ):
+        body = task._build_pr_description(
+            session,
+            existing_body=None,
+            origin_repo="https://github.com/org/repo",
+            revision="newrev",
+            old_revision="",
+            container_image="img",
+        )
+    assert body.startswith("Included PRs:")
+    assert "## Changelog" not in body
+
+
+def test_build_pr_description_uses_tag_old_revision() -> None:
+    """Pass a non-digest old revision directly to the compare API."""
+    session = github.GitHubAppSession(api_url="https://api.github.com", token="t")
+    with (
+        mock.patch(
+            "update_infra_deployments.github.pull_request_url_for_commit_sha",
+            return_value="https://github.com/o/r/pull/3",
+        ),
+        mock.patch(
+            "update_infra_deployments.github.compare_changelog",
+            return_value="## Changelog\n- item",
+        ) as compare,
+    ):
+        task._build_pr_description(
+            session,
+            existing_body=None,
+            origin_repo="https://github.com/org/repo",
+            revision="newrev",
+            old_revision="v1.0",
+            container_image="img",
+        )
+    compare.assert_called_once_with(
+        session,
+        "https://github.com/org/repo",
+        "v1.0",
+        "newrev",
+    )
+
+
+def test_snapshot_from_params(tmp_path: Path) -> None:
+    """Load snapshot context from the configured snapshot file path."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_snapshot(data_dir)
+    params = _task_params(tmp_path, data_dir)
+    snap = task._snapshot_from_params(params)
+    assert snap.revision == "rev123"
+    assert snap.origin_repo == "https://github.com/org/my-app"
+
+
+def test_run_patched_script(tmp_path: Path) -> None:
+    """Replace `{{ revision }}` and invoke bash in the clone directory."""
+    with mock.patch("update_infra_deployments._run_update_script") as run:
+        task._run_patched_script('echo "{{ revision }}"', "rev123", tmp_path)
+    run.assert_called_once_with('echo "rev123"', tmp_path)
+
+
+def test_create_or_update_pr_no_changed_paths() -> None:
+    """Skip GitHub calls when the update script changed no files."""
+    params = _task_params(Path("/tmp"), Path("/tmp"))
+    apply_result = task.ApplyResult(
+        snap=task.SnapshotContext("r", "https://github.com/o/a", "img"),
+        old_revision="",
+        changed_paths=[],
+    )
+    with mock.patch("update_infra_deployments.github.open_session") as open_session:
+        task._create_or_update_pr(
+            params,
+            {},
+            target_repo="org/infra",
+            clone_dir=Path("/cloned"),
+            apply_result=apply_result,
+        )
+    open_session.assert_not_called()
+
+
+def test_create_or_update_pr_happy_path(tmp_path: Path) -> None:
+    """Push commits, open or refresh PR, and update the body."""
+    params = _task_params(tmp_path, tmp_path)
+    session = github.GitHubAppSession(api_url="https://api.github.com", token="t")
+    with (
+        mock.patch("update_infra_deployments.github.open_session", return_value=session),
+        mock.patch("update_infra_deployments.github.force_push_updated_files"),
+        mock.patch(
+            "update_infra_deployments.github.create_pull_request",
+            return_value={"url": "https://api.github.com/pull/1", "body": "old"},
+        ),
+        mock.patch(
+            "update_infra_deployments._build_pr_description",
+            return_value="new body",
+        ),
+        mock.patch("update_infra_deployments.github.update_pull_request_body") as update,
+    ):
+        task._create_or_update_pr(
+            params,
+            {"githubAppID": "1"},
+            target_repo="org/infra",
+            clone_dir=tmp_path,
+            apply_result=task.ApplyResult(
+                snap=task.SnapshotContext("rev", "https://github.com/org/my-app", "img"),
+                old_revision="old",
+                changed_paths=["a.yaml"],
+            ),
+        )
+    update.assert_called_once()
+
+
+def test_create_or_update_pr_finds_existing_when_create_missing_url(tmp_path: Path) -> None:
+    """Reuse an existing bot PR when create returns no `url` field."""
+    params = _task_params(tmp_path, tmp_path)
+    session = github.GitHubAppSession(api_url="https://api.github.com", token="t")
+    with (
+        mock.patch("update_infra_deployments.github.open_session", return_value=session),
+        mock.patch("update_infra_deployments.github.force_push_updated_files"),
+        mock.patch(
+            "update_infra_deployments.github.create_pull_request",
+            return_value={"message": "already exists"},
+        ),
+        mock.patch(
+            "update_infra_deployments.github.find_open_pull_request_by_branch",
+            return_value={"url": "https://api.github.com/pull/9", "body": "b"},
+        ),
+        mock.patch("update_infra_deployments._build_pr_description", return_value="nb"),
+        mock.patch("update_infra_deployments.github.update_pull_request_body"),
+    ):
+        task._create_or_update_pr(
+            params,
+            {},
+            target_repo="org/infra",
+            clone_dir=tmp_path,
+            apply_result=task.ApplyResult(
+                snap=task.SnapshotContext("rev", "https://github.com/org/my-app", "img"),
+                old_revision="",
+                changed_paths=["a.yaml"],
+            ),
+        )
+
+
+def test_create_or_update_pr_raises_when_pr_missing(tmp_path: Path) -> None:
+    """Raise when create fails and no matching bot PR exists."""
+    params = _task_params(tmp_path, tmp_path)
+    session = github.GitHubAppSession(api_url="https://api.github.com", token="t")
+    with (
+        mock.patch("update_infra_deployments.github.open_session", return_value=session),
+        mock.patch("update_infra_deployments.github.force_push_updated_files"),
+        mock.patch(
+            "update_infra_deployments.github.create_pull_request",
+            return_value={"message": "nope"},
+        ),
+        mock.patch(
+            "update_infra_deployments.github.find_open_pull_request_by_branch",
+            return_value=None,
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="PR not created"):
+            task._create_or_update_pr(
+                params,
+                {},
+                target_repo="org/infra",
+                clone_dir=tmp_path,
+                apply_result=task.ApplyResult(
+                    snap=task.SnapshotContext("r", "https://github.com/o/a", "img"),
+                    old_revision="",
+                    changed_paths=["a.yaml"],
+                ),
+            )
+
+
+def test_create_or_update_pr_raises_when_body_missing(tmp_path: Path) -> None:
+    """Raise when the PR JSON has a URL but no `body` field."""
+    params = _task_params(tmp_path, tmp_path)
+    session = github.GitHubAppSession(api_url="https://api.github.com", token="t")
+    with (
+        mock.patch("update_infra_deployments.github.open_session", return_value=session),
+        mock.patch("update_infra_deployments.github.force_push_updated_files"),
+        mock.patch(
+            "update_infra_deployments.github.create_pull_request",
+            return_value={"url": "https://api.github.com/pull/1"},
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="PR not created"):
+            task._create_or_update_pr(
+                params,
+                {},
+                target_repo="org/infra",
+                clone_dir=tmp_path,
+                apply_result=task.ApplyResult(
+                    snap=task.SnapshotContext("r", "https://github.com/o/a", "img"),
+                    old_revision="",
+                    changed_paths=["a.yaml"],
+                ),
+            )
+
+
+def test_run_update_infra_deployments_syncs_main(tmp_path: Path) -> None:
+    """Sync the clone to origin/main before running the update script."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_snapshot(data_dir)
+    (data_dir / "data.json").write_text(
+        json.dumps({"infra-deployment-update-script": "true"}),
+        encoding="utf-8",
+    )
+    params = _task_params(tmp_path, data_dir)
+    clone_dir = tmp_path / "cloned"
+    with (
+        mock.patch(
+            "update_infra_deployments.git.clone",
+            return_value=clone_dir,
+        ),
+        mock.patch("update_infra_deployments.git.sync_to_origin_main") as sync,
+        mock.patch.object(task, "_run_patched_script"),
+        mock.patch.object(
+            task,
+            "_collect_apply_result",
+            return_value=task.ApplyResult(
+                snap=task.SnapshotContext("rev", "https://github.com/org/my-app", "img"),
+                old_revision="",
+                changed_paths=[],
+            ),
+        ),
+        mock.patch.object(task, "_create_or_update_pr"),
+    ):
+        task.run_update_infra_deployments(params)
+    sync.assert_called_once_with(clone_dir)
+
+
+def test_run_update_infra_deployments_creates_work_dir(tmp_path: Path) -> None:
+    """Create ``PARAM_WORK_DIR`` when missing and remove a stale ``cloned`` tree."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_snapshot(data_dir)
+    (data_dir / "data.json").write_text(
+        json.dumps({"infra-deployment-update-script": "true"}),
+        encoding="utf-8",
+    )
+    work_dir = tmp_path / "missing" / "work"
+    stale_clone = work_dir / "cloned"
+    stale_clone.mkdir(parents=True)
+    (stale_clone / "old.txt").write_text("stale", encoding="utf-8")
+    params = task.TaskParams(
+        work_dir=work_dir,
+        data_dir=data_dir,
+        data_json_path=Path("data.json"),
+        snapshot_path=Path("snap.json"),
+        default_target_repo="org/infra",
+        default_app_id="1",
+        default_installation_id="2",
+        github_api_url="https://api.github.com",
+        github_app_key_path=tmp_path / "key",
+    )
+    clone_dir = work_dir / "cloned"
+    with (
+        mock.patch(
+            "update_infra_deployments.git.clone",
+            return_value=clone_dir,
+        ) as clone,
+        mock.patch("update_infra_deployments.git.sync_to_origin_main"),
+        mock.patch.object(task, "_run_patched_script"),
+        mock.patch.object(
+            task,
+            "_collect_apply_result",
+            return_value=task.ApplyResult(
+                snap=task.SnapshotContext("rev", "https://github.com/org/my-app", "img"),
+                old_revision="",
+                changed_paths=[],
+            ),
+        ),
+        mock.patch.object(task, "_create_or_update_pr"),
+    ):
+        task.run_update_infra_deployments(params)
+    assert work_dir.is_dir()
+    assert not stale_clone.exists()
+    clone.assert_called_once_with(
+        work_dir,
+        "https://github.com/org/infra.git",
+        directory_name="cloned",
+    )
+
+
+def test_run_update_infra_deployments_no_script(tmp_path: Path) -> None:
+    """Exit early without cloning when no update script is configured."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "data.json").write_text("{}", encoding="utf-8")
+    params = _task_params(tmp_path, data_dir)
+    with mock.patch("update_infra_deployments.git.clone") as clone:
+        with mock.patch.object(task, "_create_or_update_pr") as create_pr:
+            task.run_update_infra_deployments(params)
+    clone.assert_not_called()
+    create_pr.assert_not_called()
+
+
+def test_run_update_infra_deployments_full_flow(tmp_path: Path) -> None:
+    """Run clone, apply, and PR steps when a script is present."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_snapshot(data_dir)
+    (data_dir / "data.json").write_text(
+        json.dumps({"infra-deployment-update-script": "true"}),
+        encoding="utf-8",
+    )
+    params = _task_params(tmp_path, data_dir)
+    apply_result = task.ApplyResult(
+        snap=task.SnapshotContext("rev", "https://github.com/org/my-app", "img"),
+        old_revision="old",
+        changed_paths=["a.yaml"],
+    )
+    with (
+        mock.patch(
+            "update_infra_deployments.git.clone",
+            return_value=tmp_path / "cloned",
+        ),
+        mock.patch("update_infra_deployments.git.sync_to_origin_main"),
+        mock.patch.object(task, "_snapshot_from_params", return_value=apply_result.snap),
+        mock.patch.object(task, "_run_patched_script"),
+        mock.patch.object(task, "_collect_apply_result", return_value=apply_result),
+        mock.patch.object(task, "_create_or_update_pr") as create_pr,
+    ):
+        task.run_update_infra_deployments(params)
+    create_pr.assert_called_once()
+
+
+def test_params_from_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Build `TaskParams` from Tekton-style environment variables."""
+    monkeypatch.setenv("PARAM_WORK_DIR", str(tmp_path / "w"))
+    monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path / "d"))
+    monkeypatch.setenv("PARAM_DATA_JSON_PATH", "data.json")
+    monkeypatch.setenv("PARAM_SNAPSHOT_PATH", "snap.json")
+    monkeypatch.setenv("PARAM_DEFAULT_TARGET_GH_REPO", "org/infra")
+    monkeypatch.setenv("PARAM_DEFAULT_GITHUB_APP_ID", "1")
+    monkeypatch.setenv("PARAM_DEFAULT_GITHUB_APP_INSTALLATION_ID", "2")
+    monkeypatch.setenv("GITHUB_API_URL", "https://api.github.com")
+    monkeypatch.setenv("GITHUBAPP_KEY_PATH", str(tmp_path / "key"))
+    params = task._params_from_env()
+    assert params.work_dir == tmp_path / "w"
+
+
+def test_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`main` loads params from the environment and runs the workflow."""
+    monkeypatch.setattr(task, "run_update_infra_deployments", lambda _p: None)
+    monkeypatch.setattr(task, "_params_from_env", lambda: mock.MagicMock())
+    assert task.main() == 0
+
+
+def test_main_entrypoint_exits_zero() -> None:
+    """The module entrypoint exits with the return code from `main`."""
+    fake_params = mock.MagicMock()
+    with (
+        mock.patch.object(task, "_params_from_env", return_value=fake_params),
+        mock.patch.object(task, "run_update_infra_deployments") as run,
+    ):
+        with pytest.raises(SystemExit) as exc:
+            raise SystemExit(task.main())
+    assert exc.value.code == 0
+    run.assert_called_once_with(fake_params)

--- a/scripts/python/tasks/managed/update_infra_deployments.py
+++ b/scripts/python/tasks/managed/update_infra_deployments.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Clone infra-deployments, run the update script, and open or refresh the GitHub PR."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import file
+import image_ref
+import snapshot
+import tekton
+from logger import logger
+from vcs import git
+from vcs import github
+
+_REVISION_PLACEHOLDER = "{{ revision }}"
+_OLD_REVISION_LINE = re.compile(r"^-\s+(newTag|digest):\s+(\S+)", re.MULTILINE)
+_CHANGELOG_MARKER = "\n\n## Changelog"
+
+
+def _normalize_pr_body_newlines(body: str) -> str:
+    """Use LF newlines so changelog detection works on CRLF or LF bodies."""
+    return body.replace("\r\n", "\n")
+
+
+@dataclass(frozen=True)
+class TaskParams:
+    """Tekton paths, data file locations, and GitHub App defaults for one task run."""
+
+    work_dir: Path
+    data_dir: Path
+    data_json_path: Path
+    snapshot_path: Path
+    default_target_repo: str
+    default_app_id: str
+    default_installation_id: str
+    github_api_url: str
+    github_app_key_path: Path
+
+
+@dataclass(frozen=True)
+class SnapshotContext:
+    """Git revision and image metadata from the release snapshot."""
+
+    revision: str
+    origin_repo: str
+    container_image: str
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """Snapshot metadata and repo changes after running the update script."""
+
+    snap: SnapshotContext
+    old_revision: str
+    changed_paths: list[str]
+
+
+def _github_app_ids(
+    data: dict[str, Any],
+    *,
+    default_app_id: str,
+    default_installation_id: str,
+) -> tuple[str, str]:
+    """Return GitHub App ID and installation ID from *data* or task defaults."""
+    app_id = str(data.get("githubAppID", default_app_id))
+    installation_id = str(data.get("githubAppInstallationID", default_installation_id))
+    return app_id, installation_id
+
+
+def _update_script_from_data(data: dict[str, Any]) -> str | None:
+    """Return the infra update bash script from *data*, or `None` when absent."""
+    raw = data.get("infra-deployment-update-script")
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+def _run_update_script(script: str, repo_dir: Path) -> None:
+    """Execute *script* as bash in *repo_dir* and print its stdout/stderr."""
+    proc = subprocess.run(
+        ["bash", "-euo", "pipefail"],
+        cwd=repo_dir,
+        input=script,
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+    if proc.stdout:
+        print(proc.stdout, end="")
+    if proc.stderr:
+        print(proc.stderr, end="", file=sys.stderr)
+
+
+def _extract_old_revision_from_diff(diff_text: str) -> str:
+    """Parse the removed `newTag` or `digest` value from a unified diff."""
+    match = _OLD_REVISION_LINE.search(diff_text)
+    if match is None:
+        return ""
+    return match.group(2)
+
+
+def _split_pr_body(body: str | None) -> tuple[str, str]:
+    """Split PR body into the included-PR links block and any changelog section."""
+    links_part = body if body else "Included PRs:"
+    normalized = _normalize_pr_body_newlines(links_part)
+    idx = normalized.find(_CHANGELOG_MARKER)
+    if idx == -1:
+        return normalized, ""
+    return normalized[:idx], normalized[idx:]
+
+
+def _changelog_commit_lines(changelog_text: str) -> list[str]:
+    """Return markdown list lines from a changelog section."""
+    return [
+        line
+        for line in _normalize_pr_body_newlines(changelog_text).splitlines()
+        if line.startswith("- ")
+    ]
+
+
+def _merge_changelog_section(body: str, new_changelog: str) -> str:
+    """Append new changelog commit lines, keeping any existing changelog entries."""
+    body = _normalize_pr_body_newlines(body)
+    new_changelog = _normalize_pr_body_newlines(new_changelog)
+    new_lines = _changelog_commit_lines(new_changelog)
+    if not new_lines:
+        return body
+    idx = body.find(_CHANGELOG_MARKER)
+    if idx == -1:
+        return f"{body}{_CHANGELOG_MARKER}\n" + "\n".join(new_lines)
+    prefix = body[: idx + len(_CHANGELOG_MARKER)]
+    existing_lines = _changelog_commit_lines(body[idx + len(_CHANGELOG_MARKER) :])
+    merged_lines = list(existing_lines)
+    for line in new_lines:
+        if line not in merged_lines:
+            merged_lines.append(line)
+    return prefix + "\n" + "\n".join(merged_lines)
+
+
+def _build_pr_description(
+    session: github.GitHubAppSession,
+    *,
+    existing_body: str | None,
+    origin_repo: str,
+    revision: str,
+    old_revision: str,
+    container_image: str,
+) -> str:
+    """Assemble PR body text with source PR link and optional changelog section."""
+    logger.info("Building pull request description for revision %s", revision)
+    links_part, changelog_part = _split_pr_body(existing_body)
+    logger.info("Searching GitHub for pull request linked to commit %s", revision)
+    new_pr_link = github.pull_request_url_for_commit_sha(session, revision)
+    pr_line = f"- {new_pr_link}"
+    if pr_line not in links_part:
+        links_part = f"{links_part}\n{pr_line}"
+    body = links_part + changelog_part
+
+    changelog_rev = ""
+    if old_revision:
+        if old_revision.startswith("sha256:"):
+            logger.info("Resolving Quay digest to git SHA for changelog")
+            resolved = image_ref.resolve_quay_digest_to_git_sha(
+                old_revision,
+                container_image,
+            )
+            changelog_rev = resolved or ""
+        else:
+            changelog_rev = old_revision
+    if changelog_rev:
+        logger.info(
+            "Fetching changelog for %s (%s...%s)",
+            origin_repo,
+            changelog_rev,
+            revision,
+        )
+        changelog = github.compare_changelog(
+            session,
+            origin_repo,
+            changelog_rev,
+            revision,
+        )
+        body = _merge_changelog_section(body, changelog)
+    return body
+
+
+def _snapshot_from_params(params: TaskParams) -> SnapshotContext:
+    """Load snapshot fields from the task snapshot file."""
+    snapshot_file = params.data_dir / params.snapshot_path
+    return SnapshotContext(**snapshot.first_component(snapshot_file))
+
+
+def _run_patched_script(script: str, revision: str, clone_dir: Path) -> None:
+    """Patch *script* with *revision* and execute it in *clone_dir*."""
+    patched = script.replace(_REVISION_PLACEHOLDER, revision)
+    logger.info("Running update script in %s", clone_dir)
+    _run_update_script(patched, clone_dir)
+
+
+def _collect_apply_result(snap: SnapshotContext, clone_dir: Path) -> ApplyResult:
+    """Read pre-update revision and changed paths from the clone after the script."""
+    logger.info("Reading working tree diff in %s", clone_dir)
+    diff_text = git.working_tree_diff(clone_dir)
+    old_revision = _extract_old_revision_from_diff(diff_text)
+    logger.info("Reading git status in %s", clone_dir)
+    changed_paths = git.changed_paths_from_status(clone_dir)
+    if old_revision:
+        logger.info("old revision: %s", old_revision)
+    logger.info("changed files: %d", len(changed_paths))
+    return ApplyResult(
+        snap=snap,
+        old_revision=old_revision,
+        changed_paths=changed_paths,
+    )
+
+
+def _create_or_update_pr(
+    params: TaskParams,
+    data: dict[str, Any],
+    *,
+    target_repo: str,
+    clone_dir: Path,
+    apply_result: ApplyResult,
+) -> None:
+    """Push changes and open or refresh the infra-deployments pull request."""
+    changed_paths = apply_result.changed_paths
+    if not changed_paths:
+        logger.info("No files to add to a PR, exiting")
+        return
+
+    snap = apply_result.snap
+    branch = github.branch_name_from_origin_repo(snap.origin_repo)
+    logger.info(
+        "Updating pull request on %s (branch %s, %d files)",
+        target_repo,
+        branch,
+        len(changed_paths),
+    )
+
+    app_id, installation_id = _github_app_ids(
+        data,
+        default_app_id=params.default_app_id,
+        default_installation_id=params.default_installation_id,
+    )
+    logger.info("Authenticating GitHub App (application_id=%s)", app_id)
+    session = github.open_session(
+        api_url=params.github_api_url,
+        private_key_path=params.github_app_key_path,
+        app_id=app_id,
+        installation_id=installation_id,
+    )
+
+    logger.info("Committing and force-pushing branch %s to %s", branch, target_repo)
+    github.force_push_updated_files(
+        session,
+        clone_dir=clone_dir,
+        target_repo=target_repo,
+        branch=branch,
+        relative_paths=changed_paths,
+    )
+
+    logger.info("Creating pull request for branch %s", branch)
+    infra_pr = github.create_pull_request(
+        session,
+        target_repo,
+        head_branch=branch,
+        title=f"{branch} update",
+    )
+    if "url" not in infra_pr:
+        logger.info("Create returned no URL; searching for existing open pull request")
+        existing = github.find_open_pull_request_by_branch(session, target_repo, branch)
+        if existing is None:
+            message = infra_pr.get("message", infra_pr)
+            raise RuntimeError(f"PR not created or did not already exist: {message}")
+        infra_pr = existing
+        logger.info("Using existing pull request: %s", infra_pr["url"])
+
+    if "body" not in infra_pr:
+        message = infra_pr.get("message", infra_pr)
+        raise RuntimeError(f"PR not created or did not already exist: {message}")
+
+    new_body = _build_pr_description(
+        session,
+        existing_body=infra_pr.get("body"),
+        origin_repo=snap.origin_repo,
+        revision=snap.revision,
+        old_revision=apply_result.old_revision,
+        container_image=snap.container_image,
+    )
+    logger.info("Updating pull request body at %s", infra_pr["url"])
+    github.update_pull_request_body(session, infra_pr["url"], new_body)
+    logger.info("Pull request updated: %s", infra_pr["url"])
+
+
+def run_update_infra_deployments(params: TaskParams) -> None:
+    """Clone, run the update script when configured, and create or update the PR."""
+    data_path = params.data_dir / params.data_json_path
+    logger.info("Loading data from %s", data_path)
+    data = file.load_json_dict(data_path)
+    script = _update_script_from_data(data)
+    if script is None:
+        logger.info("No script provided via 'infra-deployment-update-script' key in data")
+        return
+
+    target_repo = str(data.get("targetGHRepo", params.default_target_repo)).strip()
+    params.work_dir.mkdir(parents=True, exist_ok=True)
+    clone_path = params.work_dir / "cloned"
+    if clone_path.exists():
+        shutil.rmtree(clone_path)
+    logger.info("Cloning %s into %s/cloned", target_repo, params.work_dir)
+    clone_dir = git.clone(
+        params.work_dir,
+        f"https://github.com/{target_repo}.git",
+        directory_name="cloned",
+    )
+    logger.info("Clone complete at %s", clone_dir)
+
+    snapshot_file = params.data_dir / params.snapshot_path
+    logger.info("Loading snapshot from %s", snapshot_file)
+    snap = _snapshot_from_params(params)
+    logger.info("Syncing clone to origin/main before applying updates")
+    git.sync_to_origin_main(clone_dir)
+    logger.info(
+        "Applying revision %s from %s",
+        snap.revision,
+        snap.origin_repo,
+    )
+    _run_patched_script(script, snap.revision, clone_dir)
+    apply_result = _collect_apply_result(snap, clone_dir)
+    _create_or_update_pr(
+        params,
+        data,
+        target_repo=target_repo,
+        clone_dir=clone_dir,
+        apply_result=apply_result,
+    )
+
+
+def _params_from_env() -> TaskParams:
+    """Build `TaskParams` from Tekton `PARAM_*` and GitHub App environment variables."""
+    return TaskParams(
+        work_dir=Path(tekton.require_env("PARAM_WORK_DIR")),
+        data_dir=Path(tekton.require_env("PARAM_DATA_DIR")),
+        data_json_path=Path(tekton.require_env("PARAM_DATA_JSON_PATH")),
+        snapshot_path=Path(tekton.require_env("PARAM_SNAPSHOT_PATH")),
+        default_target_repo=tekton.require_env("PARAM_DEFAULT_TARGET_GH_REPO"),
+        default_app_id=tekton.require_env("PARAM_DEFAULT_GITHUB_APP_ID"),
+        default_installation_id=tekton.require_env("PARAM_DEFAULT_GITHUB_APP_INSTALLATION_ID"),
+        github_api_url=tekton.require_env("GITHUB_API_URL"),
+        github_app_key_path=Path(tekton.require_env("GITHUBAPP_KEY_PATH")),
+    )
+
+
+def main() -> int:
+    """Entry point: load params from the environment and run the workflow."""
+    run_update_infra_deployments(_params_from_env())
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
This commit adds a python script to replicate the functionality of the inline bash script in the update-infra-deployments task in the catalog repo. The task will be updated to use this python module instead.

Assisted-By: Cursor