### PR TITLE
feat(ISV-7116): create script for direct container signing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,6 +172,7 @@ ENV PATH="$PATH:/home/pubtools-pulp-wrapper"
 ENV PATH="$PATH:/home/pubtools-marketplacesvm-wrapper"
 ENV PATH="$PATH:/home/developer-portal-wrapper"
 ENV PATH="$PATH:/home/publish-to-cgw-wrapper"
+ENV PATH="$PATH:/home/scripts/python/tasks/managed"
 # Flat imports: helpers and task scripts must be importable.
 # Tests use the same layout via pyproject [tool.pytest.ini_options] pythonpath.
 # Keep /home for other modules (e.g. pyxis, sbom) that expect it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ line-length = 95
 pythonpath = [
   ".",
   "integration-tests/lib",
+  "pyxis",
   "scripts/python/helpers",
   "scripts/python/tasks/internal",
   "scripts/python/tasks/managed",
@@ -44,6 +45,7 @@ pythonpath = [
 [dependency-groups]
 dev = [
     "black>=25.11.0",
+    "flake8>=7.3.0",
     "pytest>=8.4.2",
     "pytest-cov>=6.0",
 ]

--- a/scripts/python/helpers/kubectl.py
+++ b/scripts/python/helpers/kubectl.py
@@ -1,0 +1,27 @@
+"""Helpers for interacting with Kubernetes via kubectl."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from subprocess_cmd import run_cmd
+
+
+def get_configmap(name: str) -> dict[str, Any]:
+    """Fetch a Kubernetes ConfigMap by name and return its parsed JSON.
+
+    Args:
+        name: The ConfigMap resource name to retrieve.
+
+    Returns:
+        The full ConfigMap object as a parsed dictionary.
+
+    Raises:
+        RuntimeError: If kubectl exits with a non-zero return code.
+
+    """
+    result = run_cmd(["kubectl", "get", f"cm/{name}", "-ojson"], check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to retrieve ConfigMap '{name}': {result.stderr.strip()}")
+    return json.loads(result.stdout)

--- a/scripts/python/helpers/oras_utils.py
+++ b/scripts/python/helpers/oras_utils.py
@@ -4,7 +4,36 @@ from __future__ import annotations
 
 import re
 import subprocess
+import tempfile
 from pathlib import Path
+
+from subprocess_cmd import run_cmd
+
+
+def oras_resolve(reference: str) -> str:
+    """Resolve the digest of an OCI image reference using oras.
+
+    Obtains registry credentials via ``select-oci-auth``, writes them to a
+    temporary auth file, then runs ``oras resolve`` and returns the digest.
+
+    Raises ``RuntimeError`` if oras resolve exits non-zero.
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as auth_file:
+        select_auth = run_cmd(["select-oci-auth", reference])
+        auth_file.write(select_auth.stdout)
+        auth_file.flush()
+
+        result = run_cmd(
+            ["oras", "resolve", "--registry-config", auth_file.name, reference],
+            check=False,
+        )
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"oras resolve failed for {reference!r} (exit {result.returncode}):"
+            f" {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
 
 
 def oras_login(registry: str, username: str, password: str) -> None:

--- a/scripts/python/helpers/subprocess_cmd.py
+++ b/scripts/python/helpers/subprocess_cmd.py
@@ -26,7 +26,7 @@ def run_cmd(
     """Run *cmd*; capture stdout as text; optionally append stderr to *stderr_path*."""
     # Child must inherit pod env (PATH, KUBECONFIG, etc.); only overlay *env*.
     merged: dict[str, str] = {**os.environ, **dict(env or {})}
-    err_f: Any = subprocess.DEVNULL
+    err_f: Any = subprocess.PIPE
     fh: Any = None
     try:
         if stderr_path is not None:

--- a/scripts/python/helpers/test_kubectl.py
+++ b/scripts/python/helpers/test_kubectl.py
@@ -1,0 +1,33 @@
+"""Tests for `kubect`."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from kubectl import get_configmap
+
+
+def test_get_configmap_runs_kubectl_and_returns_parsed_json() -> None:
+    """Kubectl is called with the correct arguments and its output is parsed as JSON."""
+    cm_json = json.dumps({"data": {"SIG_KEY_NAME": "some-key"}})
+    with patch("kubectl.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock(stdout=cm_json, returncode=0)
+        result = get_configmap("signing-config-map")
+
+    mock_run.assert_called_once_with(
+        ["kubectl", "get", "cm/signing-config-map", "-ojson"], check=False
+    )
+    assert result == {"data": {"SIG_KEY_NAME": "some-key"}}
+
+
+def test_get_configmap_raises_on_kubectl_failure() -> None:
+    """RuntimeError is raised with the configmap name and stderr when kubectl fails."""
+    import pytest
+
+    with patch("kubectl.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stderr="Error from server (NotFound): configmaps not found"
+        )
+        with pytest.raises(RuntimeError, match="signing-config-map"):
+            get_configmap("signing-config-map")

--- a/scripts/python/helpers/test_oras_utils.py
+++ b/scripts/python/helpers/test_oras_utils.py
@@ -1,0 +1,62 @@
+"""Unit tests for oras_utils."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from oras_utils import oras_resolve
+
+
+def test_oras_resolve_calls_select_oci_auth_with_reference() -> None:
+    """select-oci-auth is called with the image reference."""
+    with patch("oras_utils.run_cmd") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(stdout='{"auths": {}}'),
+            MagicMock(returncode=0, stdout="sha256:abc\n"),
+        ]
+        oras_resolve("registry.io/repo:tag")
+
+    first_call = mock_run.call_args_list[0]
+    assert first_call == call(["select-oci-auth", "registry.io/repo:tag"])
+
+
+def test_oras_resolve_passes_auth_file_to_oras() -> None:
+    """Oras resolve is called with --registry-config pointing to the auth temp file."""
+    with patch("oras_utils.run_cmd") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(stdout='{"auths": {}}'),
+            MagicMock(returncode=0, stdout="sha256:abc\n"),
+        ]
+        oras_resolve("registry.io/repo:tag")
+
+    second_call = mock_run.call_args_list[1]
+    cmd = second_call.args[0]
+    assert cmd[0] == "oras"
+    assert cmd[1] == "resolve"
+    assert "--registry-config" in cmd
+    assert "registry.io/repo:tag" in cmd
+
+
+def test_oras_resolve_returns_stripped_digest() -> None:
+    """Returns the digest from oras resolve output, stripped of whitespace."""
+    with patch("oras_utils.run_cmd") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(stdout="{}"),
+            MagicMock(returncode=0, stdout="sha256:deadbeef\n"),
+        ]
+        result = oras_resolve("registry.io/repo:tag")
+
+    assert result == "sha256:deadbeef"
+
+
+def test_oras_resolve_raises_on_nonzero_returncode() -> None:
+    """Raises RuntimeError when oras resolve exits non-zero."""
+    with patch("oras_utils.run_cmd") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(stdout="{}"),
+            MagicMock(returncode=1, stdout="", stderr="unauthorized"),
+        ]
+        with pytest.raises(RuntimeError):
+            oras_resolve("registry.io/repo:tag")

--- a/scripts/python/helpers/test_subprocess_cmd.py
+++ b/scripts/python/helpers/test_subprocess_cmd.py
@@ -41,6 +41,12 @@ def test_run_cmd_stderr_path_on_success(tmp_path) -> None:
     assert log.read_text(encoding="utf-8") == ""
 
 
+def test_run_cmd_captures_stderr_when_no_path_given() -> None:
+    """Stderr is captured in the return value when no stderr_path is provided."""
+    r = subprocess_cmd.run_cmd(["sh", "-c", "echo error-msg >&2"], check=True)
+    assert "error-msg" in r.stderr
+
+
 def test_run_cmd_text_success() -> None:
     """``run_cmd_text`` returns stdout from a successful subprocess."""
     with mock.patch("subprocess_cmd.subprocess.run") as run:

