### PR TITLE
feat(RELEASE-2469): convert base64-encode-checksum to python

### DIFF
--- a/scripts/python/tasks/managed/base64_encode_checksum.py
+++ b/scripts/python/tasks/managed/base64_encode_checksum.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Base64-encode SHA256 checksum files for signing."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import tekton
+from logger import logger
+
+PROG = "base64_encode_checksum.py"
+
+
+def encode_checksums(binaries_dir: Path) -> str:
+    """Concatenate all *SHA256SUMS files in *binaries_dir* and base64-encode.
+
+    Files are read in sorted order for deterministic output. Raises
+    ``FileNotFoundError`` when *binaries_dir* does not exist or contains no
+    matching files.
+    """
+    if not binaries_dir.is_dir():
+        raise FileNotFoundError(f"Binaries directory does not exist: {binaries_dir}")
+
+    files = sorted(binaries_dir.glob("*SHA256SUMS"))
+    if not files:
+        raise FileNotFoundError(f"No *SHA256SUMS files found in {binaries_dir}")
+
+    data = b"".join(f.read_bytes() for f in files)
+    return base64.b64encode(data).decode("ascii")
+
+
+def main() -> int:
+    """Encode checksums and write the blob to the Tekton result file."""
+    (rpath,) = tekton.result_paths_from_env("RESULT_BLOB")
+
+    data_dir = tekton.require_env("DATA_DIR")
+    binaries_dir_name = tekton.require_env("BINARIES_DIR")
+
+    binaries_dir = Path(data_dir) / binaries_dir_name
+
+    try:
+        blob = encode_checksums(binaries_dir)
+    except Exception as e:
+        logger.error("%s: %s", PROG, e)
+        return 1
+
+    logger.info("%s", blob)
+    rpath.write_text(blob, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_base64_encode_checksum.py
+++ b/scripts/python/tasks/managed/test_base64_encode_checksum.py
@@ -1,0 +1,87 @@
+"""Tests for base64_encode_checksum."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from base64_encode_checksum import encode_checksums, main
+
+
+def test_single_checksum_file(tmp_path: Path) -> None:
+    """Encode a single SHA256SUMS file."""
+    content = b"abc123  somefile.tar.gz\n"
+    (tmp_path / "SHA256SUMS").write_bytes(content)
+
+    result = encode_checksums(tmp_path)
+
+    assert result == base64.b64encode(content).decode("ascii")
+
+
+def test_multiple_checksum_files(tmp_path: Path) -> None:
+    """Concatenate multiple SHA256SUMS files before encoding."""
+    content_a = b"aaa  file_a\n"
+    content_b = b"bbb  file_b\n"
+    (tmp_path / "A-SHA256SUMS").write_bytes(content_a)
+    (tmp_path / "B-SHA256SUMS").write_bytes(content_b)
+
+    result = encode_checksums(tmp_path)
+
+    assert result == base64.b64encode(content_a + content_b).decode("ascii")
+
+
+def test_no_matching_files(tmp_path: Path) -> None:
+    """Raise FileNotFoundError when no *SHA256SUMS files exist."""
+    (tmp_path / "unrelated.txt").write_text("hello")
+
+    with pytest.raises(FileNotFoundError, match="No \\*SHA256SUMS files"):
+        encode_checksums(tmp_path)
+
+
+def test_missing_directory(tmp_path: Path) -> None:
+    """Raise FileNotFoundError when the binaries directory is absent."""
+    missing = tmp_path / "nonexistent"
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        encode_checksums(missing)
+
+
+def test_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write the base64 blob to the result file and return 0."""
+    content = b"deadbeef  binary.tar.gz\n"
+    binaries = tmp_path / "binaries"
+    binaries.mkdir()
+    (binaries / "SHA256SUMS").write_bytes(content)
+
+    result_file = tmp_path / "blob_result"
+    monkeypatch.setenv("RESULT_BLOB", str(result_file))
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("BINARIES_DIR", "binaries")
+
+    rc = main()
+
+    assert rc == 0
+    assert result_file.read_text() == base64.b64encode(content).decode("ascii")
+
+
+def test_main_failure_returns_1(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return 1 and skip result file when the directory is missing."""
+    result_file = tmp_path / "blob_result"
+    monkeypatch.setenv("RESULT_BLOB", str(result_file))
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("BINARIES_DIR", "nonexistent")
+
+    rc = main()
+
+    assert rc == 1
+    assert not result_file.exists()
+
+
+def test_main_missing_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exit with SystemExit when RESULT_BLOB is not set."""
+    monkeypatch.delenv("RESULT_BLOB", raising=False)
+
+    with pytest.raises(SystemExit):
+        main()


### PR DESCRIPTION
Convert the bash script in the base64-encode-checksum task to a standalone python script with unit tests.

Assisted-by: Claude Code