### PR TITLE
feat(RELEASE-2494): convert extract-checksums-from-image to python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pythonpath = [
   "integration-tests/lib",
   "scripts/python/helpers",
   "scripts/python/tasks/internal",
+  "scripts/python/tasks/managed",
   "utils",
   "pubtools-pulp-wrapper",
   "publish-to-cgw-wrapper",

--- a/scripts/python/helpers/skopeo.py
+++ b/scripts/python/helpers/skopeo.py
@@ -20,3 +20,14 @@ def inspect(
         cmd.append("--raw")
     cmd.append(f"docker://{image_ref}")
     return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def copy(
+    source: str,
+    dest: str,
+    *,
+    retry_times: int = 3,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``skopeo copy`` to copy an image between transports."""
+    cmd = ["skopeo", "copy", "--retry-times", str(retry_times), source, dest]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)

--- a/scripts/python/helpers/test_skopeo.py
+++ b/scripts/python/helpers/test_skopeo.py
@@ -133,3 +133,67 @@ def test_inspect_image_ref_with_digest() -> None:
 
     cmd = run_mock.call_args[0][0]
     assert cmd[-1] == f"docker://{ref}"
+
+
+# ---------------------------------------------------------------------------
+# copy
+# ---------------------------------------------------------------------------
+
+
+def test_copy_basic_command() -> None:
+    """Default copy builds the correct command."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_completed(),
+    ) as run_mock:
+        skopeo.copy("docker://registry.example.com/repo:tag", "dir:/tmp/out")
+
+    cmd = run_mock.call_args[0][0]
+    assert cmd == [
+        "skopeo",
+        "copy",
+        "--retry-times",
+        "3",
+        "docker://registry.example.com/repo:tag",
+        "dir:/tmp/out",
+    ]
+    assert run_mock.call_args[1]["capture_output"] is True
+    assert run_mock.call_args[1]["text"] is True
+    assert run_mock.call_args[1]["check"] is False
+
+
+def test_copy_custom_retry_times() -> None:
+    """``retry_times`` overrides the default retry count."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_completed(),
+    ) as run_mock:
+        skopeo.copy("docker://img:v1", "dir:/tmp/out", retry_times=5)
+
+    cmd = run_mock.call_args[0][0]
+    idx = cmd.index("--retry-times")
+    assert cmd[idx + 1] == "5"
+
+
+def test_copy_returns_completed_process() -> None:
+    """The raw ``CompletedProcess`` is returned to the caller."""
+    expected = _completed(stdout="copied successfully")
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=expected,
+    ):
+        result = skopeo.copy("docker://img:v1", "dir:/tmp/out")
+
+    assert result is expected
+
+
+def test_copy_nonzero_exit_code() -> None:
+    """A non-zero exit code is returned, not raised."""
+    expected = _completed(returncode=1)
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=expected,
+    ):
+        result = skopeo.copy("docker://img:v1", "dir:/tmp/out")
+
+    assert result.returncode == 1

--- a/scripts/python/tasks/managed/extract_checksums_from_image.py
+++ b/scripts/python/tasks/managed/extract_checksums_from_image.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Extract SHA256SUMS checksum files from container images for GitHub releases.
+
+Processes container images listed in a snapshot specification, extracts
+binaries to a temporary directory, retains only checksum files (``*SHA256SUMS``)
+in the output, and writes the relative output path to a Tekton result file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import skopeo
+import tekton
+from logger import logger
+
+PROG = "extract_checksums_from_image.py"
+BINARIES_DIR = "binaries"
+
+
+def load_snapshot(snapshot_path: Path) -> dict[str, Any]:
+    """Load and return the snapshot JSON from *snapshot_path*."""
+    if not snapshot_path.is_file():
+        raise ValueError(f"No valid snapshot file was provided: {snapshot_path}")
+    return json.loads(snapshot_path.read_text(encoding="utf-8"))
+
+
+def load_components(data_path: Path) -> list[str]:
+    """Return the component name whitelist from the data file, or ``[]``."""
+    if not data_path.is_file():
+        logger.info("No data JSON was provided.")
+        return []
+
+    data = json.loads(data_path.read_text(encoding="utf-8"))
+    components = (data.get("mapping") or {}).get("components")
+    if not components:
+        return []
+
+    names: list[str] = []
+    for comp in components:
+        name = comp.get("name")
+        if name is None:
+            raise ValueError("Component entry in data file is missing 'name' field")
+        names.append(name)
+    return names
+
+
+def extract_binaries_from_layers(
+    image_dir: Path,
+    image_binaries_path: str,
+) -> None:
+    """Extract files from image layers that contain *image_binaries_path*."""
+    manifest_path = image_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    for layer in manifest.get("layers", []):
+        digest: str = layer["digest"]
+        filename = digest.removeprefix("sha256:")
+        tar_path = image_dir / filename
+
+        with tarfile.open(tar_path) as tf:
+            matching_entries = [
+                m for m in tf.getmembers() if m.name.startswith(f"{image_binaries_path}/")
+            ]
+            if matching_entries:
+                logger.info(
+                    "Extracting %s/ from %s...",
+                    image_binaries_path,
+                    filename,
+                )
+                tf.extractall(
+                    path=image_dir,
+                    members=matching_entries,
+                    filter="data",
+                )
+            else:
+                logger.info(
+                    "skipping %s. It doesn't contain the %s dir",
+                    filename,
+                    image_binaries_path,
+                )
+
+
+def copy_to_binaries(source_dir: Path, binaries_path: Path) -> None:
+    """Copy all files from *source_dir* into *binaries_path*."""
+    for item in source_dir.iterdir():
+        if item.is_file():
+            shutil.copy2(item, binaries_path)
+
+
+def remove_non_checksum_files(binaries_path: Path) -> None:
+    """Remove files in *binaries_path* not ending with ``SHA256SUMS``."""
+    for item in list(binaries_path.iterdir()):
+        if item.is_file() and not item.name.endswith("SHA256SUMS"):
+            item.unlink()
+
+
+def extract_checksums(
+    snapshot_path: Path,
+    data_path: Path,
+    data_dir: Path,
+    image_binaries_path: str,
+    snapshot_rel_path: str,
+    *,
+    copy_image: Callable[..., subprocess.CompletedProcess[str]] = skopeo.copy,
+) -> str:
+    """Extract SHA256SUMS files from container images in the snapshot.
+
+    Returns the relative binaries path (e.g. ``uid123/binaries``) for
+    writing to the Tekton result file.
+    """
+    snapshot = load_snapshot(snapshot_path)
+
+    relative_binaries = f"{Path(snapshot_rel_path).parent}/{BINARIES_DIR}"
+    binaries_path = data_dir / relative_binaries
+    binaries_path.mkdir(parents=True, exist_ok=True)
+
+    desired_set = set(load_components(data_path))
+
+    for component in snapshot.get("components") or []:
+        component_name = component.get("name", "")
+
+        if desired_set and component_name not in desired_set:
+            continue
+
+        image_url = component.get("containerImage") or ""
+        if not image_url:
+            raise ValueError("Unable to get image url from snapshot.")
+
+        tmp_dir = Path(tempfile.mkdtemp())
+        try:
+            result = copy_image(f"docker://{image_url}", f"dir:{tmp_dir}")
+            if result.returncode != 0:
+                logger.error("skopeo copy failed: %s", result.stderr)
+                raise subprocess.CalledProcessError(
+                    result.returncode,
+                    result.args,
+                    output=result.stdout,
+                    stderr=result.stderr,
+                )
+
+            extract_binaries_from_layers(tmp_dir, image_binaries_path)
+
+            extracted_dir = tmp_dir / image_binaries_path
+            if not extracted_dir.is_dir():
+                raise ValueError(
+                    f"Image {image_url} does not contain"
+                    f" the '{image_binaries_path}' directory"
+                )
+            copy_to_binaries(extracted_dir, binaries_path)
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    remove_non_checksum_files(binaries_path)
+
+    logger.info("%s", relative_binaries)
+    return relative_binaries
+
+
+def main() -> int:
+    """Read environment, extract checksums, write Tekton result."""
+    (result_path,) = tekton.result_paths_from_env("RESULT_BINARIES_PATH")
+
+    data_dir = Path(tekton.require_env("DATA_DIR"))
+    snapshot_rel_path = tekton.require_env("SNAPSHOT_PATH")
+    data_path_str = os.environ.get("DATA_PATH", "")
+    image_binaries_path = os.environ.get("IMAGE_PATH", "releases")
+
+    snapshot_path = data_dir / snapshot_rel_path
+    data_path = data_dir / data_path_str
+
+    try:
+        relative_binaries = extract_checksums(
+            snapshot_path=snapshot_path,
+            data_path=data_path,
+            data_dir=data_dir,
+            image_binaries_path=image_binaries_path,
+            snapshot_rel_path=snapshot_rel_path,
+        )
+    except Exception as e:
+        raise SystemExit(f"{PROG}: {e}") from e
+
+    result_path.write_text(relative_binaries, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_extract_checksums_from_image.py
+++ b/scripts/python/tasks/managed/test_extract_checksums_from_image.py
@@ -1,0 +1,596 @@
+"""Tests for ``extract_checksums_from_image``."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import tarfile
+from pathlib import Path
+from unittest import mock
+
+import extract_checksums_from_image as ecfi
+import pytest
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_snapshot(path: Path, components: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"components": components}), encoding="utf-8")
+
+
+def _write_data(path: Path, component_names: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    mapping = {"mapping": {"components": [{"name": n} for n in component_names]}}
+    path.write_text(json.dumps(mapping), encoding="utf-8")
+
+
+def _make_layer_tar(dest: Path, base_dir: str, files: dict[str, str]) -> str:
+    """Create a gzip tar at *dest* containing files under *base_dir*.
+
+    Returns the sha256 digest string (``sha256:<hex>``).
+    """
+    import hashlib
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name=f"{base_dir}/{name}")
+            data = content.encode("utf-8")
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    raw = buf.getvalue()
+    digest = hashlib.sha256(raw).hexdigest()
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / digest).write_bytes(raw)
+    return f"sha256:{digest}"
+
+
+def _make_empty_layer_tar(dest_dir: Path) -> str:
+    """Create a tar with no relevant entries. Returns digest string."""
+    import hashlib
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name="unrelated/file.txt")
+        data = b"nope"
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+    raw = buf.getvalue()
+    digest = hashlib.sha256(raw).hexdigest()
+    (dest_dir / digest).write_bytes(raw)
+    return f"sha256:{digest}"
+
+
+def _write_manifest(image_dir: Path, digests: list[str]) -> None:
+    manifest = {"layers": [{"digest": d} for d in digests]}
+    (image_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def _fake_copy_image(image_dir: Path, base_dir: str, files: dict[str, str]):
+    """Return a copy_image callable that populates *image_dir* with a layer."""
+    digest = _make_layer_tar(image_dir, base_dir, files)
+    _write_manifest(image_dir, [digest])
+
+    def _copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
+        import shutil
+
+        dest_path = Path(dest.removeprefix("dir:"))
+        for item in image_dir.iterdir():
+            if item.is_file():
+                shutil.copy2(item, dest_path)
+        return subprocess.CompletedProcess(
+            args=["skopeo", "copy"], returncode=0, stdout="", stderr=""
+        )
+
+    return _copy
+
+
+def _stub_copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
+    """Copy stub that writes a minimal valid layer with a SHA256SUMS file."""
+    dest_path = Path(dest.removeprefix("dir:"))
+    digest = _make_layer_tar(dest_path, "releases", {"SHA256SUMS": "stub"})
+    _write_manifest(dest_path, [digest])
+    return subprocess.CompletedProcess(
+        args=["skopeo", "copy"], returncode=0, stdout="", stderr=""
+    )
+
+
+# ---------------------------------------------------------------------------
+# load_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_load_snapshot_valid(tmp_path: Path) -> None:
+    """Valid JSON file is parsed and returned."""
+    p = tmp_path / "snapshot.json"
+    expected = {"components": [{"name": "c1"}]}
+    p.write_text(json.dumps(expected), encoding="utf-8")
+
+    assert ecfi.load_snapshot(p) == expected
+
+
+def test_load_snapshot_missing_file(tmp_path: Path) -> None:
+    """Missing file raises ValueError."""
+    with pytest.raises(ValueError, match="No valid snapshot file"):
+        ecfi.load_snapshot(tmp_path / "nope.json")
+
+
+def test_load_snapshot_invalid_json(tmp_path: Path) -> None:
+    """Malformed JSON raises ValueError (JSONDecodeError is a subclass)."""
+    p = tmp_path / "bad.json"
+    p.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        ecfi.load_snapshot(p)
+
+
+# ---------------------------------------------------------------------------
+# load_components
+# ---------------------------------------------------------------------------
+
+
+def test_load_components_file_missing(tmp_path: Path) -> None:
+    """Missing data file returns empty list (no filtering)."""
+    assert ecfi.load_components(tmp_path / "nope.json") == []
+
+
+def test_load_components_no_mapping_key(tmp_path: Path) -> None:
+    """Data file without ``mapping.components`` returns empty list."""
+    p = tmp_path / "data.json"
+    p.write_text("{}", encoding="utf-8")
+
+    assert ecfi.load_components(p) == []
+
+
+def test_load_components_empty_components(tmp_path: Path) -> None:
+    """Empty components array returns empty list."""
+    p = tmp_path / "data.json"
+    p.write_text(json.dumps({"mapping": {"components": []}}), encoding="utf-8")
+
+    assert ecfi.load_components(p) == []
+
+
+def test_load_components_extracts_names(tmp_path: Path) -> None:
+    """Component names are extracted in order."""
+    p = tmp_path / "data.json"
+    _write_data(p, ["comp-a", "comp-b"])
+
+    assert ecfi.load_components(p) == ["comp-a", "comp-b"]
+
+
+def test_load_components_missing_name_raises(tmp_path: Path) -> None:
+    """Component entry without ``name`` raises ValueError."""
+    p = tmp_path / "data.json"
+    p.write_text(
+        json.dumps({"mapping": {"components": [{"repo": "x"}]}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="missing 'name' field"):
+        ecfi.load_components(p)
+
+
+# ---------------------------------------------------------------------------
+# extract_binaries_from_layers
+# ---------------------------------------------------------------------------
+
+
+def test_extract_binaries_from_layers_matching(tmp_path: Path) -> None:
+    """Layers containing the target path are extracted."""
+    digest = _make_layer_tar(
+        tmp_path, "releases", {"binary.zip": "data", "SHA256SUMS": "abc 123"}
+    )
+    _write_manifest(tmp_path, [digest])
+
+    ecfi.extract_binaries_from_layers(tmp_path, "releases")
+
+    assert (tmp_path / "releases" / "binary.zip").exists()
+    assert (tmp_path / "releases" / "SHA256SUMS").exists()
+
+
+def test_extract_binaries_from_layers_skips_non_matching(
+    tmp_path: Path,
+) -> None:
+    """Layers without the target path are skipped."""
+    digest = _make_empty_layer_tar(tmp_path)
+    _write_manifest(tmp_path, [digest])
+
+    ecfi.extract_binaries_from_layers(tmp_path, "releases")
+
+    assert not (tmp_path / "releases").exists()
+
+
+def test_extract_binaries_from_layers_mixed(tmp_path: Path) -> None:
+    """Only matching layers are extracted when mixed with non-matching."""
+    d1 = _make_layer_tar(tmp_path, "releases", {"file.bin": "content"})
+    d2 = _make_empty_layer_tar(tmp_path)
+    _write_manifest(tmp_path, [d1, d2])
+
+    ecfi.extract_binaries_from_layers(tmp_path, "releases")
+
+    assert (tmp_path / "releases" / "file.bin").exists()
+    assert not (tmp_path / "unrelated").exists()
+
+
+# ---------------------------------------------------------------------------
+# copy_to_binaries
+# ---------------------------------------------------------------------------
+
+
+def test_copy_to_binaries(tmp_path: Path) -> None:
+    """All files from source are copied to destination."""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    (src / "a.txt").write_text("aaa", encoding="utf-8")
+    (src / "b.txt").write_text("bbb", encoding="utf-8")
+
+    ecfi.copy_to_binaries(src, dst)
+
+    assert (dst / "a.txt").read_text(encoding="utf-8") == "aaa"
+    assert (dst / "b.txt").read_text(encoding="utf-8") == "bbb"
+
+
+# ---------------------------------------------------------------------------
+# remove_non_checksum_files
+# ---------------------------------------------------------------------------
+
+
+def test_remove_non_checksum_files_keeps_sha256sums(tmp_path: Path) -> None:
+    """Files ending with SHA256SUMS are kept."""
+    (tmp_path / "linux-amd64-SHA256SUMS").write_text("hash", encoding="utf-8")
+    (tmp_path / "SHA256SUMS").write_text("hash2", encoding="utf-8")
+
+    ecfi.remove_non_checksum_files(tmp_path)
+
+    assert (tmp_path / "linux-amd64-SHA256SUMS").exists()
+    assert (tmp_path / "SHA256SUMS").exists()
+
+
+def test_remove_non_checksum_files_removes_binaries(tmp_path: Path) -> None:
+    """Non-checksum files are deleted."""
+    (tmp_path / "binary.zip").write_text("bin", encoding="utf-8")
+    (tmp_path / "app.tar.gz").write_text("tar", encoding="utf-8")
+    (tmp_path / "linux-SHA256SUMS").write_text("hash", encoding="utf-8")
+
+    ecfi.remove_non_checksum_files(tmp_path)
+
+    assert not (tmp_path / "binary.zip").exists()
+    assert not (tmp_path / "app.tar.gz").exists()
+    assert (tmp_path / "linux-SHA256SUMS").exists()
+
+
+def test_remove_non_checksum_files_empty_dir(tmp_path: Path) -> None:
+    """Empty directory is a no-op."""
+    ecfi.remove_non_checksum_files(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# extract_checksums
+# ---------------------------------------------------------------------------
+
+
+def _setup_extract(
+    tmp_path: Path,
+    components: list[dict],
+    data_names: list[str] | None = None,
+) -> tuple[Path, Path, Path, str]:
+    """Set up directories and files for extract_checksums tests.
+
+    Returns (snapshot_path, data_path, data_dir, snapshot_rel_path).
+    """
+    data_dir = tmp_path / "workdir"
+    uid = "uid123"
+    snapshot_rel_path = f"{uid}/snapshot.json"
+    snapshot_path = data_dir / snapshot_rel_path
+    data_path = data_dir / uid / "data.json"
+
+    _write_snapshot(snapshot_path, components)
+    if data_names is not None:
+        _write_data(data_path, data_names)
+
+    return snapshot_path, data_path, data_dir, snapshot_rel_path
+
+
+def test_extract_checksums_single_component(tmp_path: Path) -> None:
+    """Single component: image downloaded, checksums extracted, binaries removed."""
+    snapshot_path, data_path, data_dir, rel = _setup_extract(
+        tmp_path,
+        [{"name": "c1", "containerImage": "registry.io/img:v1"}],
+    )
+
+    image_staging = tmp_path / "staging"
+    image_staging.mkdir()
+    copy_fn = _fake_copy_image(
+        image_staging,
+        "releases",
+        {"app.zip": "binary", "app-SHA256SUMS": "deadbeef  app.zip"},
+    )
+
+    result = ecfi.extract_checksums(
+        snapshot_path, data_path, data_dir, "releases", rel, copy_image=copy_fn
+    )
+
+    assert result == "uid123/binaries"
+    binaries = data_dir / result
+    assert (binaries / "app-SHA256SUMS").exists()
+    assert not (binaries / "app.zip").exists()
+
+
+def test_extract_checksums_multiple_components(tmp_path: Path) -> None:
+    """All components are processed when no filtering is applied."""
+    components = [
+        {"name": f"c{i}", "containerImage": f"registry.io/img{i}:v1"} for i in range(3)
+    ]
+    snapshot_path, data_path, data_dir, rel = _setup_extract(tmp_path, components)
+
+    call_count = 0
+
+    def _counting_copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
+        nonlocal call_count
+        call_count += 1
+        return _stub_copy(source, dest)
+
+    ecfi.extract_checksums(
+        snapshot_path,
+        data_path,
+        data_dir,
+        "releases",
+        rel,
+        copy_image=_counting_copy,
+    )
+
+    assert call_count == 3
+
+
+def test_extract_checksums_component_filtering(tmp_path: Path) -> None:
+    """Only desired components from data file are processed."""
+    components = [
+        {"name": "c1", "containerImage": "registry.io/img1:v1"},
+        {"name": "c2", "containerImage": "registry.io/img2:v1"},
+        {"name": "c3", "containerImage": "registry.io/img3:v1"},
+    ]
+    snapshot_path, data_path, data_dir, rel = _setup_extract(
+        tmp_path, components, data_names=["c1", "c3"]
+    )
+
+    processed: list[str] = []
+
+    def _tracking_copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
+        processed.append(source)
+        return _stub_copy(source, dest)
+
+    ecfi.extract_checksums(
+        snapshot_path,
+        data_path,
+        data_dir,
+        "releases",
+        rel,
+        copy_image=_tracking_copy,
+    )
+
+    assert len(processed) == 2
+    assert any("img1" in s for s in processed)
+    assert any("img3" in s for s in processed)
+    assert not any("img2" in s for s in processed)
+
+
+def test_extract_checksums_empty_image_url_raises(tmp_path: Path) -> None:
+    """Component with empty containerImage raises ValueError."""
+    snapshot_path, data_path, data_dir, rel = _setup_extract(
+        tmp_path,
+        [{"name": "c1", "containerImage": ""}],
+    )
+
+    with pytest.raises(ValueError, match="Unable to get image url"):
+        ecfi.extract_checksums(snapshot_path, data_path, data_dir, "releases", rel)
+
+
+def test_extract_checksums_missing_image_url_raises(tmp_path: Path) -> None:
+    """Component without containerImage key raises ValueError."""
+    snapshot_path, data_path, data_dir, rel = _setup_extract(
+        tmp_path,
+        [{"name": "c1"}],
+    )
+
+    with pytest.raises(ValueError, match="Unable to get image url"):
+        ecfi.extract_checksums(snapshot_path, data_path, data_dir, "releases", rel)
+
+
+def test_extract_checksums_null_components(tmp_path: Path) -> None:
+    """Snapshot with ``components: null`` is treated as no components."""
+    data_dir = tmp_path / "workdir"
+    rel = "uid/snapshot.json"
+    snapshot_path = data_dir / rel
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_path.write_text(json.dumps({"components": None}), encoding="utf-8")
+
+    result = ecfi.extract_checksums(
+        snapshot_path, data_dir / "data.json", data_dir, "releases", rel
+    )
+
+    assert result == "uid/binaries"
+
+
+def test_extract_checksums_missing_snapshot_raises(tmp_path: Path) -> None:
+    """Missing snapshot file raises ValueError."""
+    data_dir = tmp_path / "workdir"
+    data_dir.mkdir()
+
+    with pytest.raises(ValueError, match="No valid snapshot file"):
+        ecfi.extract_checksums(
+            data_dir / "nope.json",
+            data_dir / "data.json",
+            data_dir,
+            "releases",
+            "uid/nope.json",
+        )
+
+
+def test_extract_checksums_missing_binaries_path_raises(tmp_path: Path) -> None:
+    """Image without the expected binaries directory raises ValueError."""
+    snapshot_path, data_path, data_dir, rel = _setup_extract(
+        tmp_path,
+        [{"name": "c1", "containerImage": "registry.io/img:v1"}],
+    )
+
+    def _copy_without_binaries(source: str, dest: str) -> subprocess.CompletedProcess[str]:
+        dest_path = Path(dest.removeprefix("dir:"))
+        digest = _make_empty_layer_tar(dest_path)
+        _write_manifest(dest_path, [digest])
+        return subprocess.CompletedProcess(
+            args=["skopeo", "copy"], returncode=0, stdout="", stderr=""
+        )
+
+    with pytest.raises(ValueError, match="does not contain the 'releases' directory"):
+        ecfi.extract_checksums(
+            snapshot_path,
+            data_path,
+            data_dir,
+            "releases",
+            rel,
+            copy_image=_copy_without_binaries,
+        )
+
+
+def test_extract_checksums_skopeo_failure_raises(tmp_path: Path) -> None:
+    """Non-zero skopeo exit code raises CalledProcessError."""
+    snapshot_path, data_path, data_dir, rel = _setup_extract(
+        tmp_path,
+        [{"name": "c1", "containerImage": "registry.io/img:v1"}],
+    )
+
+    def _failing_copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["skopeo", "copy"],
+            returncode=1,
+            stdout="",
+            stderr="unauthorized",
+        )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        ecfi.extract_checksums(
+            snapshot_path,
+            data_path,
+            data_dir,
+            "releases",
+            rel,
+            copy_image=_failing_copy,
+        )
+
+
+def test_extract_checksums_returns_correct_relative_path(
+    tmp_path: Path,
+) -> None:
+    """Returned path is ``{snapshot_parent}/binaries``."""
+    snapshot_path, data_path, data_dir, _ = _setup_extract(
+        tmp_path,
+        [{"name": "c1", "containerImage": "registry.io/img:v1"}],
+    )
+    rel = "deep/nested/snapshot.json"
+    _write_snapshot(data_dir / rel, [{"name": "c1", "containerImage": "r/i:1"}])
+
+    def _noop_copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
+        return _stub_copy(source, dest)
+
+    result = ecfi.extract_checksums(
+        data_dir / rel,
+        data_dir / "data.json",
+        data_dir,
+        "releases",
+        rel,
+        copy_image=_noop_copy,
+    )
+
+    assert result == "deep/nested/binaries"
+
+
+def test_extract_checksums_temp_dir_cleaned_on_failure(
+    tmp_path: Path,
+) -> None:
+    """Temporary directories are cleaned up even when extraction fails."""
+    snapshot_path, data_path, data_dir, rel = _setup_extract(
+        tmp_path,
+        [{"name": "c1", "containerImage": "registry.io/img:v1"}],
+    )
+
+    created_dirs: list[Path] = []
+    original_mkdtemp = ecfi.tempfile.mkdtemp
+
+    def _tracking_mkdtemp() -> str:
+        d = original_mkdtemp()
+        created_dirs.append(Path(d))
+        return d
+
+    def _failing_copy(source: str, dest: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="fail")
+
+    with mock.patch.object(ecfi.tempfile, "mkdtemp", _tracking_mkdtemp):
+        with pytest.raises(subprocess.CalledProcessError):
+            ecfi.extract_checksums(
+                snapshot_path,
+                data_path,
+                data_dir,
+                "releases",
+                rel,
+                copy_image=_failing_copy,
+            )
+
+    assert created_dirs
+    for d in created_dirs:
+        assert not d.exists()
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_writes_result(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Successful run writes relative binaries path to result file."""
+    result_file = tmp_path / "result"
+    monkeypatch.setenv("RESULT_BINARIES_PATH", str(result_file))
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "workdir"))
+    monkeypatch.setenv("SNAPSHOT_PATH", "uid/snapshot.json")
+    monkeypatch.setenv("DATA_PATH", "")
+
+    with mock.patch.object(ecfi, "extract_checksums", return_value="uid/binaries"):
+        rc = ecfi.main()
+
+    assert rc == 0
+    assert result_file.read_text(encoding="utf-8") == "uid/binaries"
+
+
+def test_main_missing_result_env_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing RESULT_BINARIES_PATH causes SystemExit."""
+    monkeypatch.delenv("RESULT_BINARIES_PATH", raising=False)
+    with pytest.raises(SystemExit):
+        ecfi.main()
+
+
+def test_main_missing_data_dir_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Missing DATA_DIR causes SystemExit."""
+    monkeypatch.setenv("RESULT_BINARIES_PATH", str(tmp_path / "r"))
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    with pytest.raises(SystemExit):
+        ecfi.main()
+
+
+def test_main_extract_error_exits_with_message(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Exceptions from extract_checksums become SystemExit with PROG prefix."""
+    monkeypatch.setenv("RESULT_BINARIES_PATH", str(tmp_path / "r"))
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("SNAPSHOT_PATH", "uid/snapshot.json")
+
+    with mock.patch.object(ecfi, "extract_checksums", side_effect=ValueError("boom")):
+        with pytest.raises(SystemExit, match="extract_checksums_from_image.py: boom"):
+            ecfi.main()


### PR DESCRIPTION
Convert the bash script embedded in the extract-checksums-from-image Tekton task to a standalone Python script with unit tests. Adds skopeo.copy() to the helper module and uses tarfile for extraction.

Assisted-by: Claude Code