### PR TITLE
refactor: use git cli instead of GitPython

### DIFF
--- a/scripts/python/helpers/vcs/git.py
+++ b/scripts/python/helpers/vcs/git.py
@@ -1,17 +1,15 @@
-"""Host-agnostic Git operations via GitPython."""
+"""Host-agnostic Git operations via the `git` CLI."""
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from pathlib import Path
-from typing import TypeVar
+from typing import IO, Any
 
-import git
-from git.exc import GitCommandError
-
-_T = TypeVar("_T")
+import retry
 
 
 def repository_workdir_name(repository_url: str) -> str:
@@ -22,23 +20,21 @@ def repository_workdir_name(repository_url: str) -> str:
     return base
 
 
-def _append_git_stderr(stderr_path: Path | None, exc: BaseException) -> None:
-    # GitPython does not tee subprocess stderr to a file; append on failure only.
-    if stderr_path is None:
-        return
-    err = getattr(exc, "stderr", None)
-    if err is None:
-        err = str(exc)
-    if not str(err).strip():
-        return
-    safe_text = str(err)
+def _redact_credential_urls(text: str) -> str:
     # Git errors often echo clone URLs with embedded oauth2 / token credentials.
-    safe_text = re.sub(
+    return re.sub(
         r"https://([^/@\s:]+):([^@\s]+)@",
         r"https://\1:[REDACTED]@",
-        safe_text,
+        text,
         flags=re.IGNORECASE,
     )
+
+
+def _append_cmd_stderr(stderr_path: Path | None, message: str) -> None:
+    # CLI git stderr is captured on failure and written here (redacted).
+    if stderr_path is None or not message.strip():
+        return
+    safe_text = _redact_credential_urls(str(message))
     with open(
         stderr_path,
         "a",
@@ -48,19 +44,52 @@ def _append_git_stderr(stderr_path: Path | None, exc: BaseException) -> None:
         errf.write(f"\n{safe_text}\n")
 
 
-def _with_git_stderr(stderr_path: Path | None, action: Callable[[], _T]) -> _T:
-    try:
-        return action()
-    except GitCommandError as exc:
-        _append_git_stderr(stderr_path, exc)
-        raise
+def _run_git_cmd(
+    cmd: Sequence[str | Path],
+    *,
+    cwd: Path | None = None,
+    stderr_path: Path | None = None,
+    check: bool = True,
+    stdout: int | IO[Any] | None = subprocess.PIPE,
+) -> subprocess.CompletedProcess[str]:
+    """Run a git CLI command.
+
+    Captures stderr in memory and, on failure, appends redacted stderr plus a
+    redacted command line to *stderr_path*. Avoids `subprocess_cmd.run_cmd` so
+    credential-bearing clone URLs are never logged verbatim.
+    """
+    argv = [str(x) for x in cmd]
+    result = subprocess.run(
+        argv,
+        cwd=cwd,
+        env=os.environ,
+        stdout=stdout,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        if stderr_path is not None:
+            if result.stderr.strip():
+                _append_cmd_stderr(stderr_path, result.stderr)
+            _append_cmd_stderr(
+                stderr_path,
+                "command exited with failure: " + " ".join(argv),
+            )
+        if check:
+            raise subprocess.CalledProcessError(
+                result.returncode,
+                argv,
+                output=result.stdout,
+                stderr=result.stderr,
+            )
+    return result
 
 
 def configure_git_global_user(name: str, email: str) -> None:
     """Set `user.name` and `user.email` in the global Git config."""
-    git_global = git.Git()
-    git_global.config("--global", "user.name", name)
-    git_global.config("--global", "user.email", email)
+    _run_git_cmd(["git", "config", "--global", "user.name", name])
+    _run_git_cmd(["git", "config", "--global", "user.email", email])
 
 
 def clone(
@@ -72,46 +101,68 @@ def clone(
     sparse_dirs: Sequence[str],
     stderr_path: Path | None = None,
 ) -> Path:
-    """
-    Shallow clone *clone_url* with sparse checkout of *sparse_dirs* at *revision*.
+    """Shallow clone *clone_url* with sparse checkout of *sparse_dirs* at *revision*.
+
+    Returns the repository root directory.
     """
     dir_name = directory_name or repository_workdir_name(clone_url)
     repo_dir = parent_dir / dir_name
-
-    def _clone() -> Path:
-        git.Repo.clone_from(
+    _run_git_cmd(
+        [
+            "git",
+            "clone",
+            "--filter=blob:none",
+            "--no-checkout",
+            "--depth",
+            "1",
+            "--branch",
+            revision,
             clone_url,
             str(repo_dir),
-            multi_options=[
-                "--filter=blob:none",
-                "--no-checkout",
-                "--depth",
-                "1",
-                "--branch",
-                revision,
-            ],
-        )
-        repo = git.Repo(repo_dir)
-        # Sparse paths must be set after clone metadata exists, before checkout.
-        repo.git.sparse_checkout("set", *sparse_dirs)
-        repo.git.checkout(revision)
-        return repo_dir
+        ],
+        cwd=parent_dir,
+        stderr_path=stderr_path,
+    )
+    _run_git_cmd(
+        ["git", "sparse-checkout", "set", *sparse_dirs],
+        cwd=repo_dir,
+        stderr_path=stderr_path,
+    )
+    _run_git_cmd(
+        ["git", "checkout", revision],
+        cwd=repo_dir,
+        stderr_path=stderr_path,
+    )
+    return repo_dir
 
-    return _with_git_stderr(stderr_path, _clone)
 
-
-def origin_ls_tree_name_only(
+def origin_main_has_path_matching(
     repo_root: Path,
-    ref: str,
+    pattern: str,
+    listing_path: Path,
     *,
-    stderr_path: Path | None,
-) -> str:
-    """Return `git ls-tree -r --name-only` stdout for *ref*."""
+    stderr_path: Path | None = None,
+) -> bool:
+    """Return True when `git ls-tree -r --name-only origin/main` has a matching line.
 
-    def _ls_tree() -> str:
-        return git.Repo(repo_root).git.ls_tree("-r", "--name-only", ref)
-
-    return _with_git_stderr(stderr_path, _ls_tree)
+    Writes the tree listing to *listing_path* and scans it line-by-line with *pattern*
+    so the full output is never held in the Python process (large monorepos can be
+    tens of MB).
+    """
+    listing_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(listing_path, "w", encoding="utf-8") as listing_file:
+        _run_git_cmd(
+            ["git", "ls-tree", "-r", "--name-only", "origin/main"],
+            cwd=repo_root,
+            stderr_path=stderr_path,
+            stdout=listing_file,
+        )
+    compiled = re.compile(pattern)
+    with open(listing_path, encoding="utf-8", errors="replace") as listing_file:
+        for line in listing_file:
+            if compiled.search(line):
+                return True
+    return False
 
 
 def index_add_commit(
@@ -119,16 +170,45 @@ def index_add_commit(
     relative_paths: Sequence[str],
     message: str,
     *,
-    stderr_path: Path | None,
+    stderr_path: Path | None = None,
 ) -> None:
-    """Stage *relative_paths* and commit with *message*."""
+    """Stage *relative_paths* and commit with *message* via the git CLI."""
+    _run_git_cmd(
+        ["git", "add", *relative_paths],
+        cwd=repo_root,
+        stderr_path=stderr_path,
+    )
+    _run_git_cmd(
+        ["git", "commit", "-m", message],
+        cwd=repo_root,
+        stderr_path=stderr_path,
+    )
 
-    def _commit() -> None:
-        repo = git.Repo(repo_root)
-        repo.index.add(list(relative_paths))
-        repo.index.commit(message)
 
-    _with_git_stderr(stderr_path, _commit)
+def commit_and_push(
+    repo_root: Path,
+    relative_paths: Sequence[str],
+    message: str,
+    branch: str,
+    *,
+    remote: str = "origin",
+    retries: int = 0,
+    stderr_path: Path | None = None,
+) -> None:
+    """Stage, commit, and push *branch* via the git CLI (with pull --rebase retries)."""
+    index_add_commit(
+        repo_root,
+        relative_paths,
+        message,
+        stderr_path=stderr_path,
+    )
+    push(
+        repo_root,
+        branch,
+        remote=remote,
+        retries=retries,
+        stderr_path=stderr_path,
+    )
 
 
 def push(
@@ -139,34 +219,45 @@ def push(
     retries: int = 0,
     stderr_path: Path | None = None,
 ) -> None:
-    """
-    Push *branch* to *remote*.
+    """Push *branch* to *remote* via the git CLI.
 
-    On rejection, run `pull --rebase` and retry until *retries* recovery cycles
-    are exhausted, then raise `CalledProcessError`.
+    On rejection, run `pull --rebase` and retry with exponential backoff until
+    *retries* recovery cycles are exhausted, then raise `CalledProcessError`.
     """
-    repo = git.Repo(repo_root)
+    max_attempts = retries + 1
     attempt = 0
-    while True:
+
+    def _push_with_rebase() -> None:
+        nonlocal attempt
+        attempt += 1
+        current_attempt = attempt
         try:
-            remote_obj = getattr(repo.remotes, remote)
-            remote_obj.push(branch).raise_if_error()
-            return
-        except GitCommandError as push_error:
-            _append_git_stderr(stderr_path, push_error)
-            attempt += 1
-            try:
-                repo.git.pull("--rebase", remote, branch)
-            except GitCommandError as pull_error:
-                _append_git_stderr(stderr_path, pull_error)
+            _run_git_cmd(
+                ["git", "push", remote, branch],
+                cwd=repo_root,
+                stderr_path=stderr_path,
+            )
+        except subprocess.CalledProcessError as push_error:
+            if current_attempt >= max_attempts:
                 raise
-            # After each failed push: increment counter, pull, then retry push.
-            # Stop and raise once `attempt` exceeds *retries*.
-            if attempt > retries:
-                code = getattr(push_error, "status", None)
-                if code is None:
-                    code = 1
-                raise subprocess.CalledProcessError(
-                    int(code),
-                    f"git push {remote}",
-                ) from push_error
+            # Pull failure is a CalledProcessError too; let it propagate as-is.
+            _run_git_cmd(
+                ["git", "pull", "--rebase", remote, branch],
+                cwd=repo_root,
+                stderr_path=stderr_path,
+            )
+            # Signal retry without using CalledProcessError (pull uses that too).
+            raise RuntimeError("git push rejected") from push_error
+
+    try:
+        retry.retry_with_exponential_backoff(
+            _push_with_rebase,
+            max_attempts=max_attempts,
+            retry_on=RuntimeError,
+            base_sleep_seconds=5,
+        )
+    except RuntimeError as retry_error:
+        cause = retry_error.__cause__
+        if isinstance(cause, subprocess.CalledProcessError):
+            raise cause from retry_error
+        raise

--- a/scripts/python/helpers/vcs/gitlab.py
+++ b/scripts/python/helpers/vcs/gitlab.py
@@ -29,8 +29,7 @@ class GitLabCredentials:
 
 
 def read_credentials_from_mount(secret_mount: Path) -> GitLabCredentials:
-    """
-    Load credentials from *secret_mount*, where each field is a separate file:
+    """Load credentials from *secret_mount*, where each field is a separate file.
 
     `gitlab_host`, `gitlab_access_token`, `git_author_name`,
     `git_author_email`, `git_repo`.
@@ -53,8 +52,7 @@ def export_env_for_image_helpers(credentials: GitLabCredentials) -> None:
 
 
 def configure_git_oauth2_auth(access_token: str) -> None:
-    """
-    Set process env so git HTTPS uses OAuth2 without embedding the token in URLs.
+    """Set process env so git HTTPS uses OAuth2 without embedding the token in URLs.
 
     Installs a small `GIT_ASKPASS` helper for clone, fetch, and push in this
     process. Call once before any GitLab git operations.
@@ -88,11 +86,12 @@ def clone_project_sparse(
     parent_dir: Path,
     stderr_path: Path | None,
 ) -> Path:
-    """
-    Shallow sparse clone of a GitLab *repository* HTTPS URL.
+    """Shallow sparse clone of a GitLab *repository* HTTPS URL.
 
     Requires `configure_git_oauth2_auth()` in this process so git can
     authenticate without a token embedded in the clone URL.
+
+    Returns the repository root directory.
     """
     return git.clone(
         parent_dir,

--- a/scripts/python/helpers/vcs/test_git.py
+++ b/scripts/python/helpers/vcs/test_git.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from git.exc import GitCommandError
 
 from . import git
 
@@ -26,57 +25,71 @@ def test_repository_workdir_name(url: str, expected: str) -> None:
     assert git.repository_workdir_name(url) == expected
 
 
-def test_append_git_stderr_skips_when_path_none() -> None:
+def test_append_cmd_stderr_skips_when_path_none() -> None:
     """Do nothing when no stderr log path is configured."""
-    git._append_git_stderr(None, GitCommandError(["git"], 1, "err"))
+    git._append_cmd_stderr(None, "err")
 
 
-def test_append_git_stderr_skips_empty_message(tmp_path: Path) -> None:
-    """Do not create a log file when the error message is blank."""
-    log = tmp_path / "log.txt"
-    git._append_git_stderr(log, Exception("   "))
-    assert not log.exists()
-
-
-def test_append_git_stderr_uses_str_when_no_stderr_attr(tmp_path: Path) -> None:
-    """Append `str(exc)` when the exception has no `stderr` attribute."""
-    log = tmp_path / "log.txt"
-    git._append_git_stderr(log, Exception("plain"))
-    assert "plain" in log.read_text(encoding="utf-8")
-
-
-def test_append_git_stderr_redacts_oauth2_url(tmp_path: Path) -> None:
+def test_append_cmd_stderr_redacts_oauth2_url(tmp_path: Path) -> None:
     """Mask oauth2 tokens embedded in clone URLs written to the stderr log."""
     log = tmp_path / "log.txt"
-    git._append_git_stderr(
+    git._append_cmd_stderr(
         log,
-        GitCommandError(
-            ["git", "clone"],
-            1,
-            "fatal: https://oauth2:secret@gitlab.com/g/r.git",
-        ),
+        "fatal: https://oauth2:secret@gitlab.com/g/r.git",
     )
     text = log.read_text(encoding="utf-8")
     assert "secret" not in text
     assert "oauth2:[REDACTED]@" in text
 
 
+def test_redact_credential_urls() -> None:
+    """Mask oauth2 tokens in arbitrary text (stderr or argv)."""
+    text = "fatal: https://oauth2:secret@gitlab.com/g/r.git"
+    redacted = git._redact_credential_urls(text)
+    assert "secret" not in redacted
+    assert "oauth2:[REDACTED]@" in redacted
+
+
+def test_run_git_cmd_redacts_clone_failure_log(tmp_path: Path) -> None:
+    """Failed clone must not write credential-bearing URLs to the stderr log."""
+    log = tmp_path / "log.txt"
+    clone_url = "https://oauth2:secret@gitlab.com/g/r.git"
+
+    def _fake_run(
+        argv: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            argv,
+            1,
+            stdout="",
+            stderr=f"fatal: unable to access {clone_url}/",
+        )
+
+    with mock.patch("vcs.git.subprocess.run", side_effect=_fake_run):
+        with pytest.raises(subprocess.CalledProcessError):
+            git._run_git_cmd(
+                ["git", "clone", clone_url, str(tmp_path / "repo")],
+                cwd=tmp_path,
+                stderr_path=log,
+            )
+    text = log.read_text(encoding="utf-8")
+    assert "secret" not in text
+    assert "oauth2:[REDACTED]@" in text
+    assert "command exited with failure" in text
+
+
 def test_configure_git_global_user() -> None:
-    """Set global `user.name` and `user.email` via GitPython."""
-    with mock.patch("vcs.git.git.Git") as git_cls:
+    """Set global `user.name` and `user.email` via the git CLI."""
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
         git.configure_git_global_user("Name", "e@x.com")
-    inst = git_cls.return_value
-    inst.config.assert_any_call("--global", "user.name", "Name")
-    inst.config.assert_any_call("--global", "user.email", "e@x.com")
+    assert run_cmd.call_count == 2
 
 
 def test_clone_shallow_sparse(tmp_path: Path) -> None:
-    """Sparse-checkout clone checks out the requested revision."""
+    """Sparse-checkout clone returns the repository root path."""
     repo_dir = tmp_path / "proj"
-    mock_repo = mock.MagicMock()
-    with mock.patch("vcs.git.git.Repo") as repo_cls:
-        repo_cls.clone_from.return_value = mock_repo
-        repo_cls.return_value = mock_repo
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
         out = git.clone(
             tmp_path,
             "https://x/proj.git",
@@ -85,17 +98,18 @@ def test_clone_shallow_sparse(tmp_path: Path) -> None:
             sparse_dirs=["schema"],
         )
     assert out == repo_dir
-    mock_repo.git.sparse_checkout.assert_called_once_with("set", "schema")
-    mock_repo.git.checkout.assert_called_once_with("main")
+    assert run_cmd.call_count == 3
 
 
 def test_clone_appends_stderr(tmp_path: Path) -> None:
     """Write clone failures to the optional stderr log file."""
     log = tmp_path / "log.txt"
-    with mock.patch(
-        "vcs.git.git.Repo.clone_from", side_effect=GitCommandError(["git"], 1, "clone fail")
+    with mock.patch.object(
+        git,
+        "_run_git_cmd",
+        side_effect=subprocess.CalledProcessError(1, "git clone"),
     ):
-        with pytest.raises(GitCommandError):
+        with pytest.raises(subprocess.CalledProcessError):
             git.clone(
                 tmp_path,
                 "https://x/p.git",
@@ -103,118 +117,158 @@ def test_clone_appends_stderr(tmp_path: Path) -> None:
                 sparse_dirs=["a"],
                 stderr_path=log,
             )
-    assert "clone fail" in log.read_text(encoding="utf-8")
 
 
-def test_origin_ls_tree_name_only(tmp_path: Path) -> None:
-    """Return `git ls-tree -r --name-only` output for a ref."""
-    mock_repo = mock.MagicMock()
-    mock_repo.git.ls_tree.return_value = "path/a\npath/b\n"
-    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
-        out = git.origin_ls_tree_name_only(tmp_path, "origin/main", stderr_path=None)
-    assert "path/a" in out
+def test_origin_main_has_path_matching_found(tmp_path: Path) -> None:
+    """Return True when a listing line matches *pattern*."""
+    listing = tmp_path / "tree.txt"
+
+    def _write_listing(*_args: object, **kwargs: object) -> mock.MagicMock:
+        stdout = kwargs.get("stdout")
+        assert stdout is not None
+        stdout.write("data/advisories/t/2025/0042/advisory.yaml\n")
+        return mock.MagicMock()
+
+    with mock.patch.object(git, "_run_git_cmd", side_effect=_write_listing) as run_cmd:
+        assert git.origin_main_has_path_matching(
+            tmp_path,
+            r"data/advisories/.*/2025/0042/",
+            listing,
+        )
+    run_cmd.assert_called_once()
+    assert run_cmd.call_args.args[0] == [
+        "git",
+        "ls-tree",
+        "-r",
+        "--name-only",
+        "origin/main",
+    ]
+    assert run_cmd.call_args.kwargs["stdout"] is not None
 
 
-def test_origin_ls_tree_logs_stderr(tmp_path: Path) -> None:
-    """Append `ls-tree` failures to the optional stderr log file."""
-    log = tmp_path / "log.txt"
-    with mock.patch("vcs.git.git.Repo") as repo_cls:
-        repo_cls.return_value.git.ls_tree.side_effect = GitCommandError(["git"], 1, "ls fail")
-        with pytest.raises(GitCommandError):
-            git.origin_ls_tree_name_only(tmp_path, "origin/main", stderr_path=log)
-    assert "ls fail" in log.read_text(encoding="utf-8")
+def test_origin_main_has_path_matching_not_found(tmp_path: Path) -> None:
+    """Return False when no listing line matches *pattern*."""
+    listing = tmp_path / "tree.txt"
+
+    def _write_listing(*_args: object, **kwargs: object) -> mock.MagicMock:
+        stdout = kwargs.get("stdout")
+        assert stdout is not None
+        stdout.write("data/advisories/t/2025/0001/advisory.yaml\n")
+        return mock.MagicMock()
+
+    with mock.patch.object(git, "_run_git_cmd", side_effect=_write_listing):
+        assert not git.origin_main_has_path_matching(
+            tmp_path,
+            r"data/advisories/.*/2025/9999/",
+            listing,
+        )
 
 
 def test_index_add_commit(tmp_path: Path) -> None:
-    """Stage paths and commit without an explicit author."""
-    mock_repo = mock.MagicMock()
-    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
+    """Stage paths and commit via the git CLI."""
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
         git.index_add_commit(tmp_path, ["a.yaml"], "msg", stderr_path=None)
-    mock_repo.index.add.assert_called_once_with(["a.yaml"])
-    mock_repo.index.commit.assert_called_once_with("msg")
+    assert run_cmd.call_count == 2
 
 
-def test_index_add_commit_logs_stderr(tmp_path: Path) -> None:
-    """Append stage/commit failures to the optional stderr log file."""
-    log = tmp_path / "log.txt"
-    with mock.patch("vcs.git.git.Repo") as repo_cls:
-        repo_cls.return_value.index.add.side_effect = GitCommandError(["git"], 1, "add fail")
-        with pytest.raises(GitCommandError):
-            git.index_add_commit(tmp_path, ["a.yaml"], "msg", stderr_path=log)
-    assert "add fail" in log.read_text(encoding="utf-8")
+def test_commit_and_push(tmp_path: Path) -> None:
+    """Stage, commit, and push via the git CLI."""
+    with mock.patch.object(git, "index_add_commit") as add:
+        with mock.patch.object(git, "push") as push:
+            git.commit_and_push(
+                tmp_path,
+                ["a.yaml"],
+                "msg",
+                "main",
+                retries=2,
+                stderr_path=None,
+            )
+    add.assert_called_once()
+    push.assert_called_once_with(
+        tmp_path,
+        "main",
+        remote="origin",
+        retries=2,
+        stderr_path=None,
+    )
 
 
 def test_push_success_first_try(tmp_path: Path) -> None:
-    """Return immediately when the first push succeeds."""
-    mock_repo = mock.MagicMock()
-    push_result = mock.MagicMock()
-    mock_repo.remotes.origin.push.return_value = push_result
-    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
+    """Return immediately when the first CLI push succeeds."""
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
         git.push(tmp_path, "main", retries=2, stderr_path=None)
-    mock_repo.remotes.origin.push.assert_called_once_with("main")
-    push_result.raise_if_error.assert_called_once()
+    run_cmd.assert_called_once()
 
 
-def test_push_rejected_ref(tmp_path: Path) -> None:
-    """Push rejections that only set PushInfo flags must not look like success."""
-    err_log = tmp_path / "err.log"
-    mock_repo = mock.MagicMock()
-    push_result = mock.MagicMock()
-    push_result.raise_if_error.side_effect = GitCommandError(
-        ["git", "push", "origin"],
-        1,
-        "error: failed to push some refs",
-    )
-    mock_repo.remotes.origin.push.return_value = push_result
-    mock_repo.git.pull.return_value = ""
+def test_push_retries_after_rejection_with_backoff(tmp_path: Path) -> None:
+    """Retry push after `pull --rebase` with exponential backoff between attempts."""
+    sleeps: list[float] = []
+    push_calls = {"n": 0}
+    pull_calls = {"n": 0}
 
-    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
+    def _cmd_side_effect(cmd: list[str], **_kwargs: object) -> mock.MagicMock:
+        if "pull" in cmd:
+            pull_calls["n"] += 1
+            return mock.MagicMock()
+        push_calls["n"] += 1
+        raise subprocess.CalledProcessError(1, "git push")
+
+    with mock.patch("retry.time.sleep", side_effect=sleeps.append):
+        with mock.patch.object(
+            git,
+            "_run_git_cmd",
+            side_effect=_cmd_side_effect,
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                git.push(tmp_path, "main", retries=1, stderr_path=None)
+    assert push_calls["n"] == 2
+    assert pull_calls["n"] == 1
+    assert sleeps == [5]
+
+
+def test_push_zero_retries_skips_pull(tmp_path: Path) -> None:
+    """Do not pull when push fails and no recovery retries are configured."""
+    pull_calls = {"n": 0}
+
+    def _cmd_side_effect(cmd: list[str], **_kwargs: object) -> mock.MagicMock:
+        if "pull" in cmd:
+            pull_calls["n"] += 1
+            return mock.MagicMock()
+        raise subprocess.CalledProcessError(1, "git push")
+
+    with mock.patch.object(git, "_run_git_cmd", side_effect=_cmd_side_effect):
         with pytest.raises(subprocess.CalledProcessError):
-            git.push(tmp_path, "main", retries=0, stderr_path=err_log)
-    push_result.raise_if_error.assert_called_once()
-    assert "failed to push" in err_log.read_text(encoding="utf-8")
+            git.push(tmp_path, "main", retries=0, stderr_path=None)
+    assert pull_calls["n"] == 0
 
 
 def test_push_raises_after_limit(tmp_path: Path) -> None:
     """Raise `CalledProcessError` after pull/retry cycles are exhausted."""
     err_log = tmp_path / "err.log"
-    mock_repo = mock.MagicMock()
 
-    def _fail_push(*_args: object, **_kwargs: object) -> None:
-        raise GitCommandError(["git", "push", "origin"], 1, "push failed")
+    def _always_fail(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.CalledProcessError(1, "git push")
 
-    mock_repo.remotes.origin.push.side_effect = _fail_push
-    mock_repo.git.pull.return_value = ""
-
-    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
+    with mock.patch.object(git, "_run_git_cmd", side_effect=_always_fail):
         with pytest.raises(subprocess.CalledProcessError):
             git.push(tmp_path, "main", retries=1, stderr_path=err_log)
-    assert mock_repo.remotes.origin.push.call_count == 2
-    assert "push failed" in err_log.read_text(encoding="utf-8")
 
 
 def test_push_pull_failure_raises(tmp_path: Path) -> None:
-    """Re-raise when `pull --rebase` fails after a rejected push."""
+    """Re-raise when CLI `pull --rebase` fails after a rejected push."""
     log = tmp_path / "log.txt"
-    mock_repo = mock.MagicMock()
-    mock_repo.remotes.origin.push.side_effect = GitCommandError(["git", "push"], 1, "push")
-    mock_repo.git.pull.side_effect = GitCommandError(["git", "pull"], 1, "pull")
+    push_error = subprocess.CalledProcessError(1, "git push")
+    pull_error = subprocess.CalledProcessError(1, "git pull")
 
-    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
-        with pytest.raises(GitCommandError):
+    def _cmd_side_effect(cmd: list[str], **_kwargs: object) -> mock.MagicMock:
+        if "pull" in cmd:
+            raise pull_error
+        raise push_error
+
+    with mock.patch.object(
+        git,
+        "_run_git_cmd",
+        side_effect=_cmd_side_effect,
+    ):
+        with pytest.raises(subprocess.CalledProcessError):
             git.push(tmp_path, "main", retries=3, stderr_path=log)
-    assert "pull" in log.read_text(encoding="utf-8")
-
-
-def test_push_no_status_on_error(tmp_path: Path) -> None:
-    """Default to exit code 1 when GitPython omits `status` on push failure."""
-    mock_repo = mock.MagicMock()
-    err = GitCommandError(["git", "push"], 0, "push")
-    del err.status
-    mock_repo.remotes.origin.push.side_effect = err
-    mock_repo.git.pull.return_value = ""
-
-    with mock.patch("vcs.git.git.Repo", return_value=mock_repo):
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            git.push(tmp_path, "main", retries=0, stderr_path=None)
-    assert exc_info.value.returncode == 1

--- a/scripts/python/helpers/vcs/test_gitlab.py
+++ b/scripts/python/helpers/vcs/test_gitlab.py
@@ -13,6 +13,7 @@ from . import gitlab
 
 
 def test_read_credentials_from_mount(tmp_path: Path) -> None:
+    """Load GitLab host, token, author, and repo URL from a secret mount."""
     secret = tmp_path / "secret"
     secret.mkdir()
     (secret / "gitlab_host").write_text("gitlab.example.com", encoding="utf-8")
@@ -27,6 +28,7 @@ def test_read_credentials_from_mount(tmp_path: Path) -> None:
 
 
 def test_export_env_for_image_helpers(tmp_path: Path) -> None:
+    """Export GitLab credentials to env vars for image helper scripts."""
     secret = tmp_path / "secret"
     secret.mkdir()
     (secret / "gitlab_host").write_text("h", encoding="utf-8")
@@ -41,6 +43,7 @@ def test_export_env_for_image_helpers(tmp_path: Path) -> None:
 
 
 def test_raw_file_url() -> None:
+    """Build a GitLab raw file URL for a path on the default branch."""
     url = gitlab.raw_file_url(
         "https://gitlab.example.com/g/r.git",
         "path/to/file.yaml",
@@ -49,6 +52,7 @@ def test_raw_file_url() -> None:
 
 
 def test_configure_git_oauth2_auth_sets_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure OAuth2 token and GIT_ASKPASS for non-interactive git."""
     monkeypatch.delenv("GIT_ASKPASS", raising=False)
     gitlab.configure_git_oauth2_auth("my-token")
     assert os.environ["GITLAB_OAUTH2_TOKEN"] == "my-token"
@@ -57,7 +61,9 @@ def test_configure_git_oauth2_auth_sets_env(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_clone_project_sparse_delegates_to_git(tmp_path: Path) -> None:
-    with mock.patch.object(git, "clone", return_value=tmp_path / "repo") as m:
+    """Sparse-clone via `git.clone` using an OAuth2-authenticated URL."""
+    repo_root = tmp_path / "repo"
+    with mock.patch.object(git, "clone", return_value=repo_root) as m:
         out = gitlab.clone_project_sparse(
             "https://gitlab.example.com/g/r.git",
             "main",
@@ -65,7 +71,7 @@ def test_clone_project_sparse_delegates_to_git(tmp_path: Path) -> None:
             parent_dir=tmp_path,
             stderr_path=None,
         )
-    assert out == tmp_path / "repo"
+    assert out is repo_root
     m.assert_called_once()
     assert m.call_args.args[1] == "https://gitlab.example.com/g/r.git"
     assert "oauth2:" not in m.call_args.args[1]

--- a/scripts/python/tasks/internal/create_advisory.py
+++ b/scripts/python/tasks/internal/create_advisory.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import shutil
 import sys
 import tempfile
@@ -34,9 +33,9 @@ import file
 import http_client
 import internal_request
 import requests
-import yaml
 import subprocess_cmd
 import tekton
+import yaml
 from jsonschema import ValidationError
 from jsonschema.validators import validator_for
 from requests_kerberos import OPTIONAL, HTTPKerberosAuth
@@ -186,8 +185,7 @@ def _finish_if_all_content_already_published(
     stderr_path: Path,
     result_paths: dict[str, Path],
 ) -> bool:
-    """
-    Walk existing advisories (newest first) and filter *content_file*.
+    """Walk existing advisories (newest first) and filter *content_file*.
 
     Return True when every row was already published and success results were
     written; False when a new advisory must be created.
@@ -304,16 +302,19 @@ def _ensure_advisory_number_unused(
     repo_root: Path,
     year: str,
     advisory_number_segment: str,
+    listing_path: Path,
     *,
     stderr_path: Path,
 ) -> None:
     # Another pipeline may have pushed the same year/number.
     # Sparse clone may not list every tenant path.
-    origin_main_tree = git.origin_ls_tree_name_only(
-        repo_root, "origin/main", stderr_path=stderr_path
-    )
-    duplicate_pattern = re.compile(rf"data/advisories/.*/{year}/{advisory_number_segment}/")
-    if any(duplicate_pattern.search(tree_line) for tree_line in origin_main_tree.splitlines()):
+    pattern = rf"data/advisories/.*/{year}/{advisory_number_segment}/"
+    if git.origin_main_has_path_matching(
+        repo_root,
+        pattern,
+        listing_path,
+        stderr_path=stderr_path,
+    ):
         msg = f"An advisory with number {advisory_number_segment} already exists"
         raise ValueError(msg)
 
@@ -375,15 +376,10 @@ def _commit_and_push_new_advisory(
     *,
     stderr_path: Path,
 ) -> None:
-    git.index_add_commit(
+    git.commit_and_push(
         repo_root,
         [yaml_repo_path],
         f"[Konflux Release] new advisory for {component_group}",
-        stderr_path=stderr_path,
-    )
-    # Rebase on push handles concurrent advisory commits to the same default branch.
-    git.push(
-        repo_root,
         gitlab.DEFAULT_BRANCH,
         retries=5,
         stderr_path=stderr_path,
@@ -504,10 +500,12 @@ def run_create_advisory(
         )
         # Directory name under data/advisories/<origin>/<year>/ (four-digit live id).
         advisory_number_segment = f"{live_num:04d}"
+        origin_ls_tree_listing = work_dir / "origin_ls_tree.txt"
         _ensure_advisory_number_unused(
             repo_root,
             year,
             advisory_number_segment,
+            origin_ls_tree_listing,
             stderr_path=stderr_path,
         )
         portal_advisory_id = f"{year}:{advisory_number_segment}"
@@ -533,6 +531,11 @@ def run_create_advisory(
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry: decode advisory JSON, run the workflow, and write Tekton results.
+
+    Always returns 0; logical success is ``Success`` in ``RESULT_RESULT``, and
+    failures are recorded there via ``write_failure_result``.
+    """
     (
         path_step_result,
         path_advisory_url,

--- a/scripts/python/tasks/internal/test_create_advisory.py
+++ b/scripts/python/tasks/internal/test_create_advisory.py
@@ -6,6 +6,7 @@ import base64
 import gzip
 import json
 import os
+import subprocess
 from pathlib import Path
 from unittest import mock
 
@@ -65,12 +66,14 @@ def _valid_advisory_yaml_dict() -> dict:
 
 @pytest.fixture
 def creds(tmp_path: Path) -> gitlab.GitLabCredentials:
+    """GitLab credentials loaded from a temporary secret mount."""
     secret = tmp_path / "gitlab"
     _write_gitlab_secret(secret)
     return gitlab.read_credentials_from_mount(secret)
 
 
 def test_reserve_errata_live_id_posts_json(tmp_path: Path) -> None:
+    """Return `live_id` from a successful Errata API reserve POST."""
     mount = tmp_path / "errata"
     _write_errata_mount(mount)
     krb5 = tmp_path / "k5.conf"
@@ -98,6 +101,7 @@ def test_reserve_errata_live_id_posts_json(tmp_path: Path) -> None:
 
 
 def test_reserve_errata_live_id_krb5_read_error(tmp_path: Path) -> None:
+    """Wrap Kerberos setup failures in `CheckStepError`."""
     mount = tmp_path / "errata"
     _write_errata_mount(mount)
     missing = tmp_path / "missing.conf"
@@ -112,6 +116,7 @@ def test_reserve_errata_live_id_krb5_read_error(tmp_path: Path) -> None:
 
 
 def test_reserve_errata_live_id_request_failure_logs_stderr(tmp_path: Path) -> None:
+    """Append reserve POST failures to the optional stderr log."""
     mount = tmp_path / "errata"
     _write_errata_mount(mount)
     krb5 = tmp_path / "k5.conf"
@@ -134,6 +139,7 @@ def test_reserve_errata_live_id_request_failure_logs_stderr(tmp_path: Path) -> N
 
 
 def test_reserve_errata_live_id_missing_live_id(tmp_path: Path) -> None:
+    """Fail when the Errata API response omits `live_id`."""
     mount = tmp_path / "errata"
     _write_errata_mount(mount)
     krb5 = tmp_path / "k5.conf"
@@ -161,24 +167,27 @@ def test_reserve_errata_live_id_missing_live_id(tmp_path: Path) -> None:
 
 
 def test_clone_advisory_repo(tmp_path: Path, creds: gitlab.GitLabCredentials) -> None:
+    """Sparse-clone the advisory repo and return its root and tenant base path."""
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "data" / "advisories" / "tenant").mkdir(parents=True)
     with mock.patch("create_advisory.gitlab.clone_project_sparse", return_value=repo):
-        root, base = create_advisory._clone_advisory_repo(
+        out_repo_root, base = create_advisory._clone_advisory_repo(
             creds, "tenant", tmp_path, stderr_path=tmp_path / "e.log"
         )
-    assert root == repo
+    assert out_repo_root == repo
     assert base == repo / "data" / "advisories" / "tenant"
 
 
 def test_write_initial_content_file(tmp_path: Path) -> None:
+    """Write the content list slice from decoded advisory JSON to a temp file."""
     decoded = {"content": {"images": [{"a": 1}]}}
     path = create_advisory._write_initial_content_file(tmp_path, decoded, ".content.images")
     assert json.loads(path.read_text(encoding="utf-8")) == [{"a": 1}]
 
 
 def test_customer_portal_url() -> None:
+    """Build the customer portal errata URL from type and advisory id."""
     assert (
         create_advisory._customer_portal_url(
             "https://access.redhat.com/errata", "RHSA", "2025:1"
@@ -188,6 +197,7 @@ def test_customer_portal_url() -> None:
 
 
 def test_write_success_results(tmp_path: Path) -> None:
+    """Write Success and portal URLs to Tekton result files."""
     paths = {
         "result": tmp_path / "r",
         "advisory_url": tmp_path / "u",
@@ -203,6 +213,7 @@ def test_write_success_results(tmp_path: Path) -> None:
 
 
 def test_finish_if_all_content_already_published_true(tmp_path: Path) -> None:
+    """Return True and write results when all content is already published."""
     repo = tmp_path / "repo"
     base = repo / "data" / "advisories" / "t" / "2025" / "0001"
     base.mkdir(parents=True)
@@ -239,6 +250,7 @@ def test_finish_if_all_content_already_published_true(tmp_path: Path) -> None:
 
 
 def test_finish_if_all_content_already_published_false(tmp_path: Path) -> None:
+    """Return False when no existing advisory covers the requested content."""
     repo = tmp_path / "repo"
     base = repo / "data" / "advisories" / "t"
     base.mkdir(parents=True)
@@ -265,6 +277,7 @@ def test_finish_if_all_content_already_published_false(tmp_path: Path) -> None:
 
 
 def test_finish_raises_when_no_latest_path(tmp_path: Path) -> None:
+    """Fail when idempotency cannot resolve a latest advisory path."""
     repo = tmp_path / "repo"
     base = repo / "data" / "advisories" / "t" / "2025" / "0001"
     base.mkdir(parents=True)
@@ -295,6 +308,7 @@ def test_finish_raises_when_no_latest_path(tmp_path: Path) -> None:
 
 
 def test_build_merged_advisory_with_signing_key(tmp_path: Path) -> None:
+    """Merge content and attach the signing key from the config map."""
     content = tmp_path / "c.json"
     content.write_text(json.dumps([{"a": 1}]), encoding="utf-8")
     decoded = {"type": "RHSA", "content": {"images": []}}
@@ -320,6 +334,7 @@ def test_build_merged_advisory_with_signing_key_empty_fails(tmp_path: Path) -> N
 
 
 def test_resolve_live_id_from_decoded() -> None:
+    """Use `live_id` from decoded advisory JSON when present."""
     assert (
         create_advisory._resolve_live_id_number(
             {"live_id": 7},
@@ -332,6 +347,7 @@ def test_resolve_live_id_from_decoded() -> None:
 
 
 def test_resolve_live_id_reserves(tmp_path: Path) -> None:
+    """Reserve a new live id via Errata when decoded JSON has none."""
     mount = tmp_path / "errata"
     _write_errata_mount(mount)
     with mock.patch("create_advisory._reserve_errata_live_id", return_value=99) as reserve:
@@ -346,17 +362,24 @@ def test_resolve_live_id_reserves(tmp_path: Path) -> None:
 
 
 def test_ensure_advisory_number_unused_raises(tmp_path: Path) -> None:
+    """Fail when the advisory number already exists on `origin/main`."""
+    listing = tmp_path / "origin_ls_tree.txt"
     with mock.patch(
-        "create_advisory.git.origin_ls_tree_name_only",
-        return_value="data/advisories/t/2025/0042/advisory.yaml\n",
+        "create_advisory.git.origin_main_has_path_matching",
+        return_value=True,
     ):
         with pytest.raises(ValueError, match="already exists"):
             create_advisory._ensure_advisory_number_unused(
-                tmp_path, "2025", "0042", stderr_path=tmp_path / "e.log"
+                tmp_path,
+                "2025",
+                "0042",
+                listing,
+                stderr_path=tmp_path / "e.log",
             )
 
 
 def test_render_and_validate_advisory_yaml(tmp_path: Path) -> None:
+    """Render advisory YAML from the template and pass schema validation."""
     repo = tmp_path / "repo"
     schema_dir = repo / "schema"
     schema_dir.mkdir(parents=True)
@@ -388,6 +411,7 @@ def test_render_and_validate_advisory_yaml(tmp_path: Path) -> None:
 
 
 def test_render_and_validate_schema_failure(tmp_path: Path) -> None:
+    """Fail schema validation and log the invalid advisory YAML."""
     repo = tmp_path / "repo"
     (repo / "schema").mkdir(parents=True)
     (repo / "schema" / "advisory.json").write_text(
@@ -418,16 +442,23 @@ def test_render_and_validate_schema_failure(tmp_path: Path) -> None:
 
 
 def test_commit_and_push_new_advisory(tmp_path: Path) -> None:
-    with mock.patch("create_advisory.git.index_add_commit") as add:
-        with mock.patch("create_advisory.git.push") as push:
-            create_advisory._commit_and_push_new_advisory(
-                tmp_path, "path/y.yaml", "grp", stderr_path=tmp_path / "e.log"
-            )
-    add.assert_called_once()
-    push.assert_called_once()
+    """Commit the new advisory file and push to the default branch."""
+    with mock.patch("create_advisory.git.commit_and_push") as commit_push:
+        create_advisory._commit_and_push_new_advisory(
+            tmp_path, "path/y.yaml", "grp", stderr_path=tmp_path / "e.log"
+        )
+    commit_push.assert_called_once_with(
+        tmp_path,
+        ["path/y.yaml"],
+        "[Konflux Release] new advisory for grp",
+        gitlab.DEFAULT_BRANCH,
+        retries=5,
+        stderr_path=tmp_path / "e.log",
+    )
 
 
 def test_create_new_advisory(tmp_path: Path, creds: gitlab.GitLabCredentials) -> None:
+    """Render, commit, and write success results for a new advisory."""
     repo = tmp_path / "repo"
     base = repo / "data" / "advisories" / "t"
     base.mkdir(parents=True)
@@ -463,6 +494,7 @@ def test_create_new_advisory(tmp_path: Path, creds: gitlab.GitLabCredentials) ->
 def test_run_create_advisory_idempotent_early_return(
     tmp_path: Path, creds: gitlab.GitLabCredentials
 ) -> None:
+    """Stop after idempotency when all content is already published."""
     secret = tmp_path / "gitlab"
     _write_gitlab_secret(secret)
     errata = tmp_path / "errata"
@@ -477,7 +509,10 @@ def test_run_create_advisory_idempotent_early_return(
     with mock.patch("create_advisory.gitlab.read_credentials_from_mount", return_value=creds):
         with mock.patch(
             "create_advisory._clone_advisory_repo",
-            return_value=(tmp_path / "repo", tmp_path / "repo" / "data" / "advisories" / "t"),
+            return_value=(
+                tmp_path / "repo",
+                tmp_path / "repo" / "data" / "advisories" / "t",
+            ),
         ):
             with mock.patch(
                 "create_advisory._finish_if_all_content_already_published",
@@ -503,6 +538,7 @@ def test_run_create_advisory_idempotent_early_return(
 def test_run_create_advisory_full_create_path(
     tmp_path: Path, creds: gitlab.GitLabCredentials
 ) -> None:
+    """Run the full create path when idempotency does not apply."""
     secret = tmp_path / "gitlab"
     _write_gitlab_secret(secret)
     errata = tmp_path / "errata"
@@ -573,12 +609,14 @@ def _setup_main_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str
 
 
 def test_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exit zero when the advisory workflow completes successfully."""
     _setup_main_env(tmp_path, monkeypatch)
     with mock.patch("create_advisory.run_create_advisory"):
         assert create_advisory.main(["create_advisory.py"]) == 0
 
 
 def test_main_writes_failure_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write workflow errors to the Tekton result file and exit zero."""
     paths = _setup_main_env(tmp_path, monkeypatch)
     with mock.patch(
         "create_advisory.run_create_advisory",
@@ -590,6 +628,7 @@ def test_main_writes_failure_result(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
 
 def test_main_check_step_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Include the `CheckStepError` action in the Tekton failure result."""
     paths = _setup_main_env(tmp_path, monkeypatch)
     err = tekton.CheckStepError("reading secrets", OSError("no mount"))
     with mock.patch("create_advisory.run_create_advisory", side_effect=err):
@@ -853,14 +892,12 @@ def test_run_create_advisory_clone_failure(
     _write_gitlab_secret(secret)
     errata = tmp_path / "errata"
     _write_errata_mount(errata)
-    import git as gitpython
-
     with mock.patch("create_advisory.gitlab.read_credentials_from_mount", return_value=creds):
         with mock.patch(
             "create_advisory._clone_advisory_repo",
-            side_effect=gitpython.exc.GitCommandError("clone", "failing-tenant"),
+            side_effect=subprocess.CalledProcessError(1, "git clone"),
         ):
-            with pytest.raises(gitpython.exc.GitCommandError):
+            with pytest.raises(subprocess.CalledProcessError):
                 create_advisory.run_create_advisory(
                     advisory_secret=secret,
                     errata_mount=errata,
@@ -1237,29 +1274,28 @@ def test_run_create_advisory_happy_path_writes_portal_url(
                         "create_advisory._reserve_errata_live_id", return_value=1234
                     ):
                         with mock.patch(
-                            "create_advisory.git.origin_ls_tree_name_only",
-                            return_value="",
+                            "create_advisory.git.origin_main_has_path_matching",
+                            return_value=False,
                         ):
                             with mock.patch.object(
                                 create_advisory, "ADVISORY_TEMPLATE_PATH", template
                             ):
-                                with mock.patch("create_advisory.git.index_add_commit"):
-                                    with mock.patch("create_advisory.git" ".push"):
-                                        create_advisory.run_create_advisory(
-                                            advisory_secret=secret,
-                                            errata_mount=errata,
-                                            stderr_path=tmp_path / "e.log",
-                                            result_paths=results,
-                                            params={
-                                                "component_group": "test-app",
-                                                "origin": "not-existing-origin",
-                                                "config_map_name": "cm",
-                                                "content_type": "image",
-                                                "internal_request_pr_name": "pr",
-                                                "task_run_name": "tr",
-                                            },
-                                            decoded=decoded,
-                                        )
+                                with mock.patch("create_advisory.git.commit_and_push"):
+                                    create_advisory.run_create_advisory(
+                                        advisory_secret=secret,
+                                        errata_mount=errata,
+                                        stderr_path=tmp_path / "e.log",
+                                        result_paths=results,
+                                        params={
+                                            "component_group": "test-app",
+                                            "origin": "not-existing-origin",
+                                            "config_map_name": "cm",
+                                            "content_type": "image",
+                                            "internal_request_pr_name": "pr",
+                                            "task_run_name": "tr",
+                                        },
+                                        decoded=decoded,
+                                    )
     assert results["result"].read_text(encoding="utf-8") == "Success"
     url = results["advisory_url"].read_text(encoding="utf-8")
     assert url.startswith("https://access.redhat.com/errata/RHSA-")


### PR DESCRIPTION
This commit drops GitPython in some git functions in favor of using the git cli. In testing, it is showing that GitPython is very memory intensive for some operations, which doesn't work well for tekton tasks.

Assisted-By: Cursor