### PR TITLE
feat(RELEASE-2471): add check-data-keys.py script

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -58,3 +58,31 @@ jobs:
       - uses: konflux-ci/renovate-config-validator-action@main
         with:
           config_file: .github/renovate.json
+  check-jsonschema:
+    name: Validate json schema file
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - name: Setup python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.12'
+      - run: pip install check-jsonschema
+      - name: Run json meta schema check
+        run: check-jsonschema --check-metaschema schemas/dataKeys.json
+  lint-jsonschema:
+    name: Lint json schema file
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - name: Run json schema lint
+        run: |
+          FILE="schemas/dataKeys.json"
+          if ! diff -u "$FILE" <(jq . "$FILE"); then
+            echo "Linting issue in $FILE"
+            echo "To fix: jq . $FILE | sponge $FILE"
+            exit 1
+          fi
+          echo "$FILE is formatted correctly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,6 +132,7 @@ COPY pubtools-pulp-wrapper /home/pubtools-pulp-wrapper
 COPY pubtools-marketplacesvm-wrapper /home/pubtools-marketplacesvm-wrapper
 COPY developer-portal-wrapper /home/developer-portal-wrapper
 COPY publish-to-cgw-wrapper /home/publish-to-cgw-wrapper
+COPY schemas /home/schemas
 
 # It is mandatory to set these labels
 LABEL name="Konflux Release Service Utils"