--- a/scripts/python/tasks/managed/rh_direct_sign_image.py
+++ b/scripts/python/tasks/managed/rh_direct_sign_image.py
@@ -1,0 +1,811 @@
+#!/usr/bin/env python3
+"""Prepare container signing batches for Konflux release snapshot components."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import logging
+import re
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pyxis
+from kubectl import get_configmap
+from logger import logger as LOGGER
+from oras_utils import oras_resolve
+from subprocess_cmd import run_cmd
+
+PYXIS_INSTANCE_MAP = {
+    "production": "https://graphql-pyxis.api.redhat.com/graphql/",
+    "production-internal": "https://graphql.pyxis.engineering.redhat.com/graphql/",
+    "stage": "https://graphql-pyxis.preprod.api.redhat.com/graphql/",
+    "stage-internal": "https://graphql.pyxis.stage.engineering.redhat.com/graphql/",
+}
+
+SINGLE_MANIFEST_MEDIA_TYPES = {
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+}
+
+
+@dataclass(frozen=True)
+class PyxisSignature:
+    """An existing signature record returned from Pyxis."""
+
+    reference: str
+    sig_key_id: str
+
+
+@dataclass
+class SigningItem:
+    """A single image reference, digest, and signing key that needs to be signed."""
+
+    reference: str  # e.g. "registry.redhat.io/myproduct/myrepo:v1.0"
+    digest: str  # e.g. "sha256:abc123"
+    repository: str  # stripped repo used for Pyxis lookup, e.g. "myproduct/myrepo"
+    key: str  # signing key ID, e.g. "redhate2etesting"
+
+
+_TASK_LABEL = "internal-services.appstudio.openshift.io/group-id"
+_PIPELINERUN_LABEL = "internal-services.appstudio.openshift.io/pipelinerun-uid"
+_INTENTION_LABEL = "internal-services.appstudio.openshift.io/intention"
+
+
+@dataclass(frozen=True)
+class SubmitConfig:
+    """Configuration for submitting signing batches via the internal-request CLI."""
+
+    pipeline: str
+    pipeline_image: str
+    requester: str
+    pyxis_ssl_cert_secret_name: str
+    pyxis_graphql_url: str
+    kerberos_keytab_secret: str
+    kerberos_keytab: str
+    kerberos_principal: str
+    signing_repo: str
+    signing_revision: str
+    service_account: str
+    request_timeout: str
+    pipeline_timeout: str
+    task_timeout: str
+    task_id: str
+    pipelinerun_uid: str
+    concurrent_limit: int
+    intention: str
+
+
+def validate_file(arg: str) -> Path:
+    """Return a Path for *arg* if the file exists, otherwise raise FileNotFoundError.
+
+    Intended for use as an argparse ``type`` validator.
+
+    Args:
+        arg: File path string provided on the command line.
+
+    Returns:
+        Resolved Path object pointing to the existing file.
+
+    Raises:
+        FileNotFoundError: If the path does not point to an existing file.
+
+    """
+    if (file := Path(arg)).is_file():
+        return file
+    raise FileNotFoundError(arg)
+
+
+def setup_argparser() -> argparse.ArgumentParser:
+    """Build and return the CLI argument parser.
+
+    Returns:
+        Configured argument parser with all signing preparation arguments.
+
+    """
+    parser = argparse.ArgumentParser(description="Prepare container signing configuration.")
+    parser.add_argument(
+        "--pyxis-server",
+        required=True,
+        choices=PYXIS_INSTANCE_MAP.keys(),
+        help="Pyxis server instance to use",
+    )
+    parser.add_argument(
+        "--snapshot", required=True, type=validate_file, help="Konflux release snapshot path"
+    )
+    parser.add_argument(
+        "--data-file", required=True, type=validate_file, help="Konflux data file path"
+    )
+    parser.add_argument(
+        "--sign-registry-access-file",
+        required=True,
+        type=validate_file,
+        help="File listing repositories that require registry-access signing (one per line)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Directory where batch files are written (one per batch); omit to skip",
+    )
+    parser.add_argument(
+        "--batch-max-size",
+        type=int,
+        default=14 * 1024,
+        help="Maximum size in bytes of each base64-encoded batch (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+
+    submit = parser.add_argument_group(
+        "request submission (active when --submit-requests is set)"
+    )
+    submit.add_argument(
+        "--submit-requests",
+        action="store_true",
+        help="Submit signing batches via internal-request after collecting them",
+    )
+    submit.add_argument(
+        "--pipeline",
+        default="container-signing",
+        help="Internal pipeline name for signing (default: %(default)s)",
+    )
+    submit.add_argument(
+        "--pipeline-image",
+        required=True,
+        help="Container image override for the signing pipeline",
+    )
+    submit.add_argument(
+        "--requester",
+        required=True,
+        help="Name of the user requesting signing, for auditing",
+    )
+    submit.add_argument(
+        "--request-timeout",
+        default="1800",
+        help="InternalRequest timeout in seconds (default: %(default)s)",
+    )
+    submit.add_argument(
+        "--pipeline-timeout",
+        default="0h30m0s",
+        help="Pipeline timeout (default: %(default)s)",
+    )
+    submit.add_argument(
+        "--task-timeout",
+        default="0h25m0s",
+        help="Task timeout (default: %(default)s)",
+    )
+    submit.add_argument(
+        "--service-account",
+        default="signing-pipeline-sa",
+        help="Service account for the signing pipeline (default: %(default)s)",
+    )
+    submit.add_argument(
+        "--task-id",
+        default="",
+        help="Task run UID used as a label on internal requests",
+    )
+    submit.add_argument(
+        "--pipelinerun-uid",
+        default="",
+        help="Pipeline run UID used as a label on internal requests",
+    )
+    submit.add_argument(
+        "--signing-repo",
+        default="https://gitlab.cee.redhat.com/signing/signing.git",
+        help="Git repository URL for signing tasks (default: %(default)s)",
+    )
+    submit.add_argument(
+        "--signing-revision",
+        default="main",
+        help="Git revision in the signing repository (default: %(default)s)",
+    )
+    submit.add_argument(
+        "--concurrent-limit",
+        type=int,
+        default=8,
+        help="Maximum number of parallel signing requests (default: %(default)s)",
+    )
+
+    return parser
+
+
+def get_signing_keys(configmap: dict[str, Any]) -> list[str]:
+    """Extract the list of signing key IDs from a signing ConfigMap.
+
+    Prefers the comma-separated ``SIG_KEY_NAMES`` field when present; falls
+    back to the single-value ``SIG_KEY_NAME`` field otherwise.
+
+    Args:
+        configmap: Parsed ConfigMap dictionary as returned by get_configmap.
+
+    Returns:
+        List of signing key ID strings.
+
+    Raises:
+        KeyError: If neither SIG_KEY_NAMES nor SIG_KEY_NAME is present in data.
+
+    """
+    data = configmap["data"]
+    if "SIG_KEY_NAMES" in data:
+        return [k for k in re.split(r"[,\s]+", data["SIG_KEY_NAMES"].strip()) if k]
+    return [data["SIG_KEY_NAME"]]
+
+
+def get_all_image_digests(image_reference: str) -> list[str]:
+    """Return all manifest digests for an image.
+
+    Always includes the top-level digest. For multi-arch index images, also
+    includes the digest of every nested manifest (e.g. per-arch manifests).
+
+    Args:
+        image_reference: Fully qualified image reference including digest,
+            e.g. ``registry.redhat.io/repo/image@sha256:abc123``.
+
+    Returns:
+        List of digest strings starting with the top-level digest.
+
+    """
+    top_level_digest = image_reference.split("@", 1)[1]
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as auth_file:
+        select_auth = run_cmd(["select-oci-auth", image_reference])
+        auth_file.write(select_auth.stdout)
+        auth_file.flush()
+
+        result = run_cmd(
+            [
+                "skopeo",
+                "inspect",
+                "--retry-times",
+                "3",
+                "--raw",
+                "--authfile",
+                auth_file.name,
+                f"docker://{image_reference}",
+            ]
+        )
+    raw_manifest = json.loads(result.stdout)
+
+    digests = [top_level_digest]
+
+    media_type = raw_manifest.get("mediaType", "")
+    if media_type not in SINGLE_MANIFEST_MEDIA_TYPES:
+        manifests = raw_manifest.get("manifests")
+        if manifests:
+            digests.extend(m["digest"] for m in manifests)
+        else:
+            LOGGER.info("Single-manifest artifact (e.g. Helm chart), no nested digests to add")
+
+    return digests
+
+
+def get_source_container_digest(
+    component: dict[str, Any], default_push_source_container: bool
+) -> str | None:
+    """Resolve the source container digest for a component.
+
+    Uses ``select-oci-auth`` and ``oras resolve`` to look up the digest of the
+    ``.src`` source container image. Returns ``None`` when source container
+    signing is disabled for this component.
+
+    Args:
+        component: A single component entry from the Konflux release snapshot.
+        default_push_source_container: Fallback value when the component does
+            not specify its own ``pushSourceContainer`` flag.
+
+    Returns:
+        The source container digest string, or None if not applicable.
+
+    """
+    if not component.get("pushSourceContainer", default_push_source_container):
+        return None
+
+    reference_container_image = component["containerImage"]
+    source_repo = reference_container_image.split("@sha256:", 1)[0]
+    sha = reference_container_image.split("@sha256:", 1)[1]
+    source_reference = f"{source_repo}:sha256-{sha}.src"
+    return oras_resolve(source_reference)
+
+
+SIGNATURES_GRAPHQL_QUERY = """
+query ($repository: String!, $manifest_digest: String!, $page: Int!, $page_size: Int!) {
+    find_signatures(
+        page: $page
+        page_size: $page_size
+        sort_by: [{field: "last_update_date", order: DESC}]
+        filter: {and: [{manifest_digest: {eq: $manifest_digest}},
+            {repository: {eq: $repository}}]}
+    ) {
+        error { detail status }
+        data { reference sig_key_id }
+    }
+}
+"""
+
+
+def find_signatures_for_repository(
+    graphql_api: str, repository: str, manifest_digest: str, page_size: int = 50
+) -> set[PyxisSignature]:
+    """Query Pyxis for all existing signatures for a given repository and digest.
+
+    Paginates automatically until all results have been retrieved.
+
+    Args:
+        graphql_api: The Pyxis GraphQL endpoint URL.
+        repository: Repository path without registry prefix, e.g.
+            ``myproduct/myrepo``.
+        manifest_digest: The image manifest digest to look up, e.g.
+            ``sha256:abc123``.
+        page_size: Number of records to request per page.
+
+    Returns:
+        Set of PyxisSignature objects already recorded in Pyxis.
+
+    """
+    signatures: set[PyxisSignature] = set()
+    page = 0
+    while True:
+        variables = {
+            "repository": repository,
+            "manifest_digest": manifest_digest,
+            "page": page,
+            "page_size": page_size,
+        }
+        data = pyxis.graphql_query(
+            graphql_api, {"query": SIGNATURES_GRAPHQL_QUERY, "variables": variables}
+        )
+        page_data = data["find_signatures"]["data"]
+        signatures.update(
+            PyxisSignature(reference=s["reference"], sig_key_id=s["sig_key_id"])
+            for s in page_data
+        )
+        if len(page_data) < page_size:
+            break
+        page += 1
+    LOGGER.info(
+        "Found %d existing signatures for %s @ %s",
+        len(signatures),
+        repository,
+        manifest_digest,
+    )
+    return signatures
+
+
+def find_existing_signatures(
+    pyxis_url: str,
+    lookups: set[tuple[str, str]],
+    max_workers: int = 10,
+) -> dict[tuple[str, str], set[PyxisSignature]]:
+    """Look up existing signatures in Pyxis for a set of (digest, repository) pairs.
+
+    Issues concurrent requests using a thread pool to minimise latency.
+
+    Args:
+        pyxis_url: The Pyxis GraphQL endpoint URL.
+        lookups: Exact set of ``(digest, repository)`` pairs to query.
+        max_workers: Maximum number of concurrent Pyxis requests.
+
+    Returns:
+        Mapping from ``(digest, repository)`` tuples to the set of
+        PyxisSignature objects already recorded in Pyxis.
+
+    """
+    results: dict[tuple[str, str], set[PyxisSignature]] = {}
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {
+            pool.submit(find_signatures_for_repository, pyxis_url, repo, digest): (
+                digest,
+                repo,
+            )
+            for digest, repo in lookups
+        }
+        for future in as_completed(futures):
+            key = futures[future]
+            results[key] = future.result()
+
+    return results
+
+
+def write_batches(batches: list[str], output_dir: Path) -> None:
+    """Write each batch to a numbered file in output_dir, creating it if needed.
+
+    Files are named ``batch_0000.txt``, ``batch_0001.txt``, and so on.
+
+    Args:
+        batches: List of base64-encoded batch strings to write.
+        output_dir: Directory where batch files will be created.
+
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for i, batch in enumerate(batches):
+        (output_dir / f"batch_{i:04d}.txt").write_text(batch)
+
+
+def _encode_batch(items: list[SigningItem]) -> str:
+    data = [{"reference": i.reference, "digest": i.digest, "key": i.key} for i in items]
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+
+def batch_signing_items(
+    items: list[SigningItem], max_batch_bytes: int = 14 * 1024
+) -> list[str]:
+    """Split signing items into base64-encoded JSON batches, each under max_batch_bytes.
+
+    Uses a greedy packing strategy: items are added to the current batch until
+    adding the next item would exceed the byte limit, at which point the current
+    batch is flushed and a new one is started.
+
+    Args:
+        items: Ordered list of SigningItem objects to batch.
+        max_batch_bytes: Maximum encoded size in bytes for each batch.
+
+    Returns:
+        List of base64-encoded JSON strings, one per batch.
+
+    """
+    batches: list[str] = []
+    current: list[SigningItem] = []
+
+    for item in items:
+        candidate = current + [item]
+        encoded = _encode_batch(candidate)
+        if current and len(encoded) >= max_batch_bytes:
+            batches.append(_encode_batch(current))
+            current = [item]
+        else:
+            current = candidate
+
+    if current:
+        batches.append(_encode_batch(current))
+
+    return batches
+
+
+def collect_signing_items(
+    component: dict[str, Any],
+    sign_registry_access_repos: set[str],
+    digests: list[str],
+    source_container_digest: str | None,
+    signing_keys: list[str],
+) -> list[SigningItem]:
+    """Enumerate all (reference, digest, key) triples that are candidates for signing.
+
+    For each repository defined on the component, signing items are produced
+    for every combination of tag, digest, registry reference, and signing key.
+    The ``registry-access-repo`` variant is only included when the repository
+    path appears in ``sign_registry_access_repos``. Source container items are
+    appended with a ``-source`` tag suffix when a source digest is provided.
+
+    Args:
+        component: A single component entry from the Konflux release snapshot.
+        sign_registry_access_repos: Set of repository paths for which
+            registry-access signing is required.
+        digests: All manifest digests for the component's container image.
+        source_container_digest: Digest of the source container image, or None.
+        signing_keys: List of signing key IDs to produce items for.
+
+    Returns:
+        List of SigningItem objects covering all signing candidates.
+
+    """
+    items: list[SigningItem] = []
+
+    for repo in component.get("repositories", []):
+        rh_registry_repo = repo["rh-registry-repo"]
+        registry_access_repo = repo.get("registry-access-repo")
+        tags: list[str] = repo.get("tags", [])
+        repository = rh_registry_repo.split("/", 1)[1]
+
+        registry_references = [rh_registry_repo]
+        if registry_access_repo and repository in sign_registry_access_repos:
+            registry_references.append(registry_access_repo)
+
+        for digest in digests:
+            for tag in tags:
+                for ref in registry_references:
+                    for key in signing_keys:
+                        items.append(SigningItem(f"{ref}:{tag}", digest, repository, key))
+
+        if source_container_digest:
+            for tag in tags:
+                for ref in registry_references:
+                    for key in signing_keys:
+                        items.append(
+                            SigningItem(
+                                f"{ref}:{tag}-source", source_container_digest, repository, key
+                            )
+                        )
+
+    return items
+
+
+def filter_already_signed(
+    items: list[SigningItem],
+    pyxis_url: str,
+    max_workers: int = 10,
+) -> list[SigningItem]:
+    """Return only items that do not yet have a matching signature in Pyxis.
+
+    Derives the set of repositories and digests directly from the items, so it
+    is independent of how the items were produced.
+
+    Args:
+        items: All signing candidates to check.
+        pyxis_url: The Pyxis GraphQL endpoint URL.
+        max_workers: Maximum number of concurrent Pyxis lookup requests.
+
+    Returns:
+        Subset of items for which no matching ``(reference, key)`` signature
+        exists in Pyxis.
+
+    """
+    lookups = {(item.digest, item.repository) for item in items}
+    existing_signatures = find_existing_signatures(pyxis_url, lookups, max_workers)
+
+    to_sign: list[SigningItem] = []
+    for item in items:
+        existing = existing_signatures.get((item.digest, item.repository), set())
+        if any(
+            sig.reference == item.reference and sig.sig_key_id == item.key for sig in existing
+        ):
+            LOGGER.info(
+                "Signature already exists for %s @ %s with key %s, skipping",
+                item.reference,
+                item.digest,
+                item.key,
+            )
+        else:
+            to_sign.append(item)
+
+    return to_sign
+
+
+def process_component(
+    component: dict[str, Any],
+    data_file: dict[str, Any],
+    sign_registry_access_repos: set[str],
+    signing_keys: list[str],
+) -> list[SigningItem]:
+    """Collect all signing candidates for a single snapshot component.
+
+    Resolves all manifest digests (including nested manifests for multi-arch
+    images) and optionally the source container digest, then enumerates every
+    ``(reference, digest, key)`` triple that is a candidate for signing.
+
+    Args:
+        component: A single component entry from the Konflux release snapshot.
+        data_file: Parsed Konflux data file, used for the default
+            ``pushSourceContainer`` flag.
+        sign_registry_access_repos: Set of repository paths for which
+            registry-access signing is required.
+        signing_keys: List of signing key IDs to produce candidates for.
+
+    Returns:
+        List of all SigningItem candidates for this component.
+
+    """
+    LOGGER.info("Processing component: %s", component.get("name"))
+    default_push_source_container = (
+        data_file.get("mapping", {}).get("defaults", {}).get("pushSourceContainer", True)
+    )
+
+    digests = get_all_image_digests(component["containerImage"])
+    source_container_digest = get_source_container_digest(
+        component, default_push_source_container
+    )
+
+    items = collect_signing_items(
+        component, sign_registry_access_repos, digests, source_container_digest, signing_keys
+    )
+
+    LOGGER.info(
+        "Found %d signing candidates for component %s",
+        len(items),
+        component.get("name"),
+    )
+
+    return items
+
+
+def get_submit_config(
+    configmap: dict[str, Any], args: argparse.Namespace, data_file: dict[str, Any]
+) -> SubmitConfig:
+    """Build a SubmitConfig from a signing ConfigMap, CLI arguments, and data file.
+
+    Args:
+        configmap: Parsed ConfigMap dictionary as returned by get_configmap.
+        args: Parsed CLI arguments containing submission-related flags.
+        data_file: Parsed Konflux data file; provides the ``intention`` value.
+
+    Returns:
+        SubmitConfig populated from the configmap, CLI args, and data file.
+
+    Raises:
+        KeyError: If a required key is missing from the configmap data.
+
+    """
+    data = configmap["data"]
+    return SubmitConfig(
+        pipeline=args.pipeline,
+        pipeline_image=args.pipeline_image,
+        requester=args.requester,
+        pyxis_ssl_cert_secret_name=data["PYXIS_SSL_CERT_SECRET_NAME"],
+        pyxis_graphql_url=data["PYXIS_GRAPHQL_URL"],
+        kerberos_keytab_secret=data["KERBEROS_KEYTAB_SECRET"],
+        kerberos_keytab=data["KERBEROS_KEYTAB"],
+        kerberos_principal=data["KERBEROS_PRINCIPAL"],
+        signing_repo=args.signing_repo,
+        signing_revision=args.signing_revision,
+        service_account=args.service_account,
+        request_timeout=args.request_timeout,
+        pipeline_timeout=args.pipeline_timeout,
+        task_timeout=args.task_timeout,
+        task_id=args.task_id,
+        pipelinerun_uid=args.pipelinerun_uid,
+        concurrent_limit=args.concurrent_limit,
+        intention=data_file.get("intention", "unknown"),
+    )
+
+
+def submit_batch(batch_file: Path, config: SubmitConfig) -> None:
+    """Submit a single signing batch via the internal-request CLI.
+
+    Reads the base64-encoded batch content from *batch_file* and passes it
+    as the ``signing_requests`` parameter.
+
+    Args:
+        batch_file: Path to a file containing the base64-encoded batch string.
+        config: Submission configuration containing all CLI parameters.
+
+    """
+    batch_content = batch_file.read_text()
+    cmd = [
+        "internal-request",
+        "--pipeline",
+        config.pipeline,
+        "-p",
+        f"pipeline_image={config.pipeline_image}",
+        "-p",
+        f"signing_requests={batch_content}",
+        "-p",
+        f"requester={config.requester}",
+        "-p",
+        f"pyxis_ssl_cert_secret_name={config.pyxis_ssl_cert_secret_name}",
+        "-p",
+        f"pyxis_graphql_url={config.pyxis_graphql_url}",
+        "-p",
+        f"kerberos_keytab_secret={config.kerberos_keytab_secret}",
+        "-p",
+        f"kerberos_keytab={config.kerberos_keytab}",
+        "-p",
+        f"kerberos_principal={config.kerberos_principal}",
+        "-p",
+        f"taskGitUrl={config.signing_repo}",
+        "-p",
+        f"taskGitRevision={config.signing_revision}",
+        "-l",
+        f"{_TASK_LABEL}={config.task_id}",
+        "-l",
+        f"{_PIPELINERUN_LABEL}={config.pipelinerun_uid}",
+        "-l",
+        f"{_INTENTION_LABEL}={config.intention}",
+        "-l",
+        "internal-services.appstudio.openshift.io/rate-limited=true",
+        "-l",
+        "internal-services.appstudio.openshift.io/rate-limiting-group=signing-server",
+        "-t",
+        config.request_timeout,
+        "--pipeline-timeout",
+        config.pipeline_timeout,
+        "--task-timeout",
+        config.task_timeout,
+        "--service-account",
+        config.service_account,
+        "-s",
+        "true",
+    ]
+
+    LOGGER.debug("Submitting batch with command: %s", " ".join(cmd))
+    result = run_cmd(
+        cmd,
+        check=False,
+    )
+    if result.returncode != 0:
+        LOGGER.error("Failed to submit batch '%s': %s", batch_file, result.stderr.strip())
+        raise RuntimeError(f"Failed to submit batch '{batch_file}': {result.stderr.strip()}")
+    LOGGER.info("Submitted batch '%s' successfully", batch_file)
+
+
+def submit_batches(batch_dir: Path, config: SubmitConfig) -> None:
+    """Submit all batch files in *batch_dir* concurrently via internal-request.
+
+    Each file in *batch_dir* is submitted as a separate signing request.
+    Runs up to ``config.concurrent_limit`` requests in parallel. If any
+    batch submission fails, the exception is re-raised after all in-flight
+    requests have settled.
+
+    Args:
+        batch_dir: Directory containing batch files written by write_batches.
+        config: Submission configuration including concurrency limit.
+
+    """
+    batch_files = sorted(batch_dir.iterdir())
+    LOGGER.info(
+        "Submitting %d batch file(s) from '%s' with concurrent limit %d",
+        len(batch_files),
+        batch_dir,
+        config.concurrent_limit,
+    )
+    failures: list[Exception] = []
+    with ThreadPoolExecutor(max_workers=config.concurrent_limit) as pool:
+        futures = [pool.submit(submit_batch, bf, config) for bf in batch_files]
+        for future in as_completed(futures):
+            exc = future.exception()
+            if exc is not None:
+                failures.append(exc)
+
+    succeeded = len(batch_files) - len(failures)
+    LOGGER.info("Batch submission summary: %d succeeded, %d failed", succeeded, len(failures))
+    if failures:
+        for i, failure in enumerate(failures, 1):
+            LOGGER.error("Batch submission failure %d/%d: %s", i, len(failures), failure)
+        raise RuntimeError(f"{len(failures)} batch(es) failed during submission")
+
+
+def main() -> int:
+    """Entry point: parse arguments, collect signing items, and write batch files."""
+    parser = setup_argparser()
+
+    try:
+        args = parser.parse_args()
+        LOGGER.setLevel(logging.DEBUG if args.verbose else logging.INFO)
+        pyxis_url = PYXIS_INSTANCE_MAP[args.pyxis_server]
+        LOGGER.info("Using Pyxis instance URL: %s", pyxis_url)
+        sign_registry_access_repos = set(
+            args.sign_registry_access_file.read_text().splitlines()
+        )
+
+        data_file = json.loads(args.data_file.read_text())
+        snapshot = json.loads(args.snapshot.read_text())
+
+        config_map_name = data_file.get("sign", {}).get("configMapName", "signing-config-map")
+        configmap = get_configmap(config_map_name)
+        signing_keys = get_signing_keys(configmap)
+        LOGGER.info("Signing keys: %s", signing_keys)
+
+        all_candidates: list[SigningItem] = []
+        for component in snapshot.get("components", []):
+            candidates = process_component(
+                component, data_file, sign_registry_access_repos, signing_keys
+            )
+            all_candidates.extend(candidates)
+
+        LOGGER.info("Total signing candidates across all components: %d", len(all_candidates))
+        all_to_sign = filter_already_signed(all_candidates, pyxis_url)
+        LOGGER.info("Total items to sign after excluding already signed: %d", len(all_to_sign))
+
+        batches = batch_signing_items(all_to_sign, max_batch_bytes=args.batch_max_size)
+        batch_dir = args.output if args.output else Path(tempfile.mkdtemp())
+        write_batches(batches, batch_dir)
+        LOGGER.info("Wrote %d batch(es) to '%s'", len(batches), batch_dir)
+
+        if args.submit_requests:
+            submit_config = get_submit_config(configmap, args, data_file)
+            submit_batches(batch_dir, submit_config)
+    except Exception as e:
+        LOGGER.error("Fatal error during signing preparation: %s", e, exc_info=True)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_rh_direct_sign_image.py
+++ b/scripts/python/tasks/managed/test_rh_direct_sign_image.py
@@ -1,0 +1,1251 @@
+"""Unit tests for rh_direct_sign_image."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rh_direct_sign_image import (
+    PyxisSignature,
+    SigningItem,
+    batch_signing_items,
+    collect_signing_items,
+    filter_already_signed,
+    find_existing_signatures,
+    find_signatures_for_repository,
+    get_all_image_digests,
+    get_signing_keys,
+    get_source_container_digest,
+    get_submit_config,
+    main,
+    process_component,
+    setup_argparser,
+    submit_batch,
+    submit_batches,
+    validate_file,
+    write_batches,
+)
+
+COMPONENT = {
+    "name": "comp0",
+    "containerImage": "registry.io/image@sha256:abc",
+    "repositories": [
+        {
+            "rh-registry-repo": "registry.redhat.io/myproduct/myrepo",
+            "registry-access-repo": "registry.access.redhat.com/myproduct/myrepo",
+            "tags": ["v1.0", "latest"],
+        }
+    ],
+}
+
+DATA_FILE: dict = {"mapping": {"defaults": {"pushSourceContainer": False}}}
+PYXIS_URL = "https://graphql-pyxis.example.com/graphql/"
+
+
+# --- setup_argparser --output ---
+
+
+def test_setup_argparser_output_is_optional_path(tmp_path) -> None:
+    """--output defaults to None and --batch-max-size defaults to 14 KiB."""
+    snap = tmp_path / "snap.json"
+    snap.write_text("{}")
+    data = tmp_path / "data.json"
+    data.write_text("{}")
+    sign = tmp_path / "sign.txt"
+    sign.write_text("")
+
+    base_args = [
+        "--pyxis-server",
+        "stage",
+        "--snapshot",
+        str(snap),
+        "--data-file",
+        str(data),
+        "--sign-registry-access-file",
+        str(sign),
+        "--requester",
+        "tester",
+        "--pipeline-image",
+        "quay.io/signing/pipeline:latest",
+    ]
+
+    parser = setup_argparser()
+    args_without = parser.parse_args(base_args)
+    args_with = parser.parse_args(base_args + ["--output", "/tmp/out"])
+    args_custom_batch = parser.parse_args(base_args + ["--batch-max-size", "8192"])
+
+    assert args_without.output is None
+    assert args_without.batch_max_size == 14 * 1024
+    assert args_with.output == Path("/tmp/out")
+    assert args_custom_batch.batch_max_size == 8192
+
+
+def test_setup_argparser_rejects_missing_file(tmp_path) -> None:
+    """parse_args raises FileNotFoundError when a required file argument does not exist."""
+    snap = tmp_path / "snap.json"
+    snap.write_text("{}")
+    data = tmp_path / "data.json"
+    data.write_text("{}")
+
+    parser = setup_argparser()
+    with pytest.raises(FileNotFoundError):
+        parser.parse_args(
+            [
+                "--pyxis-server",
+                "stage",
+                "--snapshot",
+                str(snap),
+                "--data-file",
+                str(data),
+                "--sign-registry-access-file",
+                str(tmp_path / "missing.txt"),
+                "--requester",
+                "tester",
+                "--pipeline-image",
+                "quay.io/signing/pipeline:latest",
+            ]
+        )
+
+
+# --- write_batches ---
+
+
+def test_write_batches_creates_one_file_per_batch(tmp_path) -> None:
+    """Each batch string is written to a separate numbered file."""
+    write_batches(["aGVsbG8=", "d29ybGQ="], tmp_path)
+    assert (tmp_path / "batch_0000.txt").read_text() == "aGVsbG8="
+    assert (tmp_path / "batch_0001.txt").read_text() == "d29ybGQ="
+
+
+def test_write_batches_creates_output_directory_if_missing(tmp_path) -> None:
+    """Output directory is created when it does not exist."""
+    output_dir = tmp_path / "new" / "subdir"
+    write_batches(["aGVsbG8="], output_dir)
+    assert output_dir.is_dir()
+
+
+def test_write_batches_empty_list_creates_no_files(tmp_path) -> None:
+    """No files are written when the batch list is empty."""
+    write_batches([], tmp_path)
+    assert list(tmp_path.iterdir()) == []
+
+
+# --- batch_signing_items ---
+
+ITEM = SigningItem("registry.redhat.io/repo:tag", "sha256:abc", "repo", "key-a")
+
+
+def test_batch_signing_items_empty_list_returns_empty() -> None:
+    """Empty input produces no batches."""
+    assert batch_signing_items([]) == []
+
+
+def test_batch_signing_items_single_item_produces_one_batch() -> None:
+    """A single item is placed in exactly one batch."""
+    assert len(batch_signing_items([ITEM])) == 1
+
+
+def test_batch_signing_items_batch_is_valid_base64_encoded_json() -> None:
+    """Each batch is a base64-encoded JSON array of signing items."""
+    (batch,) = batch_signing_items([ITEM])
+    decoded = json.loads(base64.b64decode(batch))
+    assert decoded == [
+        {"reference": "registry.redhat.io/repo:tag", "digest": "sha256:abc", "key": "key-a"}
+    ]
+
+
+def test_batch_signing_items_omits_repository_field() -> None:
+    """The repository field is not included in the serialised batch."""
+    (batch,) = batch_signing_items([ITEM])
+    decoded = json.loads(base64.b64decode(batch))
+    assert "repository" not in decoded[0]
+
+
+def test_batch_signing_items_all_items_fit_in_one_batch() -> None:
+    """Items that fit within the limit are packed into a single batch."""
+    items = [
+        SigningItem(f"registry.redhat.io/repo:tag{i}", "sha256:abc", "repo", "key-a")
+        for i in range(10)
+    ]
+    batches = batch_signing_items(items)
+    assert len(batches) == 1
+    assert len(json.loads(base64.b64decode(batches[0]))) == 10
+
+
+def test_batch_signing_items_splits_when_limit_reached() -> None:
+    """A new batch is started when adding an item would exceed the byte limit."""
+    # Measure the encoded size of a single-item batch and set limit just above it
+    single_size = len(
+        base64.b64encode(
+            json.dumps(
+                [{"reference": ITEM.reference, "digest": ITEM.digest, "key": ITEM.key}]
+            ).encode()
+        )
+    )
+    batches = batch_signing_items([ITEM, ITEM, ITEM], max_batch_bytes=single_size + 1)
+    assert len(batches) == 3
+
+
+def test_batch_signing_items_packs_as_many_as_fit() -> None:
+    """Items are greedily packed until the limit is reached before splitting."""
+    # Measure two-item batch size, set limit just above it → 4 items → 2 batches of 2
+    two_item_json = json.dumps(
+        [
+            {"reference": ITEM.reference, "digest": ITEM.digest, "key": ITEM.key},
+            {"reference": ITEM.reference, "digest": ITEM.digest, "key": ITEM.key},
+        ]
+    )
+    two_size = len(base64.b64encode(two_item_json.encode()))
+    batches = batch_signing_items([ITEM] * 4, max_batch_bytes=two_size + 1)
+    assert len(batches) == 2
+    for batch in batches:
+        assert len(json.loads(base64.b64decode(batch))) == 2
+
+
+# --- get_signing_keys ---
+
+
+def test_get_signing_keys_returns_single_key() -> None:
+    """SIG_KEY_NAME is returned as a single-element list."""
+    cm = {"data": {"SIG_KEY_NAME": "redhate2etesting"}}
+    assert get_signing_keys(cm) == ["redhate2etesting"]
+
+
+def test_get_signing_keys_prefers_sig_key_names_over_sig_key_name() -> None:
+    """SIG_KEY_NAMES takes precedence over SIG_KEY_NAME when both are present."""
+    cm = {"data": {"SIG_KEY_NAME": "old-key", "SIG_KEY_NAMES": "key-a,key-b"}}
+    assert get_signing_keys(cm) == ["key-a", "key-b"]
+
+
+def test_get_signing_keys_splits_on_space() -> None:
+    """SIG_KEY_NAMES splits on spaces as well as commas."""
+    cm = {"data": {"SIG_KEY_NAMES": "key-a key-b key-c"}}
+    assert get_signing_keys(cm) == ["key-a", "key-b", "key-c"]
+
+
+def test_get_signing_keys_strips_whitespace() -> None:
+    """Leading and trailing whitespace is stripped from each key name."""
+    cm = {"data": {"SIG_KEY_NAMES": " key-a , key-b , key-c "}}
+    assert get_signing_keys(cm) == ["key-a", "key-b", "key-c"]
+
+
+def test_get_signing_keys_raises_when_no_key_defined() -> None:
+    """KeyError is raised when neither SIG_KEY_NAME nor SIG_KEY_NAMES is present."""
+    cm = {"data": {}}
+    with pytest.raises(KeyError):
+        get_signing_keys(cm)
+
+
+# --- find_signatures_for_repository ---
+
+
+@patch("rh_direct_sign_image.pyxis.graphql_query")
+def test_find_signatures_for_repository_returns_signature_objects(mock_graphql) -> None:
+    """Pyxis response is mapped to a set of PyxisSignature objects."""
+    mock_graphql.return_value = {
+        "find_signatures": {
+            "data": [{"reference": "registry.redhat.io/repo:tag", "sig_key_id": "some-key"}],
+            "error": None,
+        }
+    }
+
+    result = find_signatures_for_repository("https://pyxis.example.com/", "repo", "sha256:abc")
+
+    assert len(result) == 1
+    sig = next(iter(result))
+    assert sig.reference == "registry.redhat.io/repo:tag"
+    assert sig.sig_key_id == "some-key"
+
+
+@patch("rh_direct_sign_image.pyxis.graphql_query")
+def test_find_signatures_for_repository_empty_returns_empty_set(mock_graphql) -> None:
+    """An empty Pyxis response returns an empty set."""
+    mock_graphql.return_value = {"find_signatures": {"data": [], "error": None}}
+
+    result = find_signatures_for_repository("https://pyxis.example.com/", "repo", "sha256:abc")
+
+    assert result == set()
+
+
+@patch("rh_direct_sign_image.pyxis.graphql_query")
+def test_find_signatures_for_repository_paginates(mock_graphql) -> None:
+    """Multiple pages are fetched and their results are combined."""
+    page_size = 2
+    page1 = [
+        {"reference": "registry.redhat.io/repo:tag1", "sig_key_id": "key"},
+        {"reference": "registry.redhat.io/repo:tag2", "sig_key_id": "key"},
+    ]
+    page2 = [{"reference": "registry.redhat.io/repo:tag3", "sig_key_id": "key"}]
+    mock_graphql.side_effect = [
+        {"find_signatures": {"data": page1, "error": None}},
+        {"find_signatures": {"data": page2, "error": None}},
+    ]
+
+    result = find_signatures_for_repository(
+        "https://pyxis.example.com/", "repo", "sha256:abc", page_size=page_size
+    )
+
+    assert len(result) == 3
+
+
+# --- collect_signing_items ---
+
+
+def test_collect_signing_items_single_arch_rh_registry_only() -> None:
+    """One item per tag is produced for the rh-registry-repo when no registry-access set."""
+    items = collect_signing_items(COMPONENT, set(), ["sha256:abc"], None, ["key-a"])
+
+    assert len(items) == 2  # 2 tags x 1 digest x 1 key
+    assert (
+        SigningItem(
+            "registry.redhat.io/myproduct/myrepo:v1.0",
+            "sha256:abc",
+            "myproduct/myrepo",
+            "key-a",
+        )
+        in items
+    )
+    assert (
+        SigningItem(
+            "registry.redhat.io/myproduct/myrepo:latest",
+            "sha256:abc",
+            "myproduct/myrepo",
+            "key-a",
+        )
+        in items
+    )
+
+
+def test_collect_signing_items_includes_registry_access_when_repo_in_set() -> None:
+    """registry-access-repo references are added when the repo is in the allowed set."""
+    items = collect_signing_items(
+        COMPONENT, {"myproduct/myrepo"}, ["sha256:abc"], None, ["key-a"]
+    )
+
+    assert len(items) == 4  # 2 tags x 2 registries x 1 key
+    references = {i.reference for i in items}
+    assert "registry.redhat.io/myproduct/myrepo:v1.0" in references
+    assert "registry.access.redhat.com/myproduct/myrepo:v1.0" in references
+    assert "registry.redhat.io/myproduct/myrepo:latest" in references
+    assert "registry.access.redhat.com/myproduct/myrepo:latest" in references
+
+
+def test_collect_signing_items_excludes_registry_access_when_repo_not_in_set() -> None:
+    """registry-access-repo references are omitted when the repo is not in the allowed set."""
+    items = collect_signing_items(COMPONENT, {"other/repo"}, ["sha256:abc"], None, ["key-a"])
+
+    references = {i.reference for i in items}
+    assert not any("registry.access" in r for r in references)
+
+
+def test_collect_signing_items_multi_arch_creates_item_per_digest() -> None:
+    """A signing item is created for every digest in a multi-arch image."""
+    digests = ["sha256:index", "sha256:amd64", "sha256:arm64"]
+    items = collect_signing_items(COMPONENT, set(), digests, None, ["key-a"])
+
+    assert len(items) == 6  # 3 digests x 2 tags x 1 key
+    assert {i.digest for i in items} == {"sha256:index", "sha256:amd64", "sha256:arm64"}
+
+
+def test_collect_signing_items_creates_item_per_key() -> None:
+    """A signing item is created for each signing key."""
+    items = collect_signing_items(COMPONENT, set(), ["sha256:abc"], None, ["key-a", "key-b"])
+
+    assert len(items) == 4  # 2 tags x 1 digest x 2 keys
+    assert {i.key for i in items} == {"key-a", "key-b"}
+
+
+def test_collect_signing_items_source_container_adds_source_tag() -> None:
+    """Source container items use a -source tag suffix for each regular tag."""
+    items = collect_signing_items(COMPONENT, set(), ["sha256:abc"], "sha256:src", ["key-a"])
+
+    source_items = [i for i in items if i.digest == "sha256:src"]
+    assert len(source_items) == 2  # 2 tags x 1 key
+    references = {i.reference for i in source_items}
+    assert "registry.redhat.io/myproduct/myrepo:v1.0-source" in references
+    assert "registry.redhat.io/myproduct/myrepo:latest-source" in references
+
+
+def test_collect_signing_items_source_container_uses_source_digest() -> None:
+    """Source container items carry the source digest, not the image digest."""
+    items = collect_signing_items(COMPONENT, set(), ["sha256:abc"], "sha256:src", ["key-a"])
+
+    for item in items:
+        if "source" in item.reference:
+            assert item.digest == "sha256:src"
+        else:
+            assert item.digest == "sha256:abc"
+
+
+def test_collect_signing_items_repository_stripped_of_registry() -> None:
+    """The repository field contains only the path without the registry hostname."""
+    items = collect_signing_items(COMPONENT, set(), ["sha256:abc"], None, ["key-a"])
+
+    assert all(i.repository == "myproduct/myrepo" for i in items)
+
+
+# --- filter_already_signed ---
+
+
+def test_filter_already_signed_returns_all_when_nothing_signed() -> None:
+    """All items are returned when Pyxis has no existing signatures."""
+    items = [
+        SigningItem(
+            "registry.redhat.io/myproduct/myrepo:v1.0",
+            "sha256:abc",
+            "myproduct/myrepo",
+            "key-a",
+        ),
+        SigningItem(
+            "registry.redhat.io/myproduct/myrepo:latest",
+            "sha256:abc",
+            "myproduct/myrepo",
+            "key-a",
+        ),
+    ]
+    with patch("rh_direct_sign_image.find_existing_signatures", return_value={}):
+        result = filter_already_signed(items, PYXIS_URL)
+
+    assert result == items
+
+
+def test_filter_already_signed_removes_already_signed_item() -> None:
+    """Items already signed in Pyxis are excluded from the result."""
+    items = [
+        SigningItem(
+            "registry.redhat.io/myproduct/myrepo:v1.0",
+            "sha256:abc",
+            "myproduct/myrepo",
+            "key-a",
+        ),
+        SigningItem(
+            "registry.redhat.io/myproduct/myrepo:latest",
+            "sha256:abc",
+            "myproduct/myrepo",
+            "key-a",
+        ),
+    ]
+    existing = {
+        ("sha256:abc", "myproduct/myrepo"): {
+            PyxisSignature("registry.redhat.io/myproduct/myrepo:v1.0", "key-a")
+        }
+    }
+    with patch("rh_direct_sign_image.find_existing_signatures", return_value=existing):
+        result = filter_already_signed(items, PYXIS_URL)
+
+    references = {i.reference for i in result}
+    assert "registry.redhat.io/myproduct/myrepo:v1.0" not in references
+    assert "registry.redhat.io/myproduct/myrepo:latest" in references
+
+
+def test_filter_already_signed_keeps_item_when_different_key_signed() -> None:
+    """An item signed with a different key is not filtered out."""
+    items = [
+        SigningItem(
+            "registry.redhat.io/myproduct/myrepo:v1.0",
+            "sha256:abc",
+            "myproduct/myrepo",
+            "key-a",
+        ),
+    ]
+    existing = {
+        ("sha256:abc", "myproduct/myrepo"): {
+            PyxisSignature("registry.redhat.io/myproduct/myrepo:v1.0", "other-key")
+        }
+    }
+    with patch("rh_direct_sign_image.find_existing_signatures", return_value=existing):
+        result = filter_already_signed(items, PYXIS_URL)
+
+    assert len(result) == 1
+
+
+def test_filter_already_signed_source_container_items_filtered() -> None:
+    """Already-signed source container items are excluded from the result."""
+    items = [
+        SigningItem(
+            "registry.redhat.io/myproduct/myrepo:v1.0-source",
+            "sha256:src",
+            "myproduct/myrepo",
+            "key-a",
+        ),
+        SigningItem(
+            "registry.redhat.io/myproduct/myrepo:latest-source",
+            "sha256:src",
+            "myproduct/myrepo",
+            "key-a",
+        ),
+    ]
+    existing = {
+        ("sha256:src", "myproduct/myrepo"): {
+            PyxisSignature("registry.redhat.io/myproduct/myrepo:v1.0-source", "key-a")
+        }
+    }
+    with patch("rh_direct_sign_image.find_existing_signatures", return_value=existing):
+        result = filter_already_signed(items, PYXIS_URL)
+
+    references = {i.reference for i in result}
+    assert "registry.redhat.io/myproduct/myrepo:v1.0-source" not in references
+    assert "registry.redhat.io/myproduct/myrepo:latest-source" in references
+
+
+def test_filter_already_signed_passes_exact_pairs_to_pyxis() -> None:
+    """find_existing_signatures is called with the exact (digest, repo) pairs from items."""
+    items = [
+        SigningItem("registry.redhat.io/prod/repo:v1.0", "sha256:aaa", "prod/repo", "key-a"),
+        SigningItem("registry.redhat.io/other/repo:v1.0", "sha256:bbb", "other/repo", "key-a"),
+    ]
+    with patch("rh_direct_sign_image.find_existing_signatures", return_value={}) as mock_find:
+        filter_already_signed(items, PYXIS_URL)
+
+    _, lookups, *_ = mock_find.call_args.args
+    assert lookups == {("sha256:aaa", "prod/repo"), ("sha256:bbb", "other/repo")}
+
+
+# --- process_component ---
+
+
+def test_process_component_returns_all_candidates() -> None:
+    """All signing candidates are collected without filtering against Pyxis."""
+    with (
+        patch("rh_direct_sign_image.get_all_image_digests", return_value=["sha256:abc"]),
+        patch("rh_direct_sign_image.get_source_container_digest", return_value=None),
+    ):
+        candidates = process_component(COMPONENT, DATA_FILE, set(), signing_keys=["key-a"])
+
+    assert len(candidates) == 2
+    references = {i.reference for i in candidates}
+    assert "registry.redhat.io/myproduct/myrepo:v1.0" in references
+    assert "registry.redhat.io/myproduct/myrepo:latest" in references
+
+
+def test_process_component_includes_source_container_candidates() -> None:
+    """Source container signing candidates are included in the returned list."""
+    with (
+        patch("rh_direct_sign_image.get_all_image_digests", return_value=["sha256:abc"]),
+        patch("rh_direct_sign_image.get_source_container_digest", return_value="sha256:src"),
+    ):
+        candidates = process_component(COMPONENT, DATA_FILE, set(), signing_keys=["key-a"])
+
+    references = {i.reference for i in candidates}
+    assert "registry.redhat.io/myproduct/myrepo:v1.0-source" in references
+    assert "registry.redhat.io/myproduct/myrepo:latest-source" in references
+
+
+# --- get_all_image_digests ---
+
+_SINGLE_MANIFEST = json.dumps(
+    {"mediaType": "application/vnd.oci.image.manifest.v1+json", "schemaVersion": 2}
+)
+_INDEX_MANIFEST = json.dumps(
+    {
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {"digest": "sha256:amd64"},
+            {"digest": "sha256:arm64"},
+        ],
+    }
+)
+_HELM_MANIFEST = json.dumps({"schemaVersion": 2})  # no mediaType, no manifests
+
+
+def test_get_all_image_digests_single_arch_returns_only_top_level() -> None:
+    """A single-arch image returns only its own digest."""
+    ref = "registry.io/repo/image@sha256:toplevel"
+    with patch("rh_direct_sign_image.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock(stdout=_SINGLE_MANIFEST)
+        digests = get_all_image_digests(ref)
+
+    assert digests == ["sha256:toplevel"]
+
+
+def test_get_all_image_digests_multi_arch_includes_nested_digests() -> None:
+    """A multi-arch index image includes the top-level and all nested digests."""
+    ref = "registry.io/repo/image@sha256:index"
+    with patch("rh_direct_sign_image.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock(stdout=_INDEX_MANIFEST)
+        digests = get_all_image_digests(ref)
+
+    assert digests == ["sha256:index", "sha256:amd64", "sha256:arm64"]
+
+
+def test_get_all_image_digests_helm_chart_returns_only_top_level() -> None:
+    """Single-manifest artifact with no nested manifests returns only the top-level digest."""
+    ref = "registry.io/repo/chart@sha256:chart"
+    with patch("rh_direct_sign_image.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock(stdout=_HELM_MANIFEST)
+        digests = get_all_image_digests(ref)
+
+    assert digests == ["sha256:chart"]
+
+
+def test_get_all_image_digests_calls_select_oci_auth_with_reference() -> None:
+    """select-oci-auth is called with the image reference before skopeo inspect."""
+    ref = "registry.io/repo/image@sha256:abc"
+    with patch("rh_direct_sign_image.run_cmd") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(stdout="{}"),
+            MagicMock(stdout=_SINGLE_MANIFEST),
+        ]
+        get_all_image_digests(ref)
+
+    first_call = mock_run.call_args_list[0].args[0]
+    assert first_call == ["select-oci-auth", ref]
+
+
+def test_get_all_image_digests_passes_authfile_to_skopeo() -> None:
+    """Skopeo inspect is called with --authfile pointing to the auth credentials."""
+    ref = "registry.io/repo/image@sha256:abc"
+    with patch("rh_direct_sign_image.run_cmd") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(stdout="{}"),
+            MagicMock(stdout=_SINGLE_MANIFEST),
+        ]
+        get_all_image_digests(ref)
+
+    skopeo_call = mock_run.call_args_list[1].args[0]
+    assert skopeo_call[0] == "skopeo"
+    assert "--authfile" in skopeo_call
+    assert f"docker://{ref}" in skopeo_call
+
+
+# --- get_source_container_digest ---
+
+
+def test_get_source_container_digest_returns_none_when_disabled() -> None:
+    """Returns None when pushSourceContainer is False."""
+    component = {"containerImage": "registry.io/repo@sha256:abc", "pushSourceContainer": False}
+    result = get_source_container_digest(component, default_push_source_container=True)
+    assert result is None
+
+
+def test_get_source_container_digest_uses_default_when_flag_absent() -> None:
+    """Returns None when pushSourceContainer is absent and default is False."""
+    component = {"containerImage": "registry.io/repo@sha256:abc"}
+    result = get_source_container_digest(component, default_push_source_container=False)
+    assert result is None
+
+
+def test_get_source_container_digest_resolves_digest() -> None:
+    """Delegates to oras_resolve and returns the digest."""
+    component = {
+        "containerImage": "registry.io/repo@sha256:deadbeef",
+        "pushSourceContainer": True,
+    }
+    with patch("rh_direct_sign_image.oras_resolve", return_value="sha256:sourceabc"):
+        result = get_source_container_digest(component, default_push_source_container=False)
+
+    assert result == "sha256:sourceabc"
+
+
+def test_get_source_container_digest_constructs_correct_source_reference() -> None:
+    """Source reference is built as <repo>:sha256-<sha>.src."""
+    component = {
+        "containerImage": "registry.io/myrepo@sha256:deadbeef",
+        "pushSourceContainer": True,
+    }
+    with patch("rh_direct_sign_image.oras_resolve", return_value="sha256:src") as mock_resolve:
+        get_source_container_digest(component, default_push_source_container=False)
+
+    mock_resolve.assert_called_once_with("registry.io/myrepo:sha256-deadbeef.src")
+
+
+# --- find_existing_signatures ---
+
+
+def test_find_existing_signatures_queries_each_pair() -> None:
+    """find_signatures_for_repository is called once per (digest, repo) pair."""
+    lookups = {("sha256:aaa", "repo/a"), ("sha256:bbb", "repo/b")}
+    sig_a = PyxisSignature("registry.io/repo/a:tag", "key")
+    with patch(
+        "rh_direct_sign_image.find_signatures_for_repository",
+        side_effect=[{sig_a}, set()],
+    ):
+        results = find_existing_signatures(PYXIS_URL, lookups)
+
+    assert len(results) == 2
+    assert any(results[k] == {sig_a} for k in results)
+
+
+def test_find_existing_signatures_returns_empty_set_for_missing_pair() -> None:
+    """A pair with no signatures maps to an empty set."""
+    lookups = {("sha256:abc", "repo/x")}
+    with patch("rh_direct_sign_image.find_signatures_for_repository", return_value=set()):
+        results = find_existing_signatures(PYXIS_URL, lookups)
+
+    assert results[("sha256:abc", "repo/x")] == set()
+
+
+# --- main ---
+
+
+def test_main_collects_candidates_and_writes_batches(tmp_path) -> None:
+    """Main writes batch files when --output is provided."""
+    snapshot = {"components": [COMPONENT]}
+    data_file = {"mapping": {"defaults": {"pushSourceContainer": False}}}
+    sign_file = tmp_path / "sign.txt"
+    sign_file.write_text("")
+    snap_file = tmp_path / "snapshot.json"
+    snap_file.write_text(json.dumps(snapshot))
+    data_path = tmp_path / "data.json"
+    data_path.write_text(json.dumps(data_file))
+    output_dir = tmp_path / "batches"
+
+    item = SigningItem(
+        "registry.redhat.io/myproduct/myrepo:v1.0", "sha256:abc", "myproduct/myrepo", "key-a"
+    )
+    with (
+        patch(
+            "rh_direct_sign_image.get_configmap",
+            return_value={"data": {"SIG_KEY_NAME": "key-a"}},
+        ),
+        patch("rh_direct_sign_image.process_component", return_value=[item]),
+        patch("rh_direct_sign_image.filter_already_signed", return_value=[item]),
+        patch(
+            "sys.argv",
+            [
+                "prepare_container_signing",
+                "--pyxis-server",
+                "stage",
+                "--snapshot",
+                str(snap_file),
+                "--data-file",
+                str(data_path),
+                "--sign-registry-access-file",
+                str(sign_file),
+                "--output",
+                str(output_dir),
+                "--requester",
+                "tester",
+                "--pipeline-image",
+                "quay.io/signing/pipeline:latest",
+            ],
+        ),
+    ):
+        main()
+
+    assert output_dir.is_dir()
+    assert len(list(output_dir.iterdir())) == 1
+
+
+# --- validate_file ---
+
+
+def test_validate_file_returns_path_for_existing_file(tmp_path) -> None:
+    """validate_file returns a Path when the file exists."""
+    f = tmp_path / "test.txt"
+    f.write_text("x")
+    assert validate_file(str(f)) == f
+
+
+def test_validate_file_raises_for_missing_file(tmp_path) -> None:
+    """validate_file raises FileNotFoundError when the file does not exist."""
+    with pytest.raises(FileNotFoundError):
+        validate_file(str(tmp_path / "missing.txt"))
+
+
+def test_main_returns_zero_on_success(tmp_path) -> None:
+    """Main returns 0 when the workflow completes successfully."""
+    snapshot = {"components": []}
+    data_file = {"mapping": {"defaults": {"pushSourceContainer": False}}}
+    sign_file = tmp_path / "sign.txt"
+    sign_file.write_text("")
+    snap_file = tmp_path / "snapshot.json"
+    snap_file.write_text(json.dumps(snapshot))
+    data_path = tmp_path / "data.json"
+    data_path.write_text(json.dumps(data_file))
+
+    with (
+        patch(
+            "rh_direct_sign_image.get_configmap",
+            return_value={"data": {"SIG_KEY_NAME": "key-a"}},
+        ),
+        patch("rh_direct_sign_image.filter_already_signed", return_value=[]),
+        patch(
+            "sys.argv",
+            [
+                "prepare_container_signing",
+                "--pyxis-server",
+                "stage",
+                "--snapshot",
+                str(snap_file),
+                "--data-file",
+                str(data_path),
+                "--sign-registry-access-file",
+                str(sign_file),
+                "--requester",
+                "tester",
+                "--pipeline-image",
+                "quay.io/signing/pipeline:latest",
+            ],
+        ),
+    ):
+        result = main()
+
+    assert result == 0
+
+
+def test_main_returns_one_on_unexpected_error(tmp_path) -> None:
+    """Main returns 1 and does not propagate exceptions on unexpected failure."""
+    sign_file = tmp_path / "sign.txt"
+    sign_file.write_text("")
+    snap_file = tmp_path / "snapshot.json"
+    snap_file.write_text(json.dumps({"components": []}))
+    data_path = tmp_path / "data.json"
+    data_path.write_text(json.dumps({}))
+
+    with (
+        patch(
+            "rh_direct_sign_image.get_configmap",
+            side_effect=RuntimeError("something went wrong"),
+        ),
+        patch(
+            "sys.argv",
+            [
+                "prepare_container_signing",
+                "--pyxis-server",
+                "stage",
+                "--snapshot",
+                str(snap_file),
+                "--data-file",
+                str(data_path),
+                "--sign-registry-access-file",
+                str(sign_file),
+                "--requester",
+                "tester",
+                "--pipeline-image",
+                "quay.io/signing/pipeline:latest",
+            ],
+        ),
+    ):
+        result = main()
+
+    assert result == 1
+
+
+# --- get_submit_config ---
+
+_FULL_CONFIGMAP = {
+    "data": {
+        "SIG_KEY_NAME": "key-a",
+        "PYXIS_SSL_CERT_SECRET_NAME": "pyxis-cert-secret",
+        "PYXIS_GRAPHQL_URL": "https://graphql-pyxis.example.com/graphql/",
+        "KERBEROS_PRINCIPAL": "svc@REALM",
+        "KERBEROS_KEYTAB": "/etc/keytab",
+        "KERBEROS_KEYTAB_SECRET": "keytab-secret",
+    }
+}
+
+
+def _make_submit_args(**overrides):
+    """Return a Namespace with all submit-related args set to safe defaults."""
+    import argparse
+
+    defaults = dict(
+        pipeline="container-signing",
+        requester="tester",
+        request_timeout="1800",
+        pipeline_timeout="0h30m0s",
+        task_timeout="0h25m0s",
+        service_account="signing-pipeline-sa",
+        task_id="task-uid-123",
+        pipelinerun_uid="pr-uid-456",
+        signing_repo="https://gitlab.cee.redhat.com/signing/signing.git",
+        signing_revision="main",
+        concurrent_limit=8,
+        pipeline_image="quay.io/signing/pipeline:latest",
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_get_submit_config_builds_from_configmap_and_args() -> None:
+    """get_submit_config maps configmap fields and CLI args into a SubmitConfig."""
+    args = _make_submit_args()
+    cfg = get_submit_config(_FULL_CONFIGMAP, args, {})
+
+    assert cfg.pyxis_ssl_cert_secret_name == "pyxis-cert-secret"
+    assert cfg.pyxis_graphql_url == "https://graphql-pyxis.example.com/graphql/"
+    assert cfg.kerberos_principal == "svc@REALM"
+    assert cfg.kerberos_keytab == "/etc/keytab"
+    assert cfg.kerberos_keytab_secret == "keytab-secret"
+    assert cfg.pipeline == "container-signing"
+    assert cfg.requester == "tester"
+    assert cfg.task_id == "task-uid-123"
+    assert cfg.pipelinerun_uid == "pr-uid-456"
+    assert cfg.concurrent_limit == 8
+    assert cfg.pipeline_image == "quay.io/signing/pipeline:latest"
+
+
+def test_get_submit_config_uses_intention_from_data_file() -> None:
+    """get_submit_config reads intention from data_file."""
+    cfg = get_submit_config(_FULL_CONFIGMAP, _make_submit_args(), {"intention": "release"})
+    assert cfg.intention == "release"
+
+
+def test_get_submit_config_defaults_intention_to_unknown() -> None:
+    """get_submit_config defaults intention to 'unknown' when absent from data_file."""
+    cfg = get_submit_config(_FULL_CONFIGMAP, _make_submit_args(), {})
+    assert cfg.intention == "unknown"
+
+
+def test_get_submit_config_raises_on_missing_configmap_key() -> None:
+    """get_submit_config raises KeyError when a required configmap key is absent."""
+    bad_cm = {"data": {"SIG_KEY_NAME": "key-a"}}
+    with pytest.raises(KeyError):
+        get_submit_config(bad_cm, _make_submit_args(), {})
+
+
+# --- submit_batch ---
+
+
+def test_submit_batch_reads_file_and_calls_internal_request(tmp_path) -> None:
+    """submit_batch reads the batch file content and passes it to internal-request."""
+    cfg = get_submit_config(_FULL_CONFIGMAP, _make_submit_args(), {})
+    batch_file = tmp_path / "batch_0000.txt"
+    batch_file.write_text("base64content==")
+
+    with patch("rh_direct_sign_image.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        submit_batch(batch_file, cfg)
+
+    cmd = mock_run.call_args.args[0]
+    assert cmd[0] in ("internal-request", "internal-request")
+    assert "--pipeline" in cmd and "container-signing" in cmd
+    assert "-p" in cmd
+    assert any("signing_requests=base64content==" in a for a in cmd)
+    assert any("requester=tester" in a for a in cmd)
+    assert any("pyxis_ssl_cert_secret_name=pyxis-cert-secret" in a for a in cmd)
+    assert any(
+        "pyxis_graphql_url=https://graphql-pyxis.example.com/graphql/" in a for a in cmd
+    )
+    assert any("kerberos_principal=svc@REALM" in a for a in cmd)
+    assert any("kerberos_keytab=/etc/keytab" in a for a in cmd)
+    assert any("kerberos_keytab_secret=keytab-secret" in a for a in cmd)
+    assert any(
+        "internal-services.appstudio.openshift.io/group-id=task-uid-123" in a for a in cmd
+    )
+    assert any(
+        "internal-services.appstudio.openshift.io/pipelinerun-uid=pr-uid-456" in a for a in cmd
+    )
+    assert any("internal-services.appstudio.openshift.io/rate-limited=true" in a for a in cmd)
+    assert "-t" in cmd and "1800" in cmd
+    assert "--pipeline-timeout" in cmd and "0h30m0s" in cmd
+    assert "--task-timeout" in cmd and "0h25m0s" in cmd
+    assert "--service-account" in cmd and "signing-pipeline-sa" in cmd
+    assert "-s" in cmd and "true" in cmd
+    assert any("pipeline_image=quay.io/signing/pipeline:latest" in a for a in cmd)
+
+
+def test_submit_batch_includes_intention_label(tmp_path) -> None:
+    """submit_batch passes the intention label to internal-request."""
+    cfg = get_submit_config(_FULL_CONFIGMAP, _make_submit_args(), {"intention": "release"})
+    batch_file = tmp_path / "batch_0000.txt"
+    batch_file.write_text("base64content==")
+
+    with patch("rh_direct_sign_image.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        submit_batch(batch_file, cfg)
+
+    cmd = mock_run.call_args.args[0]
+    assert any("internal-services.appstudio.openshift.io/intention=release" in a for a in cmd)
+
+
+# --- submit_batches ---
+
+
+def test_submit_batches_submits_each_batch_file(tmp_path) -> None:
+    """submit_batches calls submit_batch once per file in the batch directory."""
+    cfg = get_submit_config(_FULL_CONFIGMAP, _make_submit_args(), {})
+    for i, content in enumerate(["batch1==", "batch2==", "batch3=="]):
+        (tmp_path / f"batch_{i:04d}.txt").write_text(content)
+
+    with patch("rh_direct_sign_image.submit_batch") as mock_submit:
+        submit_batches(tmp_path, cfg)
+
+    assert mock_submit.call_count == 3
+    submitted_paths = {call.args[0] for call in mock_submit.call_args_list}
+    assert submitted_paths == {
+        tmp_path / "batch_0000.txt",
+        tmp_path / "batch_0001.txt",
+        tmp_path / "batch_0002.txt",
+    }
+
+
+def test_submit_batches_uses_concurrent_limit(tmp_path) -> None:
+    """submit_batches passes concurrent_limit as max_workers to ThreadPoolExecutor."""
+    cfg = get_submit_config(_FULL_CONFIGMAP, _make_submit_args(concurrent_limit=3), {})
+    (tmp_path / "batch_0000.txt").write_text("b1")
+
+    with (
+        patch("rh_direct_sign_image.submit_batch"),
+        patch("rh_direct_sign_image.ThreadPoolExecutor") as mock_pool_cls,
+        patch("rh_direct_sign_image.as_completed", return_value=[]),
+    ):
+        mock_pool = MagicMock()
+        mock_pool_cls.return_value.__enter__ = MagicMock(return_value=mock_pool)
+        mock_pool_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_pool.submit = MagicMock(return_value=MagicMock())
+        submit_batches(tmp_path, cfg)
+
+    mock_pool_cls.assert_called_once_with(max_workers=3)
+
+
+def test_submit_batches_logs_all_succeeded(tmp_path) -> None:
+    """submit_batches logs that all batches succeeded when none fail."""
+    cfg = get_submit_config(_FULL_CONFIGMAP, _make_submit_args(), {})
+    for i in range(3):
+        (tmp_path / f"batch_{i:04d}.txt").write_text(f"b{i}")
+
+    with (
+        patch("rh_direct_sign_image.submit_batch"),
+        patch("rh_direct_sign_image.LOGGER") as mock_logger,
+    ):
+        submit_batches(tmp_path, cfg)
+
+    mock_logger.info.assert_any_call("Batch submission summary: %d succeeded, %d failed", 3, 0)
+
+
+def test_submit_batches_logs_partial_failure_counts(tmp_path) -> None:
+    """submit_batches logs correct success/failure counts when some batches fail."""
+    cfg = get_submit_config(_FULL_CONFIGMAP, _make_submit_args(), {})
+    for i in range(3):
+        (tmp_path / f"batch_{i:04d}.txt").write_text(f"b{i}")
+
+    call_count = 0
+
+    def fail_first(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("request failed")
+
+    with (
+        patch("rh_direct_sign_image.submit_batch", side_effect=fail_first),
+        patch("rh_direct_sign_image.LOGGER") as mock_logger,
+        pytest.raises(RuntimeError),
+    ):
+        submit_batches(tmp_path, cfg)
+
+    mock_logger.info.assert_any_call("Batch submission summary: %d succeeded, %d failed", 2, 1)
+
+
+def test_submit_batches_raises_after_logging_summary(tmp_path) -> None:
+    """submit_batches raises RuntimeError after logging the summary when batches fail."""
+    cfg = get_submit_config(_FULL_CONFIGMAP, _make_submit_args(), {})
+    (tmp_path / "batch_0000.txt").write_text("b1")
+
+    with (
+        patch("rh_direct_sign_image.submit_batch", side_effect=RuntimeError("request failed")),
+        pytest.raises(RuntimeError, match="1 batch.*failed"),
+    ):
+        submit_batches(tmp_path, cfg)
+
+
+# --- setup_argparser with submit flags ---
+
+
+def test_setup_argparser_submit_requests_defaults(tmp_path) -> None:
+    """--submit-requests is False by default; submission flags have correct defaults."""
+    snap = tmp_path / "s.json"
+    snap.write_text("{}")
+    data = tmp_path / "d.json"
+    data.write_text("{}")
+    sign = tmp_path / "r.txt"
+    sign.write_text("")
+
+    parser = setup_argparser()
+    args = parser.parse_args(
+        [
+            "--pyxis-server",
+            "stage",
+            "--snapshot",
+            str(snap),
+            "--data-file",
+            str(data),
+            "--sign-registry-access-file",
+            str(sign),
+            "--requester",
+            "tester",
+            "--pipeline-image",
+            "quay.io/signing/pipeline:latest",
+        ]
+    )
+
+    assert args.submit_requests is False
+    assert args.concurrent_limit == 8
+    assert args.request_timeout == "1800"
+    assert args.pipeline_timeout == "0h30m0s"
+    assert args.task_timeout == "0h25m0s"
+    assert args.service_account == "signing-pipeline-sa"
+
+
+# --- main with submit ---
+
+
+def test_main_submits_batches_when_flag_set(tmp_path) -> None:
+    """Main writes batches to files and calls submit_batches when --submit-requests is set."""
+    snapshot = {"components": []}
+    data_file = {"mapping": {"defaults": {"pushSourceContainer": False}}}
+    sign_file = tmp_path / "sign.txt"
+    sign_file.write_text("")
+    snap_file = tmp_path / "snapshot.json"
+    snap_file.write_text(json.dumps(snapshot))
+    data_path = tmp_path / "data.json"
+    data_path.write_text(json.dumps(data_file))
+    output_dir = tmp_path / "batches"
+
+    with (
+        patch(
+            "rh_direct_sign_image.get_configmap",
+            return_value=_FULL_CONFIGMAP,
+        ),
+        patch(
+            "rh_direct_sign_image.filter_already_signed",
+            return_value=[
+                SigningItem("registry.redhat.io/repo:tag", "sha256:abc", "repo", "key-a"),
+            ],
+        ),
+        patch("rh_direct_sign_image.submit_batches") as mock_submit,
+        patch(
+            "sys.argv",
+            [
+                "rh_direct_sign_image",
+                "--pyxis-server",
+                "stage",
+                "--snapshot",
+                str(snap_file),
+                "--data-file",
+                str(data_path),
+                "--sign-registry-access-file",
+                str(sign_file),
+                "--output",
+                str(output_dir),
+                "--submit-requests",
+                "--pipeline",
+                "container-signing",
+                "--requester",
+                "tester",
+                "--pipeline-image",
+                "quay.io/signing/pipeline:latest",
+                "--task-id",
+                "task-123",
+                "--pipelinerun-uid",
+                "pr-456",
+            ],
+        ),
+    ):
+        result = main()
+
+    assert result == 0
+    mock_submit.assert_called_once()
+    # first arg to submit_batches is the batch directory
+    assert mock_submit.call_args.args[0] == output_dir
+
+
+def test_main_uses_temp_dir_when_output_not_specified(tmp_path) -> None:
+    """Main uses a temporary directory for batches when --output is omitted."""
+    snapshot = {"components": []}
+    data_file = {"mapping": {"defaults": {"pushSourceContainer": False}}}
+    sign_file = tmp_path / "sign.txt"
+    sign_file.write_text("")
+    snap_file = tmp_path / "snapshot.json"
+    snap_file.write_text(json.dumps(snapshot))
+    data_path = tmp_path / "data.json"
+    data_path.write_text(json.dumps(data_file))
+
+    with (
+        patch(
+            "rh_direct_sign_image.get_configmap",
+            return_value=_FULL_CONFIGMAP,
+        ),
+        patch(
+            "rh_direct_sign_image.filter_already_signed",
+            return_value=[
+                SigningItem("registry.redhat.io/repo:tag", "sha256:abc", "repo", "key-a"),
+            ],
+        ),
+        patch("rh_direct_sign_image.submit_batches") as mock_submit,
+        patch(
+            "sys.argv",
+            [
+                "rh_direct_sign_image",
+                "--pyxis-server",
+                "stage",
+                "--snapshot",
+                str(snap_file),
+                "--data-file",
+                str(data_path),
+                "--sign-registry-access-file",
+                str(sign_file),
+                "--submit-requests",
+                "--pipeline",
+                "container-signing",
+                "--requester",
+                "tester",
+                "--pipeline-image",
+                "quay.io/signing/pipeline:latest",
+                "--task-id",
+                "task-123",
+                "--pipelinerun-uid",
+                "pr-456",
+            ],
+        ),
+    ):
+        result = main()
+
+    assert result == 0
+    mock_submit.assert_called_once()
+    # batch dir is some temporary path (not None)
+    assert mock_submit.call_args.args[0] is not None
+
+
+def test_main_always_writes_batches(tmp_path) -> None:
+    """Main writes batches to a temp dir even when --output is omitted."""
+    snapshot = {"components": []}
+    data_file = {"mapping": {"defaults": {"pushSourceContainer": False}}}
+    sign_file = tmp_path / "sign.txt"
+    sign_file.write_text("")
+    snap_file = tmp_path / "snapshot.json"
+    snap_file.write_text(json.dumps(snapshot))
+    data_path = tmp_path / "data.json"
+    data_path.write_text(json.dumps(data_file))
+
+    with (
+        patch(
+            "rh_direct_sign_image.get_configmap",
+            return_value={"data": {"SIG_KEY_NAME": "key-a"}},
+        ),
+        patch(
+            "rh_direct_sign_image.filter_already_signed",
+            return_value=[
+                SigningItem("registry.redhat.io/repo:tag", "sha256:abc", "repo", "key-a"),
+            ],
+        ),
+        patch("rh_direct_sign_image.write_batches") as mock_write,
+        patch(
+            "sys.argv",
+            [
+                "prepare_container_signing",
+                "--pyxis-server",
+                "stage",
+                "--snapshot",
+                str(snap_file),
+                "--data-file",
+                str(data_path),
+                "--sign-registry-access-file",
+                str(sign_file),
+                "--requester",
+                "tester",
+                "--pipeline-image",
+                "quay.io/signing/pipeline:latest",
+            ],
+        ),
+    ):
+        result = main()
+
+    assert result == 0
+    mock_write.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -635,6 +635,20 @@ wheels = [
 ]
 
 [[package]]
+name = "flake8"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mccabe" },
+    { name = "pycodestyle" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
 name = "frozendict"
 version = "2.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -946,6 +960,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/7e/1dbd4096eb7c148cd2841841916f78820bb85a4d80a0c25c02d30815a7fb/marshmallow-4.3.0.tar.gz", hash = "sha256:fb43c53b3fe240b8f6af37223d6ef1636f927ad9bea8ab323afad95dff090880", size = 224485, upload-time = "2026-04-03T21:46:32.72Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/e0/ff24e25218bb59eb6290a530cea40651b14068b6e3659b20f9c175179632/marshmallow-4.3.0-py3-none-any.whl", hash = "sha256:46c4fe6984707e3cbd485dfebbf0a59874f58d695aad05c1668d15e8c6e13b46", size = 49148, upload-time = "2026-04-03T21:46:31.241Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -1453,12 +1476,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pycodestyle"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
 ]
 
 [[package]]
@@ -1751,6 +1792,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "black" },
+    { name = "flake8" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
@@ -1781,6 +1823,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "black", specifier = ">=25.11.0" },
+    { name = "flake8", specifier = ">=7.3.0" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=6.0" },
 ]


### PR DESCRIPTION
A new script rh_direct_sign_image.py is created to support direct
container signing method. The script will be used in the new Tekton task
that replaces current signing method.

The script resolves all digests for components, verifies if images are
already signed and filter them out. Whatever remains is signed using
internal request and new direct signing pipeline.

    - PyxisSignature/SigningItem dataclasses for structured data
    - Multi-arch digest collection via skopeo inspect --raw
    - Source container resolution via select-oci-auth + oras resolve
    - ConfigMap reading for SIG_KEY_NAME(S)
    - Greedy base64 batching with --batch-max-size and --output args
    - Full unit test suite (34 tests)
    
Assisted-by: Claude Sonnet 4.6
Signed-off-by: Ales Raszka <araszka@redhat.com>
