### PR TITLE
fix(ISV-7116): add /home/pyxis to PYTHONPATH and basedpyright extraPaths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,7 +177,7 @@ ENV PATH="$PATH:/home/scripts/python/tasks/managed"
 # Flat imports: helpers and task scripts must be importable.
 # Tests use the same layout via pyproject [tool.pytest.ini_options] pythonpath.
 # Keep /home for other modules (e.g. pyxis, sbom) that expect it.
-ENV PYTHONPATH="/home:/home/utils:/home/scripts/python/helpers:/home/scripts/python/tasks/internal:/home/scripts/python/tasks/managed:/home/pubtools-pulp-wrapper:/home/publish-to-cgw-wrapper"
+ENV PYTHONPATH="/home:/home/pyxis:/home/utils:/home/scripts/python/helpers:/home/scripts/python/tasks/internal:/home/scripts/python/tasks/managed:/home/pubtools-pulp-wrapper:/home/publish-to-cgw-wrapper"
 
 # uv installs newer requests and certifi which don't use the system CA like the one installed via
 # dnf. So we need to point requests to the system CA bundle explicitly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
 [tool.basedpyright]
 extraPaths = [
   "integration-tests/lib",
+  "pyxis",
   "scripts/python/helpers",
   "scripts/python/tasks/internal",
   "scripts/python/tasks/managed",


### PR DESCRIPTION
rh_direct_sign_image.py lives outside pyxis/ so import pyxis resolved to a namespace package instead of pyxis/pyxis.py, causing AttributeError on pyxis.graphql_query at runtime. Adding /home/pyxis to PYTHONPATH fixes the container. Adding pyxis to basedpyright extraPaths ensures static analysis catches this class of issue going forward.

Assisted-by: Claude Sonnet 4.6