### PR TITLE
feat(RELEASE-2460): add disk-image support to artifact helpers

### DIFF
--- a/scripts/python/helpers/compress_artifacts.py
+++ b/scripts/python/helpers/compress_artifacts.py
@@ -5,7 +5,8 @@ For each component:
 * Pulls signed macOS and Windows OCI artifacts from Quay into a ``signed/`` directory.
 * Restores supplementary files (readme, license, changelog) that were held during signing.
 * Compresses each file entry into the final deliverable format:
-  - macOS / Linux → ``.tar.gz`` (from ``os/arch/`` directory)
+  - macOS / Linux (non-disk-image) → ``.tar.gz`` (from ``os/arch/`` directory)
+  - Linux disk images (``.qcow2``, ``.iso``) → copied as-is to ``ready_for_distribution/``
   - Windows → ``.zip`` (from ``os/arch/`` directory, extension corrected from
     ``.tar.gz``/``.tar``)
 * Updates ``SNAPSHOT_JSON`` to reflect corrected Windows filenames in ``files[]``.
@@ -35,9 +36,11 @@ import tarfile
 import zipfile
 from pathlib import Path
 
+import disk_image_utils
 import oras_utils
 
 PROG = "compress_artifacts.py"
+
 
 QUAY_SECRET_MOUNT = Path(os.environ.get("QUAY_SECRET_MOUNT", "/mnt/quaySecret"))
 CONTENT_DIR = Path(os.environ.get("CONTENT_DIR", "/shared/artifacts"))
@@ -103,7 +106,12 @@ def _windows_filename(source_filename: str) -> str:
 
 
 def _compress_file_entry(
-    entry: dict, array_name: str, component_dir: Path, ready_dir: Path
+    entry: dict,
+    array_name: str,
+    component_dir: Path,
+    ready_dir: Path,
+    *,
+    is_disk_image_component: bool = False,
 ) -> str:
     """Compress one file entry into ready_dir and return the (possibly normalized) source path.
 
@@ -111,11 +119,12 @@ def _compress_file_entry(
     the archive is created as a ``.zip`` instead of ``.tar.gz``/``.tar``, and the returned
     source path reflects the corrected filename so the snapshot can be updated accordingly.
 
-    Raises RuntimeError on failure (missing source, unknown OS, or empty arch directory).
+    Files are copied directly to ``ready_dir`` (without archiving) when either:
+    - *is_disk_image_component* is True (set when contentType: disk-image), or
+    - the filename has an unambiguous disk-image suffix (.qcow2, .iso, .iso.gz,
+      .raw.gz, .vhd.gz).
 
-    Note: all files are currently compressed regardless of type. ISOs should be
-    passed through as-is rather than wrapped in a tarball — this will need to be
-    addressed before ISO delivery is supported.
+    Raises RuntimeError on failure (missing source, unknown OS, or empty arch directory).
     """
     source = entry.get("source")
     if not source:
@@ -139,12 +148,23 @@ def _compress_file_entry(
 
     # macOS and Linux follow the Unix convention of tar.gz archives; Windows uses zip
     # because that is the standard expected by Windows users and Developer Portal tooling.
+    # Disk images are an exception: they are delivered as-is without any archiving.
     if os_name in ("darwin", "linux"):
         out_path = ready_dir / source_filename
-        with tarfile.open(str(out_path), "w:gz") as tf:
-            for item in sorted(arch_dir.rglob("*")):
-                if item.is_file():
-                    tf.add(str(item), arcname=str(item.relative_to(arch_dir)))
+        if is_disk_image_component or disk_image_utils.is_disk_image_file(source_filename):
+            # Use the known filename directly — multiple disk images may share
+            # the same arch directory, so scanning the whole dir is incorrect.
+            src_file = arch_dir / source_filename
+            if not src_file.is_file():
+                raise RuntimeError(
+                    f"Disk image file '{source_filename}' not found in {arch_dir}"
+                )
+            shutil.copy2(str(src_file), str(out_path))
+        else:
+            with tarfile.open(str(out_path), "w:gz") as tf:
+                for item in sorted(arch_dir.rglob("*")):
+                    if item.is_file():
+                        tf.add(str(item), arcname=str(item.relative_to(arch_dir)))
         logger.info("  Created (%s): %s", array_name, source_filename)
         return source
 
@@ -174,13 +194,17 @@ def compress_component(component: dict, snapshot: dict) -> dict:
     files_entries = list(component.get("files") or [])
     staged_entries = list((component.get("staged") or {}).get("files") or [])
 
+    is_disk_image = disk_image_utils.is_disk_image_component(component)
+
     normalized_files = []
     if files_entries:
         logger.info(
             "  Processing %d files from files[] (Developer Portal):", len(files_entries)
         )
         for entry in files_entries:
-            normalized_source = _compress_file_entry(entry, "files", component_dir, ready_dir)
+            normalized_source = _compress_file_entry(
+                entry, "files", component_dir, ready_dir, is_disk_image_component=is_disk_image
+            )
             normalized_entry = dict(entry)
             # no-op for mac/linux, .zip correction for windows
             normalized_entry["source"] = normalized_source
@@ -191,7 +215,13 @@ def compress_component(component: dict, snapshot: dict) -> dict:
             "  Processing %d files from staged.files[] (Customer Portal):", len(staged_entries)
         )
         for entry in staged_entries:
