### PR TITLE
feat(RELEASE-1987): add get_advisory_severity.py script

### DIFF
--- a/docs/tasks/internal/get_advisory_severity.md
+++ b/docs/tasks/internal/get_advisory_severity.md
@@ -1,0 +1,220 @@
+# get_advisory_severity.py
+
+Computes the **highest advisory severity** for an RHSA by querying OSIDB for every fixed CVE on each release-note image, then writing a title-cased level (e.g. `Critical`) to Tekton results.
+
+Source: [`get_advisory_severity.py`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py)
+
+**Read this first:** On a normal Tekton run with all env vars set, the process **returns 0** even when severity lookup failed. Pass/fail is in **`result`**; the severity string is in **`severity`**. If required env vars are missing, [`main`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L383-L414) prints to stderr and exits **1** before writing results.
+
+Logs go to **stderr** as `INFO:` / `WARNING:` lines ([`logger`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/logger.py)).
+
+---
+
+## How a release triggers this
+
+Catalog task [`set-advisory-severity`](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/managed/set-advisory-severity/set-advisory-severity.yaml) step **`set-severity`**:
+
+1. Reads `data.json`. **Skips** the internal check when:
+   - `releaseNotes.type` is not `RHSA` ([L136-L142](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/managed/set-advisory-severity/set-advisory-severity.yaml#L136-L142))
+   - `releaseNotes.content.artifacts` is non-empty ([L164-L167](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/managed/set-advisory-severity/set-advisory-severity.yaml#L164-L167))
+2. For RHSA with **images only**, builds `releaseNotesImages`: `jq -c '.releaseNotes.content.images' | gzip | base64` ([L169](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/managed/set-advisory-severity/set-advisory-severity.yaml#L169)).
+3. Runs `internal-request --pipeline get-advisory-severity ... -s true` and **waits** for the internal pipeline ([L174-L184](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/managed/set-advisory-severity/set-advisory-severity.yaml#L174-L184)).
+4. **After** the wait, reads `status.results`. On `result == Success`, sets `releaseNotes.severity` from `.severity` ([L189-L200](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/managed/set-advisory-severity/set-advisory-severity.yaml#L189-L200)).
+
+On internal-services, pipeline [`get-advisory-severity`](https://github.com/konflux-ci/release-service-catalog/blob/development/pipelines/internal/get-advisory-severity/get-advisory-severity.yaml) runs catalog task [`get-advisory-severity`](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/internal/get-advisory-severity/get-advisory-severity.yaml). That task should invoke this Python script with the env vars in [Tekton env (Python step)](#tekton-env-python-step).
+
+```mermaid
+sequenceDiagram
+  participant SS as set-advisory-severity<br/>set-severity
+  participant IR as InternalRequest
+  participant TR as get-advisory-severity<br/>(this script)
+  participant DB as OSIDB
+
+  SS->>IR: internal-request creates IR
+  IR->>TR: pipeline on internal-services
+  TR->>DB: kinit + parallel flaw GETs
+  TR-->>IR: result, severity, IR names
+  Note over IR: status.results when<br/>pipeline completes
+  IR-->>SS: internal-request -s true returns
+  SS->>IR: kubectl get .status.results
+  alt .result == Success
+    SS->>SS: jq sets releaseNotes.severity
+  else
+    SS->>SS: exit 1
+  end
+```
+
+`status.results` is only meaningful **after** `internal-request` returns. InternalRequest name: `done (<name>)` in `set-severity` logs.
+
+```bash
+kubectl get internalrequest "<name>" -o jsonpath='{.status.results}'
+```
+
+On failure, `set-severity` logs **`The InternalRequest to find the severity was unsuccessful`** and prints `.result` — read that string, not only the banner.
+
+### Tekton env (Python step)
+
+When the catalog step runs this script (same contract as [`get-advisory-severity` results](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/internal/get-advisory-severity/get-advisory-severity.yaml#L30-L38)):
+
+| Env var | Source |
+|---------|--------|
+| `IMAGES_ENCODED` | `$(params.releaseNotesImages)` |
+| `RESULT_RESULT` | `$(results.result.path)` |
+| `RESULT_SEVERITY` | `$(results.severity.path)` |
+| `RESULT_INTERNAL_REQUEST_PIPELINE_RUN_NAME` | `$(results.internalRequestPipelineRunName.path)` |
+| `RESULT_INTERNAL_REQUEST_TASK_RUN_NAME` | `$(results.internalRequestTaskRunName.path)` |
+| `PARAM_INTERNAL_REQUEST_PIPELINE_RUN_NAME` | `$(params.internalRequestPipelineRunName)` |
+| `PARAM_TASK_RUN_NAME` | `$(context.taskRun.name)` |
+| OSIDB mount | `/mnt/osidb-service-account` (secret `osidb-service-account`) |
+
+[`internal_request.write_result_paths`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/internal_request.py#L9-L22) writes the pipeline and task run names at the start of [`run_get_advisory_severity`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L310-L314).
+
+---
+
+## Severity rules
+
+Constants: [`_SEVERITY_LEVELS`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L42-L43) — `CRITICAL`, `IMPORTANT`, `MODERATE`, `LOW` (order = rank).
+
+For each **image** and each **fixed CVE** on that image:
+
+1. Load flaw JSON from the parallel fetch cache.
+2. [`resolve_impact_for_repository`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L116-L134): start with flaw-level `impact`; if [`find_matching_purl`](https://github.com/konflux-ci/release-service-utils/blob/main/utils/find_matching_purl.py) finds a row in `affects` whose `purl` matches `image.repository`, use that row’s `impact` when non-empty.
+3. [`higher_severity`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L81-L88) keeps the maximum across all image/CVE pairs.
+
+Output: [`run_get_advisory_severity`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L358-L359) writes `highest.lower().capitalize()` to `severity` (e.g. `CRITICAL` → `Critical`) and `Success` to `result`.
+
+If nothing yields a known level, [`CheckStepError`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L369-L373) with message [`_NO_SEVERITY_MSG`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L43): `Unable to find severity on any cve listed in the releaseNotes`.
+
+---
+
+## What each part of the code does
+
+### Input: [`decode_release_notes_images`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L47-L58)
+
+Decodes `IMAGES_ENCODED`: base64 → gzip decompress (max [`32 MiB`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L44-L53) decompressed) → JSON **array** of image dicts. Wrong shape raises `ValueError`.
+
+### CVE list: [`unique_fixed_cves`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L61-L78)
+
+Walks each image’s `cves.fixed` keys; returns unique ids in first-seen order. Images without `cves.fixed` contribute nothing.
+
+### OSIDB fetch: [`fetch_flaw_record`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L137-L162)
+
+GET `{osidb_url}/osidb/api/v2/flaws?cve_id=…&include_fields=cve_id,impact,affects.purl,affects.impact` ([`_FLAW_INCLUDE_FIELDS`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L39)).
+
+Requires non-empty body and `results[0]` dict; otherwise `ValueError` (`empty OSIDB response`, `no OSIDB flaw row`, etc.).
+
+### Token retry: [`fetch_flaw_with_token_retry`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L165-L192)
+
+On `401`/`403` or parse/empty-body errors, logs **`WARNING: OSIDB query for {cve} failed (…), refreshing token`**, gets a new token, retries **once**. Does not retry on 5xx.
+
+### Parallel batches: [`fetch_flaws_parallel`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L226-L261) and [`_process_cve_batch`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L195-L223)
+
+- Splits CVE ids into batches of [`_BATCH_SIZE` (30)](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L40).
+- Up to [`_MAX_PARALLEL_BATCHES` (8)](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L41) batches at once via `ThreadPoolExecutor`.
+- Each batch: one `get_access_token`, then sequential CVE fetches into a shared cache (lock-protected).
+- Logs: `Processing N unique CVE(s) in M batch(es)` → per-batch `getting token` / `processing CVE` / `completed` → `All CVE data retrieved`.
+- If `cve_ids` is empty, returns `{}` immediately (**no** `Processing N unique CVE(s)` line).
+
+### Aggregate: [`highest_severity_for_images`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L264-L294)
+
+Loops images and fixed CVEs; logs `Checking CVE {id} for component with repository {repo}`; returns highest impact string (may be `""`).
+
+### Orchestration: [`run_get_advisory_severity`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L297-L380)
+
+1. Write internal-request name results.
+2. Decode images, collect CVE ids.
+3. Load OSIDB mount (`name`, `base64_keytab`, `osidb_url`), temp keytab/ccache/krb5, [`kinit_with_retry`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L352-L356) once per run.
+4. [`fetch_flaws_parallel`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L358-L363).
+5. [`highest_severity_for_images`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L364-L376) → write `severity` + `Success` to result paths.
+6. `finally`: delete temp krb5 files.
+
+### CLI: [`main`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L383-L432)
+
+Loads result paths and required env; clears `severity` before the run ([L387](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L387)). On exception, [`write_failure_result`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/tekton.py#L67-L101) with `workflow_action="computing advisory severity"` and `command_log_path=None` ([L406-L412](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L406-L412)); always [`return 0`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L413).
+
+### Stdout vs results
+
+| Channel | Success | Failure |
+|---------|---------|---------|
+| stderr | `INFO:` / `WARNING:` progress lines | same; no guaranteed final ERROR line |
+| `result` | `Success` | `get_advisory_severity.py: Failed while …` |
+| `severity` | e.g. `Critical` | cleared at start; often empty on failure |
+
+---
+
+## Troubleshooting
+
+Compare internal `get-advisory-severity` step **stderr** (`INFO:` / `WARNING:`) with:
+
+```bash
+kubectl get internalrequest "<name>" -o jsonpath='{.status.results}'
+```
+
+A **Succeeded** step with `result` ≠ `Success` is normal for handled failures.
+
+### Stale or expired Kerberos credentials
+
+Same model as other OSIDB tasks: secret holds a **keytab**, not a reusable ticket. Each run does fresh [`kinit`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L352-L356) from `base64_keytab`.
+
+| Symptom | Meaning |
+|---------|---------|
+| No `INFO: Processing … unique CVE(s)` lines; `result` has `Failed while logging in with Kerberos (kinit)` | Expired/wrong keytab or principal in `osidb-service-account` |
+| `INFO: Processing …` then `WARNING: OSIDB query … refreshing token` then failure on token | Often 401/403; if run still fails, read full `result` (may be empty body / no flaw row, not kinit) |
+| `INFO: Checking CVE …` on later CVEs then `Failed while getting` / HTTP in `result` | Possible ticket expiry mid-run (rare); refresh keytab |
+
+### OSIDB down, slow, or unreachable
+
+Not the same as “no severity found.”
+
+| Symptom | Meaning |
+|---------|---------|
+| Stuck after `INFO: Batch X: getting token` or `processing CVE` | OSIDB auth/API slow or down; 60s HTTP timeout per GET ([`http_client`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/http_client.py#L66)); retries on 5xx/429 |
+| `result` contains `Failed while computing advisory severity:` with connection/timeout/503 | Hard outage after retries — `severity` empty |
+| `Failed while determining advisory severity from release notes: Unable to find severity…` | OSIDB may be up but no usable **impact** in responses (or no fixed CVEs) — see below |
+
+Empty HTTP body / missing flaw row raises inside fetch → wrapped as `computing advisory severity`, not the “Unable to find severity” message.
+
+### InternalRequest timeout
+
+If `internal-request` fails before the pipeline finishes, `set-severity` may fail without useful `status.results` from this script (orchestration / `requestTimeout`, stuck pipeline).
+
+### By last stderr line (`INFO:` / `WARNING:`)
+
+| Last line pattern | Likely issue |
+|-------------------|--------------|
+| *(no app `INFO:` lines)* | Missing env (`SystemExit` — step Failed) **or** zero fixed CVEs → empty highest severity |
+| `INFO: Processing N unique CVE(s) in M batch(es)` then failure | OSIDB/auth during batch phase — read `result` |
+| `INFO: Batch X: getting token` (hang) | Token endpoint / Kerberos / network |
+| `WARNING: OSIDB query for CVE-… failed (…), refreshing token` | One retry; check if run still ends `Success` |
+| `INFO: All CVE data retrieved` then `INFO: Checking CVE …` then failure | Impacts missing/unknown or repo/purl mismatch — see `result` for `Unable to find severity` |
+| Last `INFO: Checking CVE … for component with repository …` | Same — OSIDB data or matching logic |
+
+### By `status.results.result`
+
+| `.result` | `.severity` | Likely issue |
+|-----------|-------------|--------------|
+| `Success` | `Critical` / `Important` / … | OK |
+| `Failed while reading the mounted OSIDB service account` | empty | Secret mount / files |
+| `Failed while reading the Kerberos configuration` | empty | `/etc/krb5.conf` |
+| `Failed while logging in with Kerberos (kinit)` | empty | [Stale keytab](#stale-or-expired-kerberos-credentials) |
+| `Failed while determining advisory severity from release notes: Unable to find severity on any cve listed in the releaseNotes` | empty | No qualifying impacts (includes images with no `cves.fixed`) |
+| `Failed while computing advisory severity:` + decode/OSIDB/HTTP text | empty | [OSIDB down](#osidb-down-slow-or-unreachable), bad `releaseNotesImages`, >32MiB gzip payload, invalid JSON array |
+
+### `set-advisory-severity` messages (this script not run)
+
+| Log | Meaning |
+|-----|---------|
+| `Advisory is not of type RHSA` | Script not invoked |
+| `Generic artifact type detected, not setting advisory severity` | Script not invoked |
+| `Provided advisory type is RHSA, but no fixed CVEs were listed` | Fails **before** InternalRequest |
+| `The InternalRequest to find the severity was unsuccessful` | Read full `.result` from IR |
+
+---
+
+## Tests and related files
+
+| Item | Link |
+|------|------|
+| Unit tests | [`test_get_advisory_severity.py`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/test_get_advisory_severity.py) |
+| Purl matching | [`find_matching_purl.py`](https://github.com/konflux-ci/release-service-utils/blob/main/utils/find_matching_purl.py) |
+| Helpers | [`authentication`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/authentication.py), [`osidb`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/osidb.py), [`http_client`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/http_client.py), [`tekton`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/tekton.py), [`internal_request`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/internal_request.py) |

--- a/scripts/python/helpers/file.py
+++ b/scripts/python/helpers/file.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import gzip
+import io
 import os
 import tempfile
 from pathlib import Path
@@ -18,6 +20,9 @@ def load_json_dict(path: Path) -> dict[str, Any]:
         msg = f"JSON root must be an object: {path}"
         raise TypeError(msg)
     return data
+
+
+_GZIP_READ_CHUNK_SIZE = 64 * 1024
 
 
 def sha256(path: Path) -> str:
@@ -73,3 +78,22 @@ def make_tempfile_path(
     finally:
         os.close(fd)
     return Path(name)
+
+
+def decompress_gzip_bounded(data: bytes, *, max_bytes: int) -> bytes:
+    """Decompress gzip *data* in chunks.
+
+    Reads at most *max_bytes* of output; raises `ValueError` if the
+    decompressed size would exceed that limit (gzip bomb protection).
+    """
+    output = bytearray()
+    with gzip.GzipFile(fileobj=io.BytesIO(data)) as gz_file:
+        while True:
+            chunk = gz_file.read(_GZIP_READ_CHUNK_SIZE)
+            if not chunk:
+                break
+            output.extend(chunk)
+            if len(output) > max_bytes:
+                msg = f"decompressed data exceeds {max_bytes} bytes (possible gzip bomb)"
+                raise ValueError(msg)
+    return bytes(output)

--- a/scripts/python/helpers/osidb.py
+++ b/scripts/python/helpers/osidb.py
@@ -14,6 +14,7 @@ helper from the ``http_client`` module.
 from __future__ import annotations
 
 import json
+import urllib.parse
 from typing import Any
 
 import http_client
@@ -21,9 +22,9 @@ from requests_kerberos import HTTPKerberosAuth, OPTIONAL
 
 
 def get_access_token(osidb_url: str) -> str:
-    """
-    Get a short-lived bearer string from the OSIDB ``/auth/token`` URL using
-    GSS/SPNEGO. You need a working Kerberos cache (for example from
+    """Get a short-lived bearer string from the OSIDB ``/auth/token`` URL.
+
+    Uses GSS/SPNEGO. You need a working Kerberos cache (for example from
     ``kinit`` / ``kinit_with_retry`` in ``authentication``). The response is
     JSON; this function returns the value of the top ``"access"`` string for
     use as ``Authorization: Bearer ...`` on later API calls. Raises
@@ -43,3 +44,28 @@ def get_access_token(osidb_url: str) -> str:
         err = f"no .access in token response: {data!r}"
         raise ValueError(err)
     return t if isinstance(t, str) else str(t)
+
+
+def fetch_flaw_response(
+    osidb_url: str,
+    token: str,
+    cve_id: str,
+    *,
+    include_fields: str,
+) -> str:
+    """GET OSIDB v2 flaws for *cve_id* and return the response body.
+
+    *include_fields* is passed through to the API as a comma-separated field
+    list (for example ``cve_id,embargoed``).
+    """
+    query = urllib.parse.urlencode(
+        [("cve_id", cve_id), ("include_fields", include_fields)],
+    )
+    url = f"{osidb_url.rstrip('/')}/osidb/api/v2/flaws?{query}"
+    return http_client.get_text(
+        url,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+    )

--- a/scripts/python/helpers/test_file.py
+++ b/scripts/python/helpers/test_file.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import gzip
 from pathlib import Path
 
 import file
@@ -78,3 +79,18 @@ def test_make_tempfile_path_with_bytes() -> None:
         assert p.read_bytes() == b"hello"
     finally:
         p.unlink(missing_ok=True)
+
+
+def test_decompress_gzip_bounded_roundtrip() -> None:
+    """Valid gzip input decompresses to the original bytes."""
+    raw = b'[{"repository": "foo"}]'
+    compressed = gzip.compress(raw)
+    assert file.decompress_gzip_bounded(compressed, max_bytes=1024) == raw
+
+
+def test_decompress_gzip_bounded_rejects_oversized_output() -> None:
+    """Decompression stops once output exceeds *max_bytes*."""
+    raw = b"x" * 5000
+    compressed = gzip.compress(raw)
+    with pytest.raises(ValueError, match="gzip bomb"):
+        file.decompress_gzip_bounded(compressed, max_bytes=1000)

--- a/scripts/python/helpers/test_osidb.py
+++ b/scripts/python/helpers/test_osidb.py
@@ -11,9 +11,10 @@ import osidb
 
 
 def test_get_access_token_returns_access_string() -> None:
-    """
-    A JSON body with a non-empty string ``access`` is returned, and the token URL
-    is ``{base}/auth/token`` (trailing slash on the base is stripped before join).
+    """Return a non-empty string ``access`` from a JSON body.
+
+    The token URL is ``{base}/auth/token`` (trailing slash on the base is
+    stripped before join).
     """
     with mock.patch("http_client.get_text", return_value='{"access": "tok-abc"}') as m:
         out = osidb.get_access_token("https://osidb.example.com/")
@@ -32,6 +33,23 @@ def test_get_access_token_rejects_empty_body() -> None:
             osidb.get_access_token("https://u")
     assert e.value
     assert "empty" in str(e.value) or "token" in str(e.value)
+
+
+def test_fetch_flaw_response_builds_url_and_headers() -> None:
+    """Flaws GET uses the v2 endpoint with bearer auth and include_fields."""
+    with mock.patch("http_client.get_text", return_value="{}") as get_text:
+        osidb.fetch_flaw_response(
+            "https://osidb.example/",
+            "tok-abc",
+            "CVE-2024-1",
+            include_fields="cve_id,embargoed",
+        )
+    get_text.assert_called_once()
+    url = get_text.call_args.args[0]
+    assert url.startswith("https://osidb.example/osidb/api/v2/flaws?")
+    assert "cve_id=CVE-2024-1" in url
+    assert "include_fields=cve_id%2Cembargoed" in url
+    assert get_text.call_args.kwargs["headers"]["Authorization"] == "Bearer tok-abc"
 
 
 @pytest.mark.parametrize("body", ['{"x": 1}', '{"access": ""}'])

--- a/scripts/python/tasks/internal/check_embargoed_cves.py
+++ b/scripts/python/tasks/internal/check_embargoed_cves.py
@@ -31,11 +31,9 @@ from pathlib import Path
 from typing import Any, Sequence
 
 import requests
-import urllib.parse
 
 import authentication
 import file
-import http_client
 import osidb
 import tekton
 
@@ -73,6 +71,8 @@ def is_embargoed_flaw_response(data: dict[str, Any]) -> bool:
 def _embargo_finding_result_text(program_name: str) -> str:
     """Build ``RESULT_RESULT`` text when listed CVEs are not clearly public.
 
+    Used when the run finished without a Python exception but the OSIDB API
+    indicates at least one listed CVE is embargoed or not clearly public.
     CVE ids are written to ``RESULT_EMBARGOED_CVES``; this string in
     ``RESULT_RESULT`` points readers there.
     """
@@ -89,14 +89,11 @@ def fetch_flaw_state(osidb_url: str, token: str, cve_id: str) -> dict[str, Any]:
     object, or an empty dict if the response body is empty (treated as no
     visible flaw for embargo decisions).
     """
-    q = urllib.parse.urlencode([("cve_id", cve_id), ("include_fields", "cve_id,embargoed")])
-    u = f"{osidb_url.rstrip('/')}/osidb/api/v2/flaws?{q}"
-    body = http_client.get_text(
-        u,
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {token}",
-        },
+    body = osidb.fetch_flaw_response(
+        osidb_url,
+        token,
+        cve_id,
+        include_fields="cve_id,embargoed",
     )
     if not body.strip():
         return {}

--- a/scripts/python/tasks/internal/get_advisory_severity.py
+++ b/scripts/python/tasks/internal/get_advisory_severity.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Compute advisory severity from release-notes images and OSIDB flaw data.
+
+* Reads OSIDB credentials from `/mnt/osidb-service-account/` (or
+  `OSIDB_SERVICE_ACCOUNT_MOUNT`): `name`, `base64_keytab`, `osidb_url`.
+* Decodes `IMAGES_ENCODED` (base64+gzip JSON array of release-note images).
+* Queries OSIDB for each fixed CVE, then returns the highest impact as a Tekton
+  result (title-cased, e.g. `Critical`).
+* Writes `RESULT_RESULT`, `RESULT_SEVERITY`, and internal-request result paths.
+* After a valid invocation with those env vars, always exits with status `0`;
+  success or failure is in the result files.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import subprocess
+import sys
+import threading
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+import authentication
+import file
+import internal_request
+import osidb
+import requests
+import tekton
+from find_matching_purl import find_matching_purl
+from logger import logger
+
+_FLAW_INCLUDE_FIELDS = "cve_id,impact,affects.purl,affects.impact"
+_BATCH_SIZE = 30
+_MAX_PARALLEL_BATCHES = 8
+_SEVERITY_LEVELS = ("CRITICAL", "IMPORTANT", "MODERATE", "LOW")
+_NO_SEVERITY_MSG = "Unable to find severity on any cve listed in the releaseNotes"
+_MAX_RELEASE_NOTES_DECOMPRESSED_BYTES = 32 * 1024 * 1024  # 32MB
+
+
+def decode_release_notes_images(encoded: str) -> list[dict[str, Any]]:
+    """Decode base64+gzip *encoded* JSON to a list of release-note image dicts."""
+    b64_decoded = base64.standard_b64decode(encoded.strip())
+    gzip_decoded = file.decompress_gzip_bounded(
+        b64_decoded,
+        max_bytes=_MAX_RELEASE_NOTES_DECOMPRESSED_BYTES,
+    )
+    data = json.loads(gzip_decoded.decode("utf-8"))
+    if not isinstance(data, list):
+        msg = "releaseNotesImages must be a JSON array"
+        raise ValueError(msg)
+    return data
+
+
+def unique_fixed_cves(images: Sequence[dict[str, Any]]) -> list[str]:
+    """Return unique CVE ids from each image's `cves.fixed` map (stable order)."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for image in images:
+        if not isinstance(image, dict):
+            continue
+        cves = image.get("cves")
+        if not isinstance(cves, dict):
+            continue
+        fixed = cves.get("fixed")
+        if not isinstance(fixed, dict):
+            continue
+        for cve_id in fixed:
+            if cve_id not in seen:
+                seen.add(cve_id)
+                ordered.append(str(cve_id))
+    return ordered
+
+
+def higher_severity(current: str, new: str) -> str:
+    """Return the higher of two OSIDB impact strings (CRITICAL down to LOW)."""
+    cur = (current or "").upper()
+    nxt = (new or "").upper()
+    for level in _SEVERITY_LEVELS:
+        if cur == level or nxt == level:
+            return level
+    return cur
+
+
+def purl_impact_entries(flaw: dict[str, Any]) -> list[dict[str, Any]]:
+    """Build `{purl, impact}` rows from a flaw's `affects` list."""
+    affects = flaw.get("affects")
+    if not isinstance(affects, list):
+        return []
+    rows: list[dict[str, Any]] = []
+    for affect in affects:
+        if not isinstance(affect, dict):
+            continue
+        purl = affect.get("purl")
+        if not purl or not isinstance(purl, str):
+            continue
+        impact = affect.get("impact")
+        rows.append({"purl": purl, "impact": impact if impact is not None else ""})
+    return rows
+
+
+def resolve_impact_for_repository(
+    flaw: dict[str, Any],
+    repository: str,
+    *,
+    find_purl_fn: Callable[[list[dict[str, Any]], str], str | None] = find_matching_purl,
+) -> str:
+    """Return the impact for *repository* on *flaw*.
+
+    Uses the flaw-level `impact` unless a matching affected-component purl
+    supplies a non-empty component impact.
+    """
+    general = flaw.get("impact")
+    impact = str(general).upper() if general is not None else ""
+    rows = purl_impact_entries(flaw)
+    if rows:
+        component_impact = find_purl_fn(rows, repository)
+        if component_impact:
+            impact = str(component_impact).upper()
+    return impact
+
+
+def fetch_flaw_record(osidb_url: str, token: str, cve_id: str) -> dict[str, Any]:
+    """GET one flaw from OSIDB v2 and return the first `results` row."""
+    body = osidb.fetch_flaw_response(
+        osidb_url,
+        token,
+        cve_id,
+        include_fields=_FLAW_INCLUDE_FIELDS,
+    )
+    if not body.strip():
+        msg = f"empty OSIDB response for {cve_id}"
+        raise ValueError(msg)
+    data: dict[str, Any] = json.loads(body)
+    results = data.get("results")
+    if not isinstance(results, list) or not results:
+        msg = f"no OSIDB flaw row for {cve_id}"
+        raise ValueError(msg)
+    first = results[0]
+    if first is None or not isinstance(first, dict):
+        msg = f"invalid OSIDB flaw row for {cve_id}"
+        raise ValueError(msg)
+    return first
+
+
+def fetch_flaw_with_token_retry(
+    osidb_url: str,
+    token: str,
+    cve_id: str,
+    *,
+    get_token: Callable[[str], str],
+    fetch_flaw: Callable[[str, str, str], dict[str, Any]] = fetch_flaw_record,
+) -> tuple[dict[str, Any], str]:
+    """Fetch one flaw; refresh the bearer token and retry once on failure."""
+    refresh_reason: str | None = None
+    try:
+        return fetch_flaw(osidb_url, token, cve_id), token
+    except requests.HTTPError as err:
+        # http_client.get_text() raises HTTPError for non-2xx; only auth failures
+        # should trigger a token refresh (not 5xx or other client errors).
+        response = err.response
+        status = response.status_code if response is not None else None
+        if status not in (401, 403):
+            raise
+        refresh_reason = f"HTTP {status}"
+    except OSError:
+        raise
+    except (ValueError, json.JSONDecodeError) as err:
+        # Empty body, bad JSON, or missing results may mean an expired token too.
+        refresh_reason = str(err)
+
+    # Both recoverable paths share one refresh-and-retry (no duplicate logic).
+    logger.warning(f"OSIDB query for {cve_id} failed ({refresh_reason}), refreshing token")
+    fresh_token = get_token(osidb_url)
+    return fetch_flaw(osidb_url, fresh_token, cve_id), fresh_token
+
+
+def _process_cve_batch(
+    batch_id: int,
+    cve_ids: Sequence[str],
+    osidb_url: str,
+    cache: dict[str, dict[str, Any]],
+    cache_lock: threading.Lock,
+    *,
+    get_token: Callable[[str], str],
+    fetch_flaw: Callable[[str, str, str], dict[str, Any]],
+) -> None:
+    """Fetch flaws for *cve_ids* into *cache* (one token per batch)."""
+    logger.info(f"Batch {batch_id}: getting token")
+    token = get_token(osidb_url)
+    logger.info(f"Batch {batch_id}: processing {len(cve_ids)} CVE(s)")
+    for cve_id in cve_ids:
+        with cache_lock:
+            if cve_id in cache:
+                continue
+        logger.info(f"Batch {batch_id}: processing CVE {cve_id}")
+        record, token = fetch_flaw_with_token_retry(
+            osidb_url,
+            token,
+            cve_id,
+            get_token=get_token,
+            fetch_flaw=fetch_flaw,
+        )
+        with cache_lock:
+            cache[cve_id] = record
+    logger.info(f"Batch {batch_id}: completed")
+
+
+def fetch_flaws_parallel(
+    osidb_url: str,
+    cve_ids: Sequence[str],
+    *,
+    get_token: Callable[[str], str],
+    fetch_flaw: Callable[[str, str, str], dict[str, Any]] = fetch_flaw_record,
+    batch_size: int = _BATCH_SIZE,
+    max_workers: int = _MAX_PARALLEL_BATCHES,
+) -> dict[str, dict[str, Any]]:
+    """Fetch flaw JSON for each CVE in parallel batches."""
+    if not cve_ids:
+        return {}
+    batches: list[list[str]] = []
+    for start in range(0, len(cve_ids), batch_size):
+        batches.append(list(cve_ids[start : start + batch_size]))
+    logger.info(f"Processing {len(cve_ids)} unique CVE(s) in {len(batches)} batch(es)")
+    cache: dict[str, dict[str, Any]] = {}
+    cache_lock = threading.Lock()
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = [
+            pool.submit(
+                _process_cve_batch,
+                batch_idx,
+                batch,
+                osidb_url,
+                cache,
+                cache_lock,
+                get_token=get_token,
+                fetch_flaw=fetch_flaw,
+            )
+            for batch_idx, batch in enumerate(batches)
+        ]
+        for future in as_completed(futures):
+            future.result()
+    logger.info("All CVE data retrieved")
+    return cache
+
+
+def highest_severity_for_images(
+    images: Sequence[dict[str, Any]],
+    flaw_cache: dict[str, dict[str, Any]],
+    *,
+    find_purl_fn: Callable[[list[dict[str, Any]], str], str | None] = find_matching_purl,
+) -> str:
+    """Return the highest impact across all fixed CVEs on all *images*."""
+    top_severity = ""
+    for image in images:
+        if not isinstance(image, dict):
+            continue
+        repository = image.get("repository", "")
+        repo_str = repository if isinstance(repository, str) else str(repository)
+        cves = image.get("cves")
+        if not isinstance(cves, dict):
+            continue
+        fixed = cves.get("fixed")
+        if not isinstance(fixed, dict):
+            continue
+        for cve_id in fixed:
+            if cve_id not in flaw_cache:
+                msg = f"CVE {cve_id} not found in cache"
+                raise ValueError(msg)
+            logger.info(f"Checking CVE {cve_id} for component with repository {repo_str}")
+            impact = resolve_impact_for_repository(
+                flaw_cache[cve_id],
+                repo_str,
+                find_purl_fn=find_purl_fn,
+            )
+            top_severity = higher_severity(top_severity, impact)
+    return top_severity
+
+
+def run_get_advisory_severity(
+    *,
+    images_encoded: str,
+    mount: Path,
+    result_paths: dict[str, Path],
+    pipeline_run_name: str,
+    task_run_name: str,
+    get_token: Callable[[str], str] = osidb.get_access_token,
+    fetch_flaw: Callable[[str, str, str], dict[str, Any]] = fetch_flaw_record,
+    find_purl_fn: Callable[..., str | None] = find_matching_purl,
+    krb5_template: Path = Path("/etc/krb5.conf"),
+) -> None:
+    """Query OSIDB and write the highest advisory severity to *result_paths*."""
+    internal_request.write_result_paths(
+        result_paths,
+        pipeline_run_name=pipeline_run_name,
+        task_run_name=task_run_name,
+    )
+
+    keytab_path: Path | None = None
+    ccache_path: Path | None = None
+    krb5_config_path: Path | None = None
+    try:
+        images = decode_release_notes_images(images_encoded)
+        cve_ids = unique_fixed_cves(images)
+
+        try:
+            principal, keytab_bytes, text = authentication.load_service_account(
+                mount,
+                ("osidb_url",),
+                principal_file="name",
+                keytab_b64_file="base64_keytab",
+            )
+        except (OSError, ValueError) as exc:
+            raise tekton.CheckStepError(
+                "reading the mounted OSIDB service account", exc
+            ) from exc
+        osidb_url = text["osidb_url"]
+
+        keytab_path = file.make_tempfile_path("keytab-", keytab_bytes)
+        ccache_path = file.make_tempfile_path("ccache-")
+        try:
+            krb5_source = krb5_template.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            raise tekton.CheckStepError("reading the Kerberos configuration", exc) from exc
+        krb5_config_path = file.make_tempfile_path(
+            "krb5-",
+            authentication.patch_krb5_config(krb5_source).encode("utf-8"),
+        )
+        kenv = {
+            "KRB5CCNAME": str(ccache_path),
+            "KRB5_CONFIG": str(krb5_config_path),
+        }
+        try:
+            authentication.kinit_with_retry(principal, keytab_path, kenv, max_attempts=5)
+        except subprocess.CalledProcessError as exc:
+            raise tekton.CheckStepError("logging in with Kerberos (kinit)", exc) from exc
+        os.environ.update(kenv)
+
+        flaw_cache = fetch_flaws_parallel(
+            osidb_url,
+            cve_ids,
+            get_token=get_token,
+            fetch_flaw=fetch_flaw,
+        )
+        highest = highest_severity_for_images(
+            images,
+            flaw_cache,
+            find_purl_fn=find_purl_fn,
+        )
+        if not highest:
+            raise tekton.CheckStepError(
+                "determining advisory severity from release notes",
+                ValueError(_NO_SEVERITY_MSG),
+            )
+        result_paths["severity"].write_text(highest.lower().capitalize(), encoding="utf-8")
+        result_paths["result"].write_text("Success", encoding="utf-8")
+    finally:
+        for temp_path in (keytab_path, ccache_path, krb5_config_path):
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+
+
+def main() -> int:
+    """CLI entry: write Tekton results and always return 0 on a normal run."""
+    (
+        path_result,
+        path_severity,
+        path_internal_pr,
+        path_internal_task_run,
+    ) = tekton.result_paths_from_env(
+        "RESULT_RESULT",
+        "RESULT_SEVERITY",
+        "RESULT_INTERNAL_REQUEST_PIPELINE_RUN_NAME",
+        "RESULT_INTERNAL_REQUEST_TASK_RUN_NAME",
+    )
+    result_paths = {
+        "result": path_result,
+        "severity": path_severity,
+        "internal_pr_name": path_internal_pr,
+        "internal_task_run_name": path_internal_task_run,
+    }
+    program_basename = str(Path(sys.argv[0]).name)
+
+    path_severity.write_text("", encoding="utf-8")
+
+    images_encoded = tekton.require_env("IMAGES_ENCODED")
+    mount = file.path_from_env_variable(
+        "OSIDB_SERVICE_ACCOUNT_MOUNT",
+        "/mnt/osidb-service-account",
+    )
+    pipeline_run_name = tekton.require_env("PARAM_INTERNAL_REQUEST_PIPELINE_RUN_NAME")
+    task_run_name = tekton.require_env("PARAM_TASK_RUN_NAME")
+
+    try:
+        run_get_advisory_severity(
+            images_encoded=images_encoded,
+            mount=mount,
+            result_paths=result_paths,
+            pipeline_run_name=pipeline_run_name,
+            task_run_name=task_run_name,
+        )
+    except Exception as exc:
+        tekton.write_failure_result(
+            path_result,
+            program_basename,
+            exc,
+            command_log_path=None,
+            workflow_action="computing advisory severity",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/internal/test_check_embargoed_cves.py
+++ b/scripts/python/tasks/internal/test_check_embargoed_cves.py
@@ -80,16 +80,16 @@ def test_is_embargoed_flaw_response(payload: dict, exp: bool) -> None:
 
 def test_fetch_flaw_state_empty_bodies() -> None:
     """An empty body from the flaws request is an empty result dict."""
-    with mock.patch("http_client.get_text", return_value="") as m:
+    with mock.patch("osidb.fetch_flaw_response", return_value="") as m:
         d = check_embargoed_cves.fetch_flaw_state("https://u", "t", "CVE-1")
-        m.assert_called()
+        m.assert_called_once()
     assert d == {}
 
 
 def test_fetch_flaw_state_parses_json_body() -> None:
     """A non-empty flaws body is parsed with `json.loads` and returned as a dict."""
     body = '{"results": [{"cve_id": "CVE-1", "embargoed": false}]}'
-    with mock.patch("http_client.get_text", return_value=body):
+    with mock.patch("osidb.fetch_flaw_response", return_value=body):
         out = check_embargoed_cves.fetch_flaw_state("https://u", "tok", "CVE-1")
     assert out == {"results": [{"cve_id": "CVE-1", "embargoed": False}]}
 
@@ -109,7 +109,7 @@ def test_parse_args_missing_cves() -> None:
 
 
 def test_parse_args_rejects_trailing_junk() -> None:
-    """argparse fails extra argv tokens (e.g. stray positionals) with exit 2."""
+    """Argparse fails extra argv tokens (e.g. stray positionals) with exit 2."""
     with pytest.raises(SystemExit) as e:
         check_embargoed_cves.parse_args(["--cves", "CVE-1", "extra"])
     assert e.value.code == 2
@@ -124,9 +124,9 @@ def test_parse_args_ok() -> None:
 def test_main_passes_service_account_mount_resolved_by_environ(
     sa_mount: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """
-    The mount directory passed to ``run_check`` is
-    ``path_from_env_variable("OSIDB_SERVICE_ACCOUNT_MOUNT", ...)`` (set vs default).
+    """``run_check`` receives the mount from ``path_from_env_variable``.
+
+    The env var is ``OSIDB_SERVICE_ACCOUNT_MOUNT`` (set vs default).
     """
     _setup_tekton_env(tmp_path, monkeypatch, sa_mount)
     seen: list[Path] = []
@@ -153,6 +153,7 @@ def test_main_passes_service_account_mount_resolved_by_environ(
 
 @pytest.fixture
 def sa_mount(tmp_path: Path) -> Path:
+    """Provide a temp directory with minimal OSIDB service-account files."""
     p = tmp_path / "m"
     _write_service_account(p)
     return p
@@ -312,10 +313,7 @@ def test_run_check_mixed_list_reports_embargoed_cve(sa_mount: Path, tmp_path: Pa
 def test_main_all_clear(
     sa_mount: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """
-    ``Success`` in ``RESULT_RESULT`` and an empty embargo list when
-    ``run_check`` finds no issues.
-    """
+    """Write ``Success`` when ``run_check`` finds no issues."""
     rpath, epath = _setup_tekton_env(tmp_path, monkeypatch, sa_mount)
     with mock.patch.object(
         check_embargoed_cves,
@@ -350,10 +348,7 @@ def test_main_cve_treated_inaccessible(
 def test_main_mixed_cves_one_reported_embargoed(
     sa_mount: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """
-    Single affected id is written to the embargo result, summary in the
-    other.
-    """
+    """Write one affected id to the embargo result and a summary to the other."""
     rpath, epath = _setup_tekton_env(tmp_path, monkeypatch, sa_mount)
     with mock.patch.object(
         check_embargoed_cves,
@@ -390,9 +385,9 @@ def test_main_kinit_failure_writes_subprocess_error(
 
 
 def test_main_arg_parse_returns_one() -> None:
-    """
-    ``main`` returns the same exit code as ``parse_args``/argparse (1 for
-    help, missing ``--cves``).
+    """``main`` returns the same exit code as ``parse_args``.
+
+    Covers exit 1 for help or missing ``--cves``.
     """
     assert check_embargoed_cves.main(["p"]) == 1
     assert check_embargoed_cves.main(["p", "-h"]) == 1

--- a/scripts/python/tasks/internal/test_get_advisory_severity.py
+++ b/scripts/python/tasks/internal/test_get_advisory_severity.py
@@ -1,0 +1,581 @@
+"""Tests for `get_advisory_severity`."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import runpy
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import requests
+import tekton
+
+try:
+    import requests_kerberos  # noqa: F401
+except ImportError:
+    kerberos_mod = mock.MagicMock()
+    kerberos_mod.HTTPKerberosAuth = mock.MagicMock
+    kerberos_mod.OPTIONAL = 1
+    sys.modules["requests_kerberos"] = kerberos_mod
+
+import get_advisory_severity
+
+
+def _gzip_b64(obj: object) -> str:
+    raw = json.dumps(obj).encode("utf-8")
+    return base64.standard_b64encode(gzip.compress(raw)).decode("ascii")
+
+
+def _write_osidb_mount(d: Path) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "name").write_text("svc/osidb", encoding="utf-8")
+    (d / "base64_keytab").write_text(
+        base64.b64encode(b"x").decode("ascii"),
+        encoding="utf-8",
+    )
+    (d / "osidb_url").write_text("https://osidb.example", encoding="utf-8")
+
+
+def _result_paths(tmp_path: Path) -> dict[str, Path]:
+    return {
+        "result": tmp_path / "result",
+        "severity": tmp_path / "severity",
+        "internal_pr_name": tmp_path / "internal_pr",
+        "internal_task_run_name": tmp_path / "internal_task",
+    }
+
+
+def _no_kinit(*_args: object, **_kwargs: object) -> None:
+    return None
+
+
+def _catalog_flaw_critical() -> dict:
+    return {
+        "impact": "CRITICAL",
+        "affects": [
+            {
+                "purl": "pkg:oci/kubernetes?repository_url=component&a=b",
+                "impact": "",
+            }
+        ],
+    }
+
+
+def _catalog_flaw_moderate() -> dict:
+    return {
+        "impact": "MODERATE",
+        "affects": [
+            {
+                "purl": "pkg:oci/kubernetes?repository_url=foo&a=b",
+                "impact": "LOW",
+            },
+            {
+                "purl": "pkg:oci/kubernetes?repository_url=component&a=b",
+                "impact": "IMPORTANT",
+            },
+            {"purl": "", "impact": "LOW"},
+        ],
+    }
+
+
+def _catalog_flaws() -> dict[str, dict]:
+    return {
+        "CVE-critical": _catalog_flaw_critical(),
+        "CVE-moderate": _catalog_flaw_moderate(),
+    }
+
+
+def _run_with_mocked_fetch(
+    tmp_path: Path,
+    images: str,
+    flaw_cache: dict[str, dict],
+) -> dict[str, Path]:
+    paths = _result_paths(tmp_path)
+    mount = tmp_path / "mount"
+    _write_osidb_mount(mount)
+    krb5 = tmp_path / "k5.conf"
+    krb5.write_text("[libdefaults]\n", encoding="utf-8")
+    with (
+        mock.patch(
+            "get_advisory_severity.authentication.kinit_with_retry",
+            side_effect=_no_kinit,
+        ),
+        mock.patch(
+            "get_advisory_severity.fetch_flaws_parallel",
+            return_value=flaw_cache,
+        ),
+    ):
+        get_advisory_severity.run_get_advisory_severity(
+            images_encoded=images,
+            mount=mount,
+            result_paths=paths,
+            pipeline_run_name="pr-1",
+            task_run_name="tr-1",
+            krb5_template=krb5,
+        )
+    return paths
+
+
+def test_unique_fixed_cves_skips_invalid_entries() -> None:
+    """Malformed image rows are skipped without raising."""
+    images = [
+        "not-a-dict",
+        {"cves": "not-a-dict"},
+        {"cves": {"fixed": "not-a-dict"}},
+        {"cves": {"fixed": {"CVE-1": {}}}},
+    ]
+    assert get_advisory_severity.unique_fixed_cves(images) == ["CVE-1"]
+
+
+def test_higher_severity_unknown_levels_returns_current() -> None:
+    """Unknown impact strings fall back to the current value."""
+    assert get_advisory_severity.higher_severity("UNKNOWN", "ALSO") == "UNKNOWN"
+
+
+def test_purl_impact_entries_skips_invalid_rows() -> None:
+    """Non-list affects and invalid affect rows are ignored."""
+    assert get_advisory_severity.purl_impact_entries({}) == []
+    flaw = {"affects": ["not-a-dict", {"purl": None}, {"purl": ""}]}
+    assert get_advisory_severity.purl_impact_entries(flaw) == []
+
+
+@pytest.mark.parametrize(
+    ("body", "match"),
+    [
+        ("", "empty OSIDB response"),
+        ('{"results": []}', "no OSIDB flaw row"),
+        ('{"results": [null]}', "invalid OSIDB flaw row"),
+        ('{"results": ["not-a-dict"]}', "invalid OSIDB flaw row"),
+    ],
+)
+def test_fetch_flaw_record_rejects_bad_response(body: str, match: str) -> None:
+    """`fetch_flaw_record` validates the OSIDB response body."""
+    with mock.patch("osidb.fetch_flaw_response", return_value=body):
+        with pytest.raises(ValueError, match=match):
+            get_advisory_severity.fetch_flaw_record("https://osidb", "tok", "CVE-x")
+
+
+def test_fetch_flaws_parallel_empty_cve_list() -> None:
+    """No CVE ids means no OSIDB calls and an empty cache."""
+    assert (
+        get_advisory_severity.fetch_flaws_parallel(
+            "https://osidb",
+            [],
+            get_token=lambda _url: pytest.fail("get_token must not be called"),
+        )
+        == {}
+    )
+
+
+def test_fetch_flaws_parallel_populates_cache() -> None:
+    """Parallel fetch stores one flaw record per CVE id."""
+    seen: list[str] = []
+
+    def _fetch(_url: str, _token: str, cve_id: str) -> dict:
+        seen.append(cve_id)
+        return {"impact": "MODERATE", "cve_id": cve_id}
+
+    cache = get_advisory_severity.fetch_flaws_parallel(
+        "https://osidb",
+        ["CVE-a", "CVE-b"],
+        get_token=lambda _url: "tok",
+        fetch_flaw=_fetch,
+        batch_size=1,
+        max_workers=2,
+    )
+    assert set(cache) == {"CVE-a", "CVE-b"}
+    assert set(seen) == {"CVE-a", "CVE-b"}
+
+
+def test_process_cve_batch_skips_cached_cve() -> None:
+    """A CVE already in the batch cache is not fetched again."""
+    cache = {"CVE-a": {"impact": "LOW"}}
+    cache_lock = threading.Lock()
+    fetch_calls: list[str] = []
+
+    def _fetch(_url: str, _token: str, cve_id: str) -> dict:
+        fetch_calls.append(cve_id)
+        return {"impact": "MODERATE"}
+
+    get_advisory_severity._process_cve_batch(
+        0,
+        ["CVE-a", "CVE-b"],
+        "https://osidb",
+        cache,
+        cache_lock,
+        get_token=lambda _url: "tok",
+        fetch_flaw=_fetch,
+    )
+    assert fetch_calls == ["CVE-b"]
+    assert cache["CVE-b"]["impact"] == "MODERATE"
+
+
+def test_highest_severity_skips_invalid_image_rows() -> None:
+    """Non-dict images and malformed cves maps are ignored."""
+    images = [
+        "skip",
+        {"repository": "foo", "cves": "skip"},
+        {"repository": "foo", "cves": {"fixed": "skip"}},
+    ]
+    assert get_advisory_severity.highest_severity_for_images(images, {}) == ""
+
+
+def test_highest_severity_raises_when_cve_missing_from_cache() -> None:
+    """A fixed CVE absent from the flaw cache raises `ValueError`."""
+    images = [{"repository": "foo", "cves": {"fixed": {"CVE-missing": {}}}}]
+    with pytest.raises(ValueError, match="not found in cache"):
+        get_advisory_severity.highest_severity_for_images(images, {})
+
+
+def test_run_krb5_template_read_error(tmp_path: Path) -> None:
+    """Missing krb5 template is wrapped as `CheckStepError`."""
+    paths = _result_paths(tmp_path)
+    mount = tmp_path / "mount"
+    _write_osidb_mount(mount)
+    missing_krb5 = tmp_path / "missing.conf"
+    with pytest.raises(tekton.CheckStepError, match="Kerberos"):
+        get_advisory_severity.run_get_advisory_severity(
+            images_encoded=_gzip_b64([{"repository": "foo", "cves": {}}]),
+            mount=mount,
+            result_paths=paths,
+            pipeline_run_name="pr-1",
+            task_run_name="tr-1",
+            krb5_template=missing_krb5,
+        )
+
+
+def test_module_main_guard_raises_system_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Executing the file as `__main__` exits via `SystemExit(main())`."""
+    _setup_main_env(tmp_path, monkeypatch)
+    monkeypatch.setattr("sys.argv", ["get_advisory_severity.py"])
+    with mock.patch("get_advisory_severity.run_get_advisory_severity"):
+        with pytest.raises(SystemExit) as exc:
+            runpy.run_path(
+                str(Path(get_advisory_severity.__file__)),
+                run_name="__main__",
+            )
+    assert exc.value.code == 0
+
+
+def test_decode_release_notes_images_roundtrip() -> None:
+    """Base64+gzip encoded release-notes JSON decodes to the original list."""
+    images = [{"repository": "foo", "cves": {"fixed": {"CVE-1": {"components": []}}}}]
+    encoded = _gzip_b64(images)
+    assert get_advisory_severity.decode_release_notes_images(encoded) == images
+
+
+def test_decode_release_notes_images_rejects_non_array() -> None:
+    """Non-array JSON after decode raises `ValueError`."""
+    with pytest.raises(ValueError, match="JSON array"):
+        get_advisory_severity.decode_release_notes_images(_gzip_b64({"x": 1}))
+
+
+def test_unique_fixed_cves_stable_order() -> None:
+    """CVE ids are deduplicated while preserving first-seen order."""
+    images = [
+        {"cves": {"fixed": {"CVE-b": {}, "CVE-a": {}}}},
+        {"cves": {"fixed": {"CVE-a": {}, "CVE-c": {}}}},
+    ]
+    assert get_advisory_severity.unique_fixed_cves(images) == ["CVE-b", "CVE-a", "CVE-c"]
+
+
+def test_higher_severity_picks_highest() -> None:
+    """`higher_severity` returns the more severe OSIDB impact string."""
+    assert get_advisory_severity.higher_severity("MODERATE", "CRITICAL") == "CRITICAL"
+    assert get_advisory_severity.higher_severity("CRITICAL", "LOW") == "CRITICAL"
+    assert get_advisory_severity.higher_severity("", "IMPORTANT") == "IMPORTANT"
+
+
+def test_resolve_impact_uses_general_when_component_empty() -> None:
+    """Empty component impact falls back to the flaw-level impact."""
+    impact = get_advisory_severity.resolve_impact_for_repository(
+        _catalog_flaw_critical(),
+        "component",
+    )
+    assert impact == "CRITICAL"
+
+
+def test_resolve_impact_uses_component_override() -> None:
+    """Matching component purl impact overrides the flaw-level impact."""
+    impact = get_advisory_severity.resolve_impact_for_repository(
+        _catalog_flaw_moderate(),
+        "component",
+    )
+    assert impact == "IMPORTANT"
+
+
+def test_highest_severity_catalog_happy_path() -> None:
+    """Critical flaw impact wins over moderate across catalog mock CVE data."""
+    images = get_advisory_severity.decode_release_notes_images(
+        _gzip_b64(
+            [
+                {
+                    "repository": "foo",
+                    "cves": {
+                        "fixed": {
+                            "CVE-critical": {"components": []},
+                            "CVE-moderate": {"components": []},
+                        }
+                    },
+                },
+            ]
+        )
+    )
+    cache = _catalog_flaws()
+    assert get_advisory_severity.highest_severity_for_images(images, cache) == "CRITICAL"
+
+
+def test_highest_severity_no_cves_returns_empty() -> None:
+    """Images with no fixed CVEs yield an empty highest-severity string."""
+    images = [{"repository": "component", "cves": {}}]
+    assert get_advisory_severity.highest_severity_for_images(images, {}) == ""
+
+
+def test_fetch_flaw_record_parses_first_result() -> None:
+    """OSIDB flaw JSON returns the first `results` row."""
+    body = json.dumps({"results": [{"impact": "CRITICAL", "cve_id": "CVE-1"}]})
+    with mock.patch("osidb.fetch_flaw_response", return_value=body):
+        row = get_advisory_severity.fetch_flaw_record("https://osidb", "tok", "CVE-1")
+    assert row["impact"] == "CRITICAL"
+
+
+def test_fetch_flaw_with_token_retry_refreshes_token() -> None:
+    """A failed flaw fetch refreshes the bearer token and retries once."""
+    fetch_calls: list[str] = []
+
+    def _fetch(_url: str, token: str, _cve_id: str) -> dict:
+        fetch_calls.append(token)
+        if len(fetch_calls) == 1:
+            raise ValueError("expired")
+        return {"impact": "LOW"}
+
+    record, token = get_advisory_severity.fetch_flaw_with_token_retry(
+        "https://osidb",
+        "old-token",
+        "CVE-1",
+        get_token=lambda _url: "fresh-token",
+        fetch_flaw=_fetch,
+    )
+    assert record["impact"] == "LOW"
+    assert token == "fresh-token"
+
+
+def test_fetch_flaw_with_token_retry_refreshes_on_http_401() -> None:
+    """HTTP 401 from OSIDB triggers a token refresh and one retry."""
+    fetch_calls: list[str] = []
+
+    def _fetch(_url: str, token: str, _cve_id: str) -> dict:
+        fetch_calls.append(token)
+        if len(fetch_calls) == 1:
+            response = requests.Response()
+            response.status_code = 401
+            raise requests.HTTPError(response=response)
+        return {"impact": "MODERATE"}
+
+    record, token = get_advisory_severity.fetch_flaw_with_token_retry(
+        "https://osidb",
+        "old-token",
+        "CVE-1",
+        get_token=lambda _url: "fresh-token",
+        fetch_flaw=_fetch,
+    )
+    assert record["impact"] == "MODERATE"
+    assert token == "fresh-token"
+    assert fetch_calls == ["old-token", "fresh-token"]
+
+
+def test_fetch_flaw_with_token_retry_does_not_refresh_on_os_error() -> None:
+    """Network failures are not retried with a refreshed token."""
+
+    def _fetch(_url: str, _token: str, _cve_id: str) -> dict:
+        raise OSError("connection refused")
+
+    with pytest.raises(OSError, match="connection refused"):
+        get_advisory_severity.fetch_flaw_with_token_retry(
+            "https://osidb",
+            "old-token",
+            "CVE-1",
+            get_token=lambda _url: pytest.fail("get_token must not be called"),
+            fetch_flaw=_fetch,
+        )
+
+
+def test_fetch_flaw_with_token_retry_does_not_refresh_on_http_500() -> None:
+    """Non-auth HTTP errors are not retried with a refreshed token."""
+    response = requests.Response()
+    response.status_code = 500
+
+    def _fetch(_url: str, _token: str, _cve_id: str) -> dict:
+        raise requests.HTTPError(response=response)
+
+    with pytest.raises(requests.HTTPError):
+        get_advisory_severity.fetch_flaw_with_token_retry(
+            "https://osidb",
+            "old-token",
+            "CVE-1",
+            get_token=lambda _url: pytest.fail("get_token must not be called"),
+            fetch_flaw=_fetch,
+        )
+
+
+def test_run_success_critical(tmp_path: Path) -> None:
+    """Catalog happy path writes `Success` and `Critical` severity."""
+    images = _gzip_b64(
+        [
+            {
+                "repository": "foo",
+                "cves": {
+                    "fixed": {
+                        "CVE-critical": {"components": []},
+                        "CVE-moderate": {"components": []},
+                    }
+                },
+            }
+        ]
+    )
+    paths = _run_with_mocked_fetch(tmp_path, images, _catalog_flaws())
+    assert paths["result"].read_text(encoding="utf-8") == "Success"
+    assert paths["severity"].read_text(encoding="utf-8") == "Critical"
+    assert paths["internal_pr_name"].read_text(encoding="utf-8") == "pr-1"
+
+
+def test_run_no_cves_raises(tmp_path: Path) -> None:
+    """Release notes with no fixed CVEs raise `CheckStepError`."""
+    images = _gzip_b64([{"repository": "component", "cves": {}}])
+    paths = _result_paths(tmp_path)
+    mount = tmp_path / "mount"
+    _write_osidb_mount(mount)
+    krb5 = tmp_path / "k5.conf"
+    krb5.write_text("[libdefaults]\n", encoding="utf-8")
+    with (
+        mock.patch(
+            "get_advisory_severity.authentication.kinit_with_retry",
+            side_effect=_no_kinit,
+        ),
+        mock.patch("get_advisory_severity.fetch_flaws_parallel", return_value={}),
+    ):
+        with pytest.raises(tekton.CheckStepError, match="Unable to find severity"):
+            get_advisory_severity.run_get_advisory_severity(
+                images_encoded=images,
+                mount=mount,
+                result_paths=paths,
+                pipeline_run_name="pr-1",
+                task_run_name="tr-1",
+                krb5_template=krb5,
+            )
+
+
+def test_run_component_important(tmp_path: Path) -> None:
+    """Component purl override yields `Important` for a moderate CVE."""
+    images = _gzip_b64(
+        [
+            {
+                "repository": "component",
+                "cves": {"fixed": {"CVE-moderate": {"components": []}}},
+            }
+        ]
+    )
+    paths = _run_with_mocked_fetch(tmp_path, images, _catalog_flaws())
+    assert paths["severity"].read_text(encoding="utf-8") == "Important"
+
+
+def test_run_empty_component_impact_critical(tmp_path: Path) -> None:
+    """Empty component impact uses flaw-level `Critical` (catalog regression)."""
+    images = _gzip_b64(
+        [
+            {
+                "repository": "component",
+                "cves": {"fixed": {"CVE-critical": {"components": []}}},
+            }
+        ]
+    )
+    paths = _run_with_mocked_fetch(tmp_path, images, _catalog_flaws())
+    assert paths["severity"].read_text(encoding="utf-8") == "Critical"
+
+
+def test_run_mount_read_error(tmp_path: Path) -> None:
+    """Missing OSIDB service-account mount is wrapped as `CheckStepError`."""
+    paths = _result_paths(tmp_path)
+    with pytest.raises(tekton.CheckStepError, match="OSIDB service account"):
+        get_advisory_severity.run_get_advisory_severity(
+            images_encoded=_gzip_b64([{"repository": "foo", "cves": {}}]),
+            mount=tmp_path / "missing",
+            result_paths=paths,
+            pipeline_run_name="pr-1",
+            task_run_name="tr-1",
+        )
+
+
+def test_run_wraps_kinit_error(tmp_path: Path) -> None:
+    """`CalledProcessError` from kinit is wrapped as `CheckStepError`."""
+    paths = _result_paths(tmp_path)
+    mount = tmp_path / "mount"
+    _write_osidb_mount(mount)
+    krb5 = tmp_path / "k5.conf"
+    krb5.write_text("[libdefaults]\n", encoding="utf-8")
+
+    def _fail_kinit(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.CalledProcessError(1, "kinit")
+
+    with mock.patch(
+        "get_advisory_severity.authentication.kinit_with_retry",
+        side_effect=_fail_kinit,
+    ):
+        with pytest.raises(tekton.CheckStepError, match="Kerberos"):
+            get_advisory_severity.run_get_advisory_severity(
+                images_encoded=_gzip_b64(
+                    [{"repository": "foo", "cves": {"fixed": {"CVE-1": {}}}}]
+                ),
+                mount=mount,
+                result_paths=paths,
+                pipeline_run_name="pr-1",
+                task_run_name="tr-1",
+                krb5_template=krb5,
+            )
+
+
+def _setup_main_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    paths = {
+        "RESULT_RESULT": tmp_path / "result",
+        "RESULT_SEVERITY": tmp_path / "severity",
+        "RESULT_INTERNAL_REQUEST_PIPELINE_RUN_NAME": tmp_path / "internal_pr",
+        "RESULT_INTERNAL_REQUEST_TASK_RUN_NAME": tmp_path / "internal_task",
+    }
+    for key, path in paths.items():
+        monkeypatch.setenv(key, str(path))
+        path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("IMAGES_ENCODED", _gzip_b64([{"repository": "foo", "cves": {}}]))
+    monkeypatch.setenv("OSIDB_SERVICE_ACCOUNT_MOUNT", str(tmp_path / "mount"))
+    monkeypatch.setenv("PARAM_INTERNAL_REQUEST_PIPELINE_RUN_NAME", "pr-main")
+    monkeypatch.setenv("PARAM_TASK_RUN_NAME", "tr-main")
+    return paths
+
+
+def test_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`main()` always returns 0 after a normal run."""
+    _setup_main_env(tmp_path, monkeypatch)
+    with mock.patch("get_advisory_severity.run_get_advisory_severity"):
+        assert get_advisory_severity.main() == 0
+
+
+def test_main_writes_failure_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Workflow failures are written to `RESULT_RESULT`; process still exits 0."""
+    paths = _setup_main_env(tmp_path, monkeypatch)
+    with mock.patch(
+        "get_advisory_severity.run_get_advisory_severity",
+        side_effect=tekton.CheckStepError(
+            "determining advisory severity from release notes",
+            ValueError("Unable to find severity on any cve"),
+        ),
+    ):
+        assert get_advisory_severity.main() == 0
+    text = paths["RESULT_RESULT"].read_text(encoding="utf-8")
+    assert "Unable to find severity" in text


### PR DESCRIPTION
This commit adds a python script to replicate the functionality of the inline bash script in the get-advisory-severity internal task in the catalog repo. The task will be updated to use this python module instead.

It also adds a document to help understand the script.

Assisted-By: Cursor