### PR TITLE
fix: advisory signing and content type fixes

### DIFF
--- a/scripts/python/helpers/advisory_data.py
+++ b/scripts/python/helpers/advisory_data.py
@@ -92,9 +92,9 @@ def decode_advisory_param(advisory_b64gzip: str) -> dict[str, Any]:
 
 
 def content_array_from_decoded(root: dict[str, Any], content_list_path: str) -> list[Any]:
-    """
-    Return the list at *content_list_path* under advisory *root*, or `[]` if
-    missing or not a list.
+    """Return the list at *content_list_path* under advisory *root*.
+
+    Returns `[]` if missing or not a list.
 
     *content_list_path* is a dotted path with an optional leading dot, for
     example `.content.images` or `.content.artifacts`.
@@ -159,12 +159,12 @@ def spec_content_array_from_advisory_yaml(
     doc: dict[str, Any],
     content_list_path: str,
 ) -> list[Any]:
-    """
-    Return the list at *content_list_path* under `doc['spec']` from an advisory
-    YAML document (`metadata` / `spec` layout).
+    """Return the list at *content_list_path* under `doc['spec']`.
 
-    Use the same dotted path as for decoded JSON (e.g. `.content.images`); it
-    is applied under `spec`, not at the document root.
+    Reads from an advisory YAML document that uses the `metadata` / `spec`
+    layout. *content_list_path* is the same dotted path as for decoded JSON
+    (e.g. `.content.images`), but is applied under `spec`, not at the document
+    root.
 
     Walking starts at `doc['spec']`; each segment is the next dict key, same
     rules as `content_array_from_decoded`.
@@ -209,8 +209,7 @@ def template_context_merge(
     advisory_name: str,
     ship_date: str,
 ) -> dict[str, Any]:
-    """
-    Merge *advisory_name* and *ship_date* into *tmpl_data* for Jinja.
+    """Merge *advisory_name* and *ship_date* into *tmpl_data* for Jinja.
 
     Duplicate top-level keys keep the value already in *tmpl_data* (later dict
     in the merge wins).
@@ -237,7 +236,7 @@ def spec_content_json_pointer(content_type: str) -> str:
     """Return the dotted *content_list_path* for *content_type* (under `spec` in YAML)."""
     if content_type == "image":
         return ".content.images"
-    if content_type in ("binary", "generic", "rpm"):
+    if content_type in ("binary", "generic", "rpm", "disk-image"):
         return ".content.artifacts"
     msg = f"Unsupported contentType: {content_type}"
     raise ValueError(msg)
@@ -275,9 +274,9 @@ def filter_content_by_existing(
     *,
     stderr_path: Path | None,
 ) -> str:
-    """
-    Return compact JSON array text: *content_file* rows not already in
-    *existing_file* (idempotency rules for image / rpm / generic / binary).
+    """Return compact JSON array text: *content_file* rows not already in *existing_file*.
+
+    (Idempotency rules for image / rpm / generic / binary / disk-image.)
     """
     try:
         content_rows = json.loads(content_file.read_text(encoding="utf-8"))
@@ -298,7 +297,7 @@ def filter_content_by_existing(
 
     if content_type in ("generic", "binary"):
         filtered = _filter_generic_binary(content_rows, existing_rows)
-    elif content_type == "rpm":
+    elif content_type in ("rpm", "disk-image"):
         filtered = _filter_rpm(content_rows, existing_rows)
     else:
         filtered = _filter_image(content_rows, existing_rows)

--- a/scripts/python/helpers/test_advisory_data.py
+++ b/scripts/python/helpers/test_advisory_data.py
@@ -20,20 +20,24 @@ def _gzip_b64(obj: dict) -> str:
 
 
 def test_spec_content_json_pointer_image() -> None:
+    """Map `image` content type to `.content.images`."""
     assert advisory_data.spec_content_json_pointer("image") == ".content.images"
 
 
 def test_spec_content_json_pointer_artifacts() -> None:
-    for t in ("binary", "generic", "rpm"):
+    """Map artifact content types to `.content.artifacts`."""
+    for t in ("binary", "generic", "rpm", "disk-image"):
         assert advisory_data.spec_content_json_pointer(t) == ".content.artifacts"
 
 
 def test_spec_content_json_pointer_rejects_unknown() -> None:
+    """Reject unsupported content types."""
     with pytest.raises(ValueError, match="Unsupported"):
-        advisory_data.spec_content_json_pointer("disk-image")
+        advisory_data.spec_content_json_pointer("unknown-type")
 
 
 def test_advisory_url_prefix_stage() -> None:
+    """Use the stage portal URL for the rhtap-release repo."""
     assert (
         advisory_data.advisory_url_prefix("https://gitlab.com/foo/rhtap-release/bar.git")
         == "https://access.stage.redhat.com/errata"
@@ -41,6 +45,7 @@ def test_advisory_url_prefix_stage() -> None:
 
 
 def test_advisory_url_prefix_prod() -> None:
+    """Use the production portal URL for other repos."""
     assert (
         advisory_data.advisory_url_prefix("https://gitlab.com/org/repo.git")
         == "https://access.redhat.com/errata"
@@ -48,24 +53,28 @@ def test_advisory_url_prefix_prod() -> None:
 
 
 def test_decode_advisory_param_roundtrip() -> None:
+    """Round-trip advisory JSON through base64 gzip encoding."""
     data = {"type": "RHSA", "live_id": None, "content": {"images": []}}
     out = advisory_data.decode_advisory_param(_gzip_b64(data))
     assert out == data
 
 
 def test_content_array_from_decoded() -> None:
+    """Read content arrays from decoded advisory JSON."""
     d = {"content": {"images": [{"x": 1}]}}
     assert advisory_data.content_array_from_decoded(d, ".content.images") == [{"x": 1}]
     assert advisory_data.content_array_from_decoded({}, ".content.images") == []
 
 
 def test_set_decoded_content_array() -> None:
+    """Write a content array back into decoded advisory JSON."""
     d: dict = {"type": "RHSA"}
     advisory_data.set_decoded_content_array(d, ".content.images", [{"a": 1}])
     assert d["content"]["images"] == [{"a": 1}]
 
 
 def test_load_advisory_yaml_roundtrip(tmp_path: Path) -> None:
+    """Load advisory YAML and read metadata, spec, and content paths."""
     p = tmp_path / "a.yaml"
     p.write_text(
         "metadata:\n  name: '2024:1'\nspec:\n  type: RHSA\n  content:\n" "    images: []\n",
@@ -78,7 +87,7 @@ def test_load_advisory_yaml_roundtrip(tmp_path: Path) -> None:
 
 
 def test_template_context_merge_order() -> None:
-    # `tmpl_data` is merged after fixed keys, so it wins on duplicate top-level keys.
+    """Let `tmpl_data` override duplicate top-level template keys."""
     base = {"advisory": {"spec": {"k": 1}}}
     out = advisory_data.template_context_merge(base, "n", "d")
     assert out["advisory_name"] == "n"
@@ -87,6 +96,7 @@ def test_template_context_merge_order() -> None:
 
 
 def test_json_dict_to_yaml_text_roundtrip() -> None:
+    """Serialize advisory dicts to readable multi-line YAML."""
     document = {"spec": {"type": "RHSA", "content": {"images": [{"tags": ["a"]}]}}}
     yml = advisory_data.json_dict_to_yaml_text(document)
     assert "RHSA" in yml
@@ -94,6 +104,7 @@ def test_json_dict_to_yaml_text_roundtrip() -> None:
 
 
 def test_list_existing_advisory_subdirs_order(tmp_path: Path) -> None:
+    """List advisory subdirs with newest leaf mtime first."""
     base = tmp_path / "t"
     d_old = base / "2024" / "0001"
     d_new = base / "2025" / "0002"
@@ -108,10 +119,12 @@ def test_list_existing_advisory_subdirs_order(tmp_path: Path) -> None:
 
 
 def test_list_existing_advisory_subdirs_missing(tmp_path: Path) -> None:
+    """Return an empty list when the advisory base path is absent."""
     assert advisory_data.list_existing_advisory_subdirs(tmp_path / "nope") == []
 
 
 def test_filter_content_by_existing_image(tmp_path: Path) -> None:
+    """Drop image rows that already exist in the existing content file."""
     content = tmp_path / "c.json"
     existing = tmp_path / "e.json"
     content.write_text(
@@ -145,6 +158,7 @@ def test_filter_content_by_existing_image(tmp_path: Path) -> None:
 
 
 def test_filter_image_keeps_when_no_match(tmp_path: Path) -> None:
+    """Keep image rows when no existing row matches."""
     rows = [{"containerImage": "a", "tags": ["1"], "repository": "r"}]
     content = tmp_path / "c.json"
     existing = tmp_path / "e.json"
@@ -160,6 +174,7 @@ def test_filter_image_keeps_when_no_match(tmp_path: Path) -> None:
 
 
 def test_filter_rpm_exact_purl(tmp_path: Path) -> None:
+    """Drop rpm rows whose purl exactly matches an existing row."""
     content = tmp_path / "c.json"
     existing = tmp_path / "e.json"
     p = "pkg:golang/example@1.0"
@@ -169,7 +184,21 @@ def test_filter_rpm_exact_purl(tmp_path: Path) -> None:
     assert json.loads(out) == []
 
 
+def test_filter_disk_image_exact_purl(tmp_path: Path) -> None:
+    """Drop disk-image rows whose purl exactly matches an existing row."""
+    content = tmp_path / "c.json"
+    existing = tmp_path / "e.json"
+    p = "pkg:golang/example@1.0"
+    content.write_text(json.dumps([{"purl": p}]), encoding="utf-8")
+    existing.write_text(json.dumps([{"purl": p}]), encoding="utf-8")
+    out = advisory_data.filter_content_by_existing(
+        "disk-image", content, existing, stderr_path=None
+    )
+    assert json.loads(out) == []
+
+
 def test_filter_generic_strips_checksum_for_match(tmp_path: Path) -> None:
+    """Match generic rows after stripping checksum query parameters."""
     content = tmp_path / "c.json"
     existing = tmp_path / "e.json"
     content.write_text(
@@ -187,6 +216,7 @@ def test_filter_generic_strips_checksum_for_match(tmp_path: Path) -> None:
 
 
 def test_filter_invalid_json_appends_stderr(tmp_path: Path) -> None:
+    """Append parse errors to the stderr log and re-raise."""
     content = tmp_path / "c.json"
     existing = tmp_path / "e.json"
     content.write_text("not-json", encoding="utf-8")
@@ -198,6 +228,7 @@ def test_filter_invalid_json_appends_stderr(tmp_path: Path) -> None:
 
 
 def test_filter_requires_arrays(tmp_path: Path) -> None:
+    """Require both content files to contain JSON arrays."""
     content = tmp_path / "c.json"
     existing = tmp_path / "e.json"
     content.write_text('"x"', encoding="utf-8")
@@ -207,6 +238,7 @@ def test_filter_requires_arrays(tmp_path: Path) -> None:
 
 
 def test_append_signing_key_to_content() -> None:
+    """Set signingKey on every content row."""
     root = {"content": {"images": [{"a": 1}, {"b": 2}]}}
     advisory_data.append_signing_key_to_content(root, ".content.images", "k1")
     for row in root["content"]["images"]:
@@ -214,6 +246,7 @@ def test_append_signing_key_to_content() -> None:
 
 
 def test_append_signing_key_skips_existing() -> None:
+    """Do not overwrite non-empty signingKey values."""
     root = {
         "content": {
             "images": [
@@ -230,6 +263,7 @@ def test_append_signing_key_skips_existing() -> None:
 
 
 def test_filter_image_skips_non_dict_rows() -> None:
+    """Ignore non-dict rows when filtering images."""
     out = advisory_data._filter_image(
         ["x", {"containerImage": "a", "tags": [], "repository": "r"}],
         [],
@@ -238,12 +272,14 @@ def test_filter_image_skips_non_dict_rows() -> None:
 
 
 def test_filter_image_skips_non_dict_existing() -> None:
+    """Ignore non-dict rows in the existing image list."""
     rows = [{"containerImage": "a", "tags": ["t"], "repository": "r"}]
     out = advisory_data._filter_image(rows, ["bad", {"containerImage": "b"}])
     assert out == rows
 
 
 def test_filter_rpm_skips_non_dict_and_keeps_unknown_purl() -> None:
+    """Keep rows with missing purl and skip invalid existing entries."""
     out = advisory_data._filter_rpm(
         ["x", {"purl": None}, {"purl": "pkg:a"}],
         [{"purl": "pkg:b"}],
@@ -252,6 +288,7 @@ def test_filter_rpm_skips_non_dict_and_keeps_unknown_purl() -> None:
 
 
 def test_filter_generic_skips_invalid_rows() -> None:
+    """Ignore invalid rows when filtering generic or binary content."""
     out = advisory_data._filter_generic_binary(
         ["x", {"purl": None}, {"purl": "pkg:new"}],
         [{"purl": "pkg:base?checksum=1"}],
@@ -260,22 +297,26 @@ def test_filter_generic_skips_invalid_rows() -> None:
 
 
 def test_content_array_from_decoded_none_segment() -> None:
+    """Return an empty list when a path segment is null."""
     d = {"content": {"images": None}}
     assert advisory_data.content_array_from_decoded(d, ".content.images") == []
 
 
 def test_set_decoded_content_array_bad_path() -> None:
+    """Reject unsupported content list paths."""
     with pytest.raises(ValueError, match="unsupported"):
         advisory_data.set_decoded_content_array({}, ".bad.path", [])
 
 
 def test_load_advisory_yaml_empty_document(tmp_path: Path) -> None:
+    """Treat an empty YAML file as an empty mapping."""
     p = tmp_path / "empty.yaml"
     p.write_text("", encoding="utf-8")
     assert advisory_data.load_advisory_yaml(p) == {}
 
 
 def test_load_advisory_yaml_rejects_non_mapping(tmp_path: Path) -> None:
+    """Reject YAML documents whose root is not a mapping."""
     p = tmp_path / "list.yaml"
     p.write_text("- a\n", encoding="utf-8")
     with pytest.raises(TypeError, match="mapping"):
@@ -283,6 +324,7 @@ def test_load_advisory_yaml_rejects_non_mapping(tmp_path: Path) -> None:
 
 
 def test_spec_content_array_from_advisory_yaml_paths() -> None:
+    """Walk spec content paths and return lists or empty results."""
     doc = {"spec": {"content": {"images": [{"i": 1}]}}}
     assert advisory_data.spec_content_array_from_advisory_yaml(doc, ".content.images") == [
         {"i": 1}
@@ -305,17 +347,20 @@ def test_spec_content_array_from_advisory_yaml_paths() -> None:
 
 
 def test_get_advisory_spec_type_and_name_defaults() -> None:
+    """Return empty strings for missing spec type and metadata name."""
     assert advisory_data.get_advisory_spec_type({}) == ""
     assert advisory_data.get_advisory_metadata_name({}) == ""
 
 
 def test_template_data_for_apply() -> None:
+    """Wrap advisory spec data for apply_template."""
     assert advisory_data.template_data_for_apply({"type": "RHSA"}) == {
         "advisory": {"spec": {"type": "RHSA"}}
     }
 
 
 def test_list_existing_advisory_subdirs_skips_files(tmp_path: Path) -> None:
+    """Ignore plain files when listing advisory subdirectories."""
     base = tmp_path / "t"
     (base / "2024").mkdir(parents=True)
     (base / "2024" / "notadir.txt").write_text("x", encoding="utf-8")

--- a/scripts/python/tasks/internal/create_advisory.py
+++ b/scripts/python/tasks/internal/create_advisory.py
@@ -246,6 +246,34 @@ def _finish_if_all_content_already_published(
     return False
 
 
+def _read_signing_key_from_config_map(
+    config_map_name: str,
+    *,
+    stderr_path: Path,
+) -> str:
+    """Return `SIG_KEY_NAMES` from the configmap, or `SIG_KEY_NAME` if absent."""
+    raw = subprocess_cmd.run_cmd(
+        [
+            "kubectl",
+            "get",
+            "configmap",
+            config_map_name,
+            "-o",
+            "json",
+        ],
+        stderr_path=stderr_path,
+    ).stdout
+    data = json.loads(raw).get("data") or {}
+    signing_key = (data.get("SIG_KEY_NAMES") or data.get("SIG_KEY_NAME") or "").strip()
+    if not signing_key:
+        msg = (
+            f"configmap {config_map_name!r} has neither SIG_KEY_NAMES nor "
+            f"SIG_KEY_NAME data"
+        )
+        raise ValueError(msg)
+    return signing_key
+
+
 def _build_merged_advisory_with_signing_key(
     decoded: dict[str, Any],
     content_file: Path,
@@ -258,21 +286,10 @@ def _build_merged_advisory_with_signing_key(
     merged = json.loads(json.dumps(decoded))
     merged_content_rows = json.loads(content_file.read_text(encoding="utf-8"))
     advisory_data.set_decoded_content_array(merged, content_list_path, merged_content_rows)
-    # Signing key name comes from cluster config; merged JSON is what the template sees.
-    signing_key = subprocess_cmd.run_cmd(
-        [
-            "kubectl",
-            "get",
-            "configmap",
-            config_map_name,
-            "-o",
-            "jsonpath={.data.SIG_KEY_NAME}",
-        ],
+    signing_key = _read_signing_key_from_config_map(
+        config_map_name,
         stderr_path=stderr_path,
-    ).stdout.strip()
-    if not signing_key:
-        msg = f"configmap {config_map_name!r} has no SIG_KEY_NAME data"
-        raise ValueError(msg)
+    )
     # Only fill signingKey when a row does not already have one (see advisory_data).
     advisory_data.append_signing_key_to_content(merged, content_list_path, signing_key)
     return merged

--- a/scripts/python/tasks/internal/test_create_advisory.py
+++ b/scripts/python/tasks/internal/test_create_advisory.py
@@ -23,6 +23,10 @@ def _gzip_b64(obj: dict) -> str:
     return base64.standard_b64encode(gzip.compress(raw)).decode("ascii")
 
 
+def _configmap_signing_key_stdout(signing_key: str = "key1") -> str:
+    return json.dumps({"data": {"SIG_KEY_NAMES": signing_key}})
+
+
 def _write_errata_mount(d: Path) -> None:
     d.mkdir(parents=True, exist_ok=True)
     (d / "name").write_text("svc/test", encoding="utf-8")
@@ -313,21 +317,54 @@ def test_build_merged_advisory_with_signing_key(tmp_path: Path) -> None:
     content.write_text(json.dumps([{"a": 1}]), encoding="utf-8")
     decoded = {"type": "RHSA", "content": {"images": []}}
     with mock.patch("create_advisory.subprocess_cmd.run_cmd") as run:
-        run.return_value = mock.MagicMock(stdout="key-name\n")
+        run.return_value = mock.MagicMock(
+            stdout=json.dumps({"data": {"SIG_KEY_NAMES": "key-name"}}),
+        )
         merged = create_advisory._build_merged_advisory_with_signing_key(
             decoded, content, ".content.images", "cm", stderr_path=tmp_path / "e.log"
         )
     assert merged["content"]["images"][0]["signingKey"] == "key-name"
 
 
+def test_read_signing_key_falls_back_to_sig_key_name(tmp_path: Path) -> None:
+    """Use SIG_KEY_NAME when SIG_KEY_NAMES is absent."""
+    with mock.patch("create_advisory.subprocess_cmd.run_cmd") as run:
+        run.return_value = mock.MagicMock(
+            stdout=json.dumps({"data": {"SIG_KEY_NAME": "legacy-key"}}),
+        )
+        key = create_advisory._read_signing_key_from_config_map(
+            "cm", stderr_path=tmp_path / "e.log"
+        )
+    assert key == "legacy-key"
+
+
+def test_read_signing_key_prefers_sig_key_names(tmp_path: Path) -> None:
+    """Prefer SIG_KEY_NAMES when both configmap keys are set."""
+    with mock.patch("create_advisory.subprocess_cmd.run_cmd") as run:
+        run.return_value = mock.MagicMock(
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "SIG_KEY_NAMES": "names-key",
+                        "SIG_KEY_NAME": "name-key",
+                    }
+                }
+            ),
+        )
+        key = create_advisory._read_signing_key_from_config_map(
+            "cm", stderr_path=tmp_path / "e.log"
+        )
+    assert key == "names-key"
+
+
 def test_build_merged_advisory_with_signing_key_empty_fails(tmp_path: Path) -> None:
-    """Fail when the configmap has no SIG_KEY_NAME value."""
+    """Fail when the configmap has neither signing key field."""
     content = tmp_path / "c.json"
     content.write_text(json.dumps([{"a": 1}]), encoding="utf-8")
     decoded = {"type": "RHSA", "content": {"images": []}}
     with mock.patch("create_advisory.subprocess_cmd.run_cmd") as run:
-        run.return_value = mock.MagicMock(stdout="  \n")
-        with pytest.raises(ValueError, match="SIG_KEY_NAME"):
+        run.return_value = mock.MagicMock(stdout=json.dumps({"data": {}}))
+        with pytest.raises(ValueError, match="SIG_KEY_NAMES nor SIG_KEY_NAME"):
             create_advisory._build_merged_advisory_with_signing_key(
                 decoded, content, ".content.images", "cm", stderr_path=tmp_path / "e.log"
             )
@@ -858,7 +895,7 @@ def test_run_create_advisory_partial_idempotency_creates_new(
         ):
             with mock.patch(
                 "create_advisory.subprocess_cmd.run_cmd",
-                return_value=mock.MagicMock(stdout="key1\n"),
+                return_value=mock.MagicMock(stdout=_configmap_signing_key_stdout()),
             ):
                 with mock.patch("create_advisory._resolve_live_id_number", return_value=1234):
                     with mock.patch("create_advisory._ensure_advisory_number_unused"):
@@ -1268,7 +1305,7 @@ def test_run_create_advisory_happy_path_writes_portal_url(
             ):
                 with mock.patch(
                     "create_advisory.subprocess_cmd.run_cmd",
-                    return_value=mock.MagicMock(stdout="key1\n"),
+                    return_value=mock.MagicMock(stdout=_configmap_signing_key_stdout()),
                 ):
                     with mock.patch(
                         "create_advisory._reserve_errata_live_id", return_value=1234


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix advisory signing key lookup and disk-image content handling
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

This commit addresses two issues in the create_advisory.py script. The first is that disk-image contentTypes should be treated the same as the rpm contentType for purl stuff. The second is that some signing configMaps have SIG_KEY_NAMES instead of SIG_KEY_NAME, so we should check for both instead of just one.

Finally, this commit fixes the ruff docstring formatting errors in the changed files.

Assisted-By: Cursor

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Treat <b><i>disk-image</i></b> contentType like <b><i>rpm</i></b> for artifact paths and idempotent filtering.
• Read signing key from configmaps supporting both <b><i>SIG_KEY_NAMES</i></b> and legacy <b><i>SIG_KEY_NAME</i></b>.
• Update unit tests and docstrings to cover new behaviors and satisfy Ruff formatting.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["create_advisory.py"] --> B{{"kubectl get configmap"}} --> C["Parse JSON data"] --> D["Signing key"]
  A --> E["Merge decoded + content"] --> F["advisory_data.set_decoded_content_array"] --> G["append_signing_key_to_content"]
  A --> H["advisory_data helpers"]
  H --> I["spec_content_json_pointer"]
  H --> J["filter_content_by_existing"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

Parsing the full configmap JSON in one kubectl call is a pragmatic way to support both SIG_KEY_NAMES and SIG_KEY_NAME without multiple queries or fragile jsonpath tricks; the approach is small, test-covered, and easy to extend if more fields are added later.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>advisory_data.py</strong> <code>Route disk-image content through artifact/rpm paths and filtering</code> <code>+14/-15</code></summary>

<br/>

>Route disk-image content through artifact/rpm paths and filtering
>
><pre>
>• Adds &#x27;disk-image&#x27; to the set of artifact content types that map to &#x27;.content.artifacts&#x27; and applies rpm-style idempotency filtering for disk-image rows. Also adjusts docstrings to satisfy Ruff formatting expectations.
></pre>
>
><a href='https://github.com/konflux-ci/release-service-utils/pull/818/files#diff-49b604b93caf079500c1e8dfee709b8511c42f7bde30ee0ef85e1d1c821cf16e'>scripts/python/helpers/advisory_data.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>create_advisory.py</strong> <code>Support SIG_KEY_NAMES and SIG_KEY_NAME when deriving signing key</code> <code>+31/-14</code></summary>

<br/>

>Support SIG_KEY_NAMES and SIG_KEY_NAME when deriving signing key
>
><pre>
>• Extracts signing-key lookup into &#x27;_read_signing_key_from_config_map&#x27;, switching kubectl output to JSON and preferring &#x27;SIG_KEY_NAMES&#x27; with a fallback to &#x27;SIG_KEY_NAME&#x27;. Keeps merged advisory building behavior the same while making signing-key retrieval more robust.
></pre>
>
><a href='https://github.com/konflux-ci/release-service-utils/pull/818/files#diff-7a22cb1e8600e77b752683a322e82bc44e3b9cef967030c4d93dd7d2b2661ac9'>scripts/python/tasks/internal/create_advisory.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>test_advisory_data.py</strong> <code>Extend advisory_data tests for disk-image and improve test docstrings</code> <code>+48/-3</code></summary>

<br/>

>Extend advisory_data tests for disk-image and improve test docstrings
>
><pre>
>• Updates content-type mapping expectations to include &#x27;disk-image&#x27;, adds a dedicated disk-image purl idempotency test, and changes the unknown-type rejection test to use a true unknown value. Adds docstrings across tests for style/lint compliance.
></pre>
>
><a href='https://github.com/konflux-ci/release-service-utils/pull/818/files#diff-180eae6e621ceb14f947cd3c37687f89bdf25f7bb19c79fb63e2916b51d8dde4'>scripts/python/helpers/test_advisory_data.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>test_create_advisory.py</strong> <code>Update create_advisory signing-key tests for configmap JSON and fallback behavior</code> <code>+43/-6</code></summary>

<br/>

>Update create_advisory signing-key tests for configmap JSON and fallback behavior
>
><pre>
>• Adjusts mocks to return configmap JSON, adds helper to generate signing-key stdout, and introduces targeted tests to validate preference and fallback between &#x27;SIG_KEY_NAMES&#x27; and &#x27;SIG_KEY_NAME&#x27;. Updates the failure case to assert the new error message semantics.
></pre>
>
><a href='https://github.com/konflux-ci/release-service-utils/pull/818/files#diff-e8699add1f2cc9a6e9115c9d28baae9fd0b2e9d4f18b98bdacbd69b8cd559668'>scripts/python/tasks/internal/test_create_advisory.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>