### PR TITLE
fix(KONFLUX-14326): fix PR links in update-infra-deployments

### DIFF
--- a/scripts/python/helpers/vcs/github.py
+++ b/scripts/python/helpers/vcs/github.py
@@ -6,6 +6,7 @@ import atexit
 import base64
 import json
 import os
+import re
 import stat
 import subprocess
 import tempfile
@@ -277,6 +278,11 @@ def compare_changelog(
             sha = commit_info["sha"][:7]
             url = commit_info["html_url"]
             message = commit_info["commit"]["message"].split("\n", 1)[0]
+            message = re.sub(
+                r"#(\d+)",
+                rf"[#\1](https://github.com/{owner_repo}/pull/\1)",
+                message,
+            )
             author = commit_info.get("author")
             login = author.get("login") if isinstance(author, dict) else None
             if login:

--- a/scripts/python/helpers/vcs/test_github.py
+++ b/scripts/python/helpers/vcs/test_github.py
@@ -378,6 +378,33 @@ def test_compare_changelog_without_github_login() -> None:
     assert "@" not in out.split("\n", 1)[1]
 
 
+def test_compare_changelog_rewrites_pr_references() -> None:
+    """Rewrite bare #<num> PR references to full markdown links."""
+    session = _session()
+    payload = {
+        "commits": [
+            {
+                "sha": "c" * 40,
+                "html_url": "https://github.com/org/repo/commit/ccc",
+                "commit": {
+                    "message": "chore(deps): update dependencies (#453)",
+                    "author": {"name": "Bot"},
+                },
+                "author": {"login": "bot"},
+            }
+        ]
+    }
+    with mock.patch.object(github, "_get_json", return_value=payload):
+        out = github.compare_changelog(
+            session,
+            "https://github.com/org/repo",
+            "old",
+            "new",
+        )
+    assert "[#453](https://github.com/org/repo/pull/453)" in out
+    assert "#453)" not in out.replace("[#453]", "")
+
+
 def test_update_pull_request_body() -> None:
     """PATCH the pull request description and return the updated JSON."""
     session = _session()


### PR DESCRIPTION
Rewrite bare #<num> PR references in changelog commit messages to full markdown links pointing to the source repository. Without this, github renders them as links to the
infra-deployments repo instead.

Assisted-by: Claude Code