### PR TITLE
feat(RELEASE-2508): add publish_pyxis_repository.py script

### DIFF
--- a/docs/tasks/managed/publish_pyxis_repository.md
+++ b/docs/tasks/managed/publish_pyxis_repository.md
@@ -1,0 +1,187 @@
+# publish_pyxis_repository.py
+
+Marks container repositories as **published** in Pyxis, records Red Hat **catalog URLs**, and builds the **sign-registry-access** list for later signing steps.
+
+Source: [`publish_pyxis_repository.py`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py)
+
+**Read this first:** Unlike internal OSIDB tasks, this script **fails the Tekton step** on error — [`main`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py) raises `SystemExit` with a `publish_pyxis_repository.py: …` message (or `must be set` from missing env). There is no `result: Success` file.
+
+Logs are on **stderr** as `INFO:` / `WARNING:` / `ERROR:` ([`logger`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/logger.py)).
+
+---
+
+## Where this runs
+
+Catalog task [`publish-pyxis-repository`](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml) runs as a **normal Tekton step** (not an InternalRequest) in:
+
+| Pipeline | Notes |
+|----------|-------|
+| [`rh-push-to-registry-redhat-io`](https://github.com/konflux-ci/release-service-catalog/blob/development/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml) | After `apply-mapping` / `collect-data` |
+| [`rh-advisories`](https://github.com/konflux-ci/release-service-catalog/blob/development/pipelines/managed/rh-advisories/rh-advisories.yaml) | **Skipped** when `filter-already-released-advisory-images` sets `skip_release=true` |
+| [`rh-push-helm-chart-to-registry-redhat-io`](https://github.com/konflux-ci/release-service-catalog/blob/development/pipelines/managed/rh-push-helm-chart-to-registry-redhat-io/rh-push-helm-chart-to-registry-redhat-io.yaml) | Same pattern |
+
+```mermaid
+sequenceDiagram
+  participant TA as use-trusted-artifact
+  participant PP as publish-pyxis-repository<br/>(this script)
+  participant PX as Pyxis API
+  participant OUT as Workspace files
+
+  TA->>PP: snapshot + data.json in dataDir
+  PP->>PX: GET each repo (cert + key)
+  PP->>PX: PATCH published=true (maybe)
+  PP->>OUT: results JSON + sign-registry-access.txt
+  PP->>OUT: Tekton signRegistryAccessPath result
+```
+
+Typical inputs come from **`collect-data`** (`snapshotPath`, `dataPath`, `resultsDirPath`) and **`collect-task-params`** (`server`, `pyxisSecret`).
+
+---
+
+## Inputs and outputs
+
+### Reads
+
+| Input | Path / source |
+|-------|----------------|
+| Snapshot | `PARAM_DATA_DIR` / `PARAM_SNAPSHOT_PATH` — `components[].repositories[].url` (Quay URLs from mapping) |
+| Data JSON | `PARAM_DATA_DIR` / `PARAM_DATA_PATH` — `pyxis.skipRepoPublishing`, `mapping.defaults.pushSourceContainer` |
+| Pyxis login | Kubernetes secret mounted at `PYXIS_SECRET_MOUNT` (default `/etc/secrets`) — two files: `cert` and `key`. The script passes both to every Pyxis HTTP call ([`cert` tuple](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py)). |
+| Pyxis environment | `PARAM_SERVER` → API base URL ([`pyxis_api_url_for_server`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/pyxis_api.py)); optional test override `PYXIS_URL` |
+
+### Quay URL → Pyxis mapping
+
+| Quay prefix | Pyxis registry | Repository name |
+|-------------|----------------|-----------------|
+| `quay.io/redhat-prod/…`, `quay.io/redhat-pending/…` | `registry.access.redhat.com` | last path segment with `----` → `/` ([`pyxis_repository_from_quay_url`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/pyxis_api.py)) |
+| `quay.io/rh-flatpaks-prod/…`, `quay.io/rh-flatpaks-stage/…` | `flatpaks.registry.redhat.io` | same `----` rule |
+
+### Writes
+
+| Output | Location |
+|--------|----------|
+| Catalog URL list | `{dataDir}/{resultsDirPath}/publish-pyxis-repository-results.json` — `{"catalog_urls": [{"name", "url"}, …]}` |
+| Sign list | `{dataDir}/{dirname(dataPath)}/sign-registry-access.txt` — one Pyxis repo per line (e.g. `my-product/my-image`) |
+| Tekton result | `signRegistryAccessPath` — **relative** path to that txt file from `dataDir` ([`publish_pyxis_repository.py`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py)) |
+
+Downstream **`rh-sign-image`** / **`rh-sign-image-cosign`** read `signRegistryAccessPath`. An empty sign file is normal when no repo qualifies.
+
+### Tekton env (Python step)
+
+| Env | Role |
+|-----|------|
+| `PARAM_DATA_DIR` | Workspace root |
+| `PARAM_SNAPSHOT_PATH` | Relative snapshot JSON |
+| `PARAM_DATA_PATH` | Relative `data.json` |
+| `PARAM_RESULTS_DIR_PATH` | Relative results directory |
+| `PARAM_SERVER` | `production`, `stage`, `production-internal`, or `stage-internal` |
+| `RESULT_SIGN_REGISTRY_ACCESS_PATH` | Path to write Tekton `signRegistryAccessPath` |
+| `PYXIS_SECRET_MOUNT` | Cert directory |
+| `TASK_NAME` | Label in logs (from `context.task.name`) |
+| `PYXIS_URL` | Optional override (tests/mocks; not set in production pipelines) |
+
+---
+
+## Publish rules
+
+For each `repositories[].url` on each snapshot component:
+
+1. **GET** Pyxis repository JSON ([`get_repository_json`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/pyxis_api.py)) — needs `_id`.
+2. **Sign list:** if registry is `registry.access.redhat.com` and Pyxis `requires_terms` is **`false`** (JSON boolean), append `pyxis_repo` to `sign-registry-access.txt` — see [`should_add_sign_registry_access`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py). (Catalog YAML text says `requires_terms=true`; the **code** uses `false`. Flatpak registries never qualify.)
+3. **PATCH** only when:
+   - `data.pyxis.skipRepoPublishing` is not true ([`skip_repo_publishing`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py)), **and**
+   - Pyxis `publish_on_push` is **exactly** `true`.
+4. PATCH body: `published: true`, plus `source_container_image_enabled: true` when [`component_push_source_container`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/snapshot.py) is true (default from `mapping.defaults.pushSourceContainer`, default **true**).
+
+`publish_on_push = false` or `skipRepoPublishing` → **WARNING** or INFO skip lines; step can still **succeed** with `0 published`.
+
+---
+
+## What each part of the code does
+
+### [`main`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py)
+
+Loads required env and paths, calls [`run_publish_pyxis_repository`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py). On `FileNotFoundError`, `ValueError`, `OSError`, or any other exception → `SystemExit(f"{PROG}: {exc}")`. Success → return `0`.
+
+### [`run_publish_pyxis_repository`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py)
+
+1. Verifies snapshot and data files exist.
+2. Writes Tekton `signRegistryAccessPath` and creates empty `sign-registry-access.txt` beside `data.json`.
+3. Logs start, Pyxis URL ([`resolve_pyxis_api_url`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py)), skip flag, default `pushSourceContainer`.
+4. Calls [`publish_repositories`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py).
+5. Writes [`publish-pyxis-repository-results.json`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py).
+6. Logs completion with published count.
+
+### [`publish_repositories`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py)
+
+Loops snapshot `components` → `repositories`:
+
+- Maps Quay URL to Pyxis registry/repo; logs `Processing repository … as Pyxis …`.
+- GET → requires `_id` or logs `ERROR: Pyxis response for …` and raises.
+- Maybe appends sign-list line; maybe PATCH and append to `catalog_urls` via [`catalog_url_for_repository`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/pyxis_api.py).
+
+### Small helpers
+
+| Function | Role |
+|----------|------|
+| [`build_publish_payload`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py) | PATCH JSON |
+| [`resolve_pyxis_api_url`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py) | `PYXIS_URL` or `PARAM_SERVER` map |
+| [`skip_repo_publishing`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/publish_pyxis_repository.py) | Reads `pyxis.skipRepoPublishing` |
+
+Pyxis HTTP: GET uses 120s timeout and returns error bodies ([`allow_error_status=True`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/pyxis_api.py)); PATCH raises on non-2xx.
+
+---
+
+## Troubleshooting
+
+Open the **`publish-pyxis-repository`** step log (not `use-trusted-artifact` / `create-trusted-artifact`).
+
+**Succeeded** with `WARNING:` or `0 published` can be normal. **Failed** means non-zero exit — read the last `INFO:`/`WARNING:`/`ERROR:` lines and the exit message.
+
+### By last stderr log line
+
+| Last log line | Step | Likely issue | What to check |
+|---------------|------|--------------|---------------|
+| *(no `INFO:` lines)* | Failed | Missing env before work starts | stderr for `PARAM_* must be set` or `RESULT_SIGN_REGISTRY_ACCESS_PATH must be set`; [catalog task env](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml) |
+| `INFO: Beginning "…" for "…"` then fail | Failed | Missing snapshot or data file | Paths under `PARAM_DATA_DIR`; upstream `collect-data` / trusted artifact |
+| `INFO: Using Pyxis API URL: …` then immediate fail | Failed | Bad `PARAM_SERVER` | `Invalid server parameter` in exit text; `collect-task-params` server value |
+| `INFO: Processing repository … as Pyxis …` (long pause) | Failed | Pyxis GET slow/down (~120s timeout) | Pyxis health; `cert` and `key` in `pyxisSecret` mount |
+| `ERROR: Pyxis response for …` (last line) | Failed | GET body without `_id` | Full JSON in log; repo exists in Pyxis for that registry/name and environment |
+| `INFO: Found Pyxis repository id …` then fail before `Published` | Failed | Catalog URL prefix or PATCH | `Unknown repository prefix` (unsupported Quay URL); or `Pyxis PATCH failed` in exit message |
+| `WARNING: repository … publish_on_push = false` | **Succeeded** (often) | Pyxis repo not set to publish-on-push | Expected skip; fix Pyxis config if publish was intended |
+| `INFO: skipRepoPublishing is set to true, skipping publishing…` | **Succeeded** (often) | `data.json` has `pyxis.skipRepoPublishing: true` | Release data intent |
+| `INFO: Published …` on some repos, then fail | Failed | Later GET or PATCH error | Exit message tail; cert; repository id |
+| `INFO: Completed "…" for "…": N published, results in …` | **Succeeded** | — | Verify `publish-pyxis-repository-results.json` and `signRegistryAccessPath` |
+
+### By step exit message
+
+| Exit text contains | Likely issue |
+|--------------------|--------------|
+| `must be set` | Tekton env not wired to the Python step |
+| `No valid snapshot file was provided` | Bad/missing `PARAM_SNAPSHOT_PATH` |
+| `No data JSON was provided` | Bad/missing `PARAM_DATA_PATH` |
+| `Invalid server parameter` | `server` param not one of four allowed values |
+| `snapshot components must be a JSON array` | Corrupt snapshot JSON |
+| `Unable to get Container Repository object id from Pyxis` | Pyxis GET missing `_id` (see `ERROR:` log) |
+| `Unknown repository prefix` | Quay URL not in prod/stage catalog prefix lists |
+| `invalid JSON from Pyxis GET` | Non-JSON GET response |
+| `Pyxis PATCH failed for` | PATCH HTTP error (status + body in message) |
+| Connection / timeout text | Network or Pyxis outage |
+
+### This script did not run
+
+| Situation | Meaning |
+|-----------|---------|
+| `rh-advisories` and `skip_release=true` | Task skipped by pipeline `when` — not a Pyxis failure |
+| No `publish-pyxis-repository` step in TaskRun | Different pipeline or conditional skip |
+
+---
+
+## Tests and related files
+
+| Item | Link |
+|------|------|
+| Unit tests | [`test_publish_pyxis_repository.py`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/managed/test_publish_pyxis_repository.py) |
+| Catalog task test | [`test-publish-pyxis-repository.yaml`](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml) |
+| Pyxis helpers | [`pyxis_api.py`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/pyxis_api.py) |
+| Snapshot helpers | [`snapshot.py`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/snapshot.py) |

--- a/scripts/python/helpers/http_client.py
+++ b/scripts/python/helpers/http_client.py
@@ -1,9 +1,11 @@
-"""HTTP helpers for task code using the third-party ``requests`` library.
+"""HTTP helpers for task code using the requests library.
 
-The catalog often shows shell with ``curl --retry 3`` and Kerberos or bearer
-auth. The equivalent here is ``get_text`` (GET with retries on the session) plus
-either ``HTTPKerberosAuth`` from the ``requests_kerberos`` package (after
-``kinit``) or regular headers, using urllib3's retry support on a ``Session``.
+get_text performs GET with retries (similar to curl --retry 3). Kerberos or
+bearer auth uses HTTPKerberosAuth from requests_kerberos after kinit, or
+headers on a Session with urllib3 retry support.
+
+Use get_retry_session to build a Session with caller-chosen methods and
+status codes. get_text uses it with GET-only retry settings.
 """
 
 from __future__ import annotations
@@ -23,61 +25,75 @@ MAX_404_ATTEMPTS = 3
 BASE_SLEEP_TIME_SECONDS = 1
 
 
-def _retries(*, allowed_methods: frozenset[str]) -> Retry:
-    """Transients similar to common `curl --retry 3` (connection + some HTTP)."""
-    return Retry(
-        total=3,
-        connect=3,
-        read=3,
-        status=2,
-        backoff_factor=0.4,
-        status_forcelist=(500, 502, 503, 504),
+def get_retry_session(
+    *,
+    total: int = 5,
+    connect: int | None = None,
+    read: int | None = None,
+    status: int | None = None,
+    backoff_factor: float = 0.4,
+    status_forcelist: tuple[int, ...] = (500, 502, 503, 504),
+    allowed_methods: frozenset[str] | set[str],
+    raise_on_status: bool = False,
+) -> requests.Session:
+    """Build a requests.Session with urllib3 retries on http and https.
+
+    Callers choose which HTTP methods and status codes are retried.
+    Tests can patch this function to supply a custom session.
+    """
+    connect_attempts = total if connect is None else connect
+    read_attempts = total if read is None else read
+    status_attempts = 2 if status is None else status
+    retry = Retry(
+        total=total,
+        connect=connect_attempts,
+        read=read_attempts,
+        status=status_attempts,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
         allowed_methods=allowed_methods,
-        raise_on_status=False,
+        raise_on_status=raise_on_status,
     )
-
-
-def post_session() -> requests.Session:
-    """`requests.Session` with retries on transient connection/HTTP errors for POST."""
     session = requests.Session()
-    adapter = HTTPAdapter(max_retries=_retries(allowed_methods=frozenset({"POST"})))
+    adapter = HTTPAdapter(max_retries=retry)
     session.mount("https://", adapter)
     session.mount("http://", adapter)
     return session
-
-
-def get_session() -> requests.Session:
-    """
-    Build a ``requests.Session`` with the shared retry policy on http and https.
-    ``get_text`` uses this. Tests can patch this function to supply a custom session.
-    """
-    s = requests.Session()
-    a = HTTPAdapter(max_retries=_retries(allowed_methods=frozenset({"GET"})))
-    s.mount("https://", a)
-    s.mount("http://", a)
-    return s
 
 
 def get_text(
     url: str,
     *,
     auth: Any = None,
+    cert: tuple[str, str] | None = None,
     headers: Mapping[str, str] | None = None,
     timeout: float = 60.0,
+    allow_error_status: bool = False,
 ) -> str:
-    """
-    Perform an HTTP(S) GET for the given URL and return the body as a string.
+    """Perform an HTTP(S) GET for the given URL and return the body as a string.
 
-    Non-2xx responses become ``requests.HTTPError`` (similar to ``curl
-    --fail``). You may pass optional ``auth`` (for example
-    ``HTTPKerberosAuth``) and request ``headers`` (bearer token, content type,
-    etc.). ``timeout`` is seconds for the call.
+    Non-2xx responses become requests.HTTPError (similar to curl --fail).
+    Optional auth (for example HTTPKerberosAuth) and headers are supported.
+    timeout is seconds for the call.
+
+    When allow_error_status is true, return the response body for any HTTP
+    status without raising (similar to curl without --fail). Retries for
+    HTTP 429 and optional 404 still run before returning a non-2xx body.
 
     HTTP 429 is retried with exponential backoff plus 0-2s jitter up to
-    ``MAX_429_ATTEMPTS`` total attempts. HTTP 404 is retried similarly only if
-    ``CURL_WITH_RETRY_RETRY_404`` is set to a non-empty value.
+    MAX_429_ATTEMPTS total attempts. HTTP 404 is retried similarly only if
+    CURL_WITH_RETRY_RETRY_404 is set to a non-empty value.
     """
-    session = get_session()
+    session = get_retry_session(
+        total=3,
+        connect=3,
+        read=3,
+        status=2,
+        backoff_factor=0.4,
+        allowed_methods=frozenset({"GET"}),
+    )
+    if cert is not None:
+        session.cert = cert
     retries_429 = 0
     retries_404 = 0
     should_retry_404 = bool(os.environ.get("CURL_WITH_RETRY_RETRY_404"))
@@ -107,6 +123,9 @@ def get_text(
                 delay += random.randint(0, 2)
                 time.sleep(delay)
                 continue
+
+        if allow_error_status:
+            return r.text
 
         r.raise_for_status()
         return r.text

--- a/scripts/python/helpers/pyxis_api.py
+++ b/scripts/python/helpers/pyxis_api.py
@@ -1,0 +1,147 @@
+"""Pyxis URL mapping and repository GET/PATCH helpers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import http_client
+import requests
+
+FLATPAK_QUAY_PREFIXES = (
+    "quay.io/rh-flatpaks-prod/",
+    "quay.io/rh-flatpaks-stage/",
+)
+
+PROD_CATALOG_QUAY_PREFIXES = (
+    "quay.io/redhat-prod/",
+    "quay.io/rh-flatpaks-prod/",
+)
+
+STAGE_CATALOG_QUAY_PREFIXES = (
+    "quay.io/redhat-pending/",
+    "quay.io/rh-flatpaks-stage/",
+)
+
+PYXIS_BASE_URL_BY_SERVER: dict[str, str] = {
+    "production": "https://pyxis.api.redhat.com",
+    "stage": "https://pyxis.preprod.api.redhat.com",
+    "production-internal": "https://pyxis.engineering.redhat.com",
+    "stage-internal": "https://pyxis.stage.engineering.redhat.com",
+}
+
+INVALID_SERVER_MESSAGE = (
+    "Invalid server parameter. Only 'production','production-internal',"
+    "'stage-internal' and 'stage' allowed."
+)
+
+
+def pyxis_api_url_for_server(server: str) -> str:
+    """Return the Pyxis v1 API base URL for a Tekton `server` param value."""
+    base = PYXIS_BASE_URL_BY_SERVER.get(server)
+    if base is None:
+        raise ValueError(INVALID_SERVER_MESSAGE)
+    return f"{base.rstrip('/')}/v1"
+
+
+def pyxis_registry_for_quay_url(repository_url: str) -> str:
+    """Return the Pyxis registry name for a mapped Quay repository URL."""
+    if repository_url.startswith(FLATPAK_QUAY_PREFIXES):
+        return "flatpaks.registry.redhat.io"
+    return "registry.access.redhat.com"
+
+
+def pyxis_repository_from_quay_url(repository_url: str) -> str:
+    """Convert the Quay repo path suffix to a Pyxis repository name."""
+    repository_name = repository_url.rsplit("/", 1)[-1]
+    return repository_name.replace("----", "/")
+
+
+def catalog_base_url_for_quay_url(repository_url: str) -> str:
+    """Return the Red Hat catalog base URL for a mapped Quay repository URL."""
+    if repository_url.startswith(PROD_CATALOG_QUAY_PREFIXES):
+        return "https://catalog.redhat.com/software/containers"
+    if repository_url.startswith(STAGE_CATALOG_QUAY_PREFIXES):
+        return "https://catalog.stage.redhat.com/software/containers"
+    msg = f"Unknown repository prefix for {repository_url!r}"
+    raise ValueError(msg)
+
+
+def catalog_url_for_repository(
+    repository_url: str,
+    pyxis_repository: str,
+    repository_id: str,
+) -> str:
+    """Build a catalog page URL for a published Pyxis repository."""
+    base = catalog_base_url_for_quay_url(repository_url)
+    return f"{base}/{pyxis_repository}/{repository_id}"
+
+
+def repository_lookup_url(
+    pyxis_api_url: str,
+    registry: str,
+    repository: str,
+) -> str:
+    """Return the Pyxis GET URL for a registry/repository pair."""
+    return (
+        f"{pyxis_api_url.rstrip('/')}/repositories/registry/"
+        f"{registry}/repository/{repository}"
+    )
+
+
+def get_repository_json(
+    pyxis_api_url: str,
+    registry: str,
+    repository: str,
+    *,
+    cert: tuple[str, str],
+) -> dict[str, Any]:
+    """GET a Pyxis container repository record and return the JSON body."""
+    url = repository_lookup_url(pyxis_api_url, registry, repository)
+    raw = http_client.get_text(
+        url,
+        cert=cert,
+        timeout=120,
+        allow_error_status=True,
+    )
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        preview = raw[:100] if raw else "(empty)"
+        msg = f"invalid JSON from Pyxis GET {url}: {preview}"
+        raise ValueError(msg) from exc
+
+
+def patch_repository_json(
+    pyxis_api_url: str,
+    repository_id: str,
+    payload: dict[str, Any],
+    *,
+    cert: tuple[str, str],
+) -> None:
+    """PATCH a Pyxis container repository by id.
+
+    Publishing is idempotent, so transient 5xx responses are retried.
+    """
+    url = f"{pyxis_api_url.rstrip('/')}/repositories/id/{repository_id}"
+    session = http_client.get_retry_session(
+        total=5,
+        connect=5,
+        read=5,
+        status=5,
+        backoff_factor=5.0,
+        allowed_methods=frozenset({"PATCH"}),
+    )
+    session.cert = cert
+    response = session.patch(
+        url,
+        json=payload,
+        headers={"Content-Type": "application/json"},
+        timeout=120,
+    )
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        raise requests.RequestException(
+            f"Pyxis PATCH failed for {url}: {response.status_code} {response.text}"
+        ) from exc

--- a/scripts/python/helpers/snapshot.py
+++ b/scripts/python/helpers/snapshot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import file
 
@@ -38,3 +39,29 @@ def first_component(snapshot_path: Path) -> dict[str, str]:
         "origin_repo": origin_repo,
         "container_image": container_image,
     }
+
+
+def default_push_source_container(data: dict[str, Any]) -> bool:
+    """Return the mapping default for `pushSourceContainer`, defaulting to true."""
+    mapping = data.get("mapping")
+    if not isinstance(mapping, dict):
+        return True
+    defaults = mapping.get("defaults")
+    if not isinstance(defaults, dict):
+        return True
+    value = defaults.get("pushSourceContainer")
+    if value is None:
+        return True
+    return bool(value)
+
+
+def component_push_source_container(
+    component: dict[str, Any],
+    default_push_source_container: bool,
+) -> bool:
+    """Return the component level pushSourceContainer value."""
+    if component.get("pushSourceContainer") is True:
+        return True
+    if "pushSourceContainer" not in component and default_push_source_container:
+        return True
+    return False

--- a/scripts/python/helpers/test_http_client.py
+++ b/scripts/python/helpers/test_http_client.py
@@ -11,56 +11,57 @@ from requests.adapters import HTTPAdapter
 import http_client
 
 
-def test_retries_policy_defaults() -> None:
-    """The shared retry config matches the module defaults."""
-    r = http_client._retries(allowed_methods=frozenset({"GET"}))
-    assert r.total == 3
-    assert r.connect == 3
-    assert r.read == 3
-    assert r.status == 2
-    assert r.backoff_factor == 0.4
-    assert r.raise_on_status is False
-    assert set(r.status_forcelist) == {500, 502, 503, 504}
-    assert set(r.allowed_methods) == {"GET"}
-
-
-def test_retries_policy_post() -> None:
-    """POST sessions retry transient connection and 5xx HTTP errors."""
-    r = http_client._retries(allowed_methods=frozenset({"POST"}))
-    assert r.total == 3
-    assert set(r.allowed_methods) == {"POST"}
-    assert set(r.status_forcelist) == {500, 502, 503, 504}
-    assert r.raise_on_status is False
-
-
-def test_post_session_mounts_post_retry_adapter() -> None:
-    """`post_session` mounts an adapter that retries POST on transients."""
-    session = http_client.post_session()
+def test_get_retry_session_custom_methods_and_status_codes() -> None:
+    """Callers can configure retried methods and HTTP status codes."""
+    session = http_client.get_retry_session(
+        total=5,
+        connect=5,
+        read=5,
+        status=5,
+        backoff_factor=5.0,
+        status_forcelist=(503,),
+        allowed_methods=frozenset({"PATCH"}),
+    )
     adapter = session.adapters["https://"]
     assert isinstance(adapter, HTTPAdapter)
-    assert set(adapter.max_retries.allowed_methods) == {"POST"}
+    retry = adapter.max_retries
+    assert retry.total == 5
+    assert retry.connect == 5
+    assert retry.read == 5
+    assert retry.status == 5
+    assert retry.backoff_factor == 5.0
+    assert set(retry.status_forcelist) == {503}
+    assert set(retry.allowed_methods) == {"PATCH"}
 
 
-def test_get_session_mounts_retry_adapter() -> None:
-    """`get_session` mounts an `HTTPAdapter` for both HTTP schemes."""
-    s = http_client.get_session()
-    https_adapter = s.adapters["https://"]
-    http_adapter = s.adapters["http://"]
+def test_get_retry_session_get_defaults() -> None:
+    """GET retry settings used by get_text mount adapters on both schemes."""
+    session = http_client.get_retry_session(
+        total=3,
+        connect=3,
+        read=3,
+        status=2,
+        backoff_factor=0.4,
+        allowed_methods=frozenset({"GET"}),
+    )
+    https_adapter = session.adapters["https://"]
+    http_adapter = session.adapters["http://"]
     assert isinstance(https_adapter, HTTPAdapter)
     assert isinstance(http_adapter, HTTPAdapter)
     assert https_adapter.max_retries.total == 3
     assert http_adapter.max_retries.total == 3
+    assert set(https_adapter.max_retries.allowed_methods) == {"GET"}
 
 
 def test_get_text_uses_session_and_headers() -> None:
-    """``get_text`` passes *headers* through to ``get_session``’s ``.get`` call."""
+    """``get_text`` passes *headers* through to the session ``.get`` call."""
     session = mock.MagicMock()
     r = mock.MagicMock()
     r.status_code = 200
     r.text = "body"
     r.raise_for_status = mock.MagicMock()
     session.get.return_value = r
-    with mock.patch("http_client.get_session", return_value=session):
+    with mock.patch("http_client.get_retry_session", return_value=session):
         out = http_client.get_text("https://e/x", headers={"A": "b", "C": "d"})
 
     assert out == "body"
@@ -80,7 +81,7 @@ def test_get_text_auth_passed() -> None:
     r.text = "t"
     session.get.return_value = r
     ra = object()
-    with mock.patch("http_client.get_session", return_value=session):
+    with mock.patch("http_client.get_retry_session", return_value=session):
         assert http_client.get_text("https://u", auth=ra) == "t"
     assert session.get.call_args[1]["auth"] is ra
 
@@ -92,7 +93,7 @@ def test_get_text_http_error() -> None:
     r.status_code = 500
     r.raise_for_status.side_effect = requests.HTTPError("nope", response=mock.MagicMock())
     session.get.return_value = r
-    with mock.patch("http_client.get_session", return_value=session):
+    with mock.patch("http_client.get_retry_session", return_value=session):
         with pytest.raises(requests.HTTPError):
             http_client.get_text("https://u/")
 
@@ -116,7 +117,7 @@ def test_get_text_retries_429_then_succeeds() -> None:
     session.get.side_effect = [r1, r2, r3]
 
     with (
-        mock.patch("http_client.get_session", return_value=session),
+        mock.patch("http_client.get_retry_session", return_value=session),
         mock.patch("http_client.random.randint", return_value=0),
         mock.patch("http_client.time.sleep") as sleep_mock,
     ):
@@ -142,7 +143,7 @@ def test_get_text_retries_404_when_enabled(monkeypatch: pytest.MonkeyPatch) -> N
     session.get.side_effect = [r1, r2]
 
     with (
-        mock.patch("http_client.get_session", return_value=session),
+        mock.patch("http_client.get_retry_session", return_value=session),
         mock.patch("http_client.random.randint", return_value=0),
         mock.patch("http_client.time.sleep") as sleep_mock,
     ):
@@ -150,3 +151,52 @@ def test_get_text_retries_404_when_enabled(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert session.get.call_count == 2
     sleep_mock.assert_called_once_with(1)
+
+
+def test_get_text_allow_error_status_returns_body() -> None:
+    """Non-2xx responses return body text when `allow_error_status` is true."""
+    session = mock.MagicMock()
+    response = mock.MagicMock()
+    response.status_code = 404
+    response.text = '{"error": true}'
+    session.get.return_value = response
+    with mock.patch("http_client.get_retry_session", return_value=session):
+        out = http_client.get_text("https://u/", allow_error_status=True)
+    assert out == '{"error": true}'
+
+
+def test_get_text_allow_error_status_retries_429() -> None:
+    """429 retries still run when `allow_error_status` is true."""
+    session = mock.MagicMock()
+
+    rate_limited = mock.MagicMock()
+    rate_limited.status_code = 429
+    rate_limited.text = "rate-limited"
+    ok = mock.MagicMock()
+    ok.status_code = 200
+    ok.text = "ok"
+    session.get.side_effect = [rate_limited, ok]
+
+    with (
+        mock.patch("http_client.get_retry_session", return_value=session),
+        mock.patch("http_client.random.randint", return_value=0),
+        mock.patch("http_client.time.sleep") as sleep_mock,
+    ):
+        out = http_client.get_text("https://u/", allow_error_status=True)
+
+    assert out == "ok"
+    assert session.get.call_count == 2
+    sleep_mock.assert_called_once_with(1)
+
+
+def test_get_text_cert_on_session() -> None:
+    """Client certificate paths are applied to the shared session."""
+    session = mock.MagicMock()
+    response = mock.MagicMock()
+    response.status_code = 200
+    response.text = "ok"
+    session.get.return_value = response
+    cert = ("/tmp/cert", "/tmp/key")
+    with mock.patch("http_client.get_retry_session", return_value=session):
+        assert http_client.get_text("https://u/", cert=cert) == "ok"
+    assert session.cert == cert

--- a/scripts/python/helpers/test_pyxis_api.py
+++ b/scripts/python/helpers/test_pyxis_api.py
@@ -1,0 +1,139 @@
+"""Tests for `pyxis_api` URL mapping and repository API helpers."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+import requests
+
+import pyxis_api
+
+
+def test_pyxis_api_url_for_production_server() -> None:
+    """Map the production server param to the public Pyxis v1 API URL."""
+    assert pyxis_api.pyxis_api_url_for_server("production") == (
+        "https://pyxis.api.redhat.com/v1"
+    )
+
+
+def test_pyxis_api_url_for_invalid_server_raises() -> None:
+    """Reject unknown server param values."""
+    with pytest.raises(ValueError, match="Invalid server parameter"):
+        pyxis_api.pyxis_api_url_for_server("invalid")
+
+
+def test_pyxis_registry_for_flatpak_quay_url() -> None:
+    """Flatpak Quay repos use the flatpaks Pyxis registry."""
+    url = "quay.io/rh-flatpaks-stage/my-product----my-image1"
+    assert pyxis_api.pyxis_registry_for_quay_url(url) == ("flatpaks.registry.redhat.io")
+
+
+def test_pyxis_registry_for_standard_quay_url() -> None:
+    """Standard Quay repos use registry.access.redhat.com in Pyxis."""
+    url = "quay.io/redhat-prod/my-product----my-image1"
+    assert pyxis_api.pyxis_registry_for_quay_url(url) == ("registry.access.redhat.com")
+
+
+def test_pyxis_repository_from_quay_url_replaces_quadruple_dash() -> None:
+    """Convert Quay repo suffix `product----image` to Pyxis `product/image`."""
+    assert (
+        pyxis_api.pyxis_repository_from_quay_url(
+            "quay.io/redhat-prod/my-product----my-image1",
+        )
+        == "my-product/my-image1"
+    )
+
+
+def test_catalog_base_url_for_prod_and_stage() -> None:
+    """Return prod or stage catalog base URLs based on Quay prefix."""
+    assert pyxis_api.catalog_base_url_for_quay_url(
+        "quay.io/redhat-prod/my-product----my-image1",
+    ).startswith("https://catalog.redhat.com/")
+    assert pyxis_api.catalog_base_url_for_quay_url(
+        "quay.io/redhat-pending/my-product----my-image1",
+    ).startswith("https://catalog.stage.redhat.com/")
+
+
+def test_catalog_base_url_unknown_prefix_raises() -> None:
+    """Fail when the Quay repository prefix is not recognized."""
+    with pytest.raises(ValueError, match="Unknown repository prefix"):
+        pyxis_api.catalog_base_url_for_quay_url("quay.io/unknown/repo")
+
+
+def test_catalog_url_for_repository_builds_expected_path() -> None:
+    """Build a catalog URL from Pyxis repository metadata."""
+    url = pyxis_api.catalog_url_for_repository(
+        "quay.io/redhat-prod/my-product----my-image1",
+        "my-product/my-image1",
+        "42",
+    )
+    assert url == ("https://catalog.redhat.com/software/containers/" "my-product/my-image1/42")
+
+
+def test_get_repository_json_returns_body() -> None:
+    """Parse JSON from a successful Pyxis repository GET."""
+    with mock.patch(
+        "pyxis_api.http_client.get_text",
+        return_value='{"_id": "1", "publish_on_push": true}',
+    ) as get_text:
+        body = pyxis_api.get_repository_json(
+            "https://pyxis/v1",
+            "registry.access.redhat.com",
+            "my-product/my-image",
+            cert=("/tmp/cert", "/tmp/key"),
+        )
+    assert body["_id"] == "1"
+    get_text.assert_called_once_with(
+        "https://pyxis/v1/repositories/registry/"
+        "registry.access.redhat.com/repository/my-product/my-image",
+        cert=("/tmp/cert", "/tmp/key"),
+        timeout=120,
+        allow_error_status=True,
+    )
+
+
+def test_get_repository_json_invalid_json_raises() -> None:
+    """Raise when Pyxis returns a non-JSON GET body."""
+    with mock.patch(
+        "pyxis_api.http_client.get_text",
+        return_value="not-json",
+    ):
+        with pytest.raises(ValueError, match="invalid JSON from Pyxis GET"):
+            pyxis_api.get_repository_json(
+                "https://pyxis/v1",
+                "registry.access.redhat.com",
+                "repo",
+                cert=("/tmp/cert", "/tmp/key"),
+            )
+
+
+def test_patch_repository_json_raises_on_http_error() -> None:
+    """Surface HTTP errors from Pyxis PATCH calls."""
+    response = mock.MagicMock()
+    response.status_code = 500
+    response.text = "boom"
+    response.raise_for_status.side_effect = requests.HTTPError("500")
+
+    session = mock.MagicMock()
+    session.patch.return_value = response
+
+    with mock.patch(
+        "pyxis_api.http_client.get_retry_session",
+        return_value=session,
+    ) as get_retry_session:
+        with pytest.raises(requests.RequestException, match="Pyxis PATCH failed"):
+            pyxis_api.patch_repository_json(
+                "https://pyxis/v1",
+                "99",
+                {"published": True},
+                cert=("/tmp/cert", "/tmp/key"),
+            )
+    get_retry_session.assert_called_once_with(
+        total=5,
+        connect=5,
+        read=5,
+        status=5,
+        backoff_factor=5.0,
+        allowed_methods=frozenset({"PATCH"}),
+    )

--- a/scripts/python/helpers/test_snapshot.py
+++ b/scripts/python/helpers/test_snapshot.py
@@ -65,3 +65,45 @@ def test_first_component(tmp_path: Path) -> None:
     assert out["revision"] == "deadbeef" * 5
     assert out["origin_repo"] == "https://github.com/org/repo"
     assert "quay.io" in out["container_image"]
+
+
+def test_default_push_source_container_defaults_true() -> None:
+    """Default pushSourceContainer to true when mapping defaults are absent."""
+    assert snapshot.default_push_source_container({}) is True
+
+
+def test_default_push_source_container_honors_false() -> None:
+    """Respect mapping.defaults.pushSourceContainer when explicitly false."""
+    data = {"mapping": {"defaults": {"pushSourceContainer": False}}}
+    assert snapshot.default_push_source_container(data) is False
+
+
+def test_default_push_source_container_null_value_defaults_true() -> None:
+    """Default pushSourceContainer to true when the key is absent in defaults."""
+    assert snapshot.default_push_source_container(
+        {"mapping": {"defaults": {}}},
+    )
+
+
+def test_default_push_source_container_without_defaults_mapping() -> None:
+    """Default pushSourceContainer to true when mapping.defaults is missing."""
+    assert snapshot.default_push_source_container(
+        {"mapping": {"defaults": "not-a-mapping"}},
+    )
+
+
+def test_component_push_source_container_true_and_default_paths() -> None:
+    """Enable source container when component or mapping default says so."""
+    assert snapshot.component_push_source_container(
+        {"pushSourceContainer": True},
+        False,
+    )
+    assert snapshot.component_push_source_container({}, True)
+
+
+def test_component_push_source_container_explicit_false() -> None:
+    """Do not enable source container when component sets false."""
+    assert not snapshot.component_push_source_container(
+        {"pushSourceContainer": False},
+        True,
+    )

--- a/scripts/python/tasks/internal/create_advisory.py
+++ b/scripts/python/tasks/internal/create_advisory.py
@@ -115,7 +115,14 @@ def _reserve_errata_live_id(
         }
         os.environ.update(krb5_env_for_process)
         reserve_live_id_url = f"{errata_api.rstrip('/')}/advisory/reserve_live_id"
-        session = http_client.post_session()
+        session = http_client.get_retry_session(
+            total=3,
+            connect=3,
+            read=3,
+            status=2,
+            backoff_factor=0.4,
+            allowed_methods=frozenset({"POST"}),
+        )
         auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL)
         try:
             resp = session.post(reserve_live_id_url, auth=auth, timeout=120)

--- a/scripts/python/tasks/internal/test_create_advisory.py
+++ b/scripts/python/tasks/internal/test_create_advisory.py
@@ -90,9 +90,9 @@ def test_reserve_errata_live_id_posts_json(tmp_path: Path) -> None:
         def json(self) -> dict:
             return {"live_id": 42}
 
-    with mock.patch("create_advisory.http_client.post_session") as post_session:
+    with mock.patch("create_advisory.http_client.get_retry_session") as session_factory:
         sess = mock.MagicMock()
-        post_session.return_value = sess
+        session_factory.return_value = sess
         sess.post.return_value = _Resp()
         out = create_advisory._reserve_errata_live_id(
             "https://errata/api/v1",
@@ -127,9 +127,9 @@ def test_reserve_errata_live_id_request_failure_logs_stderr(tmp_path: Path) -> N
     krb5.write_text("[libdefaults]\n", encoding="utf-8")
     log = tmp_path / "log.txt"
 
-    with mock.patch("create_advisory.http_client.post_session") as post_session:
+    with mock.patch("create_advisory.http_client.get_retry_session") as session_factory:
         sess = mock.MagicMock()
-        post_session.return_value = sess
+        session_factory.return_value = sess
         sess.post.side_effect = requests.RequestException("net")
         with pytest.raises(requests.RequestException):
             create_advisory._reserve_errata_live_id(
@@ -156,9 +156,9 @@ def test_reserve_errata_live_id_missing_live_id(tmp_path: Path) -> None:
         def json(self) -> dict:
             return {}
 
-    with mock.patch("create_advisory.http_client.post_session") as post_session:
+    with mock.patch("create_advisory.http_client.get_retry_session") as session_factory:
         sess = mock.MagicMock()
-        post_session.return_value = sess
+        session_factory.return_value = sess
         sess.post.return_value = _Resp()
         with pytest.raises(ValueError, match="no live_id"):
             create_advisory._reserve_errata_live_id(

--- a/scripts/python/tasks/managed/make_repo_public.py
+++ b/scripts/python/tasks/managed/make_repo_public.py
@@ -148,7 +148,14 @@ def run(
 
     default_public = data.get("mapping", {}).get("defaults", {}).get("public", False)
 
-    session = http_client.get_session()
+    session = http_client.get_retry_session(
+        total=3,
+        connect=3,
+        read=3,
+        status=2,
+        backoff_factor=0.4,
+        allowed_methods=frozenset({"GET", "POST"}),
+    )
     quay_cache: dict[str, bool] = {}
 
     target_registry: str | None = None

--- a/scripts/python/tasks/managed/publish_pyxis_repository.py
+++ b/scripts/python/tasks/managed/publish_pyxis_repository.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Mark snapshot repositories as published in Pyxis and record catalog URLs."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pyxis_api
+import tekton
+from logger import logger
+from snapshot import component_push_source_container, default_push_source_container
+
+PROG = "publish_pyxis_repository.py"
+RESULTS_FILENAME = "publish-pyxis-repository-results.json"
+SIGN_REGISTRY_ACCESS_FILENAME = "sign-registry-access.txt"
+
+
+def resolve_pyxis_api_url() -> str:
+    """Use `PYXIS_URL` when set; otherwise map `PARAM_SERVER` to a Pyxis API URL."""
+    override = os.environ.get("PYXIS_URL", "").strip()
+    if override:
+        return override.rstrip("/")
+    return pyxis_api.pyxis_api_url_for_server(tekton.require_env("PARAM_SERVER"))
+
+
+def skip_repo_publishing(data: dict[str, Any]) -> bool:
+    """Return whether `pyxis.skipRepoPublishing` is enabled in the data JSON."""
+    pyxis = data.get("pyxis")
+    if not isinstance(pyxis, dict):
+        return False
+    return bool(pyxis.get("skipRepoPublishing", False))
+
+
+def build_publish_payload(source_enabled: bool) -> dict[str, bool]:
+    """Build the Pyxis PATCH body for marking a repository published."""
+    payload: dict[str, bool] = {"published": True}
+    if source_enabled:
+        payload["source_container_image_enabled"] = True
+    return payload
+
+
+def should_patch_repository(
+    *,
+    skip_publishing: bool,
+    publish_on_push: Any,
+    pyxis_registry: str,
+    pyxis_repo: str,
+) -> bool:
+    """Return whether to PATCH Pyxis with the published flag for this repo."""
+    if skip_publishing:
+        logger.info("skipRepoPublishing is set to true, skipping publishing...")
+        return False
+    if publish_on_push is not True:
+        logger.warning(
+            "repository %s/%s is marked as publish_on_push = false",
+            pyxis_registry,
+            pyxis_repo,
+        )
+        logger.warning("Skipping the setting of the published flag.")
+        return False
+    return True
+
+
+def should_record_catalog_url(
+    *,
+    repository_published: bool,
+    should_patch: bool,
+) -> bool:
+    """Return whether to add a catalog URL for this repository."""
+    return repository_published or should_patch
+
+
+def should_add_sign_registry_access(
+    pyxis_registry: str,
+    requires_terms: Any,
+) -> bool:
+    """Return whether a repo belongs on the sign-registry-access list."""
+    return pyxis_registry == "registry.access.redhat.com" and requires_terms is False
+
+
+def publish_repositories(
+    *,
+    snapshot: dict[str, Any],
+    pyxis_api_url: str,
+    cert: tuple[str, str],
+    sign_registry_access_file: Path,
+    skip_publishing: bool,
+    default_push_source_container: bool,
+) -> dict[str, Any]:
+    """Process snapshot components and return the results JSON payload."""
+    results: dict[str, list[dict[str, str]]] = {"catalog_urls": []}
+    components = snapshot.get("components")
+    if not isinstance(components, list):
+        msg = "snapshot components must be a JSON array"
+        raise ValueError(msg)
+
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        component_name = str(component.get("name", ""))
+        repositories = component.get("repositories")
+        if not isinstance(repositories, list):
+            continue
+
+        push_source_container = component_push_source_container(
+            component,
+            default_push_source_container,
+        )
+        payload = build_publish_payload(push_source_container)
+
+        for repository_row in repositories:
+            if not isinstance(repository_row, dict):
+                continue
+            repository_url = repository_row.get("url")
+            if not isinstance(repository_url, str) or not repository_url.strip():
+                continue
+
+            pyxis_registry = pyxis_api.pyxis_registry_for_quay_url(repository_url)
+            pyxis_repo = pyxis_api.pyxis_repository_from_quay_url(repository_url)
+            logger.info(
+                "Processing repository %s as Pyxis %s/%s",
+                repository_url,
+                pyxis_registry,
+                pyxis_repo,
+            )
+
+            repository_json = pyxis_api.get_repository_json(
+                pyxis_api_url,
+                pyxis_registry,
+                pyxis_repo,
+                cert=cert,
+            )
+            repository_id = repository_json.get("_id")
+            if not repository_id:
+                logger.error(
+                    "Pyxis response for %s/%s: %s",
+                    pyxis_registry,
+                    pyxis_repo,
+                    repository_json,
+                )
+                msg = "Unable to get Container Repository object id from Pyxis"
+                raise ValueError(msg)
+
+            logger.info(
+                "Found Pyxis repository id %s for %s/%s",
+                repository_id,
+                pyxis_registry,
+                pyxis_repo,
+            )
+
+            if should_add_sign_registry_access(
+                pyxis_registry,
+                repository_json.get("requires_terms"),
+            ):
+                with sign_registry_access_file.open("a", encoding="utf-8") as fh:
+                    fh.write(f"{pyxis_repo}\n")
+                logger.info(
+                    "Added %s to sign-registry-access list",
+                    pyxis_repo,
+                )
+
+            repository_published = repository_json.get("published", False) is True
+            should_patch = should_patch_repository(
+                skip_publishing=skip_publishing,
+                publish_on_push=repository_json.get("publish_on_push", False),
+                pyxis_registry=pyxis_registry,
+                pyxis_repo=pyxis_repo,
+            )
+
+            if should_patch:
+                pyxis_api.patch_repository_json(
+                    pyxis_api_url,
+                    str(repository_id),
+                    payload,
+                    cert=cert,
+                )
+                logger.info(
+                    "Published %s/%s (id %s)",
+                    pyxis_registry,
+                    pyxis_repo,
+                    repository_id,
+                )
+
+            if should_record_catalog_url(
+                repository_published=repository_published,
+                should_patch=should_patch,
+            ):
+                catalog_url = pyxis_api.catalog_url_for_repository(
+                    repository_url,
+                    pyxis_repo,
+                    str(repository_id),
+                )
+                results["catalog_urls"].append(
+                    {"name": component_name, "url": catalog_url},
+                )
+
+    return results
+
+
+def run_publish_pyxis_repository(
+    *,
+    data_dir: Path,
+    snapshot_path: Path,
+    data_path: Path,
+    results_dir_path: Path,
+    sign_registry_access_result_path: Path,
+    pyxis_secret_mount: Path,
+    pyxis_api_url: str,
+    task_name: str,
+) -> None:
+    """Load inputs, publish repositories in Pyxis, and write workspace outputs."""
+    if not snapshot_path.is_file():
+        msg = "No valid snapshot file was provided."
+        raise FileNotFoundError(msg)
+    if not data_path.is_file():
+        msg = "No data JSON was provided."
+        raise FileNotFoundError(msg)
+
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    data = json.loads(data_path.read_text(encoding="utf-8"))
+
+    sign_registry_relative = (data_path.parent / SIGN_REGISTRY_ACCESS_FILENAME).relative_to(
+        data_dir
+    )
+    sign_registry_access_result_path.write_text(
+        sign_registry_relative.as_posix(),
+        encoding="utf-8",
+    )
+    sign_registry_access_file = data_dir / sign_registry_relative
+    sign_registry_access_file.parent.mkdir(parents=True, exist_ok=True)
+    sign_registry_access_file.write_text("", encoding="utf-8")
+
+    component_group = snapshot.get("componentGroup", "")
+    logger.info('Beginning "%s" for "%s"', task_name, component_group)
+    logger.info("Using Pyxis API URL: %s", pyxis_api_url)
+
+    skip_publishing = skip_repo_publishing(data)
+    if skip_publishing:
+        logger.info(
+            "skipRepoPublishing is enabled; Pyxis PATCH will be skipped",
+        )
+    push_source = default_push_source_container(data)
+    logger.info("Default pushSourceContainer: %s", str(push_source).lower())
+
+    cert_path = pyxis_secret_mount / "cert"
+    key_path = pyxis_secret_mount / "key"
+    cert = (str(cert_path), str(key_path))
+
+    results = publish_repositories(
+        snapshot=snapshot,
+        pyxis_api_url=pyxis_api_url,
+        cert=cert,
+        sign_registry_access_file=sign_registry_access_file,
+        skip_publishing=skip_publishing,
+        default_push_source_container=push_source,
+    )
+
+    results_dir_path.mkdir(parents=True, exist_ok=True)
+    results_file = results_dir_path / RESULTS_FILENAME
+    results_file.write_text(json.dumps(results) + "\n", encoding="utf-8")
+
+    logger.info(
+        'Completed "%s" for "%s": %d published, results in %s',
+        task_name,
+        component_group,
+        len(results["catalog_urls"]),
+        results_file,
+    )
+
+
+def main() -> int:
+    """Run the publish workflow; exit non-zero on failure."""
+    data_dir = Path(tekton.require_env("PARAM_DATA_DIR"))
+    run_publish_pyxis_repository(
+        data_dir=data_dir,
+        snapshot_path=data_dir / tekton.require_env("PARAM_SNAPSHOT_PATH"),
+        data_path=data_dir / tekton.require_env("PARAM_DATA_PATH"),
+        results_dir_path=data_dir / tekton.require_env("PARAM_RESULTS_DIR_PATH"),
+        sign_registry_access_result_path=tekton.result_paths_from_env(
+            "RESULT_SIGN_REGISTRY_ACCESS_PATH",
+        )[0],
+        pyxis_secret_mount=Path(
+            os.environ.get("PYXIS_SECRET_MOUNT", "/etc/secrets"),
+        ),
+        pyxis_api_url=resolve_pyxis_api_url(),
+        task_name=os.environ.get("TASK_NAME", PROG),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_make_repo_public.py
+++ b/scripts/python/tasks/managed/test_make_repo_public.py
@@ -166,7 +166,7 @@ class TestRun:
         )
         session = _mock_session(get_status=200, post_ok=True)
         with mock.patch(
-            "make_repo_public.http_client.get_session",
+            "make_repo_public.http_client.get_retry_session",
             return_value=session,
         ):
             make_repo_public.run(
@@ -191,7 +191,7 @@ class TestRun:
         )
         session = _mock_session(get_status=200, post_ok=True)
         with mock.patch(
-            "make_repo_public.http_client.get_session",
+            "make_repo_public.http_client.get_retry_session",
             return_value=session,
         ):
             make_repo_public.run(
@@ -216,7 +216,7 @@ class TestRun:
         )
         session = _mock_session(get_status=200, post_ok=True)
         with mock.patch(
-            "make_repo_public.http_client.get_session",
+            "make_repo_public.http_client.get_retry_session",
             return_value=session,
         ):
             make_repo_public.run(
@@ -243,7 +243,7 @@ class TestRun:
         )
         session = _mock_session(get_status=404, post_ok=True)
         with mock.patch(
-            "make_repo_public.http_client.get_session",
+            "make_repo_public.http_client.get_retry_session",
             return_value=session,
         ):
             make_repo_public.run(
@@ -271,7 +271,7 @@ class TestRun:
         )
         session = _mock_session(get_status=200, post_ok=True)
         with mock.patch(
-            "make_repo_public.http_client.get_session",
+            "make_repo_public.http_client.get_retry_session",
             return_value=session,
         ):
             with pytest.raises(RuntimeError, match="Multiple Quay registries"):
@@ -340,7 +340,7 @@ class TestRun:
         )
         session = _mock_session(get_status=200, post_ok=True)
         with mock.patch(
-            "make_repo_public.http_client.get_session",
+            "make_repo_public.http_client.get_retry_session",
             return_value=session,
         ):
             make_repo_public.run(
@@ -371,7 +371,7 @@ class TestRun:
         )
         session = _mock_session(get_status=200, post_ok=True)
         with mock.patch(
-            "make_repo_public.http_client.get_session",
+            "make_repo_public.http_client.get_retry_session",
             return_value=session,
         ):
             make_repo_public.run(
@@ -397,7 +397,7 @@ class TestRun:
         )
         session = _mock_session(get_status=200, post_ok=True)
         with mock.patch(
-            "make_repo_public.http_client.get_session",
+            "make_repo_public.http_client.get_retry_session",
             return_value=session,
         ):
             with pytest.raises(RuntimeError, match="missing the 'url' field"):

--- a/scripts/python/tasks/managed/test_publish_pyxis_repository.py
+++ b/scripts/python/tasks/managed/test_publish_pyxis_repository.py
@@ -1,0 +1,801 @@
+"""Tests for `publish_pyxis_repository` task logic."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+import publish_pyxis_repository
+
+
+def _snapshot(
+    *,
+    components: list[dict[str, object]],
+    component_group: str = "my-group",
+) -> dict[str, object]:
+    return {"componentGroup": component_group, "components": components}
+
+
+def _repo(url: str) -> dict[str, str]:
+    return {"url": url}
+
+
+def test_resolve_pyxis_api_url_prefers_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use PYXIS_URL when the test harness sets a mock server URL."""
+    monkeypatch.setenv("PYXIS_URL", "http://127.0.0.1:8080/v1")
+    assert publish_pyxis_repository.resolve_pyxis_api_url() == "http://127.0.0.1:8080/v1"
+
+
+def test_build_publish_payload_with_and_without_source() -> None:
+    """Include source_container_image_enabled only when requested."""
+    assert publish_pyxis_repository.build_publish_payload(False) == {
+        "published": True,
+    }
+    assert publish_pyxis_repository.build_publish_payload(True) == {
+        "published": True,
+        "source_container_image_enabled": True,
+    }
+
+
+def test_should_add_sign_registry_access_only_for_non_terms() -> None:
+    """Add sign-registry entries only for standard repos without terms."""
+    assert publish_pyxis_repository.should_add_sign_registry_access(
+        "registry.access.redhat.com",
+        False,
+    )
+    assert not publish_pyxis_repository.should_add_sign_registry_access(
+        "registry.access.redhat.com",
+        True,
+    )
+    assert not publish_pyxis_repository.should_add_sign_registry_access(
+        "flatpaks.registry.redhat.io",
+        False,
+    )
+
+
+def test_should_patch_repository_skip_and_publish_on_push() -> None:
+    """PATCH only when publishing is enabled and publish_on_push is true."""
+    assert (
+        publish_pyxis_repository.should_patch_repository(
+            skip_publishing=True,
+            publish_on_push=True,
+            pyxis_registry="registry.access.redhat.com",
+            pyxis_repo="p/i",
+        )
+        is False
+    )
+    assert (
+        publish_pyxis_repository.should_patch_repository(
+            skip_publishing=False,
+            publish_on_push=False,
+            pyxis_registry="registry.access.redhat.com",
+            pyxis_repo="p/i",
+        )
+        is False
+    )
+    assert (
+        publish_pyxis_repository.should_patch_repository(
+            skip_publishing=False,
+            publish_on_push=True,
+            pyxis_registry="registry.access.redhat.com",
+            pyxis_repo="p/i",
+        )
+        is True
+    )
+
+
+def test_should_record_catalog_url() -> None:
+    """Record catalog URL when already published or when PATCH runs."""
+    assert publish_pyxis_repository.should_record_catalog_url(
+        repository_published=True,
+        should_patch=False,
+    )
+    assert publish_pyxis_repository.should_record_catalog_url(
+        repository_published=False,
+        should_patch=True,
+    )
+    assert not publish_pyxis_repository.should_record_catalog_url(
+        repository_published=False,
+        should_patch=False,
+    )
+
+
+def test_publish_repositories_happy_path(tmp_path: Path) -> None:
+    """Publish standard repos and record catalog URLs for each component."""
+    sign_file = tmp_path / "sign-registry-access.txt"
+    sign_file.write_text("", encoding="utf-8")
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_get(
+        _api: str,
+        registry: str,
+        repository: str,
+        *,
+        cert: tuple[str, str],
+    ) -> dict[str, object]:
+        return {
+            "_id": repository.split("/")[-1].replace("image", ""),
+            "publish_on_push": True,
+            "requires_terms": True,
+        }
+
+    def fake_patch(
+        _api: str,
+        repository_id: str,
+        payload: dict[str, object],
+        *,
+        cert: tuple[str, str],
+    ) -> None:
+        calls.append((repository_id, payload))
+
+    snapshot = _snapshot(
+        components=[
+            {
+                "name": "component1",
+                "repositories": [
+                    _repo("quay.io/redhat-prod/my-product----my-image1"),
+                    _repo("quay.io/redhat-prod/my-product----my-image2"),
+                ],
+            },
+            {
+                "name": "component3",
+                "repositories": [_repo("quay.io/redhat-prod/my-product----my-image3")],
+            },
+        ],
+    )
+
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            side_effect=fake_get,
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+            side_effect=fake_patch,
+        ),
+    ):
+        results = publish_pyxis_repository.publish_repositories(
+            snapshot=snapshot,
+            pyxis_api_url="https://pyxis/v1",
+            cert=("/tmp/cert", "/tmp/key"),
+            sign_registry_access_file=sign_file,
+            skip_publishing=False,
+            default_push_source_container=False,
+        )
+
+    assert len(results["catalog_urls"]) == 3
+    assert sign_file.read_text(encoding="utf-8") == ""
+    assert len(calls) == 3
+
+
+def test_publish_repositories_no_terms_required_sign_list(tmp_path: Path) -> None:
+    """Add repos with requires_terms=false to sign-registry-access.txt."""
+    sign_file = tmp_path / "sign-registry-access.txt"
+    sign_file.write_text("", encoding="utf-8")
+
+    def fake_get(
+        _api: str,
+        _registry: str,
+        repository: str,
+        *,
+        cert: tuple[str, str],
+    ) -> dict[str, object]:
+        requires_terms = "my-image5" not in repository and "my-image6" not in repository
+        return {
+            "_id": "1",
+            "publish_on_push": True,
+            "requires_terms": requires_terms,
+        }
+
+    snapshot = _snapshot(
+        components=[
+            {
+                "name": "component2",
+                "repositories": [
+                    _repo("quay.io/redhat-prod/my-product----my-image5"),
+                    _repo("quay.io/redhat-prod/my-product----my-image6"),
+                ],
+            },
+        ],
+    )
+
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            side_effect=fake_get,
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+        ),
+    ):
+        publish_pyxis_repository.publish_repositories(
+            snapshot=snapshot,
+            pyxis_api_url="https://pyxis/v1",
+            cert=("/tmp/cert", "/tmp/key"),
+            sign_registry_access_file=sign_file,
+            skip_publishing=False,
+            default_push_source_container=False,
+        )
+
+    lines = sign_file.read_text(encoding="utf-8").splitlines()
+    assert "my-product/my-image5" in lines
+    assert "my-product/my-image6" in lines
+
+
+def test_publish_repositories_skip_publishing_skips_patch(tmp_path: Path) -> None:
+    """Still query Pyxis but skip PATCH when skipRepoPublishing is true."""
+    sign_file = tmp_path / "sign-registry-access.txt"
+    sign_file.write_text("", encoding="utf-8")
+    patched = {"count": 0}
+
+    def fake_patch(*_args: object, **_kwargs: object) -> None:
+        patched["count"] += 1
+
+    snapshot = _snapshot(
+        components=[
+            {"name": "c", "repositories": [_repo("quay.io/redhat-prod/p----i1")]},
+        ],
+    )
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            return_value={
+                "_id": "1",
+                "publish_on_push": True,
+                "published": False,
+                "requires_terms": True,
+            },
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+            side_effect=fake_patch,
+        ),
+    ):
+        results = publish_pyxis_repository.publish_repositories(
+            snapshot=snapshot,
+            pyxis_api_url="https://pyxis/v1",
+            cert=("/tmp/cert", "/tmp/key"),
+            sign_registry_access_file=sign_file,
+            skip_publishing=True,
+            default_push_source_container=False,
+        )
+
+    assert results["catalog_urls"] == []
+    assert patched["count"] == 0
+
+
+def test_publish_repositories_skip_publishing_records_already_published(
+    tmp_path: Path,
+) -> None:
+    """Skip PATCH but still record catalog URL when Pyxis reports published."""
+    sign_file = tmp_path / "sign-registry-access.txt"
+    sign_file.write_text("", encoding="utf-8")
+
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            return_value={
+                "_id": "1",
+                "publish_on_push": True,
+                "published": True,
+                "requires_terms": True,
+            },
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+            side_effect=lambda *_a, **_k: pytest.fail("patch should not run"),
+        ),
+    ):
+        results = publish_pyxis_repository.publish_repositories(
+            snapshot=_snapshot(
+                components=[
+                    {
+                        "name": "c",
+                        "repositories": [_repo("quay.io/redhat-prod/p----i1")],
+                    },
+                ],
+            ),
+            pyxis_api_url="https://pyxis/v1",
+            cert=("/tmp/cert", "/tmp/key"),
+            sign_registry_access_file=sign_file,
+            skip_publishing=True,
+            default_push_source_container=False,
+        )
+
+    assert len(results["catalog_urls"]) == 1
+    assert results["catalog_urls"][0]["name"] == "c"
+
+
+def test_publish_repositories_publish_on_push_false_skips_patch(tmp_path: Path) -> None:
+    """Skip PATCH when publish_on_push is false and repo is not yet published."""
+    sign_file = tmp_path / "sign-registry-access.txt"
+    sign_file.write_text("", encoding="utf-8")
+
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            return_value={
+                "_id": "1",
+                "publish_on_push": False,
+                "published": False,
+                "requires_terms": True,
+            },
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+            side_effect=lambda *_a, **_k: pytest.fail("patch should not run"),
+        ),
+    ):
+        results = publish_pyxis_repository.publish_repositories(
+            snapshot=_snapshot(
+                components=[
+                    {
+                        "repositories": [
+                            _repo("quay.io/redhat-prod/my-product----my-image0"),
+                        ],
+                    },
+                ],
+            ),
+            pyxis_api_url="https://pyxis/v1",
+            cert=("/tmp/cert", "/tmp/key"),
+            sign_registry_access_file=sign_file,
+            skip_publishing=False,
+            default_push_source_container=False,
+        )
+
+    assert results["catalog_urls"] == []
+
+
+def test_publish_repositories_publish_on_push_false_records_already_published(
+    tmp_path: Path,
+) -> None:
+    """Skip PATCH but record catalog URL when repo is already published."""
+    sign_file = tmp_path / "sign-registry-access.txt"
+    sign_file.write_text("", encoding="utf-8")
+
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            return_value={
+                "_id": "1",
+                "publish_on_push": False,
+                "published": True,
+                "requires_terms": True,
+            },
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+            side_effect=lambda *_a, **_k: pytest.fail("patch should not run"),
+        ),
+    ):
+        results = publish_pyxis_repository.publish_repositories(
+            snapshot=_snapshot(
+                components=[
+                    {
+                        "name": "c",
+                        "repositories": [
+                            _repo("quay.io/redhat-prod/my-product----my-image0"),
+                        ],
+                    },
+                ],
+            ),
+            pyxis_api_url="https://pyxis/v1",
+            cert=("/tmp/cert", "/tmp/key"),
+            sign_registry_access_file=sign_file,
+            skip_publishing=False,
+            default_push_source_container=False,
+        )
+
+    assert len(results["catalog_urls"]) == 1
+
+
+def test_publish_repositories_missing_repository_id_raises(tmp_path: Path) -> None:
+    """Fail when Pyxis GET does not return a repository _id."""
+    sign_file = tmp_path / "sign-registry-access.txt"
+    sign_file.write_text("", encoding="utf-8")
+
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            return_value={"detail": "not found"},
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+        ),
+    ):
+        with pytest.raises(ValueError, match="Unable to get Container Repository"):
+            publish_pyxis_repository.publish_repositories(
+                snapshot=_snapshot(
+                    components=[
+                        {
+                            "repositories": [
+                                _repo("quay.io/redhat-prod/my-product----my-image9"),
+                            ],
+                        },
+                    ],
+                ),
+                pyxis_api_url="https://pyxis/v1",
+                cert=("/tmp/cert", "/tmp/key"),
+                sign_registry_access_file=sign_file,
+                skip_publishing=False,
+                default_push_source_container=False,
+            )
+
+
+def test_publish_repositories_source_container_payload(tmp_path: Path) -> None:
+    """PATCH payload includes source_container_image_enabled when enabled."""
+    sign_file = tmp_path / "sign-registry-access.txt"
+    sign_file.write_text("", encoding="utf-8")
+    captured: list[dict[str, object]] = []
+
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            return_value={
+                "_id": "1",
+                "publish_on_push": True,
+                "requires_terms": True,
+            },
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+            side_effect=lambda _a, _b, payload, **_k: captured.append(payload),
+        ),
+    ):
+        publish_pyxis_repository.publish_repositories(
+            snapshot=_snapshot(
+                components=[
+                    {
+                        "name": "c",
+                        "pushSourceContainer": True,
+                        "repositories": [_repo("quay.io/redhat-prod/p----i1")],
+                    },
+                ],
+            ),
+            pyxis_api_url="https://pyxis/v1",
+            cert=("/tmp/cert", "/tmp/key"),
+            sign_registry_access_file=sign_file,
+            skip_publishing=False,
+            default_push_source_container=False,
+        )
+
+    assert captured == [
+        {"published": True, "source_container_image_enabled": True},
+    ]
+
+
+def test_publish_repositories_flatpak_never_sign_registry(tmp_path: Path) -> None:
+    """Flatpak repos publish but never appear in sign-registry-access.txt."""
+    sign_file = tmp_path / "sign-registry-access.txt"
+    sign_file.write_text("", encoding="utf-8")
+
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            return_value={
+                "_id": "9",
+                "publish_on_push": True,
+                "requires_terms": False,
+            },
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+        ),
+    ):
+        results = publish_pyxis_repository.publish_repositories(
+            snapshot=_snapshot(
+                components=[
+                    {
+                        "name": "component1",
+                        "repositories": [
+                            _repo("quay.io/rh-flatpaks-stage/my-product----my-image1"),
+                        ],
+                    },
+                ],
+            ),
+            pyxis_api_url="https://pyxis/v1",
+            cert=("/tmp/cert", "/tmp/key"),
+            sign_registry_access_file=sign_file,
+            skip_publishing=False,
+            default_push_source_container=False,
+        )
+
+    assert sign_file.read_text(encoding="utf-8") == ""
+    assert results["catalog_urls"][0]["url"].startswith(
+        "https://catalog.stage.redhat.com/",
+    )
+
+
+def test_run_publish_pyxis_repository_writes_outputs(tmp_path: Path) -> None:
+    """Write results JSON and sign-registry-access Tekton result path."""
+    data_dir = tmp_path / "data"
+    uid = "run-1"
+    snapshot_path = data_dir / uid / "snapshot_spec.json"
+    data_path = data_dir / uid / "mydata.json"
+    results_dir = data_dir / uid / "results"
+    snapshot_path.parent.mkdir(parents=True)
+    snapshot_path.write_text(
+        json.dumps(
+            _snapshot(
+                components=[
+                    {
+                        "name": "component1",
+                        "repositories": [
+                            _repo("quay.io/redhat-prod/my-product----my-image1"),
+                        ],
+                    },
+                ],
+            ),
+        ),
+        encoding="utf-8",
+    )
+    data_path.write_text(json.dumps({"mapping": {}}), encoding="utf-8")
+    secret = tmp_path / "secret"
+    secret.mkdir()
+    (secret / "cert").write_text("cert", encoding="utf-8")
+    (secret / "key").write_text("key", encoding="utf-8")
+    result_path = tmp_path / "sign-result.txt"
+
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            return_value={
+                "_id": "1",
+                "publish_on_push": True,
+                "requires_terms": True,
+            },
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+        ),
+    ):
+        publish_pyxis_repository.run_publish_pyxis_repository(
+            data_dir=data_dir,
+            snapshot_path=snapshot_path,
+            data_path=data_path,
+            results_dir_path=results_dir,
+            sign_registry_access_result_path=result_path,
+            pyxis_secret_mount=secret,
+            pyxis_api_url="https://pyxis/v1",
+            task_name="publish-pyxis-repository",
+        )
+
+    assert result_path.read_text(encoding="utf-8") == f"{uid}/sign-registry-access.txt"
+    sign_file = data_dir / uid / "sign-registry-access.txt"
+    assert sign_file.is_file()
+    assert not (data_dir / "data" / uid / "sign-registry-access.txt").exists()
+    results = json.loads(
+        (results_dir / "publish-pyxis-repository-results.json").read_text(
+            encoding="utf-8",
+        ),
+    )
+    assert results["catalog_urls"][0]["name"] == "component1"
+
+
+def test_run_publish_missing_snapshot_raises(tmp_path: Path) -> None:
+    """Fail fast when the snapshot file is missing."""
+    with pytest.raises(FileNotFoundError, match="No valid snapshot file"):
+        publish_pyxis_repository.run_publish_pyxis_repository(
+            data_dir=tmp_path,
+            snapshot_path=tmp_path / "missing.json",
+            data_path=tmp_path / "data.json",
+            results_dir_path=tmp_path / "results",
+            sign_registry_access_result_path=tmp_path / "result",
+            pyxis_secret_mount=tmp_path,
+            pyxis_api_url="https://pyxis/v1",
+            task_name="task",
+        )
+
+
+def test_run_publish_missing_data_raises(tmp_path: Path) -> None:
+    """Fail fast when the data JSON file is missing."""
+    snapshot = tmp_path / "snap.json"
+    snapshot.write_text("{}", encoding="utf-8")
+    with pytest.raises(FileNotFoundError, match="No data JSON"):
+        publish_pyxis_repository.run_publish_pyxis_repository(
+            data_dir=tmp_path,
+            snapshot_path=snapshot,
+            data_path=tmp_path / "missing-data.json",
+            results_dir_path=tmp_path / "results",
+            sign_registry_access_result_path=tmp_path / "result",
+            pyxis_secret_mount=tmp_path,
+            pyxis_api_url="https://pyxis/v1",
+            task_name="task",
+        )
+
+
+def test_resolve_pyxis_api_url_from_server_param(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Map PARAM_SERVER to a Pyxis URL when PYXIS_URL is unset."""
+    monkeypatch.delenv("PYXIS_URL", raising=False)
+    monkeypatch.setenv("PARAM_SERVER", "stage")
+    assert publish_pyxis_repository.resolve_pyxis_api_url().endswith(
+        "pyxis.preprod.api.redhat.com/v1",
+    )
+
+
+def test_resolve_pyxis_api_url_uses_pyxis_url_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prefer PYXIS_URL over PARAM_SERVER when both are available."""
+    monkeypatch.setenv("PYXIS_URL", "https://custom.example/pyxis/")
+    monkeypatch.setenv("PARAM_SERVER", "production")
+    assert publish_pyxis_repository.resolve_pyxis_api_url() == "https://custom.example/pyxis"
+
+
+def test_skip_repo_publishing_reads_data_flag() -> None:
+    """Return true when pyxis.skipRepoPublishing is set in data JSON."""
+    assert publish_pyxis_repository.skip_repo_publishing(
+        {"pyxis": {"skipRepoPublishing": True}},
+    )
+
+
+def test_publish_unknown_catalog_prefix_raises(tmp_path: Path) -> None:
+    """Fail when a repository URL has an unsupported Quay prefix after PATCH."""
+    sign_file = tmp_path / "sign-registry-access.txt"
+    sign_file.write_text("", encoding="utf-8")
+    patch_called = False
+
+    def track_patch(*_a: Any, **_k: Any) -> None:
+        nonlocal patch_called
+        patch_called = True
+
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            return_value={
+                "_id": "1",
+                "publish_on_push": True,
+                "published": False,
+                "requires_terms": True,
+            },
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+            side_effect=track_patch,
+        ),
+    ):
+        with pytest.raises(ValueError, match="Unknown repository prefix"):
+            publish_pyxis_repository.publish_repositories(
+                snapshot=_snapshot(
+                    components=[
+                        {
+                            "repositories": [_repo("quay.io/unknown/product----image")],
+                        },
+                    ],
+                ),
+                pyxis_api_url="https://pyxis/v1",
+                cert=("/tmp/cert", "/tmp/key"),
+                sign_registry_access_file=sign_file,
+                skip_publishing=False,
+                default_push_source_container=False,
+            )
+    assert patch_called
+
+
+def test_module_main_guard_raises_system_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Executing the file as `__main__` triggers `raise SystemExit(main())`."""
+    import runpy
+
+    import publish_pyxis_repository
+
+    monkeypatch.setattr("sys.argv", ["publish_pyxis_repository.py"])
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_path(
+            str(Path(publish_pyxis_repository.__file__)),
+            run_name="__main__",
+        )
+    assert exc.value.code == 1
+
+
+def test_publish_repositories_skips_invalid_snapshot_rows(tmp_path: Path) -> None:
+    """Ignore malformed component and repository rows without failing."""
+    sign_file = tmp_path / "sign-registry-access.txt"
+    sign_file.write_text("", encoding="utf-8")
+
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            side_effect=lambda *_a, **_k: pytest.fail("get should not run"),
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+        ),
+    ):
+        results = publish_pyxis_repository.publish_repositories(
+            snapshot={
+                "components": [
+                    "not-a-mapping",
+                    {"repositories": "not-a-list"},
+                    {"repositories": ["bad", {"url": ""}, {"url": 1}]},
+                ],
+            },
+            pyxis_api_url="https://pyxis/v1",
+            cert=("/tmp/cert", "/tmp/key"),
+            sign_registry_access_file=sign_file,
+            skip_publishing=False,
+            default_push_source_container=False,
+        )
+
+    assert results["catalog_urls"] == []
+
+
+def test_publish_repositories_invalid_components_type_raises(tmp_path: Path) -> None:
+    """Fail when snapshot components is not a JSON array."""
+    sign_file = tmp_path / "sign-registry-access.txt"
+    with (
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.get_repository_json",
+            return_value={},
+        ),
+        mock.patch(
+            "publish_pyxis_repository.pyxis_api.patch_repository_json",
+        ),
+    ):
+        with pytest.raises(ValueError, match="components must be a JSON array"):
+            publish_pyxis_repository.publish_repositories(
+                snapshot={"components": "bad"},
+                pyxis_api_url="https://pyxis/v1",
+                cert=("/tmp/cert", "/tmp/key"),
+                sign_registry_access_file=sign_file,
+                skip_publishing=False,
+                default_push_source_container=False,
+            )
+
+
+def test_main_unexpected_failure_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Propagate unexpected exceptions from the workflow."""
+    monkeypatch.setenv("PARAM_DATA_DIR", "/tmp")
+    monkeypatch.setenv("PARAM_SNAPSHOT_PATH", "snap.json")
+    monkeypatch.setenv("PARAM_DATA_PATH", "data.json")
+    monkeypatch.setenv("PARAM_RESULTS_DIR_PATH", "results")
+    monkeypatch.setenv("RESULT_SIGN_REGISTRY_ACCESS_PATH", "/tmp/r")
+    monkeypatch.setenv("PYXIS_URL", "https://pyxis/v1")
+
+    with mock.patch(
+        "publish_pyxis_repository.run_publish_pyxis_repository",
+        side_effect=RuntimeError("boom"),
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            publish_pyxis_repository.main()
+
+
+def test_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exit zero after a successful run when env vars are set."""
+    monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PARAM_SNAPSHOT_PATH", "snap.json")
+    monkeypatch.setenv("PARAM_DATA_PATH", "data.json")
+    monkeypatch.setenv("PARAM_RESULTS_DIR_PATH", "results")
+    monkeypatch.setenv("RESULT_SIGN_REGISTRY_ACCESS_PATH", str(tmp_path / "r"))
+    monkeypatch.setenv("PARAM_SERVER", "production")
+    monkeypatch.setenv("PYXIS_URL", "https://pyxis/v1")
+
+    with mock.patch(
+        "publish_pyxis_repository.run_publish_pyxis_repository",
+    ) as run:
+        assert publish_pyxis_repository.main() == 0
+    run.assert_called_once()
+
+
+def test_main_failure_propagates_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Propagate workflow failures from main()."""
+    monkeypatch.setenv("PARAM_DATA_DIR", "/tmp")
+    monkeypatch.setenv("PARAM_SNAPSHOT_PATH", "snap.json")
+    monkeypatch.setenv("PARAM_DATA_PATH", "data.json")
+    monkeypatch.setenv("PARAM_RESULTS_DIR_PATH", "results")
+    monkeypatch.setenv("RESULT_SIGN_REGISTRY_ACCESS_PATH", "/tmp/r")
+    monkeypatch.setenv("PYXIS_URL", "https://pyxis/v1")
+
+    with mock.patch(
+        "publish_pyxis_repository.run_publish_pyxis_repository",
+        side_effect=FileNotFoundError("No valid snapshot file was provided."),
+    ):
+        with pytest.raises(FileNotFoundError, match="No valid snapshot file"):
+            publish_pyxis_repository.main()


### PR DESCRIPTION
This commit adds a python script to replicate the functionality of the inline bash script in the publish-pyxis-repository managed task in the catalog repo. The task will be updated to use this python module instead.

It also adds a document to help understand the script.

Assisted-By: Cursor