### PR TITLE
fix: handle missing source PR gracefully in update-infra-deployments

### DIFF
--- a/scripts/python/helpers/vcs/github.py
+++ b/scripts/python/helpers/vcs/github.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import atexit
 import base64
 import json
+import logging
 import os
 import stat
 import subprocess
@@ -19,6 +20,8 @@ import http_client
 import requests
 
 from . import git
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -238,8 +241,12 @@ def find_open_pull_request_by_branch(
     return items[0]
 
 
-def pull_request_url_for_commit_sha(session: GitHubAppSession, sha: str) -> str:
-    """Search for a PR link associated with *sha*."""
+def pull_request_url_for_commit_sha(session: GitHubAppSession, sha: str) -> str | None:
+    """Search for a PR link associated with *sha*.
+
+    Returns ``None`` when no matching pull request is found so that
+    callers can degrade gracefully instead of aborting the entire task.
+    """
     data = _get_json(
         session,
         f"/search/issues?q={sha}",
@@ -247,13 +254,13 @@ def pull_request_url_for_commit_sha(session: GitHubAppSession, sha: str) -> str:
     )
     items = data.get("items") or []
     if not items:
-        msg = f"no pull request found for commit {sha}"
-        raise RuntimeError(msg)
+        logger.warning("no pull request found for commit %s", sha)
+        return None
     pull_request = items[0].get("pull_request") or {}
     url = pull_request.get("html_url")
     if not url:
-        msg = f"search result missing pull_request html_url for {sha}"
-        raise RuntimeError(msg)
+        logger.warning("search result missing pull_request html_url for %s", sha)
+        return None
     return str(url)
 
 

--- a/scripts/python/helpers/vcs/test_github.py
+++ b/scripts/python/helpers/vcs/test_github.py
@@ -242,23 +242,21 @@ def test_pull_request_url_for_commit_sha() -> None:
 
 
 def test_pull_request_url_for_commit_sha_no_items() -> None:
-    """Raise when the search API returns no matching issues."""
+    """Return None when the search API returns no matching issues."""
     session = _session()
     with mock.patch.object(github, "_get_json", return_value={"items": []}):
-        with pytest.raises(RuntimeError, match="no pull request found"):
-            github.pull_request_url_for_commit_sha(session, "abc123")
+        assert github.pull_request_url_for_commit_sha(session, "abc123") is None
 
 
 def test_pull_request_url_for_commit_sha_missing_html_url() -> None:
-    """Raise when the search hit has no `pull_request.html_url`."""
+    """Return None when the search hit has no `pull_request.html_url`."""
     session = _session()
     with mock.patch.object(
         github,
         "_get_json",
         return_value={"items": [{"pull_request": {}}]},
     ):
-        with pytest.raises(RuntimeError, match="missing pull_request html_url"):
-            github.pull_request_url_for_commit_sha(session, "abc123")
+        assert github.pull_request_url_for_commit_sha(session, "abc123") is None
 
 
 def test_compare_changelog_non_200() -> None:

--- a/scripts/python/tasks/managed/test_update_infra_deployments.py
+++ b/scripts/python/tasks/managed/test_update_infra_deployments.py
@@ -176,6 +176,26 @@ def test_build_pr_description_without_changelog_rev() -> None:
     assert "## Changelog" not in body
 
 
+def test_build_pr_description_missing_pr_link() -> None:
+    """Omit the PR link line when no source PR is found for the revision."""
+    session = github.GitHubAppSession(api_url="https://api.github.com", token="t")
+    with mock.patch(
+        "update_infra_deployments.github.pull_request_url_for_commit_sha",
+        return_value=None,
+    ):
+        body = task._build_pr_description(
+            session,
+            existing_body="Included PRs:\r\n- old-link",
+            origin_repo="https://github.com/org/repo",
+            revision="newrev",
+            old_revision="",
+            container_image="img",
+        )
+    assert "old-link" in body
+    assert "None" not in body
+    assert "newrev" not in body
+
+
 def test_build_pr_description_uses_tag_old_revision() -> None:
     """Pass a non-digest old revision directly to the compare API."""
     session = github.GitHubAppSession(api_url="https://api.github.com", token="t")

--- a/scripts/python/tasks/managed/update_infra_deployments.py
+++ b/scripts/python/tasks/managed/update_infra_deployments.py
@@ -159,9 +159,10 @@ def _build_pr_description(
     links_part, changelog_part = _split_pr_body(existing_body)
     logger.info("Searching GitHub for pull request linked to commit %s", revision)
     new_pr_link = github.pull_request_url_for_commit_sha(session, revision)
-    pr_line = f"- {new_pr_link}"
-    if pr_line not in links_part:
-        links_part = f"{links_part}\n{pr_line}"
+    if new_pr_link:
+        pr_line = f"- {new_pr_link}"
+        if pr_line not in links_part:
+            links_part = f"{links_part}\n{pr_line}"
     body = links_part + changelog_part
 
     changelog_rev = ""


### PR DESCRIPTION
## Summary

- `pull_request_url_for_commit_sha()` now returns `None` instead of raising `RuntimeError` when no PR is found for the source commit SHA
- The caller in `_build_pr_description()` skips the PR link line when the result is `None`
- Prevents the `update-infra-deployments` task from failing after it has already successfully created and pushed the infra-deployments PR

## Problem

When the GitHub search API returns no results for the source component's git revision SHA, `pull_request_url_for_commit_sha()` raises `RuntimeError`, crashing the task after the PR was already created. Retries create duplicate PRs on the same branch. See #839 for full details and logs.

## Changes

| File | Change |
|------|--------|
| `scripts/python/helpers/vcs/github.py` | Return `None` + log warning instead of raising `RuntimeError` |
| `scripts/python/tasks/managed/update_infra_deployments.py` | Guard PR link insertion with `if new_pr_link:` |
| `scripts/python/helpers/vcs/test_github.py` | Update tests to expect `None` instead of `RuntimeError` |
| `scripts/python/tasks/managed/test_update_infra_deployments.py` | Add test for missing PR link case |

## Test plan

- [x] Existing tests for `pull_request_url_for_commit_sha` updated and passing
- [x] New test `test_build_pr_description_missing_pr_link` verifies the caller handles `None` correctly
- [x] Existing tests for `_build_pr_description` still passing

Fixes #839