### PR TITLE
refactor: remove try-except from managed task main()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,5 @@ Container image (UBI9) with Python scripts, wrappers, and templates used by Tekt
 
 - Some task scripts write results to Tekton result files via `tekton.result_paths_from_env()`.
 - Wrapper scripts call external tools (pubtools-pulp, pubtools-marketplacesvm, etc.) via subprocess or library APIs.
+- Internal task scripts (`scripts/python/tasks/internal/`) must catch all exceptions in `main()` and save errors to Tekton result files (the script itself must succeed).
+- Managed task scripts (`scripts/python/tasks/managed/`) must not catch exceptions in `main()` — let the script fail with traceback.

--- a/scripts/python/tasks/managed/base64_encode_checksum.py
+++ b/scripts/python/tasks/managed/base64_encode_checksum.py
@@ -9,8 +9,6 @@ from pathlib import Path
 import tekton
 from logger import logger
 
-PROG = "base64_encode_checksum.py"
-
 
 def encode_checksums(binaries_dir: Path) -> str:
     """Concatenate all *SHA256SUMS files in *binaries_dir* and base64-encode.
@@ -39,11 +37,7 @@ def main() -> int:
 
     binaries_dir = Path(data_dir) / binaries_dir_name
 
-    try:
-        blob = encode_checksums(binaries_dir)
-    except Exception as e:
-        logger.error("%s: %s", PROG, e)
-        return 1
+    blob = encode_checksums(binaries_dir)
 
     logger.info("%s", blob)
     rpath.write_text(blob, encoding="utf-8")

--- a/scripts/python/tasks/managed/extract_checksums_from_image.py
+++ b/scripts/python/tasks/managed/extract_checksums_from_image.py
@@ -22,7 +22,6 @@ import skopeo
 import tekton
 from logger import logger
 
-PROG = "extract_checksums_from_image.py"
 BINARIES_DIR = "binaries"
 
 
@@ -177,16 +176,13 @@ def main() -> int:
     snapshot_path = data_dir / snapshot_rel_path
     data_path = data_dir / data_path_str
 
-    try:
-        relative_binaries = extract_checksums(
-            snapshot_path=snapshot_path,
-            data_path=data_path,
-            data_dir=data_dir,
-            image_binaries_path=image_binaries_path,
-            snapshot_rel_path=snapshot_rel_path,
-        )
-    except Exception as e:
-        raise SystemExit(f"{PROG}: {e}") from e
+    relative_binaries = extract_checksums(
+        snapshot_path=snapshot_path,
+        data_path=data_path,
+        data_dir=data_dir,
+        image_binaries_path=image_binaries_path,
+        snapshot_rel_path=snapshot_rel_path,
+    )
 
     result_path.write_text(relative_binaries, encoding="utf-8")
     return 0

--- a/scripts/python/tasks/managed/make_repo_public.py
+++ b/scripts/python/tasks/managed/make_repo_public.py
@@ -193,8 +193,7 @@ def run(
 def main() -> int:
     """Read environment variables and call ``run()``.
 
-    Return 0 on success, 1 on missing env vars or ``RuntimeError`` from
-    ``run()``.
+    Return 0 on success, 1 on missing env vars.
     """
     data_file_str = os.environ.get("DATA_FILE", "").strip()
     snapshot_file_str = os.environ.get("SNAPSHOT_FILE", "").strip()
@@ -209,16 +208,12 @@ def main() -> int:
     secret_path = file.path_from_env_variable("REGISTRY_SECRET_PATH", "/etc/secrets")
     ca_cert_path = file.path_from_env_variable("CA_CERT_PATH", "/mnt/trusted-ca/ca-bundle.crt")
 
-    try:
-        run(
-            Path(data_file_str),
-            Path(snapshot_file_str),
-            secret_path,
-            ca_cert_path,
-        )
-    except RuntimeError as e:
-        print(f"{PROG}: {e}", file=sys.stderr)
-        return 1
+    run(
+        Path(data_file_str),
+        Path(snapshot_file_str),
+        secret_path,
+        ca_cert_path,
+    )
 
     logger.info("make-repo-public completed successfully")
     return 0

--- a/scripts/python/tasks/managed/test_base64_encode_checksum.py
+++ b/scripts/python/tasks/managed/test_base64_encode_checksum.py
@@ -66,16 +66,16 @@ def test_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     assert result_file.read_text() == base64.b64encode(content).decode("ascii")
 
 
-def test_main_failure_returns_1(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Return 1 and skip result file when the directory is missing."""
+def test_main_failure_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Raise FileNotFoundError when the directory is missing."""
     result_file = tmp_path / "blob_result"
     monkeypatch.setenv("RESULT_BLOB", str(result_file))
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
     monkeypatch.setenv("BINARIES_DIR", "nonexistent")
 
-    rc = main()
+    with pytest.raises(FileNotFoundError):
+        main()
 
-    assert rc == 1
     assert not result_file.exists()
 
 

--- a/scripts/python/tasks/managed/test_extract_checksums_from_image.py
+++ b/scripts/python/tasks/managed/test_extract_checksums_from_image.py
@@ -583,14 +583,12 @@ def test_main_missing_data_dir_raises(monkeypatch: pytest.MonkeyPatch, tmp_path:
         ecfi.main()
 
 
-def test_main_extract_error_exits_with_message(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """Exceptions from extract_checksums become SystemExit with PROG prefix."""
+def test_main_extract_error_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Exceptions from extract_checksums propagate from main."""
     monkeypatch.setenv("RESULT_BINARIES_PATH", str(tmp_path / "r"))
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
     monkeypatch.setenv("SNAPSHOT_PATH", "uid/snapshot.json")
 
     with mock.patch.object(ecfi, "extract_checksums", side_effect=ValueError("boom")):
-        with pytest.raises(SystemExit, match="extract_checksums_from_image.py: boom"):
+        with pytest.raises(ValueError, match="boom"):
             ecfi.main()

--- a/scripts/python/tasks/managed/test_make_repo_public.py
+++ b/scripts/python/tasks/managed/test_make_repo_public.py
@@ -478,15 +478,16 @@ class TestMain:
         monkeypatch.delenv("SNAPSHOT_FILE", raising=False)
         assert make_repo_public.main() == 1
 
-    def test_runtime_error_returns_1(
+    def test_runtime_error_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """`main` returns 1 when run() raises RuntimeError."""
+        """`main` raises RuntimeError when run() fails."""
         monkeypatch.setenv("DATA_FILE", str(tmp_path / "missing.json"))
         monkeypatch.setenv("SNAPSHOT_FILE", str(tmp_path / "snap.json"))
         monkeypatch.setenv("REGISTRY_SECRET_PATH", str(tmp_path))
         monkeypatch.setenv("CA_CERT_PATH", str(tmp_path / "no-ca.crt"))
-        assert make_repo_public.main() == 1
+        with pytest.raises(RuntimeError):
+            make_repo_public.main()
 
 
 class TestSetupCaBundle:


### PR DESCRIPTION
Managed task scripts should let exceptions propagate with a full traceback instead of catching and returning 1. Internal tasks continue to catch exceptions and save errors to Tekton result files.

Assisted-by: Claude Code