-            _compress_file_entry(entry, "staged.files", component_dir, ready_dir)
+            _compress_file_entry(
+                entry,
+                "staged.files",
+                component_dir,
+                ready_dir,
+                is_disk_image_component=is_disk_image,
+            )
 
     updated_component = dict(component)
     if files_entries:

--- a/scripts/python/helpers/disk_image_utils.py
+++ b/scripts/python/helpers/disk_image_utils.py
@@ -1,0 +1,31 @@
+"""Shared helpers for identifying disk-image files and components."""
+
+from __future__ import annotations
+
+# Unambiguous disk-image file suffixes (simple and compound). Files matching
+# these are handled as raw binary blobs rather than tar archives, even when the
+# component does not carry contentType: disk-image.
+# NOTE: .tar.gz is intentionally excluded — it is ambiguous between binary
+# archives and disk images (e.g. GCP images packaged as tarballs). Use
+# contentType: disk-image on the component to handle those cases.
+DISK_IMAGE_SUFFIXES: frozenset[str] = frozenset(
+    {".qcow2", ".iso", ".iso.gz", ".raw.gz", ".vhd.gz"}
+)
+
+
+def is_disk_image_file(filename: str) -> bool:
+    """Return True if *filename* has an unambiguous disk-image file suffix."""
+    lower = filename.lower()
+    return any(lower.endswith(ext) for ext in DISK_IMAGE_SUFFIXES)
+
+
+def is_disk_image_component(component: dict) -> bool:
+    """Return True if *component* is declared as a disk-image release.
+
+    A component is a disk-image if contentType: disk-image appears at the
+    top-level component field OR nested under contentGateway.
+    """
+    return (
+        component.get("contentType") == "disk-image"
+        or (component.get("contentGateway") or {}).get("contentType") == "disk-image"
+    )

--- a/scripts/python/helpers/extract_artifacts.py
+++ b/scripts/python/helpers/extract_artifacts.py
@@ -34,6 +34,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import authentication
+import disk_image_utils
 
 PROG = "extract_artifacts.py"
 
