### PR TITLE
feat(RELEASE-1989): skopeo helper client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "confluent-kafka",
     "python-gitlab>=4.0",
     "python-dotenv>=1.0.0",
+    "pydantic"
 ]
 
 [tool.black]

--- a/scripts/python/helpers/retry.py
+++ b/scripts/python/helpers/retry.py
@@ -17,8 +17,7 @@ def retry_with_exponential_backoff(
     base_sleep_seconds: int = 5,
     sleep_fn: Callable[[float], None] | None = None,
 ) -> T:
-    """
-    Run ``operation`` up to ``max_attempts`` times, retrying selected failures.
+    """Run ``operation`` up to ``max_attempts`` times, retrying selected failures.
 
     On each retry, waits ``base_sleep_seconds * 2 ** (attempt - 1)`` seconds (5,
     10, 20, 40, ... by default). If a failure is not in ``retry_on``, it is

--- a/scripts/python/helpers/rsmodels/__init__.py
+++ b/scripts/python/helpers/rsmodels/__init__.py
@@ -1,0 +1,7 @@
+"""rsmodels."""
+
+from .container_image import (  # noqa: F401
+    ContainerImage,
+    ContainerImageConfig,
+    ContainerImageRaw,
+)

--- a/scripts/python/helpers/rsmodels/container_image.py
+++ b/scripts/python/helpers/rsmodels/container_image.py
@@ -1,0 +1,409 @@
+"""Pydantic models representing the metadata of a container image from skopeo inspect."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from pydantic import BaseModel, Field
+
+
+class LayerData(BaseModel):
+    """Metadata for an individual image layer."""
+
+    media_type: str | None = Field(
+        None, alias="MIMEType", description="MIME type of the layer"
+    )
+    digest: str | None = Field(None, alias="Digest", description="Digest of the layer")
+    size: int | None = Field(None, alias="Size", description="Size of the layer in bytes")
+    annotations: dict[str, str] | None = Field(
+        None, alias="Annotations", description="Layer annotations"
+    )
+
+    class Config:
+        """Pydantic model configuration."""
+
+        populate_by_name = True
+
+
+class ContainerImage(BaseModel):
+    """Model representing a container image returned by the `skopeo inspect` command."""
+
+    name: str | None = Field(None, alias="Name", description="The image name")
+    tag: str | None = Field(None, alias="Tag", description="The image tag")
+    digest: str | None = Field(None, alias="Digest", description="The image digest")
+    architecture: str | None = Field(
+        None, alias="Architecture", description="The image CPU architecture"
+    )
+    os: str | None = Field(
+        None, alias="Os", description="The target operating system of the image"
+    )
+    created: datetime | None = Field(
+        None, alias="Created", description="The timestamp when the image was created"
+    )
+    docker_version: str | None = Field(
+        None,
+        alias="DockerVersion",
+        description="The version of Docker used to build the image",
+    )
+    labels: dict[str, str] = Field(
+        default_factory=dict, alias="Labels", description="A dictionary of image labels"
+    )
+    layers: list[str] = Field(
+        default_factory=list,
+        alias="Layers",
+        description="A list of layer digests in the image",
+    )
+    layers_data: list[LayerData] = Field(
+        default_factory=list,
+        alias="LayersData",
+        description="Detailed metadata for each layer",
+    )
+    env: list[str] = Field(
+        default_factory=list, alias="Env", description="Environment variables set in the image"
+    )
+    repo_tags: list[str] = Field(
+        default_factory=list,
+        alias="RepoTags",
+        description="Other tags associated with the repository",
+    )
+
+    config: ContainerImageConfig | None = Field(
+        None, alias="Config", description="Container runtime configuration"
+    )
+
+    def __getitem__(self, key: str) -> Any:
+        """Allow dict-like access to model fields by their field name or alias."""
+        if hasattr(self, key) and key in self.model_fields:
+            return getattr(self, key)
+        for field_name, field in self.model_fields.items():
+            if field.alias == key:
+                return getattr(self, field_name)
+        raise KeyError(key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Allow dict-like .get() access."""
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    @classmethod
+    def from_json(cls, json_str: str) -> ContainerImage:
+        """Load ContainerImage from a JSON string.
+
+        Args:
+            json_str: JSON string representation of a ContainerImage
+
+        Returns:
+            ContainerImage instance
+
+        """
+        data = json.loads(json_str)
+        return cls.model_validate(data)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ContainerImage:
+        """Load ContainerImage from a dictionary.
+
+        Args:
+            data: Dictionary representation of a ContainerImage
+
+        Returns:
+            ContainerImage instance
+
+        """
+        return cls.model_validate(data)
+
+    @classmethod
+    def from_file(cls, file_path: str | Path) -> ContainerImage:
+        """Load ContainerImage from a JSON file.
+
+        Args:
+            file_path: Path to JSON file containing a ContainerImage
+
+        Returns:
+            ContainerImage instance
+
+        """
+        path = Path(file_path)
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        return cls.model_validate(data)
+
+
+class ManifestPlatform(BaseModel):
+    """Platform configuration for a manifest in a manifest list."""
+
+    architecture: str | None = Field(None, description="CPU architecture")
+    os: str | None = Field(None, description="Operating system")
+    variant: str | None = Field(None, description="Architecture variant")
+
+    class Config:
+        """Pydantic model configuration."""
+
+        populate_by_name = True
+
+
+class ManifestConfig(BaseModel):
+    """Configuration reference in a container manifest."""
+
+    media_type: str | None = Field(
+        None, alias="mediaType", description="MIME type of the config"
+    )
+    size: int | None = Field(None, description="Size of the config in bytes")
+    digest: str | None = Field(None, description="Digest of the config")
+
+    class Config:
+        """Pydantic model configuration."""
+
+        populate_by_name = True
+
+
+class ManifestLayer(BaseModel):
+    """Layer metadata in a container manifest."""
+
+    media_type: str | None = Field(
+        None, alias="mediaType", description="MIME type of the layer"
+    )
+    size: int | None = Field(None, description="Size of the layer in bytes")
+    digest: str | None = Field(None, description="Digest of the layer")
+
+    class Config:
+        """Pydantic model configuration."""
+
+        populate_by_name = True
+
+
+class RawManifestEntry(BaseModel):
+    """An individual manifest entry within a manifest list."""
+
+    media_type: str | None = Field(
+        None, alias="mediaType", description="MIME type of the manifest"
+    )
+    size: int | None = Field(None, description="Size of the manifest in bytes")
+    digest: str | None = Field(None, description="Digest of the manifest")
+    platform: ManifestPlatform | None = Field(None, description="Platform details")
+
+    class Config:
+        """Pydantic model configuration."""
+
+        populate_by_name = True
+
+
+class ContainerImageRaw(BaseModel):
+    """Model representing the raw JSON manifest returned by `skopeo inspect --raw`."""
+
+    schema_version: int | None = Field(
+        None, alias="schemaVersion", description="Schema version of the manifest"
+    )
+    media_type: str | None = Field(
+        None, alias="mediaType", description="MIME type of the manifest or manifest list"
+    )
+    manifests: list[RawManifestEntry] = Field(
+        default_factory=list, description="List of manifests (for manifest lists)"
+    )
+    config: ManifestConfig | None = Field(
+        None, description="Config object (for single manifests)"
+    )
+    layers: list[ManifestLayer] = Field(
+        default_factory=list, description="List of layer objects (for single manifests)"
+    )
+
+    class Config:
+        """Pydantic model configuration."""
+
+        populate_by_name = True
+
+    def __getitem__(self, key: str) -> Any:
+        """Allow dict-like access to model fields by their field name or alias."""
+        if hasattr(self, key) and key in self.model_fields:
+            return getattr(self, key)
+        for field_name, field in self.model_fields.items():
+            if field.alias == key:
+                return getattr(self, field_name)
+        raise KeyError(key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Allow dict-like .get() access."""
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    @classmethod
+    def from_json(cls, json_str: str) -> ContainerImageRaw:
+        """Load ContainerImageRaw from a JSON string.
+
+        Args:
+            json_str: JSON string representation of a ContainerImageRaw
+
+        Returns:
+            ContainerImageRaw instance
+
+        """
+        data = json.loads(json_str)
+        return cls.model_validate(data)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ContainerImageRaw:
+        """Load ContainerImageRaw from a dictionary.
+
+        Args:
+            data: Dictionary representation of a ContainerImageRaw
+
+        Returns:
+            ContainerImageRaw instance
+
+        """
+        return cls.model_validate(data)
+
+    @classmethod
+    def from_file(cls, file_path: str | Path) -> ContainerImageRaw:
+        """Load ContainerImageRaw from a JSON file.
+
+        Args:
+            file_path: Path to JSON file containing a ContainerImageRaw
+
+        Returns:
+            ContainerImageRaw instance
+
+        """
+        path = Path(file_path)
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        return cls.model_validate(data)
+
+
+class ImageConfig(BaseModel):
+    """Container runtime configuration from the .config section of skopeo inspect --config."""
+
+    user: str | None = Field(None, alias="User", description="User to run as")
+    exposed_ports: dict[str, dict] | None = Field(
+        None, alias="ExposedPorts", description="Ports exposed by the container"
+    )
+    env: list[str] | None = Field(None, alias="Env", description="Environment variables")
+    entrypoint: list[str] | None = Field(
+        None, alias="Entrypoint", description="Container entrypoint command"
+    )
+    cmd: list[str] | None = Field(None, alias="Cmd", description="Default command to run")
+    volumes: dict[str, dict] | None = Field(
+        None, alias="Volumes", description="Volume mount points"
+    )
+    working_dir: str | None = Field(None, alias="WorkingDir", description="Working directory")
+    labels: dict[str, str] | None = Field(None, alias="Labels", description="Image labels")
+    stop_signal: str | None = Field(
+        None, alias="StopSignal", description="Signal to stop the container"
+    )
+
+    class Config:
+        """Pydantic model configuration."""
+
+        populate_by_name = True
+
+
+class RootFS(BaseModel):
+    """Root filesystem metadata from skopeo inspect --config."""
+
+    type: str | None = Field(None, description="Filesystem type")
+    diff_ids: list[str] | None = Field(None, alias="diff_ids", description="Layer diff IDs")
+
+    class Config:
+        """Pydantic model configuration."""
+
+        populate_by_name = True
+
+
+class HistoryEntry(BaseModel):
+    """A single history entry from skopeo inspect --config."""
+
+    created: datetime | None = Field(None, description="Timestamp of the step")
+    created_by: str | None = Field(
+        None, alias="created_by", description="Command that produced the layer"
+    )
+    empty_layer: bool | None = Field(
+        None, alias="empty_layer", description="Whether this step produced no layer"
+    )
+    comment: str | None = Field(None, description="Optional comment")
+
+    class Config:
+        """Pydantic model configuration."""
+
+        populate_by_name = True
+
+
+class ContainerImageConfig(BaseModel):
+    """Model representing the output of ``skopeo inspect --config``."""
+
+    author: str | None = Field(None, description="Image author")
+    architecture: str | None = Field(None, description="CPU architecture")
+    created: datetime | None = Field(None, description="Timestamp when the image was created")
+    os: str | None = Field(None, description="Target operating system")
+    config: ImageConfig | None = Field(None, description="Container runtime configuration")
+    rootfs: RootFS | None = Field(None, description="Root filesystem metadata")
+    history: list[HistoryEntry] | None = Field(None, description="Build history entries")
+
+    class Config:
+        """Pydantic model configuration."""
+
+        populate_by_name = True
+
+    def __getitem__(self, key: str) -> Any:
+        """Allow dict-like access to model fields by their field name or alias."""
+        if hasattr(self, key) and key in self.model_fields:
+            return getattr(self, key)
+        for field_name, field in self.model_fields.items():
+            if field.alias == key:
+                return getattr(self, field_name)
+        raise KeyError(key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Allow dict-like .get() access."""
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    @classmethod
+    def from_json(cls, json_str: str) -> ContainerImageConfig:
+        """Load ContainerImageConfig from a JSON string.
+
+        Args:
+            json_str: JSON string representation of a ContainerImageConfig
+
+        Returns:
+            ContainerImageConfig instance
+
+        """
+        data = json.loads(json_str)
+        return cls.model_validate(data)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ContainerImageConfig:
+        """Load ContainerImageConfig from a dictionary.
+
+        Args:
+            data: Dictionary representation of a ContainerImageConfig
+
+        Returns:
+            ContainerImageConfig instance
+
+        """
+        return cls.model_validate(data)
+
+    @classmethod
+    def from_file(cls, file_path: str | Path) -> ContainerImageConfig:
+        """Load ContainerImageConfig from a JSON file.
+
+        Args:
+            file_path: Path to JSON file containing a ContainerImageConfig
+
+        Returns:
+            ContainerImageConfig instance
+
+        """
+        path = Path(file_path)
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        return cls.model_validate(data)

--- a/scripts/python/helpers/rsmodels/secret.py
+++ b/scripts/python/helpers/rsmodels/secret.py
@@ -1,0 +1,71 @@
+"""Secure handling of secrets in logs and debugging."""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+
+class Secret(str):
+    """A str subclass that masks its value in logs but works normally in code.
+
+    This class is picklable and can be used with ProcessPoolExecutor.
+
+    Usage:
+        # Create a secret
+        token = Secret("my-secret-token")
+
+        # Works directly in subprocess (no unveil needed)
+        cmd = ["curl", "-H", f"Authorization: Bearer {token}"]
+        subprocess.Popen(cmd)  # Uses actual value
+
+        # Masks in debug logs
+        logger.debug(f"Command: {cmd}")  # Shows: [..., 'Authorization: Bearer ***SECRET***']
+        print(repr(token))  # Shows: ***SECRET***
+        print(f"Token: {token!r}")  # Shows: Token: ***SECRET***
+
+        # Access actual value when needed
+        actual = str(token)  # or token.unveil()
+
+        # Picklable for multiprocessing
+        with ProcessPoolExecutor() as executor:
+            executor.submit(some_func, token)  # Works!
+
+    """
+
+    _MASK = "***SECRET***"
+
+    def __new__(cls, value: str, name: Optional[str] = None) -> Secret:
+        """Create a new Secret instance."""
+        instance = super().__new__(cls, value)
+        instance._name = name
+        return instance
+
+    def __repr__(self) -> str:
+        """Return masked value for repr() and logging."""
+        if hasattr(self, "_name") and self._name:
+            return f"***SECRET:{self._name}***"
+        return self._MASK
+
+    def __str__(self) -> str:
+        """Return masked value for repr() and logging."""
+        if hasattr(self, "_name") and self._name:
+            return f"***SECRET:{self._name}***"
+        return self._MASK
+
+    def unveil(self) -> str:
+        """Explicitly return the actual secret value.
+
+        This is just an alias for str(self) for clarity.
+        """
+        return str.__str__(self)
+
+    def __reduce__(self) -> tuple[type[Secret], tuple[str, Optional[str]]]:
+        """Support pickling for ProcessPoolExecutor."""
+        return (self.__class__, (str.__str__(self), getattr(self, "_name", None)))
+
+
+def unveil(s: Union[Secret, str]) -> str:
+    """Unveil a Secret or return a regular string."""
+    if isinstance(s, Secret):
+        return s.unveil()
+    return s

--- a/scripts/python/helpers/rsmodels/test_container_image.py
+++ b/scripts/python/helpers/rsmodels/test_container_image.py
@@ -1,0 +1,293 @@
+"""Unit tests for ContainerImage Pydantic model."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+import pytest
+from rsmodels import ContainerImage, ContainerImageConfig, ContainerImageRaw
+
+
+@pytest.fixture
+def sample_container_data() -> dict:
+    """Return sample skopeo inspect dictionary data for testing."""
+    d1 = "sha256:2ae81599c5e4d682162cc4825c81d11edb6e56314bff64cf3d7ddf54aef1f38b"
+    d2 = "sha256:837b9d7bd4c8301d318ec8c5cd7e5aab81e392d60e90b733f39c67bbadc97aef"
+    return {
+        "Name": "quay.io/redhat-prod/discovery----discovery-server-rhel9",
+        "Tag": "latest",
+        "Digest": d1,
+        "Created": "2026-06-29T20:23:52.866061036Z",
+        "DockerVersion": "1.44.0",
+        "Labels": {
+            "architecture": "x86_64",
+            "com.redhat.component": "discovery-container",
+        },
+        "Architecture": "amd64",
+        "Os": "linux",
+        "Layers": ["sha256:837b9d7bd4c8301d318ec8c5cd7e5aab81e392d60e90b733f39c67bbadc97aef"],
+        "LayersData": [
+            {
+                "MIMEType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                "Digest": d2,
+                "Size": 40689274,
+                "Annotations": {"key": "value"},
+            }
+        ],
+        "Env": ["container=oci", "LANG=C.UTF-8"],
+        "RepoTags": ["latest", "v2.6.3"],
+    }
+
+
+def test_container_image_from_dict(sample_container_data: dict) -> None:
+    """Test loading ContainerImage using the from_dict method."""
+    img = ContainerImage.from_dict(sample_container_data)
+
+    assert isinstance(img, ContainerImage)
+    assert img.name == "quay.io/redhat-prod/discovery----discovery-server-rhel9"
+    assert img.tag == "latest"
+    assert (
+        img.digest == "sha256:2ae81599c5e4d682162cc4825c81d11edb6e56314bff64cf3d7ddf54aef1f38b"
+    )
+    assert img.architecture == "amd64"
+    assert img.os == "linux"
+    assert img.created == datetime(2026, 6, 29, 20, 23, 52, 866061, tzinfo=timezone.utc)
+    assert img.docker_version == "1.44.0"
+    assert img.labels == {
+        "architecture": "x86_64",
+        "com.redhat.component": "discovery-container",
+    }
+    assert img.layers == [
+        "sha256:837b9d7bd4c8301d318ec8c5cd7e5aab81e392d60e90b733f39c67bbadc97aef"
+    ]
+    assert len(img.layers_data) == 1
+    assert img.layers_data[0].media_type == "application/vnd.docker.image.rootfs.diff.tar.gzip"
+    assert (
+        img.layers_data[0].digest
+        == "sha256:837b9d7bd4c8301d318ec8c5cd7e5aab81e392d60e90b733f39c67bbadc97aef"
+    )
+    assert img.layers_data[0].size == 40689274
+    assert img.layers_data[0].annotations == {"key": "value"}
+    assert img.env == ["container=oci", "LANG=C.UTF-8"]
+    assert img.repo_tags == ["latest", "v2.6.3"]
+
+
+def test_container_image_from_json(sample_container_data: dict) -> None:
+    """Test loading ContainerImage using the from_json method."""
+    json_str = json.dumps(sample_container_data)
+    img = ContainerImage.from_json(json_str)
+
+    assert isinstance(img, ContainerImage)
+    assert img.name == "quay.io/redhat-prod/discovery----discovery-server-rhel9"
+    assert (
+        img.digest == "sha256:2ae81599c5e4d682162cc4825c81d11edb6e56314bff64cf3d7ddf54aef1f38b"
+    )
+
+
+def test_container_image_from_file(
+    sample_container_data: dict, tmp_path: pytest.TempPathFactory
+) -> None:
+    """Test loading ContainerImage from a file using the from_file method."""
+    file_path = tmp_path / "skopeo_inspect.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(sample_container_data, f)
+
+    img = ContainerImage.from_file(file_path)
+
+    assert isinstance(img, ContainerImage)
+    assert img.name == "quay.io/redhat-prod/discovery----discovery-server-rhel9"
+    assert (
+        img.digest == "sha256:2ae81599c5e4d682162cc4825c81d11edb6e56314bff64cf3d7ddf54aef1f38b"
+    )
+
+
+@pytest.fixture
+def sample_raw_manifest_data() -> dict:
+    """Return sample skopeo inspect --raw manifest list dictionary data for testing."""
+    d1 = "sha256:7f4f6ce62705fe518e3513957b4205f106992cd42d1b07975d11aff2dc6ced66"
+    return {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+        "manifests": [
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "size": 596,
+                "digest": d1,
+                "platform": {
+                    "architecture": "amd64",
+                    "os": "linux",
+                },
+            }
+        ],
+    }
+
+
+def test_container_image_raw_from_dict(sample_raw_manifest_data: dict) -> None:
+    """Test loading ContainerImageRaw using the from_dict method."""
+    img = ContainerImageRaw.from_dict(sample_raw_manifest_data)
+
+    assert isinstance(img, ContainerImageRaw)
+    assert img.schema_version == 2
+    assert img.media_type == "application/vnd.docker.distribution.manifest.list.v2+json"
+    assert len(img.manifests) == 1
+    assert (
+        img.manifests[0].media_type == "application/vnd.docker.distribution.manifest.v2+json"
+    )
+    assert img.manifests[0].size == 596
+    assert (
+        img.manifests[0].digest
+        == "sha256:7f4f6ce62705fe518e3513957b4205f106992cd42d1b07975d11aff2dc6ced66"
+    )
+    assert img.manifests[0].platform.architecture == "amd64"
+    assert img.manifests[0].platform.os == "linux"
+
+
+def test_container_image_raw_from_json(sample_raw_manifest_data: dict) -> None:
+    """Test loading ContainerImageRaw using the from_json method."""
+    json_str = json.dumps(sample_raw_manifest_data)
+    img = ContainerImageRaw.from_json(json_str)
+
+    assert isinstance(img, ContainerImageRaw)
+    assert img.schema_version == 2
+
+
+def test_container_image_raw_from_file(
+    sample_raw_manifest_data: dict, tmp_path: pytest.TempPathFactory
+) -> None:
+    """Test loading ContainerImageRaw from a file using the from_file method."""
+    file_path = tmp_path / "raw_manifest.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(sample_raw_manifest_data, f)
+
+    img = ContainerImageRaw.from_file(file_path)
+
+    assert isinstance(img, ContainerImageRaw)
+    assert img.schema_version == 2
+    assert img.media_type == "application/vnd.docker.distribution.manifest.list.v2+json"
+
+
+@pytest.fixture
+def sample_config_data() -> dict:
+    """Return sample skopeo inspect --config dictionary data for testing."""
+    return {
+        "created": "2026-06-29T20:23:52.866061036Z",
+        "architecture": "amd64",
+        "os": "linux",
+        "config": {
+            "User": "1001",
+            "ExposedPorts": {"8000/tcp": {}},
+            "Env": [
+                "container=oci",
+                "LANG=C.UTF-8",
+                "PATH=/opt/venv/bin:/usr/local/bin:/usr/bin",
+            ],
+            "Entrypoint": ["/bin/bash"],
+            "Cmd": ["/deploy/entrypoint_web.sh"],
+            "Volumes": {"/var/data": {}, "/var/log": {}},
+            "WorkingDir": "/app",
+            "Labels": {
+                "architecture": "x86_64",
+                "com.redhat.component": "discovery-container",
+                "version": "2.6.3",
+            },
+            "StopSignal": "SIGTERM",
+        },
+        "rootfs": {
+            "type": "layers",
+            "diff_ids": [
+                "sha256:76c30a19831466a2388cd37770733c4a149dba7034565b568358b06088a23bf2",
+                "sha256:4a59de577590d0a72d9d445d5ca61d1a214fc69c231a594485c0b9eb6997cc49",
+            ],
+        },
+        "history": [
+            {
+                "created": "2026-06-25T05:47:54.833873537Z",
+                "created_by": '/bin/sh -c #(nop) LABEL maintainer="Red Hat, Inc."',
+                "empty_layer": True,
+            }
+        ],
+    }
+
+
+def test_container_image_config_from_dict(sample_config_data: dict) -> None:
+    """Test loading ContainerImageConfig using the from_dict method."""
+    img = ContainerImageConfig.from_dict(sample_config_data)
+
+    assert isinstance(img, ContainerImageConfig)
+    assert img.created == datetime(2026, 6, 29, 20, 23, 52, 866061, tzinfo=timezone.utc)
+    assert img.architecture == "amd64"
+    assert img.os == "linux"
+
+    assert img.config is not None
+    assert img.config.user == "1001"
+    assert img.config.exposed_ports == {"8000/tcp": {}}
+    assert img.config.env == [
+        "container=oci",
+        "LANG=C.UTF-8",
+        "PATH=/opt/venv/bin:/usr/local/bin:/usr/bin",
+    ]
+    assert img.config.entrypoint == ["/bin/bash"]
+    assert img.config.cmd == ["/deploy/entrypoint_web.sh"]
+    assert img.config.volumes == {"/var/data": {}, "/var/log": {}}
+    assert img.config.working_dir == "/app"
+    assert img.config.labels == {
+        "architecture": "x86_64",
+        "com.redhat.component": "discovery-container",
+        "version": "2.6.3",
+    }
+    assert img.config.stop_signal == "SIGTERM"
+
+    assert img.rootfs is not None
+    assert img.rootfs.type == "layers"
+    assert len(img.rootfs.diff_ids) == 2
+
+    assert img.history is not None
+    assert len(img.history) == 1
+    assert img.history[0].created_by == ('/bin/sh -c #(nop) LABEL maintainer="Red Hat, Inc."')
+    assert img.history[0].empty_layer is True
+
+
+def test_container_image_config_from_json(sample_config_data: dict) -> None:
+    """Test loading ContainerImageConfig using the from_json method."""
+    json_str = json.dumps(sample_config_data)
+    img = ContainerImageConfig.from_json(json_str)
+
+    assert isinstance(img, ContainerImageConfig)
+    assert img.architecture == "amd64"
+    assert img.config.labels["com.redhat.component"] == "discovery-container"
+
+
+def test_container_image_config_from_file(
+    sample_config_data: dict, tmp_path: pytest.TempPathFactory
+) -> None:
+    """Test loading ContainerImageConfig from a file using the from_file method."""
+    file_path = tmp_path / "config_inspect.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(sample_config_data, f)
+
+    img = ContainerImageConfig.from_file(file_path)
+
+    assert isinstance(img, ContainerImageConfig)
+    assert img.architecture == "amd64"
+    assert img.config.user == "1001"
+
+
+def test_container_image_config_optional_fields() -> None:
+    """Test ContainerImageConfig with minimal data."""
+    img = ContainerImageConfig.from_dict({"architecture": "arm64"})
+
+    assert img.architecture == "arm64"
+    assert img.config is None
+    assert img.rootfs is None
+    assert img.history is None
+    assert img.created is None
+    assert img.author is None
+
+
+def test_container_image_config_dict_access(sample_config_data: dict) -> None:
+    """Test dict-like access on ContainerImageConfig."""
+    img = ContainerImageConfig.from_dict(sample_config_data)
+
+    assert img["architecture"] == "amd64"
+    assert img.get("os") == "linux"
+    assert img.get("nonexistent", "default") == "default"

--- a/scripts/python/helpers/rsmodels/test_secret.py
+++ b/scripts/python/helpers/rsmodels/test_secret.py
@@ -1,0 +1,134 @@
+"""Unit tests for the Secret class."""
+
+from __future__ import annotations
+
+import pickle
+
+from rsmodels.secret import Secret, unveil
+
+
+class TestSecretMasking:
+    """Tests for Secret value masking in str and repr."""
+
+    def test_str_returns_mask(self) -> None:
+        """Test that str() returns the masked value."""
+        s = Secret("my-password")
+        assert str(s) == "***SECRET***"
+
+    def test_repr_returns_mask(self) -> None:
+        """Test that repr() returns the masked value."""
+        s = Secret("my-password")
+        assert repr(s) == "***SECRET***"
+
+    def test_named_secret_str(self) -> None:
+        """Test that str() includes the name in the mask."""
+        s = Secret("my-password", name="db_pass")
+        assert str(s) == "***SECRET:db_pass***"
+
+    def test_named_secret_repr(self) -> None:
+        """Test that repr() includes the name in the mask."""
+        s = Secret("my-password", name="db_pass")
+        assert repr(s) == "***SECRET:db_pass***"
+
+    def test_fstring_masks_value(self) -> None:
+        """Test that f-string interpolation masks the value."""
+        s = Secret("my-password")
+        result = f"Token: {s}"
+        assert "my-password" not in result
+        assert "***SECRET***" in result
+
+    def test_fstring_repr_masks_value(self) -> None:
+        """Test that f-string !r interpolation masks the value."""
+        s = Secret("my-password")
+        result = f"Token: {s!r}"
+        assert "my-password" not in result
+        assert "***SECRET***" in result
+
+    def test_format_masks_value(self) -> None:
+        """Test that str.format masks the value."""
+        s = Secret("my-password")
+        result = "Token: {}".format(s)
+        assert "my-password" not in result
+
+    def test_list_str_masks_value(self) -> None:
+        """Test that Secret is masked inside a list str()."""
+        cmd = ["curl", "-H", Secret("Bearer token123")]
+        result = str(cmd)
+        assert "token123" not in result
+        assert "***SECRET***" in result
+
+    def test_list_repr_masks_value(self) -> None:
+        """Test that Secret is masked inside a list repr()."""
+        cmd = ["curl", "-H", Secret("Bearer token123")]
+        result = repr(cmd)
+        assert "token123" not in result
+        assert "***SECRET***" in result
+
+    def test_no_name_attribute_still_masks(self) -> None:
+        """Test masking still works if _name attribute is missing."""
+        s = Secret("my-password")
+        del s._name
+        assert str(s) == "***SECRET***"
+        assert repr(s) == "***SECRET***"
+
+
+class TestSecretUnveil:
+    """Tests for accessing the actual secret value."""
+
+    def test_unveil_returns_actual_value(self) -> None:
+        """Test that unveil() returns the real secret."""
+        s = Secret("my-password")
+        assert s.unveil() == "my-password"
+
+    def test_module_unveil_with_secret(self) -> None:
+        """Test the module-level unveil() with a Secret."""
+        s = Secret("my-password")
+        assert unveil(s) == "my-password"
+
+    def test_module_unveil_with_plain_string(self) -> None:
+        """Test the module-level unveil() with a plain string."""
+        assert unveil("plain-text") == "plain-text"
+
+
+class TestSecretIsStr:
+    """Tests that Secret behaves as a str subclass."""
+
+    def test_isinstance_str(self) -> None:
+        """Test that Secret is an instance of str."""
+        s = Secret("hello")
+        assert isinstance(s, str)
+
+    def test_equality_uses_actual_value(self) -> None:
+        """Test that equality comparison uses the actual value."""
+        s = Secret("hello")
+        assert s == "hello"
+
+    def test_len_uses_actual_value(self) -> None:
+        """Test that len() operates on the actual value."""
+        s = Secret("hello")
+        assert len(s) == 5
+
+    def test_contains_uses_actual_value(self) -> None:
+        """Test that 'in' operator uses the actual value."""
+        s = Secret("hello world")
+        assert "world" in s
+
+
+class TestSecretPickle:
+    """Tests for Secret pickling support."""
+
+    def test_pickle_roundtrip(self) -> None:
+        """Test that Secret survives pickle/unpickle."""
+        s = Secret("my-password")
+        restored = pickle.loads(pickle.dumps(s))
+        assert isinstance(restored, Secret)
+        assert restored.unveil() == "my-password"
+        assert str(restored) == "***SECRET***"
+
+    def test_pickle_named_roundtrip(self) -> None:
+        """Test that named Secret survives pickle/unpickle."""
+        s = Secret("my-password", name="db_pass")
+        restored = pickle.loads(pickle.dumps(s))
+        assert isinstance(restored, Secret)
+        assert restored.unveil() == "my-password"
+        assert str(restored) == "***SECRET:db_pass***"

--- a/scripts/python/helpers/skopeo.py
+++ b/scripts/python/helpers/skopeo.py
@@ -1,33 +1,362 @@
-"""Skopeo CLI wrapper helpers."""
+"""Python client for skopeo container image operations."""
 
 from __future__ import annotations
 
+from logging import Logger
 import subprocess
 
-
-def inspect(
-    image_ref: str,
-    *,
-    config: bool = False,
-    raw: bool = False,
-    retry_times: int = 3,
-) -> subprocess.CompletedProcess[str]:
-    """Run ``skopeo inspect`` on a container image reference."""
-    cmd = ["skopeo", "inspect", "--retry-times", str(retry_times)]
-    if config:
-        cmd.append("--config")
-    if raw:
-        cmd.append("--raw")
-    cmd.append(f"docker://{image_ref}")
-    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+from rsmodels import ContainerImage, ContainerImageConfig, ContainerImageRaw
+from rsmodels.secret import Secret
 
 
-def copy(
-    source: str,
-    dest: str,
-    *,
-    retry_times: int = 3,
-) -> subprocess.CompletedProcess[str]:
-    """Run ``skopeo copy`` to copy an image between transports."""
-    cmd = ["skopeo", "copy", "--retry-times", str(retry_times), source, dest]
-    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+class SkopeoClientError(Exception):
+    """Exception raised when skopeo command fails.
+
+    Attributes:
+        command: The command that was executed
+        returncode: The exit code of the process
+        stdout: Standard output from the command
+        stderr: Standard error from the command
+
+    """
+
+    def __init__(
+        self,
+        message: str,
+        command: list[str],
+        returncode: int,
+        stdout: str,
+        stderr: str,
+    ):
+        """Initialize the SkopeoClientError with command details."""
+        super().__init__(message)
+        self.command = command
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __str__(self) -> str:
+        """Return a detailed error message including command and outputs."""
+        return (
+            f"{super().__str__()}\n"
+            f"    Command: {' '.join(str(c) for c in self.command)}\n"
+            f"    Return code: {self.returncode}\n"
+            f"    Stderr: {self.stderr}"
+        )
+
+
+class SkopeoClient:
+    """Client for executing skopeo container image operations.
+
+    This client wraps skopeo CLI commands and provides a Python API for
+    common operations like inspect and copy.
+
+    Args:
+        debug: Enable debug output
+        insecure_policy: Run without policy check
+        tmpdir: Directory for temporary files
+        command_timeout: Timeout for command execution (e.g., "5m", "30s")
+        override_arch: Override architecture for image selection
+        override_os: Override OS for image selection
+        override_variant: Override architecture variant
+
+    Example:
+        client = SkopeoClient(debug=True)
+
+        # Inspect an image
+        data = client.inspect("docker://quay.io/image:tag")
+        print(data["Digest"])
+
+        # Copy with credentials
+        from secret import Secret
+        client.copy(
+            "docker://source/image:tag",
+            "docker://dest/image:tag",
+            src_creds=Secret("user:pass"),
+            dest_creds=Secret("user:pass"),
+            all=True,
+        )
+
+    """
+
+    def __init__(
+        self,
+        *,
+        debug: bool = False,
+        insecure_policy: bool = False,
+        tmpdir: str | None = None,
+        command_timeout: str | None = None,
+        override_arch: str | None = None,
+        override_os: str | None = None,
+        override_variant: str | None = None,
+        logger: Logger | None = None,
+    ):
+        """Initialize the SkopeoClient with optional global settings."""
+        self.debug = debug
+        self.insecure_policy = insecure_policy
+        self.tmpdir = tmpdir
+        self.command_timeout = command_timeout
+        self.override_arch = override_arch
+        self.override_os = override_os
+        self.override_variant = override_variant
+        self.logger = logger
+
+    def _build_global_flags(self) -> list[str]:
+        """Build global flags that apply to all skopeo commands."""
+        flags: list[str] = []
+
+        if self.debug:
+            flags.append("--debug")
+        if self.insecure_policy:
+            flags.append("--insecure-policy")
+        if self.tmpdir is not None:
+            flags.extend(["--tmpdir", self.tmpdir])
+        if self.command_timeout is not None:
+            flags.extend(["--command-timeout", self.command_timeout])
+        if self.override_arch is not None:
+            flags.extend(["--override-arch", self.override_arch])
+        if self.override_os is not None:
+            flags.extend(["--override-os", self.override_os])
+        if self.override_variant is not None:
+            flags.extend(["--override-variant", self.override_variant])
+
+        return flags
+
+    def _run_command(self, cmd: list[str]) -> subprocess.CompletedProcess:
+        """Run a skopeo command and handle errors.
+
+        Args:
+            cmd: Complete command including 'skopeo' and all arguments
+
+        Returns:
+            CompletedProcess with stdout/stderr captured
+
+        Raises:
+            SkopeoClientError: If command exits with non-zero status
+
+        """
+        try:
+            result = subprocess.run(
+                [c.unveil() if isinstance(c, Secret) else c for c in cmd],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return result
+        except subprocess.CalledProcessError as e:
+            raise SkopeoClientError(
+                f"Skopeo command failed with exit code {e.returncode}",
+                command=cmd,
+                returncode=e.returncode,
+                stdout=e.stdout or "",
+                stderr=e.stderr or "",
+            ) from e
+
+    def inspect(
+        self,
+        image: str,
+        *,
+        format: str | None = None,
+        retry_times: int | None = None,
+        creds: Secret | None = None,
+        tls_verify: bool | None = None,
+        config: bool = False,
+        raw: bool = False,
+        no_tags: bool = False,
+        authfile: str | None = None,
+        cert_dir: str | None = None,
+        registry_token: Secret | None = None,
+    ) -> ContainerImage | ContainerImageConfig | ContainerImageRaw | str:
+        """Inspect a container image and return metadata.
+
+        Args:
+            image: Image reference (e.g., "docker://quay.io/image:tag")
+            format: Output format template (e.g., "{{.Digest}}")
+                   If None, returns parsed JSON as dict
+                   If specified, returns formatted string
+            retry_times: Number of retry attempts for network operations
+            creds: Registry credentials as Secret
+            tls_verify: Whether to verify TLS certificates
+            config: Output configuration instead of manifest
+            raw: Output raw manifest or configuration
+            no_tags: Don't list available tags in output
+            authfile: Path to authentication file
+            cert_dir: Directory containing certificates
+            registry_token: Bearer token for registry access
+
+        Returns:
+            ContainerImage, ContainerImageConfig, ContainerImageRaw, or str
+
+        Raises:
+            SkopeoClientError: If inspect command fails
+
+        Example:
+            # Get full metadata as dict
+            data = client.inspect("docker://quay.io/image:tag")
+
+            # Get just the digest
+            digest = client.inspect(
+                "docker://quay.io/image:tag",
+                format="{{.Digest}}"
+            )
+
+        """
+        cmd = ["skopeo", *self._build_global_flags(), "inspect"]
+
+        if format is not None:
+            cmd.extend(["--format", format])
+        if retry_times is not None:
+            cmd.extend(["--retry-times", str(retry_times)])
+        if creds is not None:
+            cmd.extend(["--creds", creds])
+        if tls_verify is not None:
+            cmd.extend(["--tls-verify", str(tls_verify).lower()])
+        if config:
+            cmd.append("--config")
+        if raw:
+            cmd.append("--raw")
+        if no_tags:
+            cmd.append("--no-tags")
+        if authfile is not None:
+            cmd.extend(["--authfile", authfile])
+        if cert_dir is not None:
+            cmd.extend(["--cert-dir", cert_dir])
+        if registry_token is not None:
+            cmd.extend(["--registry-token", registry_token])
+
+        cmd.append(image)
+
+        result = self._run_command(cmd)
+        output = result.stdout.strip()
+
+        # If format was specified, return the formatted string
+        if format is not None:
+            return output
+
+        # Otherwise parse and return JSON as the appropriate model
+        try:
+            if raw:
+                return ContainerImageRaw.from_json(output)
+            if config:
+                return ContainerImageConfig.from_json(output)
+            return ContainerImage.from_json(output)
+        except Exception as e:
+            if raw:
+                model_name = "ContainerImageRaw"
+            elif config:
+                model_name = "ContainerImageConfig"
+            else:
+                model_name = "ContainerImage"
+            raise SkopeoClientError(
+                f"Failed to parse skopeo output as JSON ({model_name}): {e}",
+                command=cmd,
+                returncode=0,
+                stdout=output,
+                stderr=result.stderr,
+            ) from e
+
+    def copy(
+        self,
+        source: str,
+        destination: str,
+        *,
+        all: bool | None = None,
+        preserve_digests: bool | None = None,
+        format: str | None = None,
+        retry_times: int | None = None,
+        quiet: bool = False,
+        src_creds: Secret | None = None,
+        src_tls_verify: bool | None = None,
+        src_no_creds: bool = False,
+        src_cert_dir: str | None = None,
+        src_authfile: str | None = None,
+        dest_creds: Secret | None = None,
+        dest_tls_verify: bool | None = None,
+        dest_no_creds: bool = False,
+        dest_cert_dir: str | None = None,
+        dest_authfile: str | None = None,
+        remove_signatures: bool = False,
+    ) -> None:
+        """Copy a container image from source to destination.
+
+        Args:
+            source: Source image reference (e.g., "docker://quay.io/src:tag")
+            destination: Destination image reference
+            all: Copy all images if source is a multi-arch manifest list
+            preserve_digests: Preserve digests during copy
+            format: Manifest type to use (oci, v2s1, v2s2)
+            retry_times: Number of retry attempts for network operations
+            quiet: Suppress output information
+            src_creds: Source registry credentials
+            src_tls_verify: Verify source TLS certificates
+            src_no_creds: Access source registry anonymously
+            src_cert_dir: Source certificate directory
+            src_authfile: Source authentication file
+            dest_creds: Destination registry credentials
+            dest_tls_verify: Verify destination TLS certificates
+            dest_no_creds: Access destination registry anonymously
+            dest_cert_dir: Destination certificate directory
+            dest_authfile: Destination authentication file
+            remove_signatures: Don't copy signatures from source
+
+        Raises:
+            SkopeoClientError: If copy command fails
+
+        Example:
+            from secret import Secret
+
+            client.copy(
+                "docker://quay.io/src/image:tag",
+                "docker://quay.io/dest/image:tag",
+                all=True,
+                preserve_digests=True,
+                src_creds=Secret("user:pass"),
+                dest_creds=Secret("user:pass"),
+                retry_times=5,
+            )
+
+        """
+        cmd = ["skopeo", *self._build_global_flags(), "copy"]
+
+        if all is not None:
+            if all:
+                cmd.append("--all")
+        if preserve_digests is True:
+            cmd.append("--preserve-digests")
+        if format is not None:
+            cmd.extend(["--format", format])
+        if retry_times is not None:
+            cmd.extend(["--retry-times", str(retry_times)])
+        if quiet:
+            cmd.append("--quiet")
+        if remove_signatures:
+            cmd.append("--remove-signatures")
+
+        # Source options
+        if src_creds is not None:
+            cmd.extend(["--src-creds", src_creds])
+        if src_tls_verify is not None:
+            cmd.extend([f"--src-tls-verify={str(src_tls_verify).lower()}"])
+        if src_no_creds:
+            cmd.append("--src-no-creds")
+        if src_cert_dir is not None:
+            cmd.extend(["--src-cert-dir", src_cert_dir])
+        if src_authfile is not None:
+            cmd.extend(["--src-authfile", src_authfile])
+
+        # Destination options
+        if dest_creds is not None:
+            cmd.extend(["--dest-creds", dest_creds])
+        if dest_tls_verify is not None:
+            cmd.extend([f"--dest-tls-verify={str(dest_tls_verify).lower()}"])
+        if dest_no_creds:
+            cmd.append("--dest-no-creds")
+        if dest_cert_dir is not None:
+            cmd.extend(["--dest-cert-dir", dest_cert_dir])
+        if dest_authfile is not None:
+            cmd.extend(["--dest-authfile", dest_authfile])
+
+        cmd.extend([source, destination])
+        if self.logger:
+            self.logger.info(f"Running skopeo copy command: {cmd}")
+        self._run_command(cmd)

--- a/scripts/python/helpers/test_skopeo.py
+++ b/scripts/python/helpers/test_skopeo.py
@@ -1,199 +1,880 @@
-"""Tests for the ``skopeo`` helper module."""
+"""Unit tests for the SkopeoClient."""
 
 from __future__ import annotations
 
 import subprocess
-import unittest.mock as mock
+import sys
+import types
+from unittest import mock
 
-import skopeo
+from rsmodels.secret import Secret
+from rsmodels import ContainerImage, ContainerImageRaw
 
-
-def _completed(
-    stdout: str = "",
-    returncode: int = 0,
-) -> subprocess.CompletedProcess[str]:
-    return subprocess.CompletedProcess(
-        args=[], returncode=returncode, stdout=stdout, stderr=""
-    )
+from skopeo import SkopeoClient, SkopeoClientError
+import pytest
 
 
-# ---------------------------------------------------------------------------
-# inspect
-# ---------------------------------------------------------------------------
+def _assert_no_secret_leak_in_traceback(
+    tb: types.TracebackType,
+    secret_value: str,
+    skip_frames: int = 1,
+    max_frames: int = 5,
+) -> None:
+    """Walk traceback frames and assert the secret is not leaked.
+
+    Skip the first ``skip_frames`` frames (the test function itself
+    holds the plain-text value by design) and then iterate through each
+    remaining frame's local variables, verifying that neither str() nor
+    repr() of any variable exposes the raw secret.
+    """
+    current = tb
+    for _ in range(skip_frames):
+        if current is not None:
+            current = current.tb_next
+
+    frame_count = 0
+    while current is not None and frame_count < max_frames:
+        func_name = current.tb_frame.f_code.co_name
+        for name, value in current.tb_frame.f_locals.items():
+            str_val = str(value)
+            repr_val = repr(value)
+            assert secret_value not in str_val, (
+                f"Secret leaked via str() in frame " f"'{func_name}', variable '{name}'"
+            )
+            assert secret_value not in repr_val, (
+                f"Secret leaked via repr() in frame " f"'{func_name}', variable '{name}'"
+            )
+        frame_count += 1
+        current = current.tb_next
+    assert frame_count >= 2, f"Expected at least 2 traceback frames, got {frame_count}"
 
 
-def test_inspect_basic_command() -> None:
-    """Default inspect builds the correct command."""
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_completed(),
-    ) as run_mock:
-        skopeo.inspect("registry.example.com/repo:tag")
+class TestSkopeoClientInit:
+    """Tests for SkopeoClient initialization."""
 
-    cmd = run_mock.call_args[0][0]
-    assert cmd == [
-        "skopeo",
-        "inspect",
-        "--retry-times",
-        "3",
-        "docker://registry.example.com/repo:tag",
-    ]
-    assert run_mock.call_args[1]["capture_output"] is True
-    assert run_mock.call_args[1]["text"] is True
-    assert run_mock.call_args[1]["check"] is False
+    def test_init_with_defaults(self) -> None:
+        """Test creating client with default parameters."""
+        client = SkopeoClient()
+        assert client.debug is False
+        assert client.insecure_policy is False
+        assert client.tmpdir is None
+        assert client.command_timeout is None
 
-
-def test_inspect_config_flag() -> None:
-    """``config=True`` adds ``--config`` to the command."""
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_completed(),
-    ) as run_mock:
-        skopeo.inspect("img:v1", config=True)
-
-    cmd = run_mock.call_args[0][0]
-    assert "--config" in cmd
-    assert "--raw" not in cmd
+    def test_init_with_all_params(self) -> None:
+        """Test creating client with all parameters."""
+        client = SkopeoClient(
+            debug=True,
+            insecure_policy=True,
+            tmpdir="/tmp/test",
+            command_timeout="5m",
+            override_arch="amd64",
+            override_os="linux",
+            override_variant="v8",
+        )
+        assert client.debug is True
+        assert client.insecure_policy is True
+        assert client.tmpdir == "/tmp/test"
+        assert client.command_timeout == "5m"
+        assert client.override_arch == "amd64"
+        assert client.override_os == "linux"
+        assert client.override_variant == "v8"
 
 
-def test_inspect_raw_flag() -> None:
-    """``raw=True`` adds ``--raw`` to the command."""
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_completed(),
-    ) as run_mock:
-        skopeo.inspect("img:v1", raw=True)
+class TestSkopeoClientGlobalFlags:
+    """Tests for global flag building."""
 
-    cmd = run_mock.call_args[0][0]
-    assert "--raw" in cmd
-    assert "--config" not in cmd
+    def test_build_global_flags_empty(self) -> None:
+        """Test building global flags with defaults."""
+        client = SkopeoClient()
+        flags = client._build_global_flags()
+        assert flags == []
 
-
-def test_inspect_custom_retry_times() -> None:
-    """``retry_times`` overrides the default retry count."""
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_completed(),
-    ) as run_mock:
-        skopeo.inspect("img:v1", retry_times=5)
-
-    cmd = run_mock.call_args[0][0]
-    assert "--retry-times" in cmd
-    idx = cmd.index("--retry-times")
-    assert cmd[idx + 1] == "5"
-
-
-def test_inspect_returns_completed_process() -> None:
-    """The raw ``CompletedProcess`` is returned to the caller."""
-    expected = _completed(stdout='{"created": "2024-01-01T00:00:00Z"}')
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=expected,
-    ):
-        result = skopeo.inspect("img:v1", config=True)
-
-    assert result is expected
-    assert result.stdout == '{"created": "2024-01-01T00:00:00Z"}'
+    def test_build_global_flags_all_set(self) -> None:
+        """Test building global flags with all options."""
+        client = SkopeoClient(
+            debug=True,
+            insecure_policy=True,
+            tmpdir="/tmp/test",
+            command_timeout="5m",
+            override_arch="amd64",
+            override_os="linux",
+            override_variant="v8",
+        )
+        flags = client._build_global_flags()
+        assert "--debug" in flags
+        assert "--insecure-policy" in flags
+        assert "--tmpdir" in flags
+        assert "/tmp/test" in flags
+        assert "--command-timeout" in flags
+        assert "5m" in flags
+        assert "--override-arch" in flags
+        assert "amd64" in flags
+        assert "--override-os" in flags
+        assert "linux" in flags
+        assert "--override-variant" in flags
+        assert "v8" in flags
 
 
-def test_inspect_nonzero_exit_code() -> None:
-    """A non-zero exit code is returned, not raised."""
-    expected = _completed(returncode=1)
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=expected,
-    ):
-        result = skopeo.inspect("img:v1")
+class TestSkopeoClientInspect:
+    """Tests for the inspect method."""
 
-    assert result.returncode == 1
+    @mock.patch("skopeo.subprocess.run")
+    def test_inspect_returns_dict_by_default(self, mock_run) -> None:
+        """Test that inspect returns parsed JSON dict when format is None."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"Digest": "sha256:abc123", "RepoTags": ["latest"]}',
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        result = client.inspect("docker://quay.io/image:tag")
+
+        assert isinstance(result, ContainerImage)
+        assert result["Digest"] == "sha256:abc123"
+        assert result["RepoTags"] == ["latest"]
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_inspect_returns_string_with_format(self, mock_run) -> None:
+        """Test that inspect returns formatted string when format is specified."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="sha256:abc123",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        result = client.inspect(
+            "docker://quay.io/image:tag",
+            format="{{.Digest}}",
+        )
+
+        assert isinstance(result, str)
+        assert result == "sha256:abc123"
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_inspect_with_credentials(self, mock_run) -> None:
+        """Test inspect with credentials."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"Digest": "sha256:abc123"}',
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        creds = Secret("user:password")
+        client.inspect(
+            "docker://registry.io/image:tag",
+            creds=creds,
+        )
+
+        # Verify the command includes credentials
+        called_cmd = mock_run.call_args[0][0]
+        assert "--creds" in called_cmd
+        # The actual password should be in the command (unveiled)
+        creds_idx = called_cmd.index("--creds")
+        assert called_cmd[creds_idx + 1] == "user:password"
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_inspect_with_retry_times(self, mock_run) -> None:
+        """Test inspect with retry times."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"Digest": "sha256:abc123"}',
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.inspect(
+            "docker://quay.io/image:tag",
+            retry_times=5,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--retry-times" in called_cmd
+        assert "5" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_inspect_with_tls_verify_false(self, mock_run) -> None:
+        """Test inspect with tls_verify=False."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"Digest": "sha256:abc123"}',
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.inspect(
+            "docker://quay.io/image:tag",
+            tls_verify=False,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--tls-verify" in called_cmd
+        assert "false" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_inspect_with_tls_verify_true(self, mock_run) -> None:
+        """Test inspect with tls_verify=True."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"Digest": "sha256:abc123"}',
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.inspect(
+            "docker://quay.io/image:tag",
+            tls_verify=True,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--tls-verify" in called_cmd
+        assert "true" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_inspect_with_tls_verify_none(self, mock_run) -> None:
+        """Test inspect with tls_verify=None (omit flag)."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"Digest": "sha256:abc123"}',
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.inspect(
+            "docker://quay.io/image:tag",
+            tls_verify=None,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--tls-verify" not in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_inspect_with_boolean_flags(self, mock_run) -> None:
+        """Test inspect with boolean flags."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"Digest": "sha256:abc123"}',
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        result = client.inspect(
+            "docker://quay.io/image:tag",
+            config=True,
+            raw=True,
+            no_tags=True,
+        )
+
+        assert isinstance(result, ContainerImageRaw)
+        called_cmd = mock_run.call_args[0][0]
+        assert "--config" in called_cmd
+        assert "--raw" in called_cmd
+        assert "--no-tags" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_inspect_raw_returns_container_image_raw(self, mock_run) -> None:
+        """Test that inspect with raw=True returns a ContainerImageRaw instance."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"schemaVersion": 2, "mediaType": "application/json"}',
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        result = client.inspect(
+            "docker://quay.io/image:tag",
+            raw=True,
+        )
+
+        assert isinstance(result, ContainerImageRaw)
+        assert result.schema_version == 2
+        assert result.media_type == "application/json"
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_inspect_raises_on_command_failure(self, mock_run) -> None:
+        """Test that inspect raises SkopeoClientError on failure."""
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["skopeo", "inspect", "docker://image"],
+            output="",
+            stderr="Error: manifest unknown",
+        )
+
+        client = SkopeoClient()
+        with pytest.raises(SkopeoClientError) as exc_info:
+            client.inspect("docker://quay.io/nonexistent:tag")
+
+        assert exc_info.value.returncode == 1
+        assert "manifest unknown" in exc_info.value.stderr
+        assert exc_info.value.command[0] == "skopeo"
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_inspect_raises_on_invalid_json(self, mock_run) -> None:
+        """Test that inspect raises SkopeoClientError on invalid JSON."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="not valid json",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        with pytest.raises(SkopeoClientError) as exc_info:
+            client.inspect("docker://quay.io/image:tag")
+
+        assert "Failed to parse skopeo output as JSON" in str(exc_info.value)
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_inspect_with_registry_token(self, mock_run) -> None:
+        """Test inspect with registry bearer token."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"Digest": "sha256:abc123"}',
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        token = Secret("bearer-token-12345")
+        client.inspect(
+            "docker://registry.io/image:tag",
+            registry_token=token,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--registry-token" in called_cmd
+        token_idx = called_cmd.index("--registry-token")
+        assert called_cmd[token_idx + 1] == "bearer-token-12345"
 
 
-def test_inspect_config_and_raw_together() -> None:
-    """Both flags can be set simultaneously."""
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_completed(),
-    ) as run_mock:
-        skopeo.inspect("img:v1", config=True, raw=True)
+class TestSkopeoClientCopy:
+    """Tests for the copy method."""
 
-    cmd = run_mock.call_args[0][0]
-    assert "--config" in cmd
-    assert "--raw" in cmd
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_minimal(self, mock_run) -> None:
+        """Test copy with minimal parameters."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert called_cmd[0] == "skopeo"
+        assert "copy" in called_cmd
+        assert "docker://quay.io/src:tag" in called_cmd
+        assert "docker://quay.io/dest:tag" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_all_flag_true(self, mock_run) -> None:
+        """Test copy with all=True."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+            all=True,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--all" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_all_flag_false(self, mock_run) -> None:
+        """Test copy with all=False (flag not added)."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+            all=False,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--all" not in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_all_flag_none(self, mock_run) -> None:
+        """Test copy with all=None (flag not added)."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+            all=None,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--all" not in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_preserve_digests(self, mock_run) -> None:
+        """Test copy with preserve_digests=True."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+            preserve_digests=True,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--preserve-digests" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_credentials(self, mock_run) -> None:
+        """Test copy with source and destination credentials."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        src_creds = Secret("src-user:src-pass")
+        dest_creds = Secret("dest-user:dest-pass")
+
+        client.copy(
+            "docker://registry.io/src:tag",
+            "docker://registry.io/dest:tag",
+            src_creds=src_creds,
+            dest_creds=dest_creds,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--src-creds" in called_cmd
+        src_idx = called_cmd.index("--src-creds")
+        assert called_cmd[src_idx + 1] == "src-user:src-pass"
+
+        assert "--dest-creds" in called_cmd
+        dest_idx = called_cmd.index("--dest-creds")
+        assert called_cmd[dest_idx + 1] == "dest-user:dest-pass"
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_tls_verify(self, mock_run) -> None:
+        """Test copy with TLS verification options."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+            src_tls_verify=False,
+            dest_tls_verify=True,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--src-tls-verify=false" in called_cmd
+        assert "--dest-tls-verify=true" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_no_creds_flags(self, mock_run) -> None:
+        """Test copy with no-creds flags."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+            src_no_creds=True,
+            dest_no_creds=True,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--src-no-creds" in called_cmd
+        assert "--dest-no-creds" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_retry_times(self, mock_run) -> None:
+        """Test copy with retry times."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+            retry_times=10,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--retry-times" in called_cmd
+        assert "10" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_format(self, mock_run) -> None:
+        """Test copy with manifest format."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+            format="oci",
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--format" in called_cmd
+        assert "oci" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_quiet(self, mock_run) -> None:
+        """Test copy with quiet flag."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+            quiet=True,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--quiet" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_cert_dirs(self, mock_run) -> None:
+        """Test copy with certificate directories."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+            src_cert_dir="/etc/certs/src",
+            dest_cert_dir="/etc/certs/dest",
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--src-cert-dir" in called_cmd
+        assert "/etc/certs/src" in called_cmd
+        assert "--dest-cert-dir" in called_cmd
+        assert "/etc/certs/dest" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_authfiles(self, mock_run) -> None:
+        """Test copy with authfile paths."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+            src_authfile="/auth/src.json",
+            dest_authfile="/auth/dest.json",
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--src-authfile" in called_cmd
+        assert "/auth/src.json" in called_cmd
+        assert "--dest-authfile" in called_cmd
+        assert "/auth/dest.json" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_remove_signatures(self, mock_run) -> None:
+        """Test copy with remove-signatures flag."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient()
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+            remove_signatures=True,
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--remove-signatures" in called_cmd
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_raises_on_failure(self, mock_run) -> None:
+        """Test that copy raises SkopeoClientError on failure."""
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["skopeo", "copy", "docker://src", "docker://dest"],
+            output="",
+            stderr="Error: copying image failed",
+        )
+
+        client = SkopeoClient()
+        with pytest.raises(SkopeoClientError) as exc_info:
+            client.copy(
+                "docker://quay.io/src:tag",
+                "docker://quay.io/dest:tag",
+            )
+
+        assert exc_info.value.returncode == 1
+        assert "copying image failed" in exc_info.value.stderr
+
+    @mock.patch("skopeo.subprocess.run")
+    def test_copy_with_global_flags(self, mock_run) -> None:
+        """Test that copy includes global flags from client init."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        client = SkopeoClient(debug=True, tmpdir="/tmp/skopeo")
+        client.copy(
+            "docker://quay.io/src:tag",
+            "docker://quay.io/dest:tag",
+        )
+
+        called_cmd = mock_run.call_args[0][0]
+        assert "--debug" in called_cmd
+        assert "--tmpdir" in called_cmd
+        assert "/tmp/skopeo" in called_cmd
 
 
-def test_inspect_image_ref_with_digest() -> None:
-    """Digest references are passed through correctly."""
-    digest = "sha256:abc123"
-    ref = f"registry.example.com/repo@{digest}"
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_completed(),
-    ) as run_mock:
-        skopeo.inspect(ref)
+class TestSkopeoClientError:
+    """Tests for SkopeoClientError exception."""
 
-    cmd = run_mock.call_args[0][0]
-    assert cmd[-1] == f"docker://{ref}"
+    def test_error_attributes(self) -> None:
+        """Test that error stores all required attributes."""
+        err = SkopeoClientError(
+            message="Command failed",
+            command=["skopeo", "inspect", "docker://image"],
+            returncode=1,
+            stdout="",
+            stderr="Error: manifest unknown",
+        )
 
+        assert str(err).startswith("Command failed")
+        assert err.command == ["skopeo", "inspect", "docker://image"]
+        assert err.returncode == 1
+        assert err.stdout == ""
+        assert err.stderr == "Error: manifest unknown"
 
-# ---------------------------------------------------------------------------
-# copy
-# ---------------------------------------------------------------------------
+    def test_error_string_representation(self) -> None:
+        """Test error string representation includes details."""
+        err = SkopeoClientError(
+            message="Command failed",
+            command=["skopeo", "inspect", "docker://image"],
+            returncode=1,
+            stdout="",
+            stderr="Error: manifest unknown",
+        )
 
+        error_str = str(err)
+        assert "Command failed" in error_str
+        assert "skopeo inspect docker://image" in error_str
+        assert "Return code: 1" in error_str
+        assert "Error: manifest unknown" in error_str
 
-def test_copy_basic_command() -> None:
-    """Default copy builds the correct command."""
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_completed(),
-    ) as run_mock:
-        skopeo.copy("docker://registry.example.com/repo:tag", "dir:/tmp/out")
+    def test_error_str_masks_secret_in_command(self) -> None:
+        """Test that SkopeoClientError masks Secret in command list."""
+        secret_value = "super-secret-creds-xyz789"
+        err = SkopeoClientError(
+            message="Command failed",
+            command=[
+                "skopeo",
+                "inspect",
+                "--creds",
+                Secret(secret_value),
+            ],
+            returncode=1,
+            stdout="",
+            stderr="auth failed",
+        )
 
-    cmd = run_mock.call_args[0][0]
-    assert cmd == [
-        "skopeo",
-        "copy",
-        "--retry-times",
-        "3",
-        "docker://registry.example.com/repo:tag",
-        "dir:/tmp/out",
-    ]
-    assert run_mock.call_args[1]["capture_output"] is True
-    assert run_mock.call_args[1]["text"] is True
-    assert run_mock.call_args[1]["check"] is False
-
-
-def test_copy_custom_retry_times() -> None:
-    """``retry_times`` overrides the default retry count."""
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_completed(),
-    ) as run_mock:
-        skopeo.copy("docker://img:v1", "dir:/tmp/out", retry_times=5)
-
-    cmd = run_mock.call_args[0][0]
-    idx = cmd.index("--retry-times")
-    assert cmd[idx + 1] == "5"
-
-
-def test_copy_returns_completed_process() -> None:
-    """The raw ``CompletedProcess`` is returned to the caller."""
-    expected = _completed(stdout="copied successfully")
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=expected,
-    ):
-        result = skopeo.copy("docker://img:v1", "dir:/tmp/out")
-
-    assert result is expected
+        error_str = str(err)
+        assert secret_value not in error_str
+        assert "***SECRET***" in error_str
 
 
-def test_copy_nonzero_exit_code() -> None:
-    """A non-zero exit code is returned, not raised."""
-    expected = _completed(returncode=1)
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=expected,
-    ):
-        result = skopeo.copy("docker://img:v1", "dir:/tmp/out")
+class TestSkopeoSecretMasking:
+    """Tests that secrets are masked in exceptions and traceback frames."""
 
-    assert result.returncode == 1
+    @pytest.fixture
+    def fix_inspect_auth_failure(self) -> SkopeoClient:
+        """Return a SkopeoClient whose subprocess.run raises on inspect."""
+        with mock.patch("skopeo.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(
+                returncode=1,
+                cmd=["skopeo", "inspect"],
+                output="",
+                stderr="auth failed",
+            )
+            yield SkopeoClient()
+
+    @pytest.fixture
+    def fix_copy_auth_failure(self) -> SkopeoClient:
+        """Return a SkopeoClient whose subprocess.run raises on copy."""
+        with mock.patch("skopeo.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(
+                returncode=1,
+                cmd=["skopeo", "copy"],
+                output="",
+                stderr="auth failed",
+            )
+            yield SkopeoClient()
+
+    def test_inspect_error_masks_creds_in_str(
+        self, fix_inspect_auth_failure: SkopeoClient
+    ) -> None:
+        """Test that inspect error message masks Secret credentials."""
+        secret_value = "super-secret-creds-xyz789"
+
+        with pytest.raises(SkopeoClientError) as exc_info:
+            fix_inspect_auth_failure.inspect(
+                "docker://registry.io/image:tag",
+                creds=Secret(secret_value),
+            )
+
+        error_str = str(exc_info.value)
+        assert secret_value not in error_str
+        assert "***SECRET***" in error_str
+
+    def test_inspect_error_masks_token_in_str(
+        self, fix_inspect_auth_failure: SkopeoClient
+    ) -> None:
+        """Test that inspect error message masks registry token."""
+        secret_value = "bearer-token-abc999"
+
+        with pytest.raises(SkopeoClientError) as exc_info:
+            fix_inspect_auth_failure.inspect(
+                "docker://registry.io/image:tag",
+                registry_token=Secret(secret_value),
+            )
+
+        error_str = str(exc_info.value)
+        assert secret_value not in error_str
+
+    def test_inspect_error_masks_secrets_in_traceback_locals(
+        self, fix_inspect_auth_failure: SkopeoClient
+    ) -> None:
+        """Test that Secret values stay masked in traceback frame locals."""
+        secret_value = "super-secret-creds-xyz789"
+
+        try:
+            fix_inspect_auth_failure.inspect(
+                "docker://registry.io/image:tag",
+                creds=Secret(secret_value),
+            )
+        except SkopeoClientError:
+            _, _, tb = sys.exc_info()
+            _assert_no_secret_leak_in_traceback(tb, secret_value)
+        else:
+            pytest.fail("Expected SkopeoClientError")
+
+    def test_copy_error_masks_creds_in_str(self, fix_copy_auth_failure: SkopeoClient) -> None:
+        """Test that copy error message masks Secret credentials."""
+        src_secret = "src-user:src-pass-secret"
+        dest_secret = "dest-user:dest-pass-secret"
+
+        with pytest.raises(SkopeoClientError) as exc_info:
+            fix_copy_auth_failure.copy(
+                "docker://registry.io/src:tag",
+                "docker://registry.io/dest:tag",
+                src_creds=Secret(src_secret),
+                dest_creds=Secret(dest_secret),
+            )
+
+        error_str = str(exc_info.value)
+        assert src_secret not in error_str
+        assert dest_secret not in error_str
+        assert "***SECRET***" in error_str
+
+    def test_copy_error_masks_secrets_in_traceback_locals(
+        self, fix_copy_auth_failure: SkopeoClient
+    ) -> None:
+        """Test that Secret values stay masked in copy traceback locals."""
+        src_secret = "src-user:src-pass-secret"
+        dest_secret = "dest-user:dest-pass-secret"
+
+        try:
+            fix_copy_auth_failure.copy(
+                "docker://registry.io/src:tag",
+                "docker://registry.io/dest:tag",
+                src_creds=Secret(src_secret),
+                dest_creds=Secret(dest_secret),
+            )
+        except SkopeoClientError:
+            _, _, tb = sys.exc_info()
+            _assert_no_secret_leak_in_traceback(tb, src_secret)
+            _assert_no_secret_leak_in_traceback(tb, dest_secret)
+        else:
+            pytest.fail("Expected SkopeoClientError")

--- a/scripts/python/tasks/internal/check_fbc_opt_in.py
+++ b/scripts/python/tasks/internal/check_fbc_opt_in.py
@@ -51,9 +51,7 @@ def get_fbc_opt_in(
     *,
     warn_on_query_failure: bool = True,
 ) -> bool:
-    """
-    Return `True` only when the Pyxis JSON body sets `fbc_opt_in` to JSON boolean
-    true.
+    """Return `True` only when the Pyxis JSON body sets `fbc_opt_in` to JSON true.
 
     Query failures, non-JSON responses, and missing fields are treated as
     opt-out (`False`).
@@ -90,8 +88,7 @@ def run_check(
     kinit: Callable[..., None] = authentication.kinit_with_retry,
     get_opt_in: Callable[[str, str, AuthBase | None], bool] = get_fbc_opt_in,
 ) -> list[dict[str, Any]]:
-    """
-    Authenticate with Kerberos then query Pyxis FBC opt-in for each image.
+    """Authenticate with Kerberos then query Pyxis FBC opt-in for each image.
 
     Returns one result object per input image:
     `{"containerImage": "...", "fbcOptIn": bool}`.

--- a/scripts/python/tasks/internal/test_update_fbc_catalog.py
+++ b/scripts/python/tasks/internal/test_update_fbc_catalog.py
@@ -15,6 +15,7 @@ import authentication
 import iib
 import tekton
 import update_fbc_catalog
+from skopeo import SkopeoClientError, ContainerImageConfig
 
 # ---------------------------------------------------------------------------
 # parse_fbc_fragments
@@ -153,10 +154,12 @@ def _skopeo_result(
 def test_inspect_image_created_success() -> None:
     """A valid skopeo response returns the created date string."""
     with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_skopeo_result('{"created": "2024-01-15T10:30:00Z"}'),
-    ):
+        "skopeo.SkopeoClient.inspect",
+        return_value=ContainerImageConfig.from_json('{"created": "2024-01-15T10:30:00Z"}'),
+    ) as mock_inspect:
         assert update_fbc_catalog.inspect_image_created("img:v1") == "2024-01-15T10:30:00Z"
+        print(mock_inspect.mock_calls[0])
+        assert mock_inspect.mock_calls[0].args[0] == "docker://img:v1"
 
 
 def test_inspect_image_created_skopeo_failure() -> None:
@@ -171,8 +174,8 @@ def test_inspect_image_created_skopeo_failure() -> None:
 def test_inspect_image_created_no_created_field() -> None:
     """Missing ``created`` field returns ``None``."""
     with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_skopeo_result("{}"),
+        "skopeo.SkopeoClient.inspect",
+        return_value=ContainerImageConfig.from_json("{}"),
     ):
         assert update_fbc_catalog.inspect_image_created("img:v1") is None
 
@@ -711,10 +714,16 @@ def test_get_manifest_digests_not_multiarch() -> None:
 def test_get_manifest_digests_skopeo_failure() -> None:
     """Raise ``RuntimeError`` when skopeo fails."""
     with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_skopeo_result(returncode=1),
+        "skopeo.SkopeoClient.inspect",
+        side_effect=SkopeoClientError(
+            message="skopeo inspect --raw failed",
+            command="inspect",
+            returncode=1,
+            stdout="",
+            stderr="error",
+        ),
     ):
-        with pytest.raises(RuntimeError, match="skopeo inspect --raw failed"):
+        with pytest.raises(SkopeoClientError, match="skopeo inspect --raw failed.*"):
             update_fbc_catalog.get_manifest_digests("img:v1")
 
 
@@ -1230,8 +1239,14 @@ def test_poll_and_collect_digest_extraction_fails() -> None:
     with (
         mock.patch("iib.get_build", return_value=build),
         mock.patch(
-            "skopeo.subprocess.run",
-            return_value=_skopeo_result(returncode=1),
+            "skopeo.SkopeoClient.inspect",
+            side_effect=SkopeoClientError(
+                message="skopeo inspect --raw failed",
+                command="inspect",
+                returncode=1,
+                stdout="",
+                stderr="error",
+            ),
         ),
     ):
         result = update_fbc_catalog._poll_and_collect(

--- a/scripts/python/tasks/internal/update_fbc_catalog.py
+++ b/scripts/python/tasks/internal/update_fbc_catalog.py
@@ -22,7 +22,7 @@ import file
 import http_client
 import iib
 import requests
-import skopeo
+from skopeo import SkopeoClient, SkopeoClientError
 import tekton
 from logger import logger
 from requests_kerberos import OPTIONAL, HTTPKerberosAuth
@@ -117,15 +117,13 @@ def inspect_image_created(image_ref: str) -> str | None:
 
     Return ``None`` on any failure.
     """
-    result = skopeo.inspect(image_ref, config=True)
-    if result.returncode != 0:
-        return None
     try:
-        created = json.loads(result.stdout).get("created")
+        result = SkopeoClient().inspect(f"docker://{image_ref}", config=True)
+        created = result.created
         if not created or created == "null":
             return None
-        return str(created)
-    except (json.JSONDecodeError, OSError):
+        return created.strftime("%Y-%m-%dT%H:%M:%SZ")
+    except SkopeoClientError:
         return None
 
 
@@ -470,12 +468,9 @@ def get_manifest_digests(image_ref: str) -> str:
 
     Raise ``RuntimeError`` if the image is not a manifest list.
     """
-    result = skopeo.inspect(image_ref, raw=True)
-    if result.returncode != 0:
-        raise RuntimeError(f"skopeo inspect --raw failed for {image_ref}: {result.stderr}")
-    raw = json.loads(result.stdout)
+    result = SkopeoClient().inspect(image_ref, raw=True)
     media = "application/vnd.docker.distribution.manifest.v2+json"
-    digests = [m["digest"] for m in raw.get("manifests", []) if m.get("mediaType") == media]
+    digests = [m.digest for m in result.manifests if m.media_type == media]
     if not digests:
         raise RuntimeError("Index image produced is not multi-arch with a manifest list")
     return " ".join(digests)
@@ -696,7 +691,7 @@ def _poll_and_collect(
 
     try:
         digests = get_manifest_digests(internal_copy)
-    except (RuntimeError, json.JSONDecodeError) as e:
+    except (RuntimeError, SkopeoClientError) as e:
         return RunResult(
             build_info=build_info,
             state="failed",

--- a/scripts/python/tasks/managed/extract_checksums_from_image.py
+++ b/scripts/python/tasks/managed/extract_checksums_from_image.py
@@ -11,16 +11,14 @@ from __future__ import annotations
 import json
 import os
 import shutil
-import subprocess
 import tarfile
 import tempfile
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-import skopeo
 import tekton
 from logger import logger
+from skopeo import SkopeoClient
 
 BINARIES_DIR = "binaries"
 
@@ -109,13 +107,16 @@ def extract_checksums(
     image_binaries_path: str,
     snapshot_rel_path: str,
     *,
-    copy_image: Callable[..., subprocess.CompletedProcess[str]] = skopeo.copy,
+    skopeo_client: SkopeoClient | None = None,
 ) -> str:
     """Extract SHA256SUMS files from container images in the snapshot.
 
     Returns the relative binaries path (e.g. ``uid123/binaries``) for
     writing to the Tekton result file.
     """
+    if skopeo_client is None:
+        skopeo_client = SkopeoClient()
+
     snapshot = load_snapshot(snapshot_path)
 
     relative_binaries = f"{Path(snapshot_rel_path).parent}/{BINARIES_DIR}"
@@ -136,15 +137,7 @@ def extract_checksums(
 
         tmp_dir = Path(tempfile.mkdtemp())
         try:
-            result = copy_image(f"docker://{image_url}", f"dir:{tmp_dir}")
-            if result.returncode != 0:
-                logger.error("skopeo copy failed: %s", result.stderr)
-                raise subprocess.CalledProcessError(
-                    result.returncode,
-                    result.args,
-                    output=result.stdout,
-                    stderr=result.stderr,
-                )
+            skopeo_client.copy(f"docker://{image_url}", f"dir:{tmp_dir}")
 
             extract_binaries_from_layers(tmp_dir, image_binaries_path)
 

--- a/scripts/python/tasks/managed/rh_direct_sign_image.py
+++ b/scripts/python/tasks/managed/rh_direct_sign_image.py
@@ -19,6 +19,7 @@ from kubectl import get_configmap
 from logger import logger as LOGGER
 from oras_utils import oras_resolve
 from subprocess_cmd import run_cmd
+from skopeo import SkopeoClient
 
 import pyxis
 
@@ -262,27 +263,18 @@ def get_all_image_digests(image_reference: str) -> list[str]:
         auth_file.write(select_auth.stdout)
         auth_file.flush()
 
-        result = run_cmd(
-            [
-                "skopeo",
-                "inspect",
-                "--retry-times",
-                "3",
-                "--raw",
-                "--authfile",
-                auth_file.name,
-                f"docker://{image_reference}",
-            ]
+        result = SkopeoClient().inspect(
+            "docker://" + image_reference,
+            authfile=auth_file.name,
+            raw=True,
+            retry_times=3,
         )
-    raw_manifest = json.loads(result.stdout)
 
     digests = [top_level_digest]
 
-    media_type = raw_manifest.get("mediaType", "")
-    if media_type not in SINGLE_MANIFEST_MEDIA_TYPES:
-        manifests = raw_manifest.get("manifests")
-        if manifests:
-            digests.extend(m["digest"] for m in manifests)
+    if result.media_type not in SINGLE_MANIFEST_MEDIA_TYPES:
+        if result.manifests:
+            digests.extend(m.digest for m in result.manifests)
         else:
             LOGGER.info("Single-manifest artifact (e.g. Helm chart), no nested digests to add")
 

--- a/scripts/python/tasks/managed/test_extract_checksums_from_image.py
+++ b/scripts/python/tasks/managed/test_extract_checksums_from_image.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import io
 import json
-import subprocess
 import tarfile
 from pathlib import Path
 from unittest import mock
 
 import extract_checksums_from_image as ecfi
 import pytest
+from skopeo import SkopeoClient, SkopeoClientError
 
 # ---------------------------------------------------------------------------
 # helpers
@@ -70,33 +70,29 @@ def _write_manifest(image_dir: Path, digests: list[str]) -> None:
     (image_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
 
-def _fake_copy_image(image_dir: Path, base_dir: str, files: dict[str, str]):
-    """Return a copy_image callable that populates *image_dir* with a layer."""
+def _fake_copy_client(image_dir: Path, base_dir: str, files: dict[str, str]) -> mock.MagicMock:
+    """Return a mock ``SkopeoClient`` whose copy populates *image_dir*."""
     digest = _make_layer_tar(image_dir, base_dir, files)
     _write_manifest(image_dir, [digest])
 
-    def _copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
+    def _copy(source: str, dest: str, **kwargs) -> None:
         import shutil
 
         dest_path = Path(dest.removeprefix("dir:"))
         for item in image_dir.iterdir():
             if item.is_file():
                 shutil.copy2(item, dest_path)
-        return subprocess.CompletedProcess(
-            args=["skopeo", "copy"], returncode=0, stdout="", stderr=""
-        )
 
-    return _copy
+    client = mock.MagicMock(spec=SkopeoClient)
+    client.copy.side_effect = _copy
+    return client
 
 
-def _stub_copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
+def _stub_copy(source: str, dest: str, **kwargs) -> None:
     """Copy stub that writes a minimal valid layer with a SHA256SUMS file."""
     dest_path = Path(dest.removeprefix("dir:"))
     digest = _make_layer_tar(dest_path, "releases", {"SHA256SUMS": "stub"})
     _write_manifest(dest_path, [digest])
-    return subprocess.CompletedProcess(
-        args=["skopeo", "copy"], returncode=0, stdout="", stderr=""
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -306,14 +302,14 @@ def test_extract_checksums_single_component(tmp_path: Path) -> None:
 
     image_staging = tmp_path / "staging"
     image_staging.mkdir()
-    copy_fn = _fake_copy_image(
+    client = _fake_copy_client(
         image_staging,
         "releases",
         {"app.zip": "binary", "app-SHA256SUMS": "deadbeef  app.zip"},
     )
 
     result = ecfi.extract_checksums(
-        snapshot_path, data_path, data_dir, "releases", rel, copy_image=copy_fn
+        snapshot_path, data_path, data_dir, "releases", rel, skopeo_client=client
     )
 
     assert result == "uid123/binaries"
@@ -329,12 +325,8 @@ def test_extract_checksums_multiple_components(tmp_path: Path) -> None:
     ]
     snapshot_path, data_path, data_dir, rel = _setup_extract(tmp_path, components)
 
-    call_count = 0
-
-    def _counting_copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
-        nonlocal call_count
-        call_count += 1
-        return _stub_copy(source, dest)
+    client = mock.MagicMock(spec=SkopeoClient)
+    client.copy.side_effect = _stub_copy
 
     ecfi.extract_checksums(
         snapshot_path,
@@ -342,10 +334,10 @@ def test_extract_checksums_multiple_components(tmp_path: Path) -> None:
         data_dir,
         "releases",
         rel,
-        copy_image=_counting_copy,
+        skopeo_client=client,
     )
 
-    assert call_count == 3
+    assert client.copy.call_count == 3
 
 
 def test_extract_checksums_component_filtering(tmp_path: Path) -> None:
@@ -359,11 +351,8 @@ def test_extract_checksums_component_filtering(tmp_path: Path) -> None:
         tmp_path, components, data_names=["c1", "c3"]
     )
 
-    processed: list[str] = []
-
-    def _tracking_copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
-        processed.append(source)
-        return _stub_copy(source, dest)
+    client = mock.MagicMock(spec=SkopeoClient)
+    client.copy.side_effect = _stub_copy
 
     ecfi.extract_checksums(
         snapshot_path,
@@ -371,13 +360,14 @@ def test_extract_checksums_component_filtering(tmp_path: Path) -> None:
         data_dir,
         "releases",
         rel,
-        copy_image=_tracking_copy,
+        skopeo_client=client,
     )
 
-    assert len(processed) == 2
-    assert any("img1" in s for s in processed)
-    assert any("img3" in s for s in processed)
-    assert not any("img2" in s for s in processed)
+    sources = [call.args[0] for call in client.copy.call_args_list]
+    assert len(sources) == 2
+    assert any("img1" in s for s in sources)
+    assert any("img3" in s for s in sources)
+    assert not any("img2" in s for s in sources)
 
 
 def test_extract_checksums_empty_image_url_raises(tmp_path: Path) -> None:
@@ -439,13 +429,13 @@ def test_extract_checksums_missing_binaries_path_raises(tmp_path: Path) -> None:
         [{"name": "c1", "containerImage": "registry.io/img:v1"}],
     )
 
-    def _copy_without_binaries(source: str, dest: str) -> subprocess.CompletedProcess[str]:
+    def _copy_without_binaries(source: str, dest: str, **kwargs) -> None:
         dest_path = Path(dest.removeprefix("dir:"))
         digest = _make_empty_layer_tar(dest_path)
         _write_manifest(dest_path, [digest])
-        return subprocess.CompletedProcess(
-            args=["skopeo", "copy"], returncode=0, stdout="", stderr=""
-        )
+
+    client = mock.MagicMock(spec=SkopeoClient)
+    client.copy.side_effect = _copy_without_binaries
 
     with pytest.raises(ValueError, match="does not contain the 'releases' directory"):
         ecfi.extract_checksums(
@@ -454,33 +444,34 @@ def test_extract_checksums_missing_binaries_path_raises(tmp_path: Path) -> None:
             data_dir,
             "releases",
             rel,
-            copy_image=_copy_without_binaries,
+            skopeo_client=client,
         )
 
 
 def test_extract_checksums_skopeo_failure_raises(tmp_path: Path) -> None:
-    """Non-zero skopeo exit code raises CalledProcessError."""
+    """Skopeo copy failure raises SkopeoClientError."""
     snapshot_path, data_path, data_dir, rel = _setup_extract(
         tmp_path,
         [{"name": "c1", "containerImage": "registry.io/img:v1"}],
     )
 
-    def _failing_copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(
-            args=["skopeo", "copy"],
-            returncode=1,
-            stdout="",
-            stderr="unauthorized",
-        )
+    client = mock.MagicMock(spec=SkopeoClient)
+    client.copy.side_effect = SkopeoClientError(
+        "Skopeo command failed with exit code 1",
+        command=["skopeo", "copy"],
+        returncode=1,
+        stdout="",
+        stderr="unauthorized",
+    )
 
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(SkopeoClientError):
         ecfi.extract_checksums(
             snapshot_path,
             data_path,
             data_dir,
             "releases",
             rel,
-            copy_image=_failing_copy,
+            skopeo_client=client,
         )
 
 
@@ -495,8 +486,8 @@ def test_extract_checksums_returns_correct_relative_path(
     rel = "deep/nested/snapshot.json"
     _write_snapshot(data_dir / rel, [{"name": "c1", "containerImage": "r/i:1"}])
 
-    def _noop_copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
-        return _stub_copy(source, dest)
+    client = mock.MagicMock(spec=SkopeoClient)
+    client.copy.side_effect = _stub_copy
 
     result = ecfi.extract_checksums(
         data_dir / rel,
@@ -504,7 +495,7 @@ def test_extract_checksums_returns_correct_relative_path(
         data_dir,
         "releases",
         rel,
-        copy_image=_noop_copy,
+        skopeo_client=client,
     )
 
     assert result == "deep/nested/binaries"
@@ -527,18 +518,24 @@ def test_extract_checksums_temp_dir_cleaned_on_failure(
         created_dirs.append(Path(d))
         return d
 
-    def _failing_copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="fail")
+    client = mock.MagicMock(spec=SkopeoClient)
+    client.copy.side_effect = SkopeoClientError(
+        "Skopeo command failed with exit code 1",
+        command=["skopeo", "copy"],
+        returncode=1,
+        stdout="",
+        stderr="fail",
+    )
 
     with mock.patch.object(ecfi.tempfile, "mkdtemp", _tracking_mkdtemp):
-        with pytest.raises(subprocess.CalledProcessError):
+        with pytest.raises(SkopeoClientError):
             ecfi.extract_checksums(
                 snapshot_path,
                 data_path,
                 data_dir,
                 "releases",
                 rel,
-                copy_image=_failing_copy,
+                skopeo_client=client,
             )
 
     assert created_dirs

--- a/scripts/python/tasks/managed/test_rh_direct_sign_image.py
+++ b/scripts/python/tasks/managed/test_rh_direct_sign_image.py
@@ -7,9 +7,12 @@ import json
 import logging
 import re
 from pathlib import Path
+from typing import Any, Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from rsmodels.container_image import ContainerImageRaw
 
 from rh_direct_sign_image import (
     PyxisSignature,
@@ -539,10 +542,10 @@ def test_process_component_includes_source_container_candidates() -> None:
 
 # --- get_all_image_digests ---
 
-_SINGLE_MANIFEST = json.dumps(
+_SINGLE_MANIFEST = ContainerImageRaw.from_dict(
     {"mediaType": "application/vnd.oci.image.manifest.v1+json", "schemaVersion": 2}
 )
-_INDEX_MANIFEST = json.dumps(
+_INDEX_MANIFEST = ContainerImageRaw.from_dict(
     {
         "mediaType": "application/vnd.oci.image.index.v1+json",
         "manifests": [
@@ -551,67 +554,89 @@ _INDEX_MANIFEST = json.dumps(
         ],
     }
 )
-_HELM_MANIFEST = json.dumps({"schemaVersion": 2})  # no mediaType, no manifests
+
+# no mediaType, no manifests
+_HELM_MANIFEST = ContainerImageRaw.from_dict({"schemaVersion": 2})
 
 
-def test_get_all_image_digests_single_arch_returns_only_top_level() -> None:
+@pytest.fixture
+def fix_inspect_single_manifest() -> Generator[Any]:
+    """Patch SkopeoClient.inspect to return a single-arch manifest."""
+    with patch("skopeo.SkopeoClient.inspect") as mock_inspect:
+        mock_inspect.return_value = _SINGLE_MANIFEST
+        yield mock_inspect
+
+
+@pytest.fixture
+def fix_inspect_index_manifest() -> Generator[Any]:
+    """Patch SkopeoClient.inspect to return a single-arch manifest."""
+    with patch("skopeo.SkopeoClient.inspect") as mock_inspect:
+        mock_inspect.return_value = _INDEX_MANIFEST
+        yield mock_inspect
+
+
+@pytest.fixture
+def fix_inspect_helm_manifest() -> Generator[Any]:
+    """Patch SkopeoClient.inspect to return a single-arch manifest."""
+    with patch("skopeo.SkopeoClient.inspect") as mock_inspect:
+        mock_inspect.return_value = _HELM_MANIFEST
+        yield mock_inspect
+
+
+@pytest.fixture
+def fix_select_oci_auth() -> Generator[Any]:
+    """Patch run_cmd to simulate select-oci-auth returning an auth file path."""
+    with patch("rh_direct_sign_image.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock(stdout="{}")
+        yield mock_run
+
+
+def test_get_all_image_digests_single_arch_returns_only_top_level(
+    fix_inspect_single_manifest, fix_select_oci_auth
+) -> None:
     """A single-arch image returns only its own digest."""
     ref = "registry.io/repo/image@sha256:toplevel"
-    with patch("rh_direct_sign_image.run_cmd") as mock_run:
-        mock_run.return_value = MagicMock(stdout=_SINGLE_MANIFEST)
-        digests = get_all_image_digests(ref)
-
+    digests = get_all_image_digests(ref)
     assert digests == ["sha256:toplevel"]
 
 
-def test_get_all_image_digests_multi_arch_includes_nested_digests() -> None:
+def test_get_all_image_digests_multi_arch_includes_nested_digests(
+    fix_inspect_index_manifest, fix_select_oci_auth
+) -> None:
     """A multi-arch index image includes the top-level and all nested digests."""
     ref = "registry.io/repo/image@sha256:index"
-    with patch("rh_direct_sign_image.run_cmd") as mock_run:
-        mock_run.return_value = MagicMock(stdout=_INDEX_MANIFEST)
-        digests = get_all_image_digests(ref)
-
+    digests = get_all_image_digests(ref)
     assert digests == ["sha256:index", "sha256:amd64", "sha256:arm64"]
 
 
-def test_get_all_image_digests_helm_chart_returns_only_top_level() -> None:
+def test_get_all_image_digests_helm_chart_returns_only_top_level(
+    fix_inspect_helm_manifest, fix_select_oci_auth
+) -> None:
     """Single-manifest artifact with no nested manifests returns only the top-level digest."""
     ref = "registry.io/repo/chart@sha256:chart"
-    with patch("rh_direct_sign_image.run_cmd") as mock_run:
-        mock_run.return_value = MagicMock(stdout=_HELM_MANIFEST)
-        digests = get_all_image_digests(ref)
-
+    digests = get_all_image_digests(ref)
     assert digests == ["sha256:chart"]
 
 
-def test_get_all_image_digests_calls_select_oci_auth_with_reference() -> None:
+def test_get_all_image_digests_calls_select_oci_auth_with_reference(
+    fix_inspect_helm_manifest, fix_select_oci_auth
+) -> None:
     """select-oci-auth is called with the image reference before skopeo inspect."""
     ref = "registry.io/repo/image@sha256:abc"
-    with patch("rh_direct_sign_image.run_cmd") as mock_run:
-        mock_run.side_effect = [
-            MagicMock(stdout="{}"),
-            MagicMock(stdout=_SINGLE_MANIFEST),
-        ]
-        get_all_image_digests(ref)
-
-    first_call = mock_run.call_args_list[0].args[0]
+    get_all_image_digests(ref)
+    first_call = fix_select_oci_auth.call_args_list[0].args[0]
     assert first_call == ["select-oci-auth", ref]
 
 
-def test_get_all_image_digests_passes_authfile_to_skopeo() -> None:
+def test_get_all_image_digests_passes_authfile_to_skopeo(
+    fix_inspect_single_manifest, fix_select_oci_auth
+) -> None:
     """Skopeo inspect is called with --authfile pointing to the auth credentials."""
     ref = "registry.io/repo/image@sha256:abc"
-    with patch("rh_direct_sign_image.run_cmd") as mock_run:
-        mock_run.side_effect = [
-            MagicMock(stdout="{}"),
-            MagicMock(stdout=_SINGLE_MANIFEST),
-        ]
-        get_all_image_digests(ref)
-
-    skopeo_call = mock_run.call_args_list[1].args[0]
-    assert skopeo_call[0] == "skopeo"
-    assert "--authfile" in skopeo_call
-    assert f"docker://{ref}" in skopeo_call
+    get_all_image_digests(ref)
+    print(fix_inspect_single_manifest.call_args_list)
+    assert "authfile" in fix_inspect_single_manifest.call_args_list[0].kwargs
+    assert fix_inspect_single_manifest.call_args_list[0].args[0] == f"docker://{ref}"
 
 
 # --- get_source_container_digest ---

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "ansible-core"
 version = "2.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1590,6 +1599,96 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
 name = "pyflakes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1902,6 +2001,7 @@ dependencies = [
     { name = "pubtools-pyxis" },
     { name = "pubtools-sign" },
     { name = "pulp-cli" },
+    { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "python-gitlab" },
     { name = "pyyaml" },
@@ -1936,6 +2036,7 @@ requires-dist = [
     { name = "pubtools-pyxis", specifier = "==1.3.8" },
     { name = "pubtools-sign", specifier = "==1.0.6" },
     { name = "pulp-cli", specifier = "==0.36.3" },
+    { name = "pydantic" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-gitlab", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
@@ -2278,6 +2379,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This commit implements skopeo client supporting copy and inspect operations. Also it provides fake skopeo client which can be injected instead of real skopeo client during tests