### PR TITLE
feat(RELEASE-1990): add pulp-push-disk-images python script

### DIFF
--- a/scripts/python/helpers/oras_utils.py
+++ b/scripts/python/helpers/oras_utils.py
@@ -7,6 +7,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+import file
+import subprocess_cmd
 from subprocess_cmd import run_cmd
 
 
@@ -50,6 +52,37 @@ def oras_login(registry: str, username: str, password: str) -> None:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
+
+
+def oras_pull(
+    pull_spec: str,
+    download_dir: Path,
+    *,
+    stderr_path: Path | None = None,
+) -> None:
+    """Pull an OCI artifact into *download_dir* using select-oci-auth and oras."""
+    auth_file = file.make_tempfile_path("oras-auth-")
+    try:
+        auth_out = subprocess_cmd.run_cmd(
+            ["select-oci-auth", str(pull_spec)],
+            check=True,
+        ).stdout
+        auth_file.write_text(auth_out, encoding="utf-8")
+        subprocess_cmd.run_cmd(
+            [
+                "oras",
+                "pull",
+                "--registry-config",
+                str(auth_file),
+                str(pull_spec),
+            ],
+            cwd=download_dir,
+            stderr_path=stderr_path,
+            check=True,
+        )
+    finally:
+        # Always remove the auth file; subprocess failures still propagate to callers.
+        auth_file.unlink(missing_ok=True)
 
 
 def oras_push(tag: str, directory: Path, subdirectory: str, component_name: str) -> str:

--- a/scripts/python/helpers/test_oras_utils.py
+++ b/scripts/python/helpers/test_oras_utils.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
+import oras_utils
 import pytest
 
 from oras_utils import oras_resolve
@@ -60,3 +63,67 @@ def test_oras_resolve_raises_on_nonzero_returncode() -> None:
         ]
         with pytest.raises(RuntimeError):
             oras_resolve("registry.io/repo:tag")