@@ -121,6 +122,47 @@ def _safe_extract_layer(
     return found
 
 
+def _extract_from_oras(
+    manifest: dict,
+    tmp_dir: Path,
+    wanted_files: list[str],
+    destination: Path,
+    component_name: str,
+) -> None:
+    """Copy raw ORAS blob layers to destination, matching by filename.
+
+    ORAS artifacts store raw file blobs as layers with an
+    ``org.opencontainers.image.title`` annotation containing the filename.
+    We match each wanted file (by basename) to its blob and copy it directly.
+    """
+    title_to_blob: dict[str, Path] = {}
+    for layer in manifest.get("layers", []):
+        title = (layer.get("annotations") or {}).get("org.opencontainers.image.title")
+        digest = layer.get("digest", "")
+        if title and digest:
+            blob_path = tmp_dir / digest.removeprefix("sha256:")
+            title_to_blob[title] = blob_path
+
+    logger.info(
+        "ORAS artifact detected for '%s'; available blobs: %s",
+        component_name,
+        list(title_to_blob),
+    )
+
+    for wanted in wanted_files:
+        basename = Path(wanted).name
+        blob = title_to_blob.get(basename)
+        if blob is None or not blob.is_file():
+            available = sorted(title_to_blob)
+            raise RuntimeError(
+                f"ORAS layer with title '{basename}' not found in component "
+                f"'{component_name}'. Available titles: {available}"
+            )
+        out = destination / basename
+        shutil.copy2(str(blob), str(out))
+        logger.info("Copied ORAS blob '%s' -> %s", basename, out)
+
+
 def process_component(component: dict) -> None:
     """Pull and extract one component's artifacts into CONTENT_DIR/<name>/."""
     name = component.get("name")
@@ -174,32 +216,42 @@ def process_component(component: dict) -> None:
         logger.info("Files to extract from RPA: %s", wanted_files)
 
         manifest = json.loads((tmp_dir / "manifest.json").read_text())
-        layer_digests = [layer["digest"] for layer in manifest.get("layers", [])]
 
-        for digest in layer_digests:
-            layer_file = tmp_dir / digest.removeprefix("sha256:")
-            if not layer_file.exists():
-                continue
-            with tarfile.open(str(layer_file)) as tf:
-                for image_path in extract_dirs:
-                    if _safe_extract_layer(tf, image_path, tmp_dir, layer_file.name):
-                        logger.info("Extracting %s/ from %s...", image_path, layer_file.name)
-                    else:
-                        logger.info(
-                            "skipping %s. It doesn't contain the %s dir",
-                            layer_file.name,
-                            image_path,
-                        )
+        config_media_type = manifest.get("config", {}).get("mediaType", "")
+        if config_media_type == "application/vnd.oci.empty.v1+json":
+            # ORAS artifact: layers are raw file blobs, not tar archives.
+            # Each layer carries an org.opencontainers.image.title annotation
+            # that holds the original filename.  Copy blobs directly to destination.
+            _extract_from_oras(manifest, tmp_dir, wanted_files, destination, name)
+        else:
+            layer_digests = [layer["digest"] for layer in manifest.get("layers", [])]
 
-        for wanted in wanted_files:
-            src = tmp_dir / wanted
-            if src.is_file():
-                shutil.copy2(str(src), str(destination / src.name))
-            else:
-                logger.error("Expected file not found in container: %s", wanted)
-                raise RuntimeError(
-                    f"File '{wanted}' declared in RPA was not found in any container layer"
-                )
+            for digest in layer_digests:
+                layer_file = tmp_dir / digest.removeprefix("sha256:")
+                if not layer_file.exists():
+                    continue
+                with tarfile.open(str(layer_file)) as tf:
+                    for image_path in extract_dirs:
+                        if _safe_extract_layer(tf, image_path, tmp_dir, layer_file.name):
+                            logger.info(
+                                "Extracting %s/ from %s...", image_path, layer_file.name
+                            )
+                        else:
+                            logger.info(
+                                "skipping %s. It doesn't contain the %s dir",
+                                layer_file.name,
+                                image_path,
+                            )
+
+            for wanted in wanted_files:
+                src = tmp_dir / wanted
+                if src.is_file():
+                    shutil.copy2(str(src), str(destination / src.name))
+                else:
+                    logger.error("Expected file not found in container: %s", wanted)
+                    raise RuntimeError(
+                        f"File '{wanted}' declared in RPA was not found in any container layer"
+                    )
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
@@ -240,14 +292,41 @@ def _create_os_flag_files(snapshot: dict) -> None:
             logger.info("  - Linux content detected")
 
 
+def _validate_disk_image_components(components: list[dict]) -> None:
+    """Fail fast if any disk-image component has non-linux file entries.
+
+    Disk images must always target os: linux. Detecting this before pulling
+    images avoids wasting time on downloads only to fail deep in the pipeline.
+    """
+    for component in components:
+        if not disk_image_utils.is_disk_image_component(component):
+            continue
+        name = component.get("name", "<unknown>")
+        all_file_entries = list(component.get("files") or []) + list(
+            (component.get("staged") or {}).get("files") or []
+        )
+        for entry in all_file_entries:
+            entry_os = entry.get("os", "")
+            if entry_os in ("darwin", "windows"):
+                raise RuntimeError(
+                    f"Component '{name}' has contentType: disk-image but entry "
+                    f"'{entry.get('source', '<unknown>')}' has os: {entry_os}. "
+                    f"Disk images must be os: linux. Fix the RPA before releasing."
+                )
+
+
 def run(concurrent_limit: int) -> None:
     """Extract artifacts from all snapshot components and write OS flag files."""
     snapshot = json.loads(os.environ["SNAPSHOT_JSON"])
 
+    components = snapshot.get("components", [])
+
+    # Validate disk-image component constraints before doing any image pulls.
+    _validate_disk_image_components(components)
+
     _setup_docker_config()
     CONTENT_DIR.mkdir(parents=True, exist_ok=True)
 
-    components = snapshot.get("components", [])
     errors: list[str] = []
 
     with ThreadPoolExecutor(max_workers=concurrent_limit) as executor:

--- a/scripts/python/helpers/push_artifacts.py
+++ b/scripts/python/helpers/push_artifacts.py
@@ -46,6 +46,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+import disk_image_utils
 import publish_to_cgw_wrapper
 import pulp_push_wrapper
 import yaml  # type: ignore
@@ -365,6 +366,18 @@ def run(exodus_gw_env: str, cgw_hostname: str, cert_expiration_warn_days: int) -
             cg = component.get("contentGateway") or {}
             cg["contentDir"] = str(component_dir)
             component["contentGateway"] = cg
+            # Disk-image components that target both CDN and CGW describe their
+            # deliverables in staged.files[] (consumed by the CDN/Customer Portal
+            # flow) but also need those files listed in files[] for CGW registration.
+            # If files[] is already populated the team provided it directly (e.g. a
+            # CGW-only release), so we leave it untouched.
+            # NOTE: this intentionally mutates the component dict in-place. It is safe
+            # because the Pulp push and CDN exclusion logic for this component have already
+            # completed above, and the only remaining consumer is publish_to_cgw_wrapper
+            # called below via json.dumps(snapshot).
+            is_disk_image = disk_image_utils.is_disk_image_component(component)
+            if is_disk_image and not component.get("files"):
+                component["files"] = (component.get("staged") or {}).get("files", [])
 
     cgw_push = any(bool(c.get("contentGateway")) for c in snapshot.get("components", []))
     if cgw_push:

--- a/scripts/python/helpers/push_unsigned.py
+++ b/scripts/python/helpers/push_unsigned.py
@@ -30,6 +30,7 @@ import shutil
 import tarfile
 from pathlib import Path
 
+import disk_image_utils
 import oras_utils
 
 PROG = "push_unsigned.py"
@@ -39,6 +40,7 @@ CONTENT_DIR = Path(os.environ.get("CONTENT_DIR", "/shared/artifacts"))
 
 SUPPLEMENTARY_NAMES = {"readme", "license", "changelog"}
 SUPPLEMENTARY_EXTS = {".md", ".txt"}
+
 
 logger = logging.getLogger(__name__)
 
@@ -80,8 +82,21 @@ def move_supplementary_out(src_root: Path, hold_root: Path) -> None:
             logger.info("  Held supplementary file: %s", rel)
 
 
-def _unpack_file_entries(entries: list[dict], component_dir: Path, unsigned_dir: Path) -> None:
-    """Extract each archive from entries into its OS/arch subdirectory under unsigned_dir."""
+def _unpack_file_entries(
+    entries: list[dict],
+    component_dir: Path,
+    unsigned_dir: Path,
+    *,
+    is_disk_image_component: bool = False,
+) -> None:
+    """Extract each archive from entries into its OS/arch subdirectory under unsigned_dir.
+
+    Files are moved directly (without unpacking) when either:
+    - *is_disk_image_component* is True (set when contentType: disk-image), or
+    - the filename has an unambiguous disk-image suffix (.qcow2, .iso, .iso.gz,
+      .raw.gz, .vhd.gz).
+    All other files are treated as tar archives and extracted.
+    """
     for entry in entries:
         source = entry.get("source", "")
         os_name = entry.get("os", "")
@@ -103,9 +118,12 @@ def _unpack_file_entries(entries: list[dict], component_dir: Path, unsigned_dir:
             continue
 
         target_dir.mkdir(parents=True, exist_ok=True)
-        with tarfile.open(str(archive_path)) as tf:
-            _safe_extract_archive(tf, target_dir, archive_name)
-        archive_path.unlink()
+        if is_disk_image_component or disk_image_utils.is_disk_image_file(archive_name):
+            shutil.move(str(archive_path), str(target_dir / archive_name))
+        else:
+            with tarfile.open(str(archive_path)) as tf:
+                _safe_extract_archive(tf, target_dir, archive_name)
+            archive_path.unlink()
 
 
 def _safe_extract_archive(tf: tarfile.TarFile, target_dir: Path, archive_name: str) -> None:
@@ -157,9 +175,18 @@ def run(quay_url: str, pipeline_run_uid: str) -> None:
         if has_linux:
             (component_dir / "linux").mkdir(parents=True, exist_ok=True)
 
-        _unpack_file_entries(component.get("files") or [], component_dir, unsigned_dir)
+        is_disk_image = disk_image_utils.is_disk_image_component(component)
         _unpack_file_entries(
-            (component.get("staged") or {}).get("files") or [], component_dir, unsigned_dir
+            component.get("files") or [],
+            component_dir,
+            unsigned_dir,
+            is_disk_image_component=is_disk_image,
+        )
+        _unpack_file_entries(
+            (component.get("staged") or {}).get("files") or [],
+            component_dir,
+            unsigned_dir,
+            is_disk_image_component=is_disk_image,
         )
 
         supp_hold = component_dir / "supplementary"

--- a/scripts/python/helpers/test_compress_artifacts.py
+++ b/scripts/python/helpers/test_compress_artifacts.py
@@ -148,6 +148,145 @@ def test_compress_file_entry_windows(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert result is not None and result.endswith(".zip")
 
 
+def test_compress_file_entry_qcow2_passthrough(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A qcow2 disk image is copied directly to ready_for_distribution without archiving."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    linux_arch_dir = comp_dir / "linux" / "x86_64"
+    linux_arch_dir.mkdir(parents=True)
+    (linux_arch_dir / "rhel-10.0-x86_64-kvm.qcow2").write_bytes(b"qcow2 content")
+
+    result = compress_artifacts._compress_file_entry(
+        {
+            "source": "/releases/rhel-10.0-x86_64-kvm.qcow2",
+            "os": "linux",
+            "arch": "x86_64",
+        },
+        "files",
+        comp_dir,
+        ready_dir,
+    )
+    out = ready_dir / "rhel-10.0-x86_64-kvm.qcow2"
+    assert out.exists()
+    assert out.read_bytes() == b"qcow2 content"
+    assert not tarfile.is_tarfile(str(out))
+    assert result == "/releases/rhel-10.0-x86_64-kvm.qcow2"
+
+
+def test_compress_file_entry_iso_passthrough(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An iso disk image is copied directly to ready_for_distribution without archiving."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    linux_arch_dir = comp_dir / "linux" / "x86_64"
+    linux_arch_dir.mkdir(parents=True)
+    (linux_arch_dir / "rhel-10.0-x86_64-boot.iso").write_bytes(b"iso content")
+
+    result = compress_artifacts._compress_file_entry(
+        {
+            "source": "/releases/rhel-10.0-x86_64-boot.iso",
+            "os": "linux",
+            "arch": "x86_64",
+        },
+        "files",
+        comp_dir,
+        ready_dir,
+    )
+    out = ready_dir / "rhel-10.0-x86_64-boot.iso"
+    assert out.exists()
+    assert out.read_bytes() == b"iso content"
+    assert result == "/releases/rhel-10.0-x86_64-boot.iso"
+
+
+def test_compress_file_entry_disk_image_multiple_files_in_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two disk images sharing the same arch dir are each copied correctly by name."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    linux_arch_dir = comp_dir / "linux" / "x86_64"
+    linux_arch_dir.mkdir(parents=True)
+    (linux_arch_dir / "rhel-10.0-x86_64-kvm.qcow2").write_bytes(b"kvm-content")
+    (linux_arch_dir / "rhel-10.0-x86_64-boot.iso.gz").write_bytes(b"iso-content")
+
+    for source in (
+        "/releases/rhel-10.0-x86_64-kvm.qcow2",
+        "/releases/rhel-10.0-x86_64-boot.iso.gz",
+    ):
+        compress_artifacts._compress_file_entry(
+            {"source": source, "os": "linux", "arch": "x86_64"},
+            "files",
+            comp_dir,
+            ready_dir,
+        )
+
+    assert (ready_dir / "rhel-10.0-x86_64-kvm.qcow2").read_bytes() == b"kvm-content"
+    assert (ready_dir / "rhel-10.0-x86_64-boot.iso.gz").read_bytes() == b"iso-content"
+
+
+def test_compress_file_entry_iso_gz_passthrough(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A .iso.gz disk image is copied directly to ready_for_distribution via extension."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    linux_arch_dir = comp_dir / "linux" / "x86_64"
+    linux_arch_dir.mkdir(parents=True)
+    (linux_arch_dir / "rhel-ai-3.3-x86_64.iso.gz").write_bytes(b"iso.gz content")
+
+    result = compress_artifacts._compress_file_entry(
+        {"source": "/releases/rhel-ai-3.3-x86_64.iso.gz", "os": "linux", "arch": "x86_64"},
+        "files",
+        comp_dir,
+        ready_dir,
+    )
+    out = ready_dir / "rhel-ai-3.3-x86_64.iso.gz"
+    assert out.exists()
+    assert out.read_bytes() == b"iso.gz content"
+    assert result == "/releases/rhel-ai-3.3-x86_64.iso.gz"
+
+
+def test_compress_file_entry_tar_gz_passthrough_via_content_type(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A .tar.gz GCP disk image is copied as-is when is_disk_image_component=True."""
+    monkeypatch.setattr(compress_artifacts, "CONTENT_DIR", tmp_path)
+    comp_dir = tmp_path / "prod"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    linux_arch_dir = comp_dir / "linux" / "x86_64"
+    linux_arch_dir.mkdir(parents=True)
+    (linux_arch_dir / "image.tar.gz").write_bytes(b"gcp disk image content")
+
+    result = compress_artifacts._compress_file_entry(
+        {"source": "/releases/image.tar.gz", "os": "linux", "arch": "x86_64"},
+        "files",
+        comp_dir,
+        ready_dir,
+        is_disk_image_component=True,
+    )
+    out = ready_dir / "image.tar.gz"
+    assert out.exists()
+    assert out.read_bytes() == b"gcp disk image content"
+    assert result == "/releases/image.tar.gz"
+
+
 def test_compress_file_entry_missing_arch_dir_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/scripts/python/helpers/test_disk_image_utils.py
+++ b/scripts/python/helpers/test_disk_image_utils.py
@@ -1,0 +1,116 @@
+"""Tests for disk_image_utils."""
+
+from __future__ import annotations
+
+import pytest
+
+import disk_image_utils
+
+# ---------------------------------------------------------------------------
+# is_disk_image_file
+# ---------------------------------------------------------------------------
+
+
+def test_is_disk_image_file_qcow2() -> None:
+    """A .qcow2 file is recognised as a disk image."""
+    assert disk_image_utils.is_disk_image_file("disk.qcow2") is True
+
+
+def test_is_disk_image_file_iso() -> None:
+    """A .iso file is recognised as a disk image."""
+    assert disk_image_utils.is_disk_image_file("install.iso") is True
+
+
+def test_is_disk_image_file_iso_gz() -> None:
+    """A .iso.gz file is recognised as a disk image."""
+    assert disk_image_utils.is_disk_image_file("install.iso.gz") is True
+
+
+def test_is_disk_image_file_raw_gz() -> None:
+    """A .raw.gz file is recognised as a disk image."""
+    assert disk_image_utils.is_disk_image_file("disk.raw.gz") is True
+
+
+def test_is_disk_image_file_vhd_gz() -> None:
+    """A .vhd.gz file is recognised as a disk image."""
+    assert disk_image_utils.is_disk_image_file("disk.vhd.gz") is True
+
+
+def test_is_disk_image_file_case_insensitive() -> None:
+    """Extension matching is case-insensitive."""
+    assert disk_image_utils.is_disk_image_file("disk.QCOW2") is True
+    assert disk_image_utils.is_disk_image_file("install.ISO") is True
+
+
+def test_is_disk_image_file_tar_gz_is_false() -> None:
+    """A .tar.gz file is not a disk image (ambiguous with binary archives)."""
+    assert disk_image_utils.is_disk_image_file("binary.tar.gz") is False
+
+
+def test_is_disk_image_file_zip_is_false() -> None:
+    """A .zip file is not a disk image."""
+    assert disk_image_utils.is_disk_image_file("binary.zip") is False
+
+
+def test_is_disk_image_file_generic_binary_is_false() -> None:
+    """A generic binary with no extension is not a disk image."""
+    assert disk_image_utils.is_disk_image_file("my-tool-linux-amd64") is False
+
+
+def test_is_disk_image_file_with_path() -> None:
+    """A full path ending in a disk-image suffix is recognised correctly."""
+    assert disk_image_utils.is_disk_image_file("/releases/product-x86_64.iso") is True
+
+
+# ---------------------------------------------------------------------------
+# is_disk_image_component
+# ---------------------------------------------------------------------------
+
+
+def test_is_disk_image_component_top_level_content_type() -> None:
+    """A component with top-level contentType: disk-image is identified correctly."""
+    component = {"contentType": "disk-image", "name": "my-image"}
+    assert disk_image_utils.is_disk_image_component(component) is True
+
+
+def test_is_disk_image_component_content_gateway_content_type() -> None:
+    """A component with contentGateway.contentType: disk-image is identified correctly."""
+    component = {"contentGateway": {"contentType": "disk-image"}, "name": "my-image"}
+    assert disk_image_utils.is_disk_image_component(component) is True
+
+
+def test_is_disk_image_component_binary_is_false() -> None:
+    """A binary component is not a disk image."""
+    component = {"contentType": "binary", "name": "my-binary"}
+    assert disk_image_utils.is_disk_image_component(component) is False
+
+
+def test_is_disk_image_component_image_is_false() -> None:
+    """A container-image component is not a disk image."""
+    component = {"contentType": "image", "name": "my-image"}
+    assert disk_image_utils.is_disk_image_component(component) is False
+
+
+def test_is_disk_image_component_no_content_type_is_false() -> None:
+    """A component with no contentType field is not a disk image."""
+    component = {"name": "my-component"}
+    assert disk_image_utils.is_disk_image_component(component) is False
+
+
+def test_is_disk_image_component_empty_content_gateway_is_false() -> None:
+    """A component with an empty contentGateway dict is not a disk image."""
+    component = {"contentGateway": {}, "name": "my-component"}
+    assert disk_image_utils.is_disk_image_component(component) is False
+
+
+def test_is_disk_image_component_none_content_gateway_is_false() -> None:
+    """A component with contentGateway: null is not a disk image."""
+    component = {"contentGateway": None, "name": "my-component"}
+    assert disk_image_utils.is_disk_image_component(component) is False
+
+
+@pytest.mark.parametrize("content_type", ["image", "binary", "generic", "rpm", ""])
+def test_is_disk_image_component_non_disk_image_content_types(content_type: str) -> None:
+    """Non-disk-image contentType values return False."""
+    component = {"contentType": content_type}
+    assert disk_image_utils.is_disk_image_component(component) is False

--- a/scripts/python/helpers/test_extract_artifacts.py
+++ b/scripts/python/helpers/test_extract_artifacts.py
@@ -229,6 +229,23 @@ def test_create_os_flag_files_skips_missing_component_dir(
     extract_artifacts._create_os_flag_files(snapshot)  # should not raise
 
 
+def test_validate_disk_image_components_non_linux_raises() -> None:
+    """A disk-image component with a non-linux OS entry raises RuntimeError."""
+    components = [
+        {
+            "name": "diskimg",
+            "contentGateway": {"contentType": "disk-image"},
+            "files": [
+                {"source": "/releases/disk.qcow2", "os": "darwin", "arch": "amd64"},
+            ],
+        }
+    ]
+    with pytest.raises(RuntimeError) as exc_info:
+        extract_artifacts._validate_disk_image_components(components)
+    assert "disk-image" in str(exc_info.value)
+    assert "darwin" in str(exc_info.value)
+
+
 # ---------------------------------------------------------------------------
 # process_component
 # ---------------------------------------------------------------------------
@@ -372,6 +389,67 @@ def test_process_component_raises_when_file_missing_from_container(
                 extract_artifacts.process_component(component)
     finally:
         shutil.rmtree(str(tmp_layer_dir), ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# _extract_from_oras
+# ---------------------------------------------------------------------------
+
+
+def test_extract_from_oras_copies_blobs(tmp_path: Path) -> None:
+    """Blobs matching wanted filenames are copied directly to destination."""
+    blob1 = tmp_path / "aabbcc"
+    blob1.write_bytes(b"qcow2-content")
+    blob2 = tmp_path / "ddeeff"
+    blob2.write_bytes(b"iso-content")
+
+    manifest = {
+        "layers": [
+            {
+                "digest": "sha256:aabbcc",
+                "annotations": {"org.opencontainers.image.title": "disk.qcow2"},
+            },
+            {
+                "digest": "sha256:ddeeff",
+                "annotations": {"org.opencontainers.image.title": "install.iso.gz"},
+            },
+        ]
+    }
+
+    dest = tmp_path / "out"
+    dest.mkdir()
+    extract_artifacts._extract_from_oras(
+        manifest,
+        tmp_path,
+        ["releases/disk.qcow2", "releases/install.iso.gz"],
+        dest,
+        "mycomp",
+    )
+
+    assert (dest / "disk.qcow2").read_bytes() == b"qcow2-content"
+    assert (dest / "install.iso.gz").read_bytes() == b"iso-content"
+
+
+def test_extract_from_oras_raises_when_title_missing(tmp_path: Path) -> None:
+    """RuntimeError is raised when a wanted file has no matching ORAS blob."""
+    manifest = {
+        "layers": [
+            {
+                "digest": "sha256:aabbcc",
+                "annotations": {"org.opencontainers.image.title": "disk.qcow2"},
+            },
+        ]
+    }
+
+    blob = tmp_path / "aabbcc"
+    blob.write_bytes(b"data")
+    dest = tmp_path / "out"
+    dest.mkdir()
+
+    with pytest.raises(RuntimeError, match="install.iso.gz"):
+        extract_artifacts._extract_from_oras(
+            manifest, tmp_path, ["releases/install.iso.gz"], dest, "mycomp"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/python/helpers/test_push_artifacts.py
+++ b/scripts/python/helpers/test_push_artifacts.py
@@ -71,6 +71,38 @@ SNAPSHOT_BOTH = {
     ]
 }
 
+SNAPSHOT_DISK_IMAGE = {
+    "components": [
+        {
+            "name": "diskimage-product",
+            "staged": {
+                "destination": "diskimage-amd64",
+                "version": "1.0",
+                "files": [
+                    {
+                        "source": "/releases/install.iso.gz",
+                        "filename": "product-1.0-x86_64-boot.iso.gz",
+                        "os": "linux",
+                        "arch": "amd64",
+                    },
+                    {
+                        "source": "/releases/disk.qcow2",
+                        "filename": "product-1.0-x86_64-kvm.qcow2",
+                        "os": "linux",
+                        "arch": "amd64",
+                    },
+                ],
+            },
+            "contentGateway": {
+                "contentType": "disk-image",
+                "productCode": "DiskProduct",
+                "productName": "Disk Product",
+                "productVersionName": "1.0",
+            },
+        }
+    ]
+}
+
 
 def _setup_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     for secret, files in {
@@ -483,6 +515,54 @@ def test_run_preprod_sets_squid_proxy(tmp_path: Path, monkeypatch: pytest.Monkey
         push_artifacts.run("pre", "https://developers.qa.redhat.com", 7)
 
     assert "squid" in env_captured.get("HTTP_PROXY", "")
+
+
+def test_run_disk_image_injects_staged_files_into_cgw(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run() injects staged.files into files[] for disk-image components before calling CGW."""
+    monkeypatch.setattr(push_artifacts, "CONTENT_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(push_artifacts, "SHARED_DIR", tmp_path / "shared")
+    (tmp_path / "shared").mkdir()
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps(SNAPSHOT_DISK_IMAGE))
+    _setup_secrets(tmp_path, monkeypatch)
+    _setup_published_files_env(tmp_path, monkeypatch)
+
+    comp_dir = tmp_path / "artifacts" / "diskimage-product" / "ready_for_distribution"
+    comp_dir.mkdir(parents=True)
+    (comp_dir / "install.iso.gz").write_bytes(b"fakeisodata")
+    (comp_dir / "disk.qcow2").write_bytes(b"fakeqcowdata")
+
+    captured_snapshot: list[dict] = []
+
+    def fake_cgw_main(argv):
+        for arg in argv:
+            try:
+                data = json.loads(arg)
+                captured_snapshot.append(data)
+            except (ValueError, TypeError):
+                pass
+
+    def fake_check_cert(_path, _days):
+        pass
+
+    with (
+        mock.patch.object(
+            push_artifacts, "_check_cert_expiration", side_effect=fake_check_cert
+        ),
+        mock.patch("pulp_push_wrapper.main"),
+        mock.patch("subprocess.check_call"),
+        mock.patch("publish_to_cgw_wrapper.main", side_effect=fake_cgw_main),
+    ):
+        push_artifacts.run("pre", "https://cgw.example.com", 7)
+
+    assert captured_snapshot, "publish_to_cgw_wrapper.main was not called"
+    cgw_components = captured_snapshot[0].get("components", [])
+    disk_comp = next(c for c in cgw_components if c["name"] == "diskimage-product")
+    assert disk_comp.get("files"), "staged.files were not injected into files[] for disk-image"
+    file_sources = [f["source"] for f in disk_comp["files"]]
+    assert "/releases/install.iso.gz" in file_sources
+    assert "/releases/disk.qcow2" in file_sources
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/python/helpers/test_push_unsigned.py
+++ b/scripts/python/helpers/test_push_unsigned.py
@@ -283,6 +283,79 @@ def test_unpack_file_entries_skips_missing_fields(tmp_path: Path) -> None:
     # no crash
 
 
+def test_unpack_file_entries_qcow2_passthrough(tmp_path: Path) -> None:
+    """A qcow2 disk image is moved directly to the OS/arch dir without tar extraction."""
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    disk_image = comp_dir / "rhel-10.0-x86_64-kvm.qcow2"
+    disk_image.write_bytes(b"qcow2 raw content")
+
+    push_unsigned._unpack_file_entries(
+        [{"source": "/releases/rhel-10.0-x86_64-kvm.qcow2", "os": "linux", "arch": "x86_64"}],
+        comp_dir,
+        comp_dir / "unsigned",
+    )
+    dest = comp_dir / "linux" / "x86_64" / "rhel-10.0-x86_64-kvm.qcow2"
+    assert dest.exists()
+    assert dest.read_bytes() == b"qcow2 raw content"
+    assert not disk_image.exists()
+
+
+def test_unpack_file_entries_iso_passthrough(tmp_path: Path) -> None:
+    """An iso disk image is moved directly to the OS/arch dir without tar extraction."""
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    disk_image = comp_dir / "rhel-10.0-x86_64-boot.iso"
+    disk_image.write_bytes(b"iso raw content")
+
+    push_unsigned._unpack_file_entries(
+        [{"source": "/releases/rhel-10.0-x86_64-boot.iso", "os": "linux", "arch": "x86_64"}],
+        comp_dir,
+        comp_dir / "unsigned",
+    )
+    dest = comp_dir / "linux" / "x86_64" / "rhel-10.0-x86_64-boot.iso"
+    assert dest.exists()
+    assert dest.read_bytes() == b"iso raw content"
+    assert not disk_image.exists()
+
+
+def test_unpack_file_entries_iso_gz_passthrough(tmp_path: Path) -> None:
+    """A .iso.gz disk image is moved directly via extension without tar extraction."""
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    disk_image = comp_dir / "install.iso.gz"
+    disk_image.write_bytes(b"iso.gz content")
+
+    push_unsigned._unpack_file_entries(
+        [{"source": "/releases/install.iso.gz", "os": "linux", "arch": "x86_64"}],
+        comp_dir,
+        comp_dir / "unsigned",
+    )
+    dest = comp_dir / "linux" / "x86_64" / "install.iso.gz"
+    assert dest.exists()
+    assert dest.read_bytes() == b"iso.gz content"
+    assert not disk_image.exists()
+
+
+def test_unpack_file_entries_tar_gz_passthrough_via_content_type(tmp_path: Path) -> None:
+    """A .tar.gz GCP disk image is moved directly when is_disk_image_component=True."""
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    disk_image = comp_dir / "image.tar.gz"
+    disk_image.write_bytes(b"gcp disk image content")
+
+    push_unsigned._unpack_file_entries(
+        [{"source": "/releases/image.tar.gz", "os": "linux", "arch": "x86_64"}],
+        comp_dir,
+        comp_dir / "unsigned",
+        is_disk_image_component=True,
+    )
+    dest = comp_dir / "linux" / "x86_64" / "image.tar.gz"
+    assert dest.exists()
+    assert dest.read_bytes() == b"gcp disk image content"
+    assert not disk_image.exists()
+
+
 def test_unpack_file_entries_rejects_path_traversal(tmp_path: Path) -> None:
     """RuntimeError is raised when a tar entry contains an unsafe path traversal sequence."""
     comp_dir = tmp_path / "prod"


### PR DESCRIPTION
    - coincides with https://github.com/konflux-ci/release-service-catalog/pull/2334
    - compress_artifacts: copy disk images as-is; fix multi-file
      per-arch scenario (e.g. ISO + QCOW2 sharing one os+arch)
    - push_unsigned: pass disk images through without unpacking,
      handling both files[] and staged.files[] sources
    - push_artifacts: inject staged.files[] into files[] for CGW
      when disk-image component has no files[] entries
    - extract_artifacts: fail early when disk-image component
      declares a non-linux OS entry, preventing signing failures
    - all helpers: detect disk-image via contentType at both
      component level and contentGateway.contentType

Assisted-by: Cursor AI