### PR TITLE
feat(RELEASE-2509): add python scripts for publish-to-nrrc task

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "diffused-lib==0.3.0",
     "confluent-kafka",
     "python-gitlab>=4.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [tool.black]

--- a/scripts/python/helpers/charon_env.py
+++ b/scripts/python/helpers/charon_env.py
@@ -1,0 +1,82 @@
+"""Parse charon parameter files used by NRRC/MRRC publish tasks."""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+import file
+
+_REGISTRY_SPLIT = re.compile(r"%")
+
+
+def load_charon_env(path: Path) -> dict[str, str]:
+    """Load charon parameters from a dotenv file (``KEY=value`` lines)."""
+    if not path.is_file():
+        raise FileNotFoundError(f"charon env file not found: {path}")
+    values = dotenv_values(path, encoding="utf-8")
+    return {key: value for key, value in values.items() if value is not None}
+
+
+def split_oci_registries(value: str) -> list[str]:
+    """Split ``CHARON_OCI_REGISTRY`` on ``%`` into non-empty registry references."""
+    return [part.strip() for part in _REGISTRY_SPLIT.split(value) if part.strip()]
+
+
+def short_sha256_prefix(registry: str) -> str:
+    """Return the first six characters of the digest in *registry*."""
+    marker = "@sha256:"
+    if marker not in registry:
+        raise ValueError(f"registry reference missing @sha256: digest: {registry!r}")
+    return registry.split(marker, 1)[1][:6]
+
+
+def source_repo(registry: str) -> str:
+    """Return the repository part of an OCI reference (before ``@sha256:``)."""
+    return registry.split("@sha256:", 1)[0]
+
+
+def require_env_keys(env: dict[str, str], *keys: str) -> None:
+    """Raise ValueError when any *keys* are missing from *env*."""
+    for key in keys:
+        if key not in env:
+            raise ValueError(f"missing required charon env variable: {key}")
+
+
+def require_oci_registries(env: dict[str, str]) -> list[str]:
+    """Return non-empty ``CHARON_OCI_REGISTRY`` entries from *env*."""
+    try:
+        value = env["CHARON_OCI_REGISTRY"]
+    except KeyError as e:
+        raise ValueError("CHARON_OCI_REGISTRY is required in charon env file") from e
+    registries = split_oci_registries(value)
+    if not registries:
+        raise ValueError("CHARON_OCI_REGISTRY must list at least one registry reference")
+    return registries
+
+
+def charon_config_path(*, home: Path | None = None) -> Path:
+    """Return the default charon configuration file path under *home* or ``Path.home()``."""
+    root = home if home is not None else Path.home()
+    return root / ".charon" / "charon.yaml"
+
+
+def install_charon_config(config_source: Path, *, home: Path | None = None) -> Path:
+    """Copy the charon config into ``$HOME/.charon/charon.yaml``."""
+    if not config_source.is_file():
+        raise FileNotFoundError(f"charon config file not found: {config_source}")
+    dest = charon_config_path(home=home)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(config_source, dest)
+    return dest
+
+
+NRRC_WORK_DIR_DEFAULT = Path("/var/workdir/nrrc")
+
+
+def nrrc_work_dir() -> Path:
+    """Return the NRRC staging directory from ``WORK_DIR`` or ``/var/workdir/nrrc``."""
+    return file.path_from_env_variable("WORK_DIR", NRRC_WORK_DIR_DEFAULT)

--- a/scripts/python/helpers/file.py
+++ b/scripts/python/helpers/file.py
@@ -7,7 +7,10 @@ import json
 import gzip
 import io
 import os
+import re
+import subprocess
 import tempfile
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +26,7 @@ def load_json_dict(path: Path) -> dict[str, Any]:
 
 
 _GZIP_READ_CHUNK_SIZE = 64 * 1024
+_ARCHIVE_TYPE = re.compile(r"(gzip compressed data|POSIX tar archive)")
 
 
 def sha256(path: Path) -> str:
@@ -55,6 +59,25 @@ def path_from_env_variable(
     if raw is not None and str(raw).strip() != "":
         return Path(str(raw).strip())
     return default if isinstance(default, Path) else Path(default)
+
+
+def resolve_path_under_base(base: Path, relative: str | Path) -> Path:
+    """Resolve *relative* under *base* and ensure the result stays inside *base*.
+
+    Rejects absolute paths and ``..`` traversal after resolution. Typical use:
+    Tekton passes a path relative to a data directory (e.g. charon env/config files).
+    """
+    text = str(relative).strip()
+    if not text:
+        raise ValueError(f"path must be relative to {base}: {relative!r}")
+    rel = Path(text)
+    if rel.is_absolute():
+        raise ValueError(f"path must be relative to {base}: {relative!r}")
+    root = base.resolve()
+    candidate = (root / rel).resolve()
+    if not candidate.is_relative_to(root):
+        raise ValueError(f"path must stay under {base}: {relative!r}")
+    return candidate
 
 
 def make_tempfile_path(
@@ -97,3 +120,13 @@ def decompress_gzip_bounded(data: bytes, *, max_bytes: int) -> bytes:
                 msg = f"decompressed data exceeds {max_bytes} bytes (possible gzip bomb)"
                 raise ValueError(msg)
     return bytes(output)
+
+
+def is_gzip_or_tar_archive(
+    path: Path,
+    *,
+    file_cmd: Callable[[Sequence[str | Path]], subprocess.CompletedProcess[str]],
+) -> bool:
+    """Return True when ``file -b`` reports gzip or tar content for *path*."""
+    result = file_cmd(["file", "-b", str(path)])
+    return _ARCHIVE_TYPE.search(result.stdout) is not None

--- a/scripts/python/helpers/test_charon_env.py
+++ b/scripts/python/helpers/test_charon_env.py
@@ -1,0 +1,163 @@
+"""Tests for ``charon_env``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import charon_env
+import pytest
+
+
+def test_load_charon_env_parses_dotenv_lines(tmp_path: Path) -> None:
+    """Dotenv lines are parsed into a key/value mapping."""
+    env_file = tmp_path / "charon.env"
+    env_file.write_text(
+        "\nCHARON_OCI_REGISTRY=repo@sha256:abcdef0123456789\n"
+        "CHARON_TARGET=dev-npm-ga\n"
+        'CHARON_PRODUCT_NAME="Test Product"\n',
+        encoding="utf-8",
+    )
+    env = charon_env.load_charon_env(env_file)
+    assert env["CHARON_OCI_REGISTRY"] == "repo@sha256:abcdef0123456789"
+    assert env["CHARON_TARGET"] == "dev-npm-ga"
+    assert env["CHARON_PRODUCT_NAME"] == "Test Product"
+
+
+def test_load_charon_env_missing_file(tmp_path: Path) -> None:
+    """Missing env files raise FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        charon_env.load_charon_env(tmp_path / "missing.env")
+
+
+def test_load_charon_env_rejects_invalid_utf8(tmp_path: Path) -> None:
+    """Invalid UTF-8 bytes fail instead of being silently replaced."""
+    env_file = tmp_path / "charon.env"
+    env_file.write_bytes(b"CHARON_TARGET=dev\xff\n")
+    with pytest.raises(UnicodeDecodeError):
+        charon_env.load_charon_env(env_file)
+
+
+def test_split_oci_registries() -> None:
+    """Registry references are split on percent signs."""
+    value = "quay.io/a@sha256:111111%quay.io/b@sha256:222222"
+    assert charon_env.split_oci_registries(value) == [
+        "quay.io/a@sha256:111111",
+        "quay.io/b@sha256:222222",
+    ]
+
+
+def test_short_sha256_prefix() -> None:
+    """Short hash uses the first six digest characters."""
+    assert charon_env.short_sha256_prefix("repo@sha256:0b15aad24f1b847") == "0b15aa"
+
+
+def test_source_repo() -> None:
+    """Source repo strips the digest suffix."""
+    assert charon_env.source_repo("quay.io/org/app@sha256:abc") == "quay.io/org/app"
+
+
+def test_load_charon_env_skips_malformed_lines(tmp_path: Path) -> None:
+    """Lines without ``=`` are ignored."""
+    env_file = tmp_path / "charon.env"
+    env_file.write_text("CHARON_TARGET=dev\nnot-a-variable\n", encoding="utf-8")
+    env = charon_env.load_charon_env(env_file)
+    assert env == {"CHARON_TARGET": "dev"}
+
+
+def test_short_sha256_prefix_requires_digest() -> None:
+    """Registry references without a digest raise ValueError."""
+    with pytest.raises(ValueError, match="@sha256:"):
+        charon_env.short_sha256_prefix("quay.io/org/app:latest")
+
+
+def test_split_oci_registries_ignores_empty_segments() -> None:
+    """Trailing or duplicate ``%`` separators yield no empty entries."""
+    assert charon_env.split_oci_registries("quay.io/a@sha256:111111%") == [
+        "quay.io/a@sha256:111111",
+    ]
+    assert charon_env.split_oci_registries("%quay.io/a@sha256:111111%") == [
+        "quay.io/a@sha256:111111",
+    ]
+
+
+def test_load_charon_env_skips_comments_and_blank_lines(tmp_path: Path) -> None:
+    """Comments and blank lines are ignored."""
+    env_file = tmp_path / "charon.env"
+    env_file.write_text(
+        "# comment\n\nCHARON_TARGET=dev\n# CHARON_FOO=bar\n",
+        encoding="utf-8",
+    )
+    assert charon_env.load_charon_env(env_file) == {"CHARON_TARGET": "dev"}
+
+
+def test_load_charon_env_strips_single_quotes(tmp_path: Path) -> None:
+    """Single-quoted values are unquoted."""
+    env_file = tmp_path / "charon.env"
+    env_file.write_text("CHARON_PRODUCT_NAME='Test Product'\n", encoding="utf-8")
+    assert charon_env.load_charon_env(env_file)["CHARON_PRODUCT_NAME"] == "Test Product"
+
+
+def test_require_env_keys_raises_for_missing_key() -> None:
+    """Missing required keys raise ValueError."""
+    with pytest.raises(ValueError, match="missing required charon env variable"):
+        charon_env.require_env_keys({"CHARON_TARGET": "dev"}, "CHARON_PRODUCT_NAME")
+
+
+def test_require_oci_registries(tmp_path: Path) -> None:
+    """Non-empty registry lists are returned from parsed env data."""
+    env_file = tmp_path / "charon.env"
+    env_file.write_text(
+        "CHARON_OCI_REGISTRY=quay.io/a@sha256:111111%quay.io/b@sha256:222222\n",
+        encoding="utf-8",
+    )
+    env = charon_env.load_charon_env(env_file)
+    assert charon_env.require_oci_registries(env) == [
+        "quay.io/a@sha256:111111",
+        "quay.io/b@sha256:222222",
+    ]
+
+
+def test_require_oci_registries_missing_key() -> None:
+    """Missing ``CHARON_OCI_REGISTRY`` raises ValueError."""
+    with pytest.raises(ValueError, match="CHARON_OCI_REGISTRY is required"):
+        charon_env.require_oci_registries({})
+
+
+def test_require_oci_registries_empty_value() -> None:
+    """Blank ``CHARON_OCI_REGISTRY`` values raise ValueError."""
+    with pytest.raises(ValueError, match="at least one registry"):
+        charon_env.require_oci_registries({"CHARON_OCI_REGISTRY": ""})
+
+
+def test_nrrc_work_dir_default() -> None:
+    """Default NRRC work directory uses the image writable root."""
+    assert charon_env.nrrc_work_dir() == Path("/var/workdir/nrrc")
+
+
+def test_nrrc_work_dir_from_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``WORK_DIR`` overrides the default NRRC staging directory."""
+    custom = tmp_path / "staging"
+    monkeypatch.setenv("WORK_DIR", str(custom))
+    assert charon_env.nrrc_work_dir() == custom
+
+
+def test_charon_config_path_uses_explicit_home(tmp_path: Path) -> None:
+    """An explicit *home* overrides ``Path.home()``."""
+    assert charon_env.charon_config_path(home=tmp_path) == tmp_path / ".charon" / "charon.yaml"
+
+
+def test_install_charon_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Charon config is copied into ``$HOME/.charon/charon.yaml``."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    config_path = charon_env.charon_config_path()
+    source = tmp_path / "input.yaml"
+    source.write_text("charon-config\n", encoding="utf-8")
+    dest = charon_env.install_charon_config(source)
+    assert dest == config_path
+    assert config_path.read_text(encoding="utf-8") == "charon-config\n"
+
+
+def test_install_charon_config_missing_source(tmp_path: Path) -> None:
+    """Missing config sources raise FileNotFoundError."""
+    with pytest.raises(FileNotFoundError, match="charon config file not found"):
+        charon_env.install_charon_config(tmp_path / "missing.yaml")

--- a/scripts/python/helpers/test_file.py
+++ b/scripts/python/helpers/test_file.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import gzip
+import subprocess
+from collections.abc import Sequence
 from pathlib import Path
 
 import file
@@ -63,6 +65,31 @@ def test_load_json_dict_rejects_non_object(tmp_path: Path) -> None:
         file.load_json_dict(path)
 
 
+def test_resolve_path_under_base_relative_file(tmp_path: Path) -> None:
+    """A normal relative path resolves under *base*."""
+    target = tmp_path / "uid" / "charon.env"
+    target.parent.mkdir(parents=True)
+    assert file.resolve_path_under_base(tmp_path, "uid/charon.env") == target.resolve()
+
+
+def test_resolve_path_under_base_rejects_absolute(tmp_path: Path) -> None:
+    """Absolute paths are rejected even if they exist."""
+    with pytest.raises(ValueError, match="must be relative"):
+        file.resolve_path_under_base(tmp_path, "/etc/passwd")
+
+
+def test_resolve_path_under_base_rejects_traversal(tmp_path: Path) -> None:
+    """``..`` segments that escape *base* are rejected."""
+    with pytest.raises(ValueError, match="must stay under"):
+        file.resolve_path_under_base(tmp_path, "../outside")
+
+
+def test_resolve_path_under_base_rejects_blank(tmp_path: Path) -> None:
+    """Blank relative paths are rejected."""
+    with pytest.raises(ValueError, match="must be relative"):
+        file.resolve_path_under_base(tmp_path, "   ")
+
+
 def test_make_tempfile_path_empty_file() -> None:
     """A `None` payload leaves the created file with zero length."""
     p = file.make_tempfile_path("t-", None)
@@ -94,3 +121,35 @@ def test_decompress_gzip_bounded_rejects_oversized_output() -> None:
     compressed = gzip.compress(raw)
     with pytest.raises(ValueError, match="gzip bomb"):
         file.decompress_gzip_bounded(compressed, max_bytes=1000)
+
+
+def test_is_gzip_or_tar_archive_posix_tar() -> None:
+    """POSIX tar archives are recognized."""
+
+    def fake_file_cmd(
+        cmd: Sequence[str | Path],
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            [str(x) for x in cmd],
+            0,
+            stdout="POSIX tar archive\n",
+            stderr="",
+        )
+
+    assert file.is_gzip_or_tar_archive(Path("/tmp/archive.tar"), file_cmd=fake_file_cmd)
+
+
+def test_is_gzip_or_tar_archive_rejects_other_types() -> None:
+    """Non-archive ``file -b`` output returns False."""
+
+    def fake_file_cmd(
+        cmd: Sequence[str | Path],
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            [str(x) for x in cmd],
+            0,
+            stdout="ASCII text\n",
+            stderr="",
+        )
+
+    assert not file.is_gzip_or_tar_archive(Path("/tmp/readme.txt"), file_cmd=fake_file_cmd)

--- a/scripts/python/tasks/managed/publish_to_nrrc.py
+++ b/scripts/python/tasks/managed/publish_to_nrrc.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Download npm archives from OCI registries for publish-to-nrrc.
+
+Tekton injects ``DATA_DIR``, ``CHARON_PARAM_FILE_PATH``, and optionally
+``WORK_DIR`` (default ``/var/workdir/nrrc``; catalog sets ``/workdir/nrrc``) via env.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import charon_env
+import file
+import oras_utils
+import subprocess_cmd
+import tekton
+from logger import logger
+
+
+def prepare_repo(
+    *,
+    charon_param_file: Path,
+    work_dir: Path,
+) -> None:
+    """Download OCI archives and collect gzip/tar files under ``shared/``."""
+    env = charon_env.load_charon_env(charon_param_file)
+    registries = charon_env.require_oci_registries(env)
+
+    repo_dir = work_dir
+    shared_repo = repo_dir / "shared"
+    shared_repo.mkdir(parents=True, exist_ok=True)
+
+    for registry in registries:
+        logger.info("Downloading the npm archive from %s", registry)
+        short_hash = charon_env.short_sha256_prefix(registry)
+        subdir = repo_dir / short_hash
+        subdir.mkdir(parents=True, exist_ok=True)
+
+        oras_utils.oras_pull(registry, subdir)
+
+        for found in subdir.rglob("*"):
+            if not found.is_file():
+                continue
+            if not file.is_gzip_or_tar_archive(found, file_cmd=subprocess_cmd.run_cmd):
+                continue
+            move_to = shared_repo / f"{short_hash}_{found.name}"
+            if move_to.exists():
+                logger.warning("%s already exists, skipped", move_to)
+                continue
+            found.rename(move_to)
+
+
+def main() -> int:
+    """Read Tekton env vars and prepare npm archives for upload."""
+    data_dir = Path(tekton.require_env("DATA_DIR"))
+    work_dir = charon_env.nrrc_work_dir()
+    charon_param_file = file.resolve_path_under_base(
+        data_dir,
+        tekton.require_env("CHARON_PARAM_FILE_PATH"),
+    )
+    prepare_repo(
+        charon_param_file=charon_param_file,
+        work_dir=work_dir,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_publish_to_nrrc.py
+++ b/scripts/python/tasks/managed/test_publish_to_nrrc.py
@@ -1,0 +1,341 @@
+"""Tests for ``publish_to_nrrc``."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import shutil
+import tarfile
+import runpy
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+import publish_to_nrrc
+import pytest
+
+
+@pytest.fixture
+def release_log_caplog(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
+    """Allow caplog to capture records from the ``release`` logger."""
+    release_logger = logging.getLogger("release")
+    release_logger.propagate = True
+    yield caplog
+    release_logger.propagate = False
+
+
+def _write_charon_env(path: Path, registry: str) -> None:
+    path.write_text(
+        f"CHARON_OCI_REGISTRY={registry}\n",
+        encoding="utf-8",
+    )
+
+
+def _make_gzip_tar(path: Path) -> None:
+    package_dir = path.parent / "package"
+    package_dir.mkdir(parents=True, exist_ok=True)
+    (package_dir / "package.json").write_text("{}", encoding="utf-8")
+    with tarfile.open(path, "w:gz") as tar:
+        tar.add(package_dir, arcname="package")
+    shutil.rmtree(package_dir)
+
+
+def _patch_file_type_cmd(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stdout: str = "gzip compressed data\n",
+) -> None:
+    """Mock ``file -b`` used by ``file.is_gzip_or_tar_archive``."""
+
+    def fake_run_cmd(
+        cmd: Sequence[str | Path],
+        *,
+        check: bool = True,
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        del check, kwargs
+        argv = [str(x) for x in cmd]
+        if argv[:2] == ["file", "-b"]:
+            return subprocess.CompletedProcess(argv, 0, stdout=stdout, stderr="")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(publish_to_nrrc.subprocess_cmd, "run_cmd", fake_run_cmd)
+
+
+def test_prepare_repo_downloads_and_collects_archives(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each registry is pulled and archive files are moved into shared/."""
+    env_file = tmp_path / "charon.env"
+    _write_charon_env(env_file, "quay.io/test/app@sha256:0b15aad24f1b847")
+    work_dir = tmp_path / "nrrc"
+    subdir = work_dir / "0b15aa"
+
+    def fake_oras_pull(pull_spec: str, download_dir: Path, **kwargs: object) -> None:
+        del kwargs
+        assert pull_spec == "quay.io/test/app@sha256:0b15aad24f1b847"
+        download_dir.mkdir(parents=True, exist_ok=True)
+        _make_gzip_tar(download_dir / "test.tgz")
+
+    monkeypatch.setattr(publish_to_nrrc.oras_utils, "oras_pull", fake_oras_pull)
+    _patch_file_type_cmd(monkeypatch)
+    publish_to_nrrc.prepare_repo(
+        charon_param_file=env_file,
+        work_dir=work_dir,
+    )
+    shared = work_dir / "shared"
+    moved = shared / "0b15aa_test.tgz"
+    assert moved.is_file()
+    assert not (subdir / "test.tgz").exists()
+
+
+def test_prepare_repo_skips_existing_shared_file(
+    tmp_path: Path,
+    release_log_caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Duplicate archive names in shared/ produce a warning and are skipped."""
+    env_file = tmp_path / "charon.env"
+    _write_charon_env(env_file, "quay.io/test/app@sha256:0b15aad24f1b847")
+    work_dir = tmp_path / "nrrc"
+    shared = work_dir / "shared"
+    shared.mkdir(parents=True)
+    existing = shared / "0b15aa_test.tgz"
+    existing.write_text("keep", encoding="utf-8")
+
+    def fake_oras_pull(pull_spec: str, download_dir: Path, **kwargs: object) -> None:
+        del pull_spec, kwargs
+        download_dir.mkdir(parents=True, exist_ok=True)
+        (download_dir / "test.tgz").write_text("new", encoding="utf-8")
+
+    monkeypatch.setattr(publish_to_nrrc.oras_utils, "oras_pull", fake_oras_pull)
+    _patch_file_type_cmd(monkeypatch)
+    with release_log_caplog.at_level(logging.WARNING, logger="release"):
+        publish_to_nrrc.prepare_repo(
+            charon_param_file=env_file,
+            work_dir=work_dir,
+        )
+    assert existing.read_text(encoding="utf-8") == "keep"
+    assert "already exists" in release_log_caplog.text
+
+
+def _set_prepare_repo_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    charon_param_file_path: str = "charon.env",
+    work_dir: str | None = None,
+) -> None:
+    """Set Tekton env vars used by ``publish_to_nrrc.main``."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CHARON_PARAM_FILE_PATH", charon_param_file_path)
+    if work_dir is not None:
+        monkeypatch.setenv("WORK_DIR", work_dir)
+
+
+def test_main_missing_charon_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing charon env files raise FileNotFoundError."""
+    _set_prepare_repo_env(
+        monkeypatch,
+        tmp_path,
+        charon_param_file_path="missing.env",
+        work_dir=str(tmp_path / "nrrc"),
+    )
+    with pytest.raises(FileNotFoundError, match="charon env file not found"):
+        publish_to_nrrc.main()
+
+
+def test_main_missing_data_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing ``DATA_DIR`` exits before prepare logic runs."""
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    with pytest.raises(SystemExit) as exc_info:
+        publish_to_nrrc.main()
+    assert exc_info.value.code == 1
+
+
+def test_main_rejects_absolute_charon_param_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Absolute charon param paths are rejected before file access."""
+    _set_prepare_repo_env(monkeypatch, tmp_path, charon_param_file_path="/etc/passwd")
+    with pytest.raises(ValueError, match="must be relative"):
+        publish_to_nrrc.main()
+
+
+def test_prepare_repo_multiple_registries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each ``%``-separated registry is pulled into shared/."""
+    env_file = tmp_path / "charon.env"
+    env_file.write_text(
+        "CHARON_OCI_REGISTRY="
+        "quay.io/a@sha256:0b15aad24f1b847%"
+        "quay.io/b@sha256:e400bc4b4398295\n",
+        encoding="utf-8",
+    )
+    work_dir = tmp_path / "nrrc"
+    pulls: list[str] = []
+
+    def fake_oras_pull(pull_spec: str, download_dir: Path, **kwargs: object) -> None:
+        del kwargs
+        pulls.append(pull_spec)
+        download_dir.mkdir(parents=True, exist_ok=True)
+        _make_gzip_tar(download_dir / "test.tgz")
+
+    monkeypatch.setattr(publish_to_nrrc.oras_utils, "oras_pull", fake_oras_pull)
+    _patch_file_type_cmd(monkeypatch)
+    publish_to_nrrc.prepare_repo(
+        charon_param_file=env_file,
+        work_dir=work_dir,
+    )
+    assert pulls == [
+        "quay.io/a@sha256:0b15aad24f1b847",
+        "quay.io/b@sha256:e400bc4b4398295",
+    ]
+    shared = work_dir / "shared"
+    assert (shared / "0b15aa_test.tgz").is_file()
+    assert (shared / "e400bc_test.tgz").is_file()
+
+
+def test_prepare_repo_requires_charon_oci_registry(tmp_path: Path) -> None:
+    """Missing ``CHARON_OCI_REGISTRY`` raises ValueError."""
+    env_file = tmp_path / "charon.env"
+    env_file.write_text("CHARON_TARGET=dev\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="CHARON_OCI_REGISTRY"):
+        publish_to_nrrc.prepare_repo(
+            charon_param_file=env_file,
+            work_dir=tmp_path / "nrrc",
+        )
+
+
+def test_prepare_repo_skips_non_archive_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non gzip/tar files are left in the pull directory."""
+    env_file = tmp_path / "charon.env"
+    _write_charon_env(env_file, "quay.io/test/app@sha256:0b15aad24f1b847")
+    work_dir = tmp_path / "nrrc"
+    subdir = work_dir / "0b15aa"
+
+    def fake_oras_pull(pull_spec: str, download_dir: Path, **kwargs: object) -> None:
+        del pull_spec, kwargs
+        download_dir.mkdir(parents=True, exist_ok=True)
+        (download_dir / "notes.txt").write_text("skip me", encoding="utf-8")
+
+    monkeypatch.setattr(publish_to_nrrc.oras_utils, "oras_pull", fake_oras_pull)
+    _patch_file_type_cmd(monkeypatch, stdout="ASCII text\n")
+    publish_to_nrrc.prepare_repo(
+        charon_param_file=env_file,
+        work_dir=work_dir,
+    )
+    assert (subdir / "notes.txt").is_file()
+    assert list((work_dir / "shared").iterdir()) == []
+
+
+def test_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Happy-path Tekton env invocation exits with status 0."""
+    _set_prepare_repo_env(
+        monkeypatch,
+        tmp_path,
+        work_dir=str(tmp_path / "nrrc"),
+    )
+    monkeypatch.setattr(
+        publish_to_nrrc,
+        "prepare_repo",
+        lambda **_: None,
+    )
+    assert publish_to_nrrc.main() == 0
+
+
+def test_prepare_repo_empty_oci_registry(tmp_path: Path) -> None:
+    """An empty ``CHARON_OCI_REGISTRY`` value raises ValueError."""
+    env_file = tmp_path / "charon.env"
+    env_file.write_text("CHARON_OCI_REGISTRY=\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="at least one registry"):
+        publish_to_nrrc.prepare_repo(
+            charon_param_file=env_file,
+            work_dir=tmp_path / "nrrc",
+        )
+
+
+def test_prepare_repo_skips_subdirectory_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Directory entries from ``rglob`` are skipped; files are still collected."""
+    env_file = tmp_path / "charon.env"
+    _write_charon_env(env_file, "quay.io/test/app@sha256:0b15aad24f1b847")
+    work_dir = tmp_path / "nrrc"
+    subdir = work_dir / "0b15aa"
+
+    def fake_oras_pull(pull_spec: str, download_dir: Path, **kwargs: object) -> None:
+        del pull_spec, kwargs
+        (download_dir / "nested").mkdir(parents=True)
+        _make_gzip_tar(download_dir / "test.tgz")
+
+    monkeypatch.setattr(publish_to_nrrc.oras_utils, "oras_pull", fake_oras_pull)
+    _patch_file_type_cmd(monkeypatch)
+    publish_to_nrrc.prepare_repo(
+        charon_param_file=env_file,
+        work_dir=work_dir,
+    )
+    assert (work_dir / "shared" / "0b15aa_test.tgz").is_file()
+    assert (subdir / "nested").is_dir()
+
+
+def test_prepare_repo_oras_pull_failure_propagates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``oras_pull`` failures propagate from ``prepare_repo``."""
+    env_file = tmp_path / "charon.env"
+    _write_charon_env(env_file, "quay.io/test/app@sha256:0b15aad24f1b847")
+
+    def fail_oras_pull(pull_spec: str, download_dir: Path, **kwargs: object) -> None:
+        del pull_spec, download_dir, kwargs
+        raise subprocess.CalledProcessError(1, ["oras", "pull"])
+
+    monkeypatch.setattr(publish_to_nrrc.oras_utils, "oras_pull", fail_oras_pull)
+    with pytest.raises(subprocess.CalledProcessError):
+        publish_to_nrrc.prepare_repo(
+            charon_param_file=env_file,
+            work_dir=tmp_path / "nrrc",
+        )
+
+
+def test_main_oras_failure_exits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``CalledProcessError`` from prepare logic propagates from ``main()``."""
+    env_file = tmp_path / "charon.env"
+    _write_charon_env(env_file, "quay.io/test/app@sha256:0b15aad24f1b847")
+    _set_prepare_repo_env(
+        monkeypatch,
+        tmp_path,
+        work_dir=str(tmp_path / "nrrc"),
+    )
+
+    def fail_prepare(**kwargs: object) -> None:
+        del kwargs
+        raise subprocess.CalledProcessError(1, ["oras", "pull"])
+
+    monkeypatch.setattr(publish_to_nrrc, "prepare_repo", fail_prepare)
+    with pytest.raises(subprocess.CalledProcessError):
+        publish_to_nrrc.main()
+
+
+def test_main_rejects_traversal_charon_param_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Param paths that escape ``DATA_DIR`` are rejected before file access."""
+    _set_prepare_repo_env(monkeypatch, tmp_path, charon_param_file_path="../outside.env")
+    with pytest.raises(ValueError, match="must stay under"):
+        publish_to_nrrc.main()
+
+
+def test_module_main_guard_raises_system_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Executing the file as ``__main__`` runs the bottom ``raise SystemExit(main())``."""
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    monkeypatch.setattr(sys, "argv", ["publish_to_nrrc.py"])
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(Path(publish_to_nrrc.__file__)),
+            run_name="__main__",
+        )
+    assert exc_info.value.code == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1638,6 +1638,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
 name = "python-gitlab"
 version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1849,6 +1858,7 @@ dependencies = [
     { name = "pubtools-pyxis" },
     { name = "pubtools-sign" },
     { name = "pulp-cli" },
+    { name = "python-dotenv" },
     { name = "python-gitlab" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -1881,6 +1891,7 @@ requires-dist = [
     { name = "pubtools-pyxis", specifier = "==1.3.8" },
     { name = "pubtools-sign", specifier = "==1.0.6" },
     { name = "pulp-cli", specifier = "==0.36.3" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-gitlab", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "requests" },


### PR DESCRIPTION
## Describe your changes
Moves the prepare-repo and upload-npm-archive logic from inline Tekton bash into standalone Python scripts under scripts/python/tasks/managed/, with Tekton parameters passed as CLI flags. 
It adds a small charon_env helper for parsing charon parameter files, reuses the existing subprocess_cmd helper from create_advisory, and bundles the charon CLI into the utils image so both steps can run from release-service-utils. 

## Relevant Jira
[RELEASE-2509](https://redhat.atlassian.net/browse/RELEASE-2509)

Assisted-by: Claude

[RELEASE-2509]: https://redhat.atlassian.net/browse/RELEASE-2509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