+
+
+def test_oras_pull_runs_select_oci_auth_and_oras(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`oras_pull` writes auth config then pulls the artifact into *download_dir*."""
+    calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append([str(x) for x in cmd])
+        if cmd[0] == "select-oci-auth":
+            return subprocess.CompletedProcess(cmd, 0, stdout='{"auths":{}}', stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(oras_utils.subprocess_cmd, "run_cmd", fake_run_cmd)
+    oras_utils.oras_pull("quay.io/org/image@sha256:abc", tmp_path)
+
+    assert calls[0] == ["select-oci-auth", "quay.io/org/image@sha256:abc"]
+    assert calls[1][0:3] == ["oras", "pull", "--registry-config"]
+    assert calls[1][-1] == "quay.io/org/image@sha256:abc"
+
+
+def test_oras_pull_cleans_up_auth_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Temporary auth file created for oras is removed after pull completes."""
+    created: list[Path] = []
+    original = oras_utils.file.make_tempfile_path
+
+    def track_tempfile(prefix: str, data: bytes | None = None) -> Path:
+        path = original(prefix, data)
+        created.append(path)
+        return path
+
+    monkeypatch.setattr(oras_utils.file, "make_tempfile_path", track_tempfile)
+
+    def fake_run_cmd(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[0] == "select-oci-auth":
+            return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(oras_utils.subprocess_cmd, "run_cmd", fake_run_cmd)
+    oras_utils.oras_pull("quay.io/org/image:tag", tmp_path)
+
+    assert len(created) == 1
+    assert not created[0].exists()
+
+
+def test_oras_pull_raises_when_subprocess_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Subprocess failures propagate to callers after auth file cleanup."""
+
+    def fake_run_cmd(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[0] == "select-oci-auth":
+            return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+        raise subprocess.CalledProcessError(1, cmd, stderr="oras pull failed")
+
+    monkeypatch.setattr(oras_utils.subprocess_cmd, "run_cmd", fake_run_cmd)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        oras_utils.oras_pull("quay.io/org/image:tag", tmp_path)
+
+    assert exc_info.value.returncode == 1

--- a/scripts/python/tasks/internal/pulp_push_disk_images.py
+++ b/scripts/python/tasks/internal/pulp_push_disk_images.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Push disk images with Pulp and publish metadata to the Developer Portal / CGW.
+
+Reads snapshot JSON and credentials from mounted secrets, pulls OCI artifacts with
+oras, stages files, invokes pulp_push_wrapper and developer_portal_wrapper.
+
+Environment variables (set by the pulp-push-disk-images Tekton task):
+  SNAPSHOT_JSON, CERT_EXPIRATION_WARN_DAYS, CONCURRENT_LIMIT, EXODUS_GW_ENV,
+  CGW_HOSTNAME, RESULT_RESULT
+
+Mount paths default to /mnt/exodusGwSecret, /mnt/pulpSecret, /mnt/udcacheSecret,
+/mnt/redhat-workloads-token, /mnt/cgwSecret and can be overridden in tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable, Mapping
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+import authentication
+import file
+import oras_utils
+import push_artifacts
+import subprocess_cmd
+import tekton
+from logger import logger
+
+PROG = "pulp_push_disk_images.py"
+
+DEFAULT_EXODUS_MOUNT = Path("/mnt/exodusGwSecret")
+DEFAULT_PULP_MOUNT = Path("/mnt/pulpSecret")
+DEFAULT_UDCACHE_MOUNT = Path("/mnt/udcacheSecret")
+DEFAULT_WORKLOADS_MOUNT = Path("/mnt/redhat-workloads-token")
+DEFAULT_CGW_MOUNT = Path("/mnt/cgwSecret")
+
+RunCmd = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _validate_certificates(
+    warn_days: int,
+    *,
+    exodus_mount: Path,
+    pulp_mount: Path,
+    udcache_mount: Path,
+) -> None:
+    """Validate Exodus, Pulp, and UDCache certificate expiration."""
+    logger.info("=== Checking certificate expiration ===")
+    for label, cert_path in (
+        ("Exodus Gateway", exodus_mount / "cert"),
+        ("Pulp", pulp_mount / "konflux-release-rhsm-pulp.crt"),
+        ("UDCache", udcache_mount / "cert"),
+    ):
+        logger.info("Checking %s certificate", label)
+        push_artifacts._check_cert_expiration(str(cert_path), warn_days)
+    logger.info("=== All certificates are valid ===")
+
+
+def normalize_docker_config(raw: str) -> str:
+    """Strip extra quoted fields from a dockerconfigjson secret payload."""
+    return re.sub(r"(^|\})[^{}]+(\{|$)", r"\1\2", raw)
+
+
+def build_staged_payload(
+    disk_image_dir: Path,
+    version: str,
+) -> dict[str, Any]:
+    """Build the staged.json payload listing every file under *disk_image_dir*."""
+    payload: dict[str, Any] = {"header": {"version": "0.2"}, "payload": {"files": []}}
+    files: list[dict[str, str]] = []
+    for path in sorted(disk_image_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(disk_image_dir).as_posix()
+        files.append(
+            {
+                "filename": path.name,
+                "relative_path": rel,
+                "version": version,
+            }
+        )
+    payload["payload"]["files"] = files
+    return payload
+
+
+def require_json_field(data: dict[str, Any], *keys: str) -> Any:
+    """Return ``data[keys...]`` or raise ``ValueError`` with a clear message."""
+    cur: Any = data
+    path = ""
+    for key in keys:
+        path = f"{path}.{key}" if path else key
+        if not isinstance(cur, dict) or key not in cur:
+            raise ValueError(f"Missing {path} value for component")
+        cur = cur[key]
+    if cur in (None, ""):
+        raise ValueError(f"Missing {path} value for component")
+    return cur
+
+
+def require_staged_files_field(entry: dict[str, Any], field: str) -> Any:
+    """Validate one ``staged.files[]`` mapping entry (bash ``jq -er`` equivalent)."""
+    label = f"staged.files[].{field}"
+    if not isinstance(entry, dict) or field not in entry or entry[field] in (None, ""):
+        raise ValueError(f"Missing {label} value for component")
+    return entry[field]
+
+
+def process_component(
+    component: dict[str, Any],
+    disk_image_dir: Path,
+    *,
+    stderr_path: Path,
+    run_cmd: RunCmd = subprocess_cmd.run_cmd,
+) -> None:
+    """Pull one OCI artifact and stage mapped files for Pulp upload."""
+    pull_spec = require_json_field(component, "containerImage")
+    destination_name = require_json_field(component, "staged", "destination")
+    destination = disk_image_dir / str(destination_name) / "FILES"
+    destination.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as download_dir:
+        download = Path(download_dir)
+        oras_utils.oras_pull(
+            str(pull_spec),
+            download,
+            stderr_path=stderr_path,
+        )
+
+        staged_files = component.get("staged", {}).get("files", [])
+        if not isinstance(staged_files, list):
+            raise ValueError("staged.files must be a list")
+
+        for entry in staged_files:
+            if not isinstance(entry, dict):
+                raise ValueError("staged.files entries must be objects")
+            source = require_staged_files_field(entry, "source")
+            filename = require_staged_files_field(entry, "filename")
+            source_path = download / str(source)
+            gz_path = Path(str(source_path) + ".gz")
+            if gz_path.is_file():
+                run_cmd(["gzip", "-d", str(gz_path)], cwd=download, check=True)
+            dest_file = destination / str(filename)
+            if dest_file.exists():
+                raise ValueError(
+                    "Multiple files use the same destination value: "
+                    f"{destination} and filename value: {filename}. Failing..."
+                )
+            if source_path.is_file():
+                shutil.move(str(source_path), dest_file)
+            else:
+                logger.warning("didn't find mapped file: %s", source)
+
+
+def process_component_for_developer_portal(
+    component: dict[str, Any],
+    content_directory: Path,
+    cgw_hostname: str,
+    *,
+    env: Mapping[str, str] | None = None,
+    stderr_path: Path,
+    run_cmd: RunCmd = subprocess_cmd.run_cmd,
+) -> None:
+    """Upload staged files for one component via developer_portal_wrapper."""
+    product_name = require_json_field(component, "contentGateway", "productName")
+    product_code = require_json_field(component, "contentGateway", "productCode")
+    product_version_name = require_json_field(
+        component,
+        "contentGateway",
+        "productVersionName",
+    )
+    file_prefix = require_json_field(component, "contentGateway", "filePrefix")
+
+    cmd_env = dict(env or {})
+    if "developers.qa.redhat.com" in cgw_hostname:
+        cmd_env["HTTP_PROXY"] = "http://squid.corp.redhat.com:3128"
+        cmd_env["HTTPS_PROXY"] = "http://squid.corp.redhat.com:3128"
+        logger.info("Using squid proxy for preprod CGW access")
+
+    run_cmd(
+        [
+            "developer_portal_wrapper",
+            "--debug",
+            "--product-name",
+            str(product_name),
+            "--product-code",
+            str(product_code),
+            "--product-version-name",
+            str(product_version_name),
+            "--cgw-hostname",
+            cgw_hostname,
+            "--content-directory",
+            str(content_directory),
+            "--file-prefix",
+            str(file_prefix),
+        ],
+        env=cmd_env,
+        stderr_path=stderr_path,
+        check=True,
+    )
+
+
+def run_push(
+    snapshot: dict[str, Any],
+    *,
+    concurrent_limit: int,
+    exodus_gw_env: str,
+    cgw_hostname: str,
+    cert_warn_days: int,
+    exodus_mount: Path,
+    pulp_mount: Path,
+    udcache_mount: Path,
+    workloads_mount: Path,
+    cgw_mount: Path,
+    run_cmd: RunCmd = subprocess_cmd.run_cmd,
+) -> None:
+    """Execute the full pulp disk-image push workflow."""
+    _validate_certificates(
+        cert_warn_days,
+        exodus_mount=exodus_mount,
+        pulp_mount=pulp_mount,
+        udcache_mount=udcache_mount,
+    )
+
+    exodus_cert = authentication.read_mounted_text(exodus_mount, "cert")
+    exodus_key = authentication.read_mounted_text(exodus_mount, "key")
+    exodus_url = authentication.read_mounted_text(exodus_mount, "url")
+    pulp_url = authentication.read_mounted_text(pulp_mount, "pulp_url")
+    pulp_cert = authentication.read_mounted_text(pulp_mount, "konflux-release-rhsm-pulp.crt")
+    pulp_key = authentication.read_mounted_text(pulp_mount, "konflux-release-rhsm-pulp.key")
+    udc_url = authentication.read_mounted_text(udcache_mount, "url")
+    udc_cert = authentication.read_mounted_text(udcache_mount, "cert")
+    udc_key = authentication.read_mounted_text(udcache_mount, "key")
+    docker_config = authentication.read_mounted_text(workloads_mount, ".dockerconfigjson")
+    cgw_username = authentication.read_mounted_text(cgw_mount, "username")
+    cgw_password = authentication.read_mounted_text(cgw_mount, "token")
+
+    stderr_path = Path("/tmp/stderr.txt")
+    stderr_path.write_text("", encoding="utf-8")
+
+    exodus_gw_cert = file.make_tempfile_path("exodus-", exodus_cert.encode())
+    exodus_gw_key = file.make_tempfile_path("exodus-key-", exodus_key.encode())
+    pulp_cert_file = file.make_tempfile_path("pulp-", pulp_cert.encode())
+    pulp_key_file = file.make_tempfile_path("pulp-key-", pulp_key.encode())
+    udcache_cert = file.make_tempfile_path("udc-", udc_cert.encode())
+    udcache_key = file.make_tempfile_path("udc-key-", udc_key.encode())
+
+    env = {
+        **os.environ,
+        "CGW_USERNAME": cgw_username,
+        "CGW_PASSWORD": cgw_password,
+        "EXODUS_GW_CERT": str(exodus_gw_cert),
+        "EXODUS_GW_KEY": str(exodus_gw_key),
+        "PULP_CERT_FILE": str(pulp_cert_file),
+        "PULP_KEY_FILE": str(pulp_key_file),
+        "UDCACHE_CERT": str(udcache_cert),
+        "UDCACHE_KEY": str(udcache_key),
+        "EXODUS_GW_ENV": exodus_gw_env,
+        "EXODUS_GW_URL": exodus_url,
+        "EXODUS_PULP_HOOK_ENABLED": "True",
+        "EXODUS_GW_TIMEOUT": "7200",
+    }
+
+    docker_dir = Path.home() / ".docker"
+    docker_dir.mkdir(parents=True, exist_ok=True)
+    (docker_dir / "config.json").write_text(
+        normalize_docker_config(docker_config),
+        encoding="utf-8",
+    )
+
+    components = snapshot.get("components")
+    if not isinstance(components, list) or not components:
+        raise ValueError("snapshot must contain a non-empty components list")
+
+    version = (
+        components[0].get("staged", {}).get("version")
+        if isinstance(components[0], dict)
+        else None
+    )
+    if not version:
+        msg = (
+            "Error: version not specified in .components[0].staged.version. "
+            "Needed to publish to customer portal"
+        )
+        with stderr_path.open("a", encoding="utf-8") as errf:
+            errf.write(msg + "\n")
+        raise tekton.CheckStepError("validating staged version", ValueError(msg))
+
+    with tempfile.TemporaryDirectory() as disk_dir_name:
+        disk_image_dir = Path(disk_dir_name)
+
+        def _run_one(component: dict[str, Any]) -> None:
+            process_component(
+                component,
+                disk_image_dir,
+                stderr_path=stderr_path,
+                run_cmd=run_cmd,
+            )
+
+        with ThreadPoolExecutor(max_workers=max(1, concurrent_limit)) as pool:
+            futures = [
+                pool.submit(_run_one, component)
+                for component in components
+                if isinstance(component, dict)
+            ]
+            for future in as_completed(futures):
+                future.result()
+
+        staged = build_staged_payload(disk_image_dir, str(version))
+        staged_yaml = disk_image_dir / "staged.yaml"
+        staged_yaml.write_text(
+            run_cmd(
+                ["yq", "-P", "-I", "4"],
+                stdin=json.dumps(staged),
+                check=True,
+            ).stdout,
+            encoding="utf-8",
+        )
+
+        run_cmd(
+            [
+                "pulp_push_wrapper",
+                "--debug",
+                "--source",
+                str(disk_image_dir),
+                "--pulp-url",
+                pulp_url,
+                "--pulp-cert",
+                str(pulp_cert_file),
+                "--pulp-key",
+                str(pulp_key_file),
+                "--udcache-url",
+                udc_url,
+            ],
+            env=env,
+            stderr_path=stderr_path,
+            check=True,
+        )
+
+        for component in components:
+            if not isinstance(component, dict):
+                continue
+            destination_name = require_json_field(component, "staged", "destination")
+            content_directory = disk_image_dir / str(destination_name) / "FILES"
+            process_component_for_developer_portal(
+                component,
+                content_directory,
+                cgw_hostname,
+                env=env,
+                stderr_path=stderr_path,
+                run_cmd=run_cmd,
+            )
+
+
+def main() -> int:
+    """Write RESULT_RESULT and always return exit code 0 for Tekton."""
+    rpath = tekton.result_paths_from_env("RESULT_RESULT")[0]
+    snapshot_raw = os.environ.get("SNAPSHOT_JSON", "").strip()
+    if not snapshot_raw:
+        print(f"{PROG}: SNAPSHOT_JSON must be set", file=sys.stderr)
+        raise SystemExit(1)
+
+    cert_warn_days = int(os.environ.get("CERT_EXPIRATION_WARN_DAYS", "7"))
+    concurrent_limit = int(os.environ.get("CONCURRENT_LIMIT", "3"))
+    exodus_gw_env = os.environ.get("EXODUS_GW_ENV", "").strip()
+    cgw_hostname = os.environ.get("CGW_HOSTNAME", "").strip()
+    if not exodus_gw_env:
+        print(f"{PROG}: EXODUS_GW_ENV must be set", file=sys.stderr)
+        raise SystemExit(1)
+    if not cgw_hostname:
+        print(f"{PROG}: CGW_HOSTNAME must be set", file=sys.stderr)
+        raise SystemExit(1)
+
+    exodus_mount = file.path_from_env_variable("EXODUS_GW_SECRET_MOUNT", DEFAULT_EXODUS_MOUNT)
+    pulp_mount = file.path_from_env_variable("PULP_SECRET_MOUNT", DEFAULT_PULP_MOUNT)
+    udcache_mount = file.path_from_env_variable("UDCACHE_SECRET_MOUNT", DEFAULT_UDCACHE_MOUNT)
+    workloads_mount = file.path_from_env_variable(
+        "REDHAT_WORKLOADS_TOKEN_MOUNT",
+        DEFAULT_WORKLOADS_MOUNT,
+    )
+    cgw_mount = file.path_from_env_variable("CGW_SECRET_MOUNT", DEFAULT_CGW_MOUNT)
+
+    stderr_path = Path("/tmp/stderr.txt")
+    stderr_path.write_text("", encoding="utf-8")
+    try:
+        snapshot = json.loads(snapshot_raw)
+        if not isinstance(snapshot, dict):
+            raise ValueError("SNAPSHOT_JSON must decode to a JSON object")
+        run_push(
+            snapshot,
+            concurrent_limit=concurrent_limit,
+            exodus_gw_env=exodus_gw_env,
+            cgw_hostname=cgw_hostname,
+            cert_warn_days=cert_warn_days,
+            exodus_mount=exodus_mount,
+            pulp_mount=pulp_mount,
+            udcache_mount=udcache_mount,
+            workloads_mount=workloads_mount,
+            cgw_mount=cgw_mount,
+        )
+    except (ValueError, OSError, subprocess.CalledProcessError, tekton.CheckStepError) as exc:
+        tekton.write_failure_result(
+            rpath,
+            PROG,
+            exc,
+            command_log_path=stderr_path,
+            workflow_action="pushing disk images",
+        )
+        return 0
+
+    rpath.write_text("Success", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/internal/test_pulp_push_disk_images.py
+++ b/scripts/python/tasks/internal/test_pulp_push_disk_images.py
@@ -1,0 +1,633 @@
+"""Tests for `pulp_push_disk_images`."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pulp_push_disk_images
+import pytest
+import tekton
+
+
+def _patch_cert_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Skip real certificate validation in ``run_push`` integration tests."""
+    monkeypatch.setattr(
+        pulp_push_disk_images.push_artifacts,
+        "_check_cert_expiration",
+        lambda *_args: None,
+    )
+
+
+def test_normalize_docker_config_strips_k8s_quotes() -> None:
+    """Kubernetes-style quoted dockerconfigjson is normalized to valid JSON."""
+    raw = '"{"auths":{"quay.io":{"auth":"abc"}}}"'
+    out = pulp_push_disk_images.normalize_docker_config(raw)
+    assert out == '{"auths":{"quay.io":{"auth":"abc"}}}'
+
+
+def test_build_staged_payload_lists_files(tmp_path: Path) -> None:
+    """Staged payload lists files under the disk image directory with version."""
+    (tmp_path / "a" / "b").mkdir(parents=True)
+    (tmp_path / "a" / "b" / "disk.qcow2").write_text("x", encoding="utf-8")
+    payload = pulp_push_disk_images.build_staged_payload(tmp_path, "1.3")
+    assert payload["header"]["version"] == "0.2"
+    assert len(payload["payload"]["files"]) == 1
+    assert payload["payload"]["files"][0]["filename"] == "disk.qcow2"
+    assert payload["payload"]["files"][0]["version"] == "1.3"
+
+
+def test_require_json_field_missing() -> None:
+    """Missing nested JSON fields raise ValueError with a clear path."""
+    with pytest.raises(ValueError, match="Missing contentGateway value for component"):
+        pulp_push_disk_images.require_json_field({}, "contentGateway", "productName")
+
+
+def test_require_staged_files_field_missing() -> None:
+    """Missing staged.files[] keys use paths compatible with Tekton result checks."""
+    with pytest.raises(
+        ValueError,
+        match=r"Missing staged\.files\[\]\.filename value for component",
+    ):
+        pulp_push_disk_images.require_staged_files_field({"source": "disk.qcow2"}, "filename")
+
+
+def test_main_writes_check_step_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``CheckStepError`` from ``run_push`` is written to RESULT_RESULT via tekton helper."""
+    result = tmp_path / "result"
+    monkeypatch.setenv("RESULT_RESULT", str(result))
+    monkeypatch.setenv(
+        "SNAPSHOT_JSON",
+        json.dumps({"components": [_valid_component()]}),
+    )
+    monkeypatch.setenv("EXODUS_GW_ENV", "pre")
+    monkeypatch.setenv("CGW_HOSTNAME", "https://cgw.example.com")
+
+    err = tekton.CheckStepError(
+        "validating staged version",
+        ValueError("version not specified in .components[0].staged.version"),
+    )
+    with mock.patch.object(pulp_push_disk_images, "run_push", side_effect=err):
+        assert pulp_push_disk_images.main() == 0
+
+    text = result.read_text(encoding="utf-8")
+    assert "validating staged version" in text
+    assert "version not specified" in text
+
+
+def test_run_push_calls_wrappers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """run_push invokes pulp_push_wrapper and developer_portal_wrapper."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _patch_cert_checks(monkeypatch)
+    exodus = tmp_path / "exodus"
+    pulp = tmp_path / "pulp"
+    udc = tmp_path / "udc"
+    workloads = tmp_path / "workloads"
+    cgw = tmp_path / "cgw"
+    for d in (exodus, pulp, udc, workloads, cgw):
+        d.mkdir()
+    (exodus / "cert").write_text("c", encoding="utf-8")
+    (exodus / "key").write_text("k", encoding="utf-8")
+    (exodus / "url").write_text("https://exodus", encoding="utf-8")
+    (pulp / "pulp_url").write_text("https://pulp.com", encoding="utf-8")
+    (pulp / "konflux-release-rhsm-pulp.crt").write_text("pc", encoding="utf-8")
+    (pulp / "konflux-release-rhsm-pulp.key").write_text("pk", encoding="utf-8")
+    (udc / "url").write_text("https://udc", encoding="utf-8")
+    (udc / "cert").write_text("uc", encoding="utf-8")
+    (udc / "key").write_text("uk", encoding="utf-8")
+    (workloads / ".dockerconfigjson").write_text('{"auths":{}}', encoding="utf-8")
+    (cgw / "username").write_text("user", encoding="utf-8")
+    (cgw / "token").write_text("tok", encoding="utf-8")
+
+    calls: list[list[str]] = []
+    env_by_cmd: dict[str, dict[str, str]] = {}
+
+    def fake_run_cmd(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append([str(x) for x in cmd])
+        env = kwargs.get("env")
+        if env is not None:
+            env_by_cmd[str(cmd[0])] = dict(env)
+        if cmd[0] == "select-oci-auth":
+            return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+        if cmd[0] == "oras":
+            cwd = kwargs.get("cwd")
+            assert cwd is not None
+            Path(cwd, "disk.qcow2").write_text("data", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "yq":
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="payload:\n  files: []\n", stderr=""
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        pulp_push_disk_images.oras_utils.subprocess_cmd, "run_cmd", fake_run_cmd
+    )
+
+    snapshot = {
+        "components": [
+            {
+                "containerImage": "quay.io/org/image@sha256:abc",
+                "contentGateway": {
+                    "productName": "Disk",
+                    "productCode": "DISK",
+                    "productVersionName": "1.3",
+                    "filePrefix": "amd",
+                },
+                "staged": {
+                    "destination": "x86_64-isos",
+                    "version": "1.3",
+                    "files": [{"source": "disk.qcow2", "filename": "amd.qcow2"}],
+                },
+            }
+        ]
+    }
+
+    pulp_push_disk_images.run_push(
+        snapshot,
+        concurrent_limit=1,
+        exodus_gw_env="pre",
+        cgw_hostname="https://content-gateway.com",
+        cert_warn_days=7,
+        exodus_mount=exodus,
+        pulp_mount=pulp,
+        udcache_mount=udc,
+        workloads_mount=workloads,
+        cgw_mount=cgw,
+        run_cmd=fake_run_cmd,
+    )
+
+    joined = "\n".join(" ".join(c) for c in calls)
+    assert "pulp_push_wrapper" in joined
+    assert "developer_portal_wrapper" in joined
+    assert env_by_cmd["developer_portal_wrapper"]["CGW_USERNAME"] == "user"
+    assert env_by_cmd["developer_portal_wrapper"]["CGW_PASSWORD"] == "tok"
+
+
+def _setup_mount_secrets(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
+    """Create dummy secret mount directories used by ``run_push`` tests."""
+    exodus = tmp_path / "exodus"
+    pulp = tmp_path / "pulp"
+    udc = tmp_path / "udc"
+    workloads = tmp_path / "workloads"
+    cgw = tmp_path / "cgw"
+    for d in (exodus, pulp, udc, workloads, cgw):
+        d.mkdir()
+    (exodus / "cert").write_text("c", encoding="utf-8")
+    (exodus / "key").write_text("k", encoding="utf-8")
+    (exodus / "url").write_text("https://exodus", encoding="utf-8")
+    (pulp / "pulp_url").write_text("https://pulp.com", encoding="utf-8")
+    (pulp / "konflux-release-rhsm-pulp.crt").write_text("pc", encoding="utf-8")
+    (pulp / "konflux-release-rhsm-pulp.key").write_text("pk", encoding="utf-8")
+    (udc / "url").write_text("https://udc", encoding="utf-8")
+    (udc / "cert").write_text("uc", encoding="utf-8")
+    (udc / "key").write_text("uk", encoding="utf-8")
+    (workloads / ".dockerconfigjson").write_text('{"auths":{}}', encoding="utf-8")
+    (cgw / "username").write_text("user", encoding="utf-8")
+    (cgw / "token").write_text("tok", encoding="utf-8")
+    return exodus, pulp, udc, workloads, cgw
+
+
+def test_run_push_developer_portal_uses_staged_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each component's CGW upload uses ``staged.destination``, not staged file index."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _patch_cert_checks(monkeypatch)
+    exodus, pulp, udc, workloads, cgw = _setup_mount_secrets(tmp_path)
+    portal_dirs: list[str] = []
+
+    def fake_run_cmd(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[0] == "select-oci-auth":
+            return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+        if cmd[0] == "oras":
+            cwd = kwargs.get("cwd")
+            assert cwd is not None
+            Path(cwd, "disk.qcow2").write_text("data", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "yq":
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="payload:\n  files: []\n", stderr=""
+            )
+        if cmd[0] == "developer_portal_wrapper":
+            idx = cmd.index("--content-directory")
+            portal_dirs.append(str(cmd[idx + 1]))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        pulp_push_disk_images.oras_utils.subprocess_cmd, "run_cmd", fake_run_cmd
+    )
+
+    snapshot = {
+        "components": [
+            {
+                "containerImage": "quay.io/org/image-a@sha256:aaa",
+                "contentGateway": {
+                    "productName": "DiskA",
+                    "productCode": "DISKA",
+                    "productVersionName": "1.0",
+                    "filePrefix": "amd",
+                },
+                "staged": {
+                    "destination": "x86_64-isos",
+                    "version": "1.0",
+                    "files": [
+                        {"source": "disk.qcow2", "filename": "amd1.qcow2"},
+                        {"source": "disk.qcow2", "filename": "amd2.qcow2"},
+                    ],
+                },
+            },
+            {
+                "containerImage": "quay.io/org/image-b@sha256:bbb",
+                "contentGateway": {
+                    "productName": "DiskB",
+                    "productCode": "DISKB",
+                    "productVersionName": "1.0",
+                    "filePrefix": "arm",
+                },
+                "staged": {
+                    "destination": "aarch64-isos",
+                    "version": "1.0",
+                    "files": [{"source": "disk.qcow2", "filename": "arm.qcow2"}],
+                },
+            },
+        ]
+    }
+
+    pulp_push_disk_images.run_push(
+        snapshot,
+        concurrent_limit=1,
+        exodus_gw_env="pre",
+        cgw_hostname="https://content-gateway.com",
+        cert_warn_days=7,
+        exodus_mount=exodus,
+        pulp_mount=pulp,
+        udcache_mount=udc,
+        workloads_mount=workloads,
+        cgw_mount=cgw,
+        run_cmd=fake_run_cmd,
+    )
+
+    assert len(portal_dirs) == 2
+    assert any(d.endswith("/x86_64-isos/FILES") for d in portal_dirs)
+    assert any(d.endswith("/aarch64-isos/FILES") for d in portal_dirs)
+
+
+def test_main_writes_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`main` writes Success to RESULT_RESULT when run_push completes."""
+    result = tmp_path / "result"
+    monkeypatch.setenv("RESULT_RESULT", str(result))
+    monkeypatch.setenv(
+        "SNAPSHOT_JSON", json.dumps({"components": [{"staged": {"version": "1"}}]})
+    )
+    monkeypatch.setenv("EXODUS_GW_ENV", "pre")
+    monkeypatch.setenv("CGW_HOSTNAME", "https://cgw.example.com")
+
+    with mock.patch.object(pulp_push_disk_images, "run_push"):
+        assert pulp_push_disk_images.main() == 0
+    assert result.read_text(encoding="utf-8") == "Success"
+
+
+def test_main_missing_snapshot_exits_before_results() -> None:
+    """`main` exits with code 1 when SNAPSHOT_JSON is unset."""
+    with pytest.raises(SystemExit) as exc:
+        pulp_push_disk_images.main()
+    assert exc.value.code == 1
+
+
+def _valid_component() -> dict[str, object]:
+    return {
+        "containerImage": "quay.io/org/image@sha256:abc",
+        "contentGateway": {
+            "productName": "Disk",
+            "productCode": "DISK",
+            "productVersionName": "1.3",
+            "filePrefix": "amd",
+        },
+        "staged": {
+            "destination": "x86_64-isos",
+            "version": "1.3",
+            "files": [{"source": "disk.qcow2", "filename": "amd.qcow2"}],
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("component", "match"),
+    [
+        ({}, "Missing containerImage"),
+        (
+            {"containerImage": "quay.io/org/image@sha256:abc"},
+            "Missing staged value for component",
+        ),
+    ],
+)
+def test_process_component_missing_fields(component: dict[str, object], match: str) -> None:
+    """Missing containerImage or staged.destination fail during pull/stage."""
+    with pytest.raises(ValueError, match=match):
+        pulp_push_disk_images.process_component(
+            component,
+            Path("/tmp/disk"),
+            stderr_path=Path("/tmp/stderr.txt"),
+        )
+
+
+@pytest.mark.parametrize(
+    ("component", "match"),
+    [
+        (
+            {
+                "containerImage": "quay.io/org/image@sha256:abc",
+                "staged": {"destination": "x86_64-isos"},
+            },
+            "Missing contentGateway value for component",
+        ),
+        (
+            {
+                "containerImage": "quay.io/org/image@sha256:abc",
+                "contentGateway": {
+                    "productName": "Disk",
+                    "productVersionName": "1.3",
+                    "filePrefix": "amd",
+                },
+                "staged": {"destination": "x86_64-isos"},
+            },
+            "Missing contentGateway.productCode",
+        ),
+        (
+            {
+                "containerImage": "quay.io/org/image@sha256:abc",
+                "contentGateway": {
+                    "productName": "Disk",
+                    "productCode": "DISK",
+                    "filePrefix": "amd",
+                },
+                "staged": {"destination": "x86_64-isos"},
+            },
+            "Missing contentGateway.productVersionName",
+        ),
+        (
+            {
+                "containerImage": "quay.io/org/image@sha256:abc",
+                "contentGateway": {
+                    "productName": "Disk",
+                    "productCode": "DISK",
+                    "productVersionName": "1.3",
+                },
+                "staged": {"destination": "x86_64-isos"},
+            },
+            "Missing contentGateway.filePrefix",
+        ),
+    ],
+)
+def test_process_component_for_developer_portal_missing_fields(
+    component: dict[str, object], match: str
+) -> None:
+    """Missing contentGateway fields fail during developer portal upload."""
+    with pytest.raises(ValueError, match=match):
+        pulp_push_disk_images.process_component_for_developer_portal(
+            component,
+            Path("/tmp/content"),
+            "https://content-gateway.com",
+            stderr_path=Path("/tmp/stderr.txt"),
+        )
+
+
+def test_require_staged_files_field_source_missing() -> None:
+    """Missing staged.files[].source matches legacy Tekton fail test."""
+    with pytest.raises(
+        ValueError,
+        match=r"Missing staged\.files\[\]\.source value for component",
+    ):
+        pulp_push_disk_images.require_staged_files_field({"filename": "amd.qcow2"}, "source")
+
+
+def test_process_component_duplicate_filename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two staged files must not target the same destination filename."""
+    stderr_path = tmp_path / "stderr.txt"
+
+    def fake_run_cmd(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[0] == "select-oci-auth":
+            return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+        if cmd[0] == "oras":
+            cwd = kwargs.get("cwd")
+            assert cwd is not None
+            Path(cwd, "disk.qcow2").write_text("a", encoding="utf-8")
+            Path(cwd, "disk.raw").write_text("b", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        pulp_push_disk_images.oras_utils.subprocess_cmd, "run_cmd", fake_run_cmd
+    )
+
+    component = _valid_component()
+    staged = component["staged"]
+    assert isinstance(staged, dict)
+    staged["files"] = [
+        {"source": "disk.qcow2", "filename": "amd.qcow2"},
+        {"source": "disk.raw", "filename": "amd.qcow2"},
+    ]
+
+    with pytest.raises(ValueError, match="Multiple files use the same destination"):
+        pulp_push_disk_images.process_component(
+            component,
+            tmp_path / "disk",
+            stderr_path=stderr_path,
+            run_cmd=fake_run_cmd,
+        )
+
+
+def test_run_push_missing_staged_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing .components[0].staged.version fails before wrappers run."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _patch_cert_checks(monkeypatch)
+    exodus, pulp, udc, workloads, cgw = _setup_mount_secrets(tmp_path)
+
+    def fake_run_cmd(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    snapshot = {
+        "components": [
+            {
+                "containerImage": "quay.io/org/image@sha256:abc",
+                "staged": {"destination": "x86_64-isos", "files": []},
+            }
+        ]
+    }
+
+    with pytest.raises(tekton.CheckStepError, match="validating staged version"):
+        pulp_push_disk_images.run_push(
+            snapshot,
+            concurrent_limit=1,
+            exodus_gw_env="pre",
+            cgw_hostname="https://content-gateway.com",
+            cert_warn_days=7,
+            exodus_mount=exodus,
+            pulp_mount=pulp,
+            udcache_mount=udc,
+            workloads_mount=workloads,
+            cgw_mount=cgw,
+            run_cmd=fake_run_cmd,
+        )
+
+
+def test_run_push_oras_pull_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing oras pull surfaces as CalledProcessError from run_push."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _patch_cert_checks(monkeypatch)
+    exodus, pulp, udc, workloads, cgw = _setup_mount_secrets(tmp_path)
+
+    def fake_run_cmd(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[0] == "select-oci-auth":
+            return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+        if cmd[0] == "oras":
+            raise subprocess.CalledProcessError(
+                1, cmd, stderr="Simulating failing oras pull call"
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        pulp_push_disk_images.oras_utils.subprocess_cmd, "run_cmd", fake_run_cmd
+    )
+
+    snapshot = {"components": [_valid_component()]}
+
+    with pytest.raises(subprocess.CalledProcessError):
+        pulp_push_disk_images.run_push(
+            snapshot,
+            concurrent_limit=1,
+            exodus_gw_env="pre",
+            cgw_hostname="https://content-gateway.com",
+            cert_warn_days=7,
+            exodus_mount=exodus,
+            pulp_mount=pulp,
+            udcache_mount=udc,
+            workloads_mount=workloads,
+            cgw_mount=cgw,
+            run_cmd=fake_run_cmd,
+        )
+
+
+def test_run_push_gzip_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing gzip decompress surfaces as CalledProcessError from run_push."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _patch_cert_checks(monkeypatch)
+    exodus, pulp, udc, workloads, cgw = _setup_mount_secrets(tmp_path)
+
+    def fake_run_cmd(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[0] == "select-oci-auth":
+            return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+        if cmd[0] == "oras":
+            cwd = kwargs.get("cwd")
+            assert cwd is not None
+            Path(cwd, "disk.qcow2").write_text("a", encoding="utf-8")
+            Path(cwd, "fail_gzip.raw.gz").write_text("gz", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "gzip":
+            raise subprocess.CalledProcessError(1, cmd, stderr="gzip failed")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        pulp_push_disk_images.oras_utils.subprocess_cmd, "run_cmd", fake_run_cmd
+    )
+
+    component = _valid_component()
+    staged = component["staged"]
+    assert isinstance(staged, dict)
+    staged["files"] = [
+        {"source": "disk.qcow2", "filename": "amd.qcow2"},
+        {"source": "fail_gzip.raw", "filename": "amd.raw"},
+    ]
+    snapshot = {"components": [component]}
+
+    with pytest.raises(subprocess.CalledProcessError):
+        pulp_push_disk_images.run_push(
+            snapshot,
+            concurrent_limit=1,
+            exodus_gw_env="pre",
+            cgw_hostname="https://content-gateway.com",
+            cert_warn_days=7,
+            exodus_mount=exodus,
+            pulp_mount=pulp,
+            udcache_mount=udc,
+            workloads_mount=workloads,
+            cgw_mount=cgw,
+            run_cmd=fake_run_cmd,
+        )
+
+
+def test_run_push_pulp_push_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing pulp_push_wrapper surfaces as CalledProcessError from run_push."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _patch_cert_checks(monkeypatch)
+    exodus, pulp, udc, workloads, cgw = _setup_mount_secrets(tmp_path)
+    (pulp / "pulp_url").write_text("https://failing-pulp.com", encoding="utf-8")
+
+    def fake_run_cmd(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[0] == "select-oci-auth":
+            return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+        if cmd[0] == "oras":
+            cwd = kwargs.get("cwd")
+            assert cwd is not None
+            Path(cwd, "disk.qcow2").write_text("a", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "yq":
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="payload:\n  files: []\n", stderr=""
+            )
+        if cmd[0] == "pulp_push_wrapper":
+            raise subprocess.CalledProcessError(
+                1,
+                cmd,
+                stderr="Mocked failure of pulp_push_wrapper",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        pulp_push_disk_images.oras_utils.subprocess_cmd, "run_cmd", fake_run_cmd
+    )
+
+    snapshot = {"components": [_valid_component()]}
+
+    with pytest.raises(subprocess.CalledProcessError, match="pulp_push_wrapper"):
+        pulp_push_disk_images.run_push(
+            snapshot,
+            concurrent_limit=1,
+            exodus_gw_env="pre",
+            cgw_hostname="https://content-gateway.com",
+            cert_warn_days=7,
+            exodus_mount=exodus,
+            pulp_mount=pulp,
+            udcache_mount=udc,
+            workloads_mount=workloads,
+            cgw_mount=cgw,
+            run_cmd=fake_run_cmd,
+        )
+
+
+def test_main_writes_failure_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Validation errors are written to RESULT_RESULT and main exits zero."""
+    result = tmp_path / "result"
+    monkeypatch.setenv("RESULT_RESULT", str(result))
+    monkeypatch.setenv(
+        "SNAPSHOT_JSON",
+        json.dumps({"components": [_valid_component()]}),
+    )
+    monkeypatch.setenv("EXODUS_GW_ENV", "pre")
+    monkeypatch.setenv("CGW_HOSTNAME", "https://cgw.example.com")
+
+    with mock.patch.object(
+        pulp_push_disk_images,
+        "run_push",
+        side_effect=ValueError("Missing containerImage value for component"),
+    ):
+        assert pulp_push_disk_images.main() == 0
+
+    assert "Missing containerImage value for component" in result.read_text(encoding="utf-8")


### PR DESCRIPTION
This commit adds a python script to replicate the functionality of the inline bash script in the pulp-push-disk-images internal task in the catalog repo. The task will be updated to use this python module instead.

It also adds a subprocess_cmd helper module for running external commands with optional stderr logging.

Assisted-By: Cursor