--- a/schemas/dataKeys.json
+++ b/schemas/dataKeys.json
@@ -1,0 +1,2185 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "enforceContainerFirstSecurityLabels": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, name and cpe label values will be enforced"
+    },
+    "systems": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "systemName": {
+            "type": "string",
+            "description": "The name of the system",
+            "enum": [
+              "releaseNotes",
+              "cdn",
+              "fbc",
+              "sign",
+              "mrrc",
+              "nrrc",
+              "cgw",
+              "jira",
+              "infra",
+              "github",
+              "contentGateway",
+              "pyxis",
+              "mapping",
+              "ootsign",
+              "conforma",
+              "intention",
+              "atlas",
+              "pulp",
+              "cloudMarketplaces"
+            ]
+          },
+          "dynamic": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, system is optional unless one of its fields are present in the data"
+          }
+        },
+        "required": [
+          "systemName"
+        ]
+      }
+    },
+    "requestType": {
+      "type": "string",
+      "description": "The request type to be used when requesting internal workloads",
+      "enum": [
+        "internal-request",
+        "internal-pipelinerun"
+      ]
+    },
+    "fbc": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "type": "string",
+          "description": "The internal pipeline name to handle requests e.g. iib"
+        },
+        "publishingCredentials": {
+          "type": "string",
+          "description": "The credentials used to publish the image e.g. example-fbc-publishing-credentials"
+        },
+        "buildTags": {
+          "type": "array",
+          "description": "The tags to be added to the build e.g. [ 'example-tag-1', 'example-tag-2' ]",
+          "items": {
+            "type": "string"
+          }
+        },
+        "addArches": {
+          "type": "array",
+          "description": "The arches to be added to the build e.g. [ 'x86_64', 'amd64' ]",
+          "items": {
+            "type": "string"
+          }
+        },
+        "hotfix": {
+          "type": "boolean",
+          "description": "Indicates if the build is a hotfix"
+        },
+        "preGA": {
+          "type": "boolean",
+          "description": "Indicates if the build is a preGA"
+        },
+        "stagedIndex": {
+          "type": "boolean",
+          "description": "Indicates if the build is a staged index"
+        },
+        "productName": {
+          "type": "string",
+          "description": "The product name e.g. exampleproduct"
+        },
+        "productVersion": {
+          "type": "string",
+          "description": "The product version e.g v1.0.0"
+        },
+        "buildTimeoutSeconds": {
+          "type": "integer",
+          "description": "The build timeout in seconds e.g. 1500"
+        },
+        "requestTimeoutSeconds": {
+          "type": "integer",
+          "description": "The requested timeout in seconds e.g. 1500"
+        },
+        "timestampFormat": {
+          "type": "string",
+          "description": "The timestamp format which defaults to %s e.g. %Y-%m-%d"
+        },
+        "issueId": {
+          "type": "string",
+          "description": "The issue ID e.g. bz123456"
+        },
+        "allowedPackages": {
+          "type": "array",
+          "description": "The allowed packages e.g. ['example-package-1', 'example-package-2'] ",
+          "items": {
+            "type": "string"
+          }
+        },
+        "fromIndex": {
+          "type": "string",
+          "description": "The source index image e.g. registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.09"
+        },
+        "targetIndex": {
+          "type": "string",
+          "description": "The target index image e.g. quay.io/redhat/redhat----preview-operator-index:v4.10"
+        },
+        "configMapName": {
+          "type": "string",
+          "description": "The configmap that exists on the cluster"
+        },
+        "pipelineImage": {
+          "type": "string",
+          "description": "An image with CLI tools needed for the signing by the internal signing pipelines"
+        },
+        "internalRequestServiceAccount": {
+          "type": "string",
+          "description": "The service account used to run the internal request"
+        }
+      }
+    },
+    "releaseNotes": {
+      "type": "object",
+      "properties": {
+        "product_id": {
+          "type": "array",
+          "minItems": 1,
+          "description": "The list of product IDs e.g [321]",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "product_name": {
+          "type": "string",
+          "description": "The product name e.g. exampleproduct"
+        },
+        "product_version": {
+          "type": "string",
+          "description": "The product version e.g v1.0.0"
+        },
+        "product_stream": {
+          "type": "string",
+          "description": "The product stream e.g. RHEL-tp1"
+        },
+        "cpe": {
+          "type": "string",
+          "description": "The product CPE ID e.g. cpe:/a:example:openstack:el8"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "RHEA",
+            "RHBA",
+            "RHSA"
+          ],
+          "description": "Type advisory type e.g. RHSA"
+        },
+        "synopsis": {
+          "type": "string",
+          "description": "The advisory synopsis e.g. my advisory synopsis"
+        },
+        "topic": {
+          "type": "string",
+          "description": "The advisory topic e.g. my advisory topic"
+        },
+        "description": {
+          "type": "string",
+          "description": "The advisory description e.g. This advisory is for security fixes to my product"
+        },
+        "solution": {
+          "type": "string",
+          "description": "The advisory solution e.g. For details on how to apply this update, see docs.com"
+        },
+        "references": {
+          "type": "array",
+          "description": "The advisory references e.g. [ 'https://access.redhat.com/security/updates/classification', 'https://docs.redhat.com/some/example/release-notes' ] ",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cves": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "The key of the CVE (e.g. CVE-2025-1234); must not be a URL",
+                "pattern": "^CVE-[0-9]{4}-[0-9]{4,}$"
+              },
+              "component": {
+                "type": "string",
+                "description": "The name of the component"
+              },
+              "packages": {
+                "type": "array",
+                "description": "A list of packages that fixed the CVE e.g. [ 'pkg:golang/golang.org/x/net/http2@1.11.1' ]",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "issues": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "fixed": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "The ID of the fixed issue e.g. RHOSP-3414"
+                  },
+                  "source": {
+                    "type": "string",
+                    "description": "The URL where the issue is tracked e.g. bugzilla.example.com"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "content": {
+          "type": "object",
+          "properties": {
+            "images": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "containerImage": {
+                    "type": "string",
+                    "description": "The container image e.g. quay.io/example/openstack@sha256:example"
+                  },
+                  "repository": {
+                    "type": "string",
+                    "description": "The repository e.g. registry.redhat.io/rhosp16-rhel8/openstack"
+                  },
+                  "tags": {
+                    "type": "array",
+                    "description": "A list of tags e.g. [ 'latest', 'v1' ]",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "The component of the image e.g. adv-comp-1"
+                  },
+                  "architecture": {
+                    "type": "string",
+                    "description": "The architecture of the image e.g. amd64"
+                  },
+                  "signingKey": {
+                    "type": "string",
+                    "description": "The key used to sign the image"
+                  },
+                  "purl": {
+                    "type": "string",
+                    "description": "The package URL representing the image e.g. pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8"
+                  }
+                }
+              }
+            },
+            "artifacts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "component": {
+                    "type": "string",
+                    "description": "The component of the artifact e.g. adv-comp-1"
+                  },
+                  "architecture": {
+                    "type": "string",
+                    "description": "The architecture of the artifact e.g. amd64"
+                  },
+                  "os": {
+                    "type": "string",
+                    "description": "The operating system of the artifact e.g. linux"
+                  },
+                  "purl": {
+                    "type": "string",
+                    "description": "The package URL representing the artifact"
+                  },
+                  "sbom": {
+                    "type": "string",
+                    "description": "URL to the SBOM file for source RPM artifacts"
+                  },
+                  "attestation": {
+                    "type": "string",
+                    "description": "URL to the attestation file for source RPM artifacts"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "live_id": {
+          "type": "integer",
+          "description": "Custom advisory live id e.g. 1234"
+        },
+        "allow_custom_live_id": {
+          "type": "boolean",
+          "description": "Whether to allow custom live id or not e.g. true"
+        },
+        "skip_customer_notifications": {
+          "type": "boolean",
+          "description": "Whether to skip customer notifications or not e.g. true"
+        }
+      }
+    },
+    "sign": {
+      "type": "object",
+      "properties": {
+        "cosignSecretName": {
+          "type": "string",
+          "description": "Name of secret which contains AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and SIGN_KEY"
+        },
+        "request": {
+          "type": "string",
+          "description": "The signing pipeline name to handle the request"
+        },
+        "configMapName": {
+          "type": "string",
+          "description": "The configmap that exists on the cluster for signing of the images e.g. hacbs-signing-pipeline-config-redhatbeta2"
+        },
+        "pipelineImage": {
+          "type": "string",
+          "description": "An image with CLI tools needed for the signing by the internal signing pipelines"
+        }
+      }
+    },
+    "cgw": {
+      "type": "object",
+      "properties": {
+        "cgwSecret": {
+          "type": "string",
+          "description": "The secret used to authenticate content-gateway via the username/token"
+        }
+      }
+    },
+    "jira": {
+      "type": "object",
+      "properties": {
+        "jiraAdvisorySecret": {
+          "type": "string",
+          "description": "The secret used to authenticate JIRA via the JIRA token"
+        }
+      }
+    },
+    "infra": {
+      "type": "object",
+      "properties": {
+        "prCreatorSecret": {
+          "type": "string",
+          "description": "The secret used to authenticate infra-deployments repo to create PR via private key"
+        }
+      }
+    },
+    "github": {
+      "type": "object",
+      "properties": {
+        "githubSecret": {
+          "type": "string",
+          "description": "The secret used to authenticate GitHub via the GitHub token"
+        }
+      }
+    },
+    "conforma": {
+      "type": "object",
+      "properties": {
+        "workerCount": {
+          "type": "integer",
+          "description": "The value to use as the WORKERS parameter in the verify-conforma task"
+        }
+      }
+    },
+    "pyxis": {
+      "type": "object",
+      "properties": {
+        "secret": {
+          "type": "string",
+          "description": "The secret used to authenticate Pyxis e.g. example-collect-pyxis-params-cert"
+        },
+        "server": {
+          "type": "string",
+          "description": "The Pyxis server being used e.g. production-internal",
+          "enum": [
+            "stage",
+            "production",
+            "production-internal",
+            "stage-internal"
+          ]
+        },
+        "skipRepoPublishing": {
+          "type": "boolean",
+          "description": "Skip setting the pyxis repo to published"
+        },
+        "includeLayers": {
+          "type": "boolean",
+          "description": "When creating ContainerImage in Pyxis, include details about layers"
+        }
+      }
+    },
+    "pulp": {
+      "type": "object",
+      "properties": {
+        "domain": {
+          "type": "string",
+          "description": "The Pulp domain to use for publishing RPMs"
+        },
+        "secretName": {
+          "type": "string",
+          "description": "The secret containing Pulp credentials"
+        },
+        "taskTimeout": {
+          "type": "string",
+          "description": "Timeout in seconds for the push-rpms-to-pulp task e.g. 7200"
+        }
+      }
+    },
+    "signOptions": {
+      "type": "object",
+      "properties": {
+        "unsignedRpmsDomain": {
+          "type": "string",
+          "description": "The Pulp domain containing unsigned RPMs"
+        },
+        "signedRpmsDomain": {
+          "type": "string",
+          "description": "The Pulp domain containing signed RPMs"
+        },
+        "skipUploadToPulp": {
+          "type": "boolean",
+          "description": "Skip uploading signed RPMs back to Pulp after signing"
+        }
+      }
+    },
+    "atlas": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "server": {
+          "type": "string",
+          "description": "The release Atlas server to push SBOMs to",
+          "enum": [
+            "stage",
+            "production"
+          ]
+        },
+        "atlas-sso-secret-name": {
+          "type": "string",
+          "description": "The secret used to authenticate to Atlas via SSO"
+        },
+        "atlas-retry-aws-secret-name": {
+          "type": "string",
+          "description": "The secret used to authenticate to the Atlas retry AWS S3 bucket"
+        }
+      }
+    },
+    "slack": {
+      "type": "object",
+      "properties": {
+        "slack-notification-secret": {
+          "type": "string",
+          "description": "The secret key for slack notifications e.g. example-team-slack-webhook-notification-secret"
+        },
+        "slack-webhook-notification-secret-keyname": {
+          "type": "string",
+          "description": "The key name for the slack webhook notification secret e.g. release"
+        }
+      }
+    },
+    "infra-deployment-update-script": {
+      "type": "string",
+      "description": "A script that can alter files in the infra-deployment repo before a PR is created"
+    },
+    "intention": {
+      "type": "string",
+      "enum": [
+        "production",
+        "staging"
+      ],
+      "description": "The intention of the release, e.g. production or staging."
+    },
+    "singleComponentMode": {
+      "type": "boolean",
+      "description": "Whether testing and releasing single component is enabled."
+    },
+    "mapping": {
+      "type": "object",
+      "properties": {
+        "rpm-repositories": {
+          "type": "array",
+          "description": "RPM repositories configuration for Pulp publishing",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name identifier for this repository configuration"
+              },
+              "arch": {
+                "type": "string",
+                "description": "The architecture for the repository (e.g. x86_64, aarch64, source)"
+              },
+              "repository_id": {
+                "type": "string",
+                "description": "The Pulp repository ID used in the PURL for an advisory"
+              },
+              "repository_name": {
+                "type": "string",
+                "description": "The actual name of the repository in Pulp"
+              },
+              "distro": {
+                "type": "string",
+                "description": "The distribution name for the repository"
+              }
+            }
+          }
+        },
+        "components": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The component name found in the snapshot e.g. example-component"
+              },
+              "canonicalName": {
+                "type": "string",
+                "description": "Name to be used while comparing against the name label when multiple repositories are defined"
+              },
+              "repositories": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "URL where you want to push the artifact e.g. quay.io/redhat/example-component"
+                    },
+                    "tags": {
+                      "type": "array",
+                      "description": "The tags to push the artifact e.g. [ {{ git_sha }}, {{ digest_sha }}, 1.0 ]",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "tags": {
+                "type": "array",
+                "description": "The tags to push the artifact e.g. [ {{ git_sha }}, {{ digest_sha }}, 1.0 ]",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "componentTags": {
+                "type": "array",
+                "description": "The tags to push the artifact e.g. [ {{ git_sha }}, {{ digest_sha }}, 1.0 ]",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "staged": {
+                "type": "object",
+                "properties": {
+                  "destination": {
+                    "type": "string",
+                    "description": "repo in pulp where staged files should be placed"
+                  },
+                  "version": {
+                    "type": "string",
+                    "description": "version in pulp where staged files should be placed in repo"
+                  },
+                  "files": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "filename": {
+                          "type": "string",
+                          "description": "filename when file is uploaded"
+                        },
+                        "source": {
+                          "type": "string",
+                          "description": "name of file within image"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "files": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "source": {
+                      "type": "string",
+                      "description": "full path to the file within image"
+                    },
+                    "arch": {
+                      "type": "string",
+                      "description": "Target architecture"
+                    },
+                    "os": {
+                      "type": "string",
+                      "description": "Target operating system"
+                    }
+                  }
+                }
+              },
+              "contentGateway": {
+                "type": "object",
+                "properties": {
+                  "productName": {
+                    "type": "string",
+                    "description": "productName in content gateway"
+                  },
+                  "productCode": {
+                    "type": "string",
+                    "description": "productCode in content gateway"
+                  },
+                  "productVersionName": {
+                    "type": "string",
+                    "description": "productVersionName in content gateway"
+                  },
+                  "filePrefix": {
+                    "type": "string",
+                    "description": "filePrefix to use to select files to add to content gateway"
+                  },
+                  "mirrorOpenshiftPush": {
+                    "type": "boolean",
+                    "description": "whether or not to push to mirror.openshift.com"
+                  },
+                  "contentType": {
+                    "type": "string",
+                    "enum": [
+                      "disk-image",
+                      "binary",
+                      "generic"
+                    ],
+                    "description": "Specifies the type of content being published"
+                  },
+                  "sign": {
+                    "type": "boolean",
+                    "description": "Whether the artifact should be signed before publishing"
+                  }
+                }
+              },
+              "productInfo": {
+                "type": "object",
+                "properties": {
+                  "productName": {
+                    "type": "string",
+                    "description": "productName in content gateway"
+                  },
+                  "productCode": {
+                    "type": "string",
+                    "description": "productCode in content gateway"
+                  },
+                  "productVersionName": {
+                    "type": "string",
+                    "description": "productVersionName in content gateway"
+                  }
+                }
+              },
+              "starmap": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Artifact name"
+                    },
+                    "workflow": {
+                      "type": "string",
+                      "description": "Push workflow"
+                    },
+                    "cloud": {
+                      "type": "string",
+                      "description": "Cloud provider's name"
+                    },
+                    "mappings": {
+                      "type": "object",
+                      "description": "Mappings for the given artifact"
+                    },
+                    "billing-code-config": {
+                      "type": "object",
+                      "description": "Billing configuration for the community workflow"
+                    }
+                  }
+                }
+              },
+              "pushSourceContainer": {
+                "type": "boolean",
+                "description": "Indicates if the source container should be pushed"
+              },
+              "public": {
+                "type": "boolean",
+                "description": "Indicates if the target repository should be made public"
+              }
+            }
+          }
+        },
+        "defaults": {
+          "type": "object",
+          "properties": {
+            "tags": {
+              "type": "array",
+              "description": "The default tags to push for all components e.g. [ '{{ git_sha }}', '{{ digest_sha }}', '1.0' ]",
+              "items": {
+                "type": "string"
+              }
+            },
+            "pushSourceContainer": {
+              "type": "boolean",
+              "description": "Indicates if the source container should be pushed"
+            },
+            "public": {
+              "type": "boolean",
+              "description": "Indicates if the target repositories should be made public"
+            },
+            "contentGateway": {
+              "type": "object",
+              "properties": {
+                "productName": {
+                  "type": "string",
+                  "description": "productName in content gateway"
+                },
+                "productCode": {
+                  "type": "string",
+                  "description": "productCode in content gateway"
+                },
+                "productVersionName": {
+                  "type": "string",
+                  "description": "productVersionName in content gateway"
+                },
+                "filePrefix": {
+                  "type": "string",
+                  "description": "filePrefix to use to select files to add to content gateway"
+                },
+                "mirrorOpenshiftPush": {
+                  "type": "boolean",
+                  "description": "whether or not to push to mirror.openshift.com"
+                }
+              }
+            }
+          }
+        },
+        "registrySecret": {
+          "type": "string",
+          "description": "The k8s secret containing token for quay.io API"
+        },
+        "cloudMarketplacesSecret": {
+          "type": "string",
+          "description": "Secret for cloud marketplaces"
+        },
+        "cloudMarketplacesPrePush": {
+          "type": "boolean",
+          "description": "Whether perform a pre-push (true) or not (false). When true it will not publish PROD."
+        }
+      }
+    },
+    "ootsign": {
+      "type": "object",
+      "properties": {
+        "kmodsPath": {
+          "type": "string",
+          "description": "Path where kmods are built inside the image"
+        },
+        "vendor": {
+          "type": "string",
+          "description": "Vendor name of the oot kmods"
+        },
+        "signedKmodsPath": {
+          "type": "string",
+          "description": "Directory where signed kmods will be in the internal repository"
+        },
+        "signing-secret": {
+          "type": "string",
+          "description": "Secret that includes signUser, signKey and signHost keys"
+        },
+        "signingAuthor": {
+          "type": "string",
+          "description": "The name of the author that rh-signing-client will set for --onbehalfof"
+        },
+        "checksumFingerprint": {
+          "type": "string",
+          "description": "Secret containing the host key database for SSH the server running signing"
+        },
+        "checksumKeytab": {
+          "type": "string",
+          "description": "Secret containing keytab file for the Kerberos user/server"
+        }
+      }
+    },
+    "pushToGit": {
+      "type": "boolean",
+      "description": "Flag to enable pushing OOT kmods to a git repository"
+    },
+    "pushToS3": {
+      "type": "boolean",
+      "description": "Flag to enable pushing OOT kmods to an S3 bucket"
+    },
+    "pushToAzure": {
+      "type": "boolean",
+      "description": "Flag to enable pushing OOT kmods to an Azure Blob Storage"
+    },
+    "git": {
+      "type": "object",
+      "properties": {
+        "repoUrl": {
+          "type": "string",
+          "description": "Repository URL where the signed modules will be pushed"
+        },
+        "branch": {
+          "type": "string",
+          "description": "Specific branch in the repository"
+        },
+        "tokenSecret": {
+          "type": "string",
+          "description": "The name of the Kubernetes secret containing the Git token"
+        }
+      }
+    },
+    "s3": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "description": "The S3 endpoint URL"
+        },
+        "bucket": {
+          "type": "string",
+          "description": "The name of the destination S3 bucket"
+        },
+        "credentialsSecret": {
+          "type": "string",
+          "description": "The name of the Kubernetes secret containing S3 credentials"
+        }
+      }
+    },
+    "azure": {
+      "type": "object",
+      "properties": {
+        "storageAccount": {
+          "type": "string",
+          "description": "Azure Storage account name (e.g., mystorageaccount)"
+        },
+        "container": {
+          "type": "string",
+          "description": "Azure Blob container name (e.g., kmods-artifacts)"
+        },
+        "spSecret": {
+          "type": "string",
+          "description": "Kubernetes Secret with AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET"
+        }
+      }
+    },
+    "cdn": {
+      "type": "object",
+      "properties": {
+        "env": {
+          "type": "string",
+          "enum": [
+            "qa",
+            "stage",
+            "production"
+          ],
+          "description": "The environment for the CDN configuration e.g. qa"
+        }
+      }
+    },
+    "charon": {
+      "type": "object",
+      "properties": {
+        "release": {
+          "type": "string",
+          "enum": [
+            "ga",
+            "ea"
+          ],
+          "description": "The release for the configuration e.g. ga"
+        },
+        "environment": {
+          "type": "string",
+          "enum": [
+            "dev",
+            "stage",
+            "production"
+          ],
+          "description": "The environment for the configuration e.g. dev"
+        },
+        "awsSecret": {
+          "type": "string",
+          "description": "The k8s secret containing the aws credential for aws access"
+        },
+        "packageType": {
+          "type": "string",
+          "enum": [
+            "maven",
+            "npm"
+          ],
+          "description": "The package type for the charon release"
+        },
+        "signing": {
+          "type": "object",
+          "description": "The signing configuration through RADAS",
+          "properties": {
+            "signKey": {
+              "type": "string",
+              "description": "The signing key used to do signing"
+            },
+            "signCASecret": {
+              "type": "string",
+              "description": "The k8s secret containing ca files for radas access"
+            },
+            "signIgnores": {
+              "type": "array",
+              "description": "Patterns to filter the files which will not need to do signing",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "config": {
+          "type": "string",
+          "description": "The charon configuration content which will be stored as file for charon tools"
+        }
+      }
+    },
+    "pushOptions": {
+      "type": "object",
+      "properties": {
+        "koji_tags": {
+          "type": "array",
+          "description": "The koji tags that are attached to rpms after they are pushed into koji",
+          "items": {
+            "type": "string"
+          }
+        },
+        "koji_profile": {
+          "type": "string",
+          "description": "Profile name for koji CLI used for importing and tagging builds"
+        },
+        "koji_import_draft": {
+          "type": "boolean",
+          "description": "Indicates whether build will be imported to Koji as draft or a normal build"
+        },
+        "components": {
+          "type": "array",
+          "description": "The component names which rpms need to be pushed, the components are from data.mapping if this not set",
+          "items": {
+            "type": "string"
+          }
+        },
+        "pushKeytab": {
+          "type": "object",
+          "properties": {
+            "principal": {
+              "type": "string",
+              "description": "The kerberos principal of the pushKeytab"
+            },
+            "secret": {
+              "type": "string",
+              "description": "The k8s secret that contains the pushKeytab"
+            },
+            "name": {
+              "type": "string",
+              "description": "The pushKeytab file name"
+            }
+          }
+        },
+        "pushPipelineImage": {
+          "type": "string",
+          "description": "The tekton runner for running push-rpm-to-koji tekton task"
+        },
+        "pushType": {
+          "type": "string",
+          "default": "import",
+          "description": "Type of the push operation. Can be 'import' (the default; import builds to Koji) or 'promote' (promote draft builds in Koji).",
+          "enum": [
+            "import",
+            "promote"
+          ]
+        }
+      }
+    },
+    "skipFilter": {
+      "type": "boolean",
+      "description": "If true, skip filtering of already-released images and process all components in the snapshot. Default: false."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "releaseNotes"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "releaseNotes"
+        ]
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "releaseNotes"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "releaseNotes"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "releaseNotes": {
+            "required": [
+              "product_id",
+              "product_name",
+              "product_version",
+              "product_stream",
+              "cpe",
+              "synopsis",
+              "topic",
+              "description",
+              "solution",
+              "content"
+            ],
+            "properties": {
+              "content": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "images"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "artifacts"
+                    ]
+                  }
+                ]
+              },
+              "cves": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "key",
+                        "component"
+                      ]
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "key"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "component"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "packages"
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "cdn"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "cdn"
+        ]
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "cdn"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "cdn"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "cdn": {
+            "required": [
+              "env"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "fbc"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "fbc"
+        ]
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "fbc"
+        ]
+      },
+      "then": {
+        "properties": {
+          "fbc": {
+            "required": [
+              "fromIndex",
+              "publishingCredentials",
+              "allowedPackages"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "fbc"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "fbc"
+                }
+              }
+            }
+          },
+          "fbc": {
+            "properties": {
+              "preGA": {
+                "enum": [
+                  true
+                ]
+              }
+            },
+            "required": [
+              "preGA"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "fbc": {
+            "required": [
+              "targetIndex",
+              "productName",
+              "productVersion"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "fbc"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "fbc"
+                }
+              }
+            }
+          },
+          "fbc": {
+            "properties": {
+              "hotfix": {
+                "enum": [
+                  true
+                ]
+              }
+            },
+            "required": [
+              "hotfix"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "fbc": {
+            "required": [
+              "targetIndex",
+              "issueId"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "fbc"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "fbc"
+                }
+              }
+            }
+          },
+          "fbc": {
+            "properties": {
+              "stagedIndex": {
+                "not": {
+                  "enum": [
+                    true
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "fbc": {
+            "required": [
+              "targetIndex"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "sign"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "sign"
+        ]
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "sign"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "sign"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "sign": {
+            "required": [
+              "configMapName"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "mrrc"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "charon"
+        ]
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "charon"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "mrrc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "charon": {
+            "required": [
+              "environment",
+              "release",
+              "awsSecret",
+              "config",
+              "signing"
+            ],
+            "properties": {
+              "sign": {
+                "required": [
+                  "signKey",
+                  "signCASecret"
+                ]
+              }
+            }
+          },
+          "releaseNotes": {
+            "required": [
+              "product_name",
+              "product_version"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "charon"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "nrrc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "charon": {
+            "required": [
+              "environment",
+              "release",
+              "awsSecret",
+              "packageType",
+              "config"
+            ]
+          },
+          "releaseNotes": {
+            "required": [
+              "product_name",
+              "product_version"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "github"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "github"
+        ]
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "github"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "github"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "github": {
+            "required": [
+              "githubSecret"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "contentGateway"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "mapping"
+        ],
+        "properties": {
+          "mapping": {
+            "required": [
+              "components"
+            ],
+            "properties": {
+              "components": {
+                "type": "array",
+                "items": {
+                  "required": [
+                    "contentGateway"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "mapping"
+        ],
+        "properties": {
+          "mapping": {
+            "required": [
+              "components"
+            ],
+            "properties": {
+              "components": {
+                "type": "array",
+                "items": {
+                  "required": [
+                    "contentGateway"
+                  ]
+                }
+              }
+            }
+          },
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "contentGateway"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "mapping": {
+            "properties": {
+              "components": {
+                "items": {
+                  "properties": {
+                    "contentGateway": {
+                      "required": [
+                        "productName",
+                        "productCode",
+                        "productVersionName",
+                        "contentType"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "pyxis"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "pyxis"
+        ]
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "pyxis"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "pyxis"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "pyxis": {
+            "required": [
+              "server",
+              "secret"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "ootsign"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "ootsign"
+        ]
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "ootsign"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "ootsign"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "ootsign": {
+            "required": [
+              "kmodsPath",
+              "vendor",
+              "signedKmodsPath",
+              "signing-secret",
+              "signingAuthor",
+              "checksumFingerprint",
+              "checksumKeytab"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "pushToGit"
+        ],
+        "properties": {
+          "pushToGit": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "git"
+        ],
+        "properties": {
+          "git": {
+            "required": [
+              "repoUrl",
+              "tokenSecret"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "pushToS3"
+        ],
+        "properties": {
+          "pushToS3": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "s3"
+        ],
+        "properties": {
+          "s3": {
+            "required": [
+              "endpoint",
+              "bucket",
+              "credentialsSecret"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "pushToAzure"
+        ],
+        "properties": {
+          "pushToAzure": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "azure"
+        ],
+        "properties": {
+          "azure": {
+            "required": [
+              "storageAccount",
+              "container",
+              "spSecret"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "mapping"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "mapping"
+        ],
+        "properties": {
+          "mapping": {
+            "type": "object",
+            "required": [
+              "components"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "mapping"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "mapping"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "mapping": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "required": [
+                    "name"
+                  ],
+                  "anyOf": [
+                    {
+                      "required": [
+                        "repositories"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "contentType"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "cloudMarketplaces"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "mapping"
+        ],
+        "properties": {
+          "mapping": {
+            "type": "object",
+            "required": [
+              "components",
+              "cloudMarketplacesSecret"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "mapping"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "cloudMarketplaces"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "mapping": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "required": [
+                    "name",
+                    "contentType",
+                    "staged",
+                    "starmap"
+                  ],
+                  "properties": {
+                    "staged": {
+                      "type": "object",
+                      "required": [
+                        "destination",
+                        "version",
+                        "files"
+                      ],
+                      "properties": {
+                        "files": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "required": [
+                              "filename",
+                              "source"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "starmap": {
+                      "type": "array",
+                      "minItems": 1
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "const": "intention"
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "intention"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "atlas"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "atlas"
+        ]
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "atlas"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "atlas"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "atlas": {
+            "required": [
+              "server"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "pulp"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "pulp"
+        ]
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "pulp"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "pulp"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "pulp": {
+            "required": [
+              "domain",
+              "secretName"
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/scripts/python/tasks/managed/check_data_keys.py
+++ b/scripts/python/tasks/managed/check_data_keys.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Validate release data JSON keys against the dataKeys schema."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import file
+import tekton
+from check_jsonschema.checker import SchemaChecker
+from check_jsonschema.formats import FormatOptions
+from check_jsonschema.instance_loader import CustomLazyFile, InstanceLoader
+from check_jsonschema.regex_variants import RegexImplementation, RegexVariantName
+from check_jsonschema.reporter import TextReporter
+from check_jsonschema.schema_loader import SchemaLoader
+from logger import logger
+
+DEFAULT_SCHEMA_PATH = Path("/home/schemas/dataKeys.json")
+
+
+def resolve_schema_path(schema_path: Path) -> Path:
+    """Return *schema_path* when the file exists."""
+    if not schema_path.is_file():
+        msg = f"schema file not found: {schema_path}"
+        raise FileNotFoundError(msg)
+    return schema_path
+
+
+def parse_systems_param(systems_json: str) -> list[dict[str, Any]]:
+    """Parse the Tekton `systems` param as a JSON array of system objects."""
+    text = systems_json.strip()
+    if not text:
+        return []
+    data = json.loads(text)
+    if not isinstance(data, list):
+        msg = "systems parameter must be a JSON array"
+        raise ValueError(msg)
+    return data
+
+
+def merge_systems_into_data(
+    data: dict[str, Any],
+    systems: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Append *systems* to the `systems` array in *data*."""
+    existing = data.get("systems")
+    if existing is None:
+        merged: list[dict[str, Any]] = []
+    elif isinstance(existing, list):
+        merged = list(existing)
+    else:
+        msg = "data systems must be a JSON array"
+        raise ValueError(msg)
+    merged.extend(systems)
+    data["systems"] = merged
+    return data
+
+
+def validate_data_against_schema(schema_path: Path, data_path: Path) -> None:
+    """Validate *data_path* against *schema_path* using check-jsonschema."""
+    regex_impl = RegexImplementation(RegexVariantName.default)
+    checker = SchemaChecker(
+        SchemaLoader(str(schema_path)),
+        InstanceLoader([CustomLazyFile(str(data_path))]),
+        TextReporter(verbosity=1, stream=sys.stderr),
+        format_opts=FormatOptions(regex_impl=regex_impl),
+        regex_impl=regex_impl,
+    )
+    if checker.run() != 0:
+        msg = f"schema validation failed for {data_path}"
+        raise ValueError(msg)
+
+
+def run_check_data_keys(
+    *,
+    data_dir: Path,
+    data_path: Path,
+    schema_path: Path,
+    systems_json: str,
+) -> None:
+    """Load data, merge systems, and validate against the schema."""
+    data_file = data_dir / data_path
+    if not data_file.is_file():
+        msg = "No data JSON was provided."
+        raise FileNotFoundError(msg)
+
+    logger.info("Loading data from %s", data_file)
+    data = file.load_json_dict(data_file)
+    systems = parse_systems_param(systems_json)
+    if systems:
+        logger.info("Merging %d required system(s) into data", len(systems))
+    data = merge_systems_into_data(data, systems)
+    data_file.write_text(json.dumps(data) + "\n", encoding="utf-8")
+
+    schema = resolve_schema_path(schema_path)
+    logger.info("Validating %s against schema %s", data_file, schema)
+    validate_data_against_schema(schema, data_file)
+    logger.info("Schema validation succeeded")
+
+
+def main() -> int:
+    """Run the check-data-keys workflow; exit non-zero on failure."""
+    run_check_data_keys(
+        data_dir=Path(tekton.require_env("PARAM_DATA_DIR")),
+        data_path=Path(tekton.require_env("PARAM_DATA_PATH")),
+        schema_path=file.path_from_env_variable("SCHEMA_FILE", DEFAULT_SCHEMA_PATH),
+        systems_json=os.environ.get("PARAM_SYSTEMS", ""),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_check_data_keys.py
+++ b/scripts/python/tasks/managed/test_check_data_keys.py
@@ -1,0 +1,340 @@
+"""Test check_data_keys task logic."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import check_data_keys
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SCHEMA_PATH = REPO_ROOT / "schemas" / "dataKeys.json"
+
+
+@pytest.fixture(scope="session")
+def schema_path() -> Path:
+    """Return the repo dataKeys schema used by validation tests."""
+    if not SCHEMA_PATH.is_file():
+        pytest.fail(f"missing dataKeys schema: {SCHEMA_PATH}")
+    return SCHEMA_PATH
+
+
+def _valid_release_notes() -> dict[str, Any]:
+    """Minimal releaseNotes block that satisfies the dataKeys schema."""
+    return {
+        "product_id": [123],
+        "product_name": "Red Hat Openstack Product",
+        "product_version": "1.2.3",
+        "product_stream": "rhtas-tp1",
+        "cpe": "cpe:/a:example:openstack:el8",
+        "type": "RHSA",
+        "issues": {
+            "fixed": [
+                {
+                    "id": "RHOSP-12345",
+                    "source": "issues.example.com",
+                    "summary": "some text about the issue",
+                },
+                {"id": "1234567", "source": "bugzilla.example.com"},
+            ],
+        },
+        "content": {
+            "images": [
+                {
+                    "containerImage": "quay.io/example/openstack@sha256:abcde",
+                    "repository": "rhosp16-rhel8/openstack",
+                    "tags": ["latest"],
+                    "architecture": "amd64",
+                    "signingKey": "abcde",
+                    "purl": (
+                        "pkg:example/openstack@sha256:abcde?"
+                        "repository_url=quay.io/example/rhosp16-rhel8"
+                    ),
+                },
+            ],
+        },
+        "cves": [{"key": "CVE-2025-12345", "component": "my-component-1"}],
+        "synopsis": "test synopsis",
+        "topic": "test topic",
+        "description": "test description",
+        "solution": "test solution",
+        "references": ["https://docs.example.com/some/example/release-notes"],
+    }
+
+
+def _write_data(path: Path, data: dict[str, Any]) -> None:
+    """Write *data* as JSON to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data) + "\n", encoding="utf-8")
+
+
+def test_default_schema_path_is_image_location() -> None:
+    """Default schema path matches the location baked into the utils image."""
+    assert check_data_keys.DEFAULT_SCHEMA_PATH == Path("/home/schemas/dataKeys.json")
+
+
+def test_resolve_schema_path_returns_existing_file(tmp_path: Path) -> None:
+    """Return the path when the schema file exists."""
+    schema = tmp_path / "schema.json"
+    schema.write_text("{}", encoding="utf-8")
+    assert check_data_keys.resolve_schema_path(schema) == schema
+
+
+def test_resolve_schema_path_missing_file(tmp_path: Path) -> None:
+    """Fail when the schema file does not exist."""
+    missing = tmp_path / "missing-schema.json"
+    with pytest.raises(FileNotFoundError, match="schema file not found"):
+        check_data_keys.resolve_schema_path(missing)
+
+
+def test_parse_systems_param_empty_string() -> None:
+    """Treat a blank systems param as an empty array."""
+    assert check_data_keys.parse_systems_param("") == []
+    assert check_data_keys.parse_systems_param("   ") == []
+
+
+def test_parse_systems_param_invalid_type_raises() -> None:
+    """Reject systems params that are not JSON arrays."""
+    with pytest.raises(ValueError, match="JSON array"):
+        check_data_keys.parse_systems_param('{"systemName": "cdn"}')
+
+
+def test_merge_systems_into_data_appends_entries() -> None:
+    """Append required systems to an existing systems array."""
+    data = {"systems": [{"systemName": "cdn", "dynamic": False}]}
+    merged = check_data_keys.merge_systems_into_data(
+        data,
+        [{"systemName": "releaseNotes", "dynamic": False}],
+    )
+    assert merged["systems"] == [
+        {"systemName": "cdn", "dynamic": False},
+        {"systemName": "releaseNotes", "dynamic": False},
+    ]
+
+
+def test_merge_systems_into_data_rejects_non_array_systems() -> None:
+    """Reject data files whose systems value is not a JSON array."""
+    with pytest.raises(ValueError, match="data systems must be a JSON array"):
+        check_data_keys.merge_systems_into_data(
+            {"systems": "oops"},
+            [{"systemName": "cdn", "dynamic": False}],
+        )
+
+
+def test_run_check_data_keys_rejects_malformed_systems_in_data(
+    tmp_path: Path,
+    schema_path: Path,
+) -> None:
+    """Fail when the data file contains a non-array systems value."""
+    data_dir = tmp_path / "data"
+    data_file = data_dir / "data.json"
+    _write_data(data_file, {"systems": "oops"})
+    with pytest.raises(ValueError, match="data systems must be a JSON array"):
+        check_data_keys.run_check_data_keys(
+            data_dir=data_dir,
+            data_path=Path("data.json"),
+            schema_path=schema_path,
+            systems_json='[{"systemName": "cdn", "dynamic": false}]',
+        )
+
+
+def test_module_main_guard(monkeypatch: pytest.MonkeyPatch, schema_path: Path) -> None:
+    """Executing the module as `__main__` propagates failures from main()."""
+    import runpy
+
+    monkeypatch.setenv("PARAM_DATA_DIR", "/tmp")
+    monkeypatch.setenv("PARAM_DATA_PATH", "missing.json")
+    monkeypatch.setenv("SCHEMA_FILE", str(schema_path))
+    with pytest.raises(FileNotFoundError, match="No data JSON was provided"):
+        runpy.run_module("check_data_keys", run_name="__main__")
+
+
+def test_run_check_data_keys_happy_path(
+    tmp_path: Path,
+    schema_path: Path,
+) -> None:
+    """Validate complete data when all required systems are present."""
+    data_dir = tmp_path / "data"
+    data_file = data_dir / "run/data.json"
+    _write_data(
+        data_file,
+        {
+            "releaseNotes": _valid_release_notes(),
+            "cdn": {"env": "qa"},
+            "intention": "production",
+        },
+    )
+    check_data_keys.run_check_data_keys(
+        data_dir=data_dir,
+        data_path=Path("run/data.json"),
+        schema_path=schema_path,
+        systems_json=(
+            '[{"systemName": "releaseNotes", "dynamic": false},'
+            '{"systemName": "cdn", "dynamic": false},'
+            '{"systemName": "intention", "dynamic": false}]'
+        ),
+    )
+    saved = json.loads(data_file.read_text(encoding="utf-8"))
+    assert len(saved["systems"]) == 3
+
+
+def test_run_check_data_keys_missing_data_file(
+    tmp_path: Path,
+    schema_path: Path,
+) -> None:
+    """Fail when the data JSON path does not exist."""
+    with pytest.raises(FileNotFoundError, match="No data JSON was provided"):
+        check_data_keys.run_check_data_keys(
+            data_dir=tmp_path,
+            data_path=Path("missing.json"),
+            schema_path=schema_path,
+            systems_json="[]",
+        )
+
+
+def test_run_check_data_keys_missing_releasenotes_key(
+    tmp_path: Path,
+    schema_path: Path,
+) -> None:
+    """Fail when releaseNotes is required but missing product_id."""
+    data_dir = tmp_path / "data"
+    data_file = data_dir / "data.json"
+    release_notes = _valid_release_notes()
+    del release_notes["product_id"]
+    _write_data(data_file, {"releaseNotes": release_notes})
+    with pytest.raises(ValueError, match="schema validation failed"):
+        check_data_keys.run_check_data_keys(
+            data_dir=data_dir,
+            data_path=Path("data.json"),
+            schema_path=schema_path,
+            systems_json='[{"systemName": "releaseNotes", "dynamic": false}]',
+        )
+
+
+def test_run_check_data_keys_missing_cdn_key(
+    tmp_path: Path,
+    schema_path: Path,
+) -> None:
+    """Fail when cdn is required but absent from the data file."""
+    data_dir = tmp_path / "data"
+    data_file = data_dir / "data.json"
+    _write_data(data_file, {"releaseNotes": _valid_release_notes()})
+    with pytest.raises(ValueError, match="schema validation failed"):
+        check_data_keys.run_check_data_keys(
+            data_dir=data_dir,
+            data_path=Path("data.json"),
+            schema_path=schema_path,
+            systems_json='[{"systemName": "releaseNotes", "dynamic": false},'
+            '{"systemName": "cdn", "dynamic": false}]',
+        )
+
+
+def test_run_check_data_keys_dynamic_true_missing_data_passes(
+    tmp_path: Path,
+    schema_path: Path,
+) -> None:
+    """Pass when a dynamic system is declared but its data is absent."""
+    data_dir = tmp_path / "data"
+    data_file = data_dir / "data.json"
+    _write_data(data_file, {"someOtherData": {"value": "test"}})
+    check_data_keys.run_check_data_keys(
+        data_dir=data_dir,
+        data_path=Path("data.json"),
+        schema_path=schema_path,
+        systems_json='[{"systemName": "releaseNotes", "dynamic": true}]',
+    )
+
+
+def test_run_check_data_keys_dynamic_false_missing_data_fails(
+    tmp_path: Path,
+    schema_path: Path,
+) -> None:
+    """Fail when a non-dynamic system is declared but its data is absent."""
+    data_dir = tmp_path / "data"
+    data_file = data_dir / "data.json"
+    _write_data(data_file, {"someOtherData": {"value": "test"}})
+    with pytest.raises(ValueError, match="schema validation failed"):
+        check_data_keys.run_check_data_keys(
+            data_dir=data_dir,
+            data_path=Path("data.json"),
+            schema_path=schema_path,
+            systems_json='[{"systemName": "releaseNotes", "dynamic": false}]',
+        )
+
+
+def test_run_check_data_keys_pass_undeclared_system(
+    tmp_path: Path,
+    schema_path: Path,
+) -> None:
+    """Pass when releaseNotes data exists but releaseNotes is not required."""
+    data_dir = tmp_path / "data"
+    data_file = data_dir / "data.json"
+    _write_data(
+        data_file,
+        {
+            "releaseNotes": {
+                "product_stream": "test-product-stream",
+                "synopsis": "test synopsis",
+            },
+            "cdn": {"env": "qa"},
+        },
+    )
+    check_data_keys.run_check_data_keys(
+        data_dir=data_dir,
+        data_path=Path("data.json"),
+        schema_path=schema_path,
+        systems_json='[{"systemName": "cdn", "dynamic": false}]',
+    )
+
+
+def test_run_check_data_keys_malformed_cve_key(
+    tmp_path: Path,
+    schema_path: Path,
+) -> None:
+    """Fail when a CVE entry is missing its required component field."""
+    data_dir = tmp_path / "data"
+    data_file = data_dir / "data.json"
+    release_notes = _valid_release_notes()
+    release_notes["cves"] = [{"key": "CVE-2022-1234"}]
+    _write_data(data_file, {"releaseNotes": release_notes})
+    with pytest.raises(ValueError, match="schema validation failed"):
+        check_data_keys.run_check_data_keys(
+            data_dir=data_dir,
+            data_path=Path("data.json"),
+            schema_path=schema_path,
+            systems_json='[{"systemName": "releaseNotes", "dynamic": false}]',
+        )
+
+
+def test_main_failure_propagates_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    schema_path: Path,
+) -> None:
+    """Propagate failures from main() with the original exception message."""
+    monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PARAM_DATA_PATH", "missing.json")
+    monkeypatch.setenv("SCHEMA_FILE", str(schema_path))
+    with pytest.raises(FileNotFoundError, match="No data JSON was provided"):
+        check_data_keys.main()
+
+
+def test_main_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    schema_path: Path,
+) -> None:
+    """Exit zero after a successful validation run."""
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, {"cdn": {"env": "qa"}})
+    monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PARAM_DATA_PATH", "data.json")
+    monkeypatch.setenv("SCHEMA_FILE", str(schema_path))
+    monkeypatch.setenv(
+        "PARAM_SYSTEMS",
+        '[{"systemName": "cdn", "dynamic": false}]',
+    )
+    assert check_data_keys.main() == 0


### PR DESCRIPTION
This commit adds a python script to replicate the functionality of the inline bash script in the check-data-keys task in the catalog repo. The task will be updated to use this python module instead.

As part of this work, the schema file was copied into this repository. It will eventually be removed from the catalog repo. The linters for the schema file that currently exist in the catalog repo are added here.

Assisted-By: Cursor