### PR TITLE
feat(RELEASE-2479): add collect_index_images.py script

### DIFF
--- a/scripts/python/helpers/image_ref.py
+++ b/scripts/python/helpers/image_ref.py
@@ -7,9 +7,63 @@ import re
 
 import http_client
 import requests
+from logger import logger
 
 _QUAY_SHA_TAG = re.compile(r"^[0-9a-f]{40}$")
 _MAX_QUAY_TAG_PAGES = 50
+
+
+def translate_delivery_repo(repo: str) -> list[dict[str, str]]:
+    """Translate a Quay delivery-repo reference to public registry URLs.
+
+    Return two dicts with `repo` and `url` keys: one for `redhat.io` and
+    one for `access.redhat.com`.
+    """
+    if not repo.strip():
+        msg = "Please pass a repo to translate like 'quay.io/redhat-prod/product----repo'"
+        raise ValueError(msg)
+
+    normalized = repo.replace("----", "/")
+    io_url: str
+    access_url: str
+
+    if normalized.startswith("quay.io/redhat-prod/"):
+        io_url = "registry.redhat.io" + normalized[len("quay.io/redhat-prod") :]
+        access_url = "registry.access.redhat.com" + normalized[len("quay.io/redhat-prod") :]
+    elif normalized.startswith("quay.io/redhat-pending/"):
+        io_url = "registry.stage.redhat.io" + normalized[len("quay.io/redhat-pending") :]
+        access_url = (
+            "registry.access.stage.redhat.com" + normalized[len("quay.io/redhat-pending") :]
+        )
+    elif normalized.startswith("quay.io/rh-flatpaks-prod/"):
+        io_url = "flatpaks.registry.redhat.io" + normalized[len("quay.io/rh-flatpaks-prod") :]
+        access_url = (
+            "registry.access.redhat.com" + normalized[len("quay.io/rh-flatpaks-prod") :]
+        )
+    elif normalized.startswith("quay.io/rh-flatpaks-stage/"):
+        io_url = (
+            "flatpaks.registry.stage.redhat.io"
+            + normalized[len("quay.io/rh-flatpaks-stage") :]
+        )
+        access_url = (
+            "registry.access.stage.redhat.com" + normalized[len("quay.io/rh-flatpaks-stage") :]
+        )
+    elif normalized.startswith("quay.io/redhat/"):
+        io_url = "registry.redhat.io" + normalized[len("quay.io/redhat") :]
+        access_url = "registry.access.redhat.com" + normalized[len("quay.io/redhat") :]
+    else:
+        logger.warning(
+            "Repo to translate is not in expected format. If this is not "
+            "an index image, the expected format is: "
+            "quay.io/redhat-[prod,pending]/product----repo",
+        )
+        io_url = normalized
+        access_url = ""
+
+    return [
+        {"repo": "redhat.io", "url": io_url},
+        {"repo": "access.redhat.com", "url": access_url},
+    ]
 
 
 def resolve_quay_digest_to_git_sha(digest: str, container_image: str) -> str | None:

--- a/scripts/python/helpers/test_image_ref.py
+++ b/scripts/python/helpers/test_image_ref.py
@@ -3,11 +3,21 @@
 from __future__ import annotations
 
 import json
+import logging
 from unittest import mock
 
 import image_ref
 import pytest
 import requests
+
+
+@pytest.fixture(autouse=True)
+def _propagate_release_logger() -> None:
+    """Allow caplog to capture records from the 'release' logger."""
+    release_logger = logging.getLogger("release")
+    release_logger.propagate = True
+    yield
+    release_logger.propagate = False
 
 
 def test_pyxis_url_for_pull_spec_with_tag_and_registry_rewrite() -> None:
@@ -132,3 +142,90 @@ def test_resolve_quay_digest_handles_exception() -> None:
             "quay.io/org/repo@sha256:abc",
         )
     assert out is None
+
+
+def test_translate_delivery_repo_rejects_empty_repo() -> None:
+    """Empty repo input raises `ValueError`."""
+    with pytest.raises(ValueError, match="Please pass a repo"):
+        image_ref.translate_delivery_repo("")
+
+
+def test_translate_delivery_repo_redhat_prod() -> None:
+    """Translate quay.io/redhat-prod delivery repos to public registries."""
+    out = image_ref.translate_delivery_repo("quay.io/redhat-prod/product----repo:v1.0")
+    assert out == [
+        {"repo": "redhat.io", "url": "registry.redhat.io/product/repo:v1.0"},
+        {
+            "repo": "access.redhat.com",
+            "url": "registry.access.redhat.com/product/repo:v1.0",
+        },
+    ]
+
+
+def test_translate_delivery_repo_redhat_pending() -> None:
+    """Translate quay.io/redhat-pending delivery repos to stage registries."""
+    out = image_ref.translate_delivery_repo("quay.io/redhat-pending/product----repo:v1.0")
+    assert out == [
+        {"repo": "redhat.io", "url": "registry.stage.redhat.io/product/repo:v1.0"},
+        {
+            "repo": "access.redhat.com",
+            "url": "registry.access.stage.redhat.com/product/repo:v1.0",
+        },
+    ]
+
+
+def test_translate_delivery_repo_flatpaks_prod() -> None:
+    """Translate quay.io/rh-flatpaks-prod delivery repos."""
+    out = image_ref.translate_delivery_repo("quay.io/rh-flatpaks-prod/product----repo:v1")
+    assert out == [
+        {"repo": "redhat.io", "url": "flatpaks.registry.redhat.io/product/repo:v1"},
+        {
+            "repo": "access.redhat.com",
+            "url": "registry.access.redhat.com/product/repo:v1",
+        },
+    ]
+
+
+def test_translate_delivery_repo_flatpaks_stage() -> None:
+    """Translate quay.io/rh-flatpaks-stage delivery repos."""
+    out = image_ref.translate_delivery_repo("quay.io/rh-flatpaks-stage/product----repo:v1")
+    assert out == [
+        {
+            "repo": "redhat.io",
+            "url": "flatpaks.registry.stage.redhat.io/product/repo:v1",
+        },
+        {
+            "repo": "access.redhat.com",
+            "url": "registry.access.stage.redhat.com/product/repo:v1",
+        },
+    ]
+
+
+def test_translate_delivery_repo_index_image() -> None:
+    """Translate quay.io/redhat index image repos."""
+    out = image_ref.translate_delivery_repo(
+        "quay.io/redhat/redhat----fbc-target-index:v4.12",
+    )
+    assert out == [
+        {
+            "repo": "redhat.io",
+            "url": "registry.redhat.io/redhat/fbc-target-index:v4.12",
+        },
+        {
+            "repo": "access.redhat.com",
+            "url": "registry.access.redhat.com/redhat/fbc-target-index:v4.12",
+        },
+    ]
+
+
+def test_translate_delivery_repo_unknown_format_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unknown formats pass through the repo and emit a warning."""
+    with caplog.at_level(logging.WARNING, logger="release"):
+        out = image_ref.translate_delivery_repo("registry.example.com/org/repo:tag")
+    assert out == [
+        {"repo": "redhat.io", "url": "registry.example.com/org/repo:tag"},
+        {"repo": "access.redhat.com", "url": ""},
+    ]
+    assert "Repo to translate is not in expected format" in caplog.text

--- a/scripts/python/tasks/managed/collect_index_images.py
+++ b/scripts/python/tasks/managed/collect_index_images.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Build a Pyxis index-image snapshot JSON from internal-request results."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import file
+import image_ref
+import tekton
+from logger import logger
+
+SNAPSHOT_FILENAME = "index_image_snapshot.json"
+_BARE_OCP_TAG = re.compile(r"^v[0-9]+\.[0-9]+$")
+
+
+def split_target_index(target_index: str) -> tuple[str, str]:
+    """Split *target_index* into repository and tag at the last colon."""
+    repository, _, tag = target_index.rpartition(":")
+    if not repository or not tag:
+        msg = f"target_index must contain a repository and tag: {target_index!r}"
+        raise ValueError(msg)
+    return repository, tag
+
+
+def build_tags(tag: str, build_timestamp: str) -> list[str]:
+    """Return snapshot tags, appending a timestamp tag for bare OCP versions."""
+    tags = [tag]
+    if _BARE_OCP_TAG.fullmatch(tag):
+        tags.append(f"{tag}-{build_timestamp}")
+    return tags
+
+
+def translation_repo_url(translated: list[dict[str, Any]], repo_key: str) -> str:
+    """Return the host/path portion of a translated delivery-repo URL."""
+    for entry in translated:
+        if entry.get("repo") != repo_key:
+            continue
+        url = entry.get("url")
+        if not isinstance(url, str) or not url:
+            return ""
+        return url.split(":", 1)[0]
+    return ""
+
+
+def build_repo_object(
+    repository: str,
+    tags: list[str],
+    rh_registry_repo: str,
+    registry_access_repo: str,
+) -> dict[str, Any]:
+    """Build the repositories entry for one index image component."""
+    repo_object: dict[str, Any] = {
+        "url": repository,
+        "tags": tags,
+    }
+    if rh_registry_repo:
+        repo_object["rh-registry-repo"] = rh_registry_repo
+    if registry_access_repo:
+        repo_object["registry-access-repo"] = registry_access_repo
+    return repo_object
+
+
+def build_index_component(
+    *,
+    source_index: str,
+    repository: str,
+    tags: list[str],
+    image_digests: list[Any],
+    repo_object: dict[str, Any],
+) -> dict[str, Any]:
+    """Build one snapshot component object."""
+    return {
+        "containerImage": source_index,
+        "repository": repository,
+        "repositories": [repo_object],
+        "tags": tags,
+        "imageDigests": image_digests,
+    }
+
+
+def collect_index_image_components(
+    results: dict[str, Any],
+    build_timestamp: str,
+) -> dict[str, Any]:
+    """Transform internal-request results into an index-image snapshot."""
+    components_in = results.get("components")
+    if not isinstance(components_in, list):
+        msg = "internal request results components must be a JSON array"
+        raise ValueError(msg)
+
+    snapshot_components: list[dict[str, Any]] = []
+    for index, row in enumerate(components_in):
+        if not isinstance(row, dict):
+            msg = f"components[{index}] must be a JSON object"
+            raise ValueError(msg)
+
+        target_index = row.get("target_index")
+        source_index = row.get("index_image_resolved")
+        if not isinstance(target_index, str) or not target_index.strip():
+            msg = f"components[{index}].target_index must be a non-empty string"
+            raise ValueError(msg)
+        if not isinstance(source_index, str) or not source_index.strip():
+            msg = f"components[{index}].index_image_resolved must be a non-empty string"
+            raise ValueError(msg)
+
+        repository, tag = split_target_index(target_index)
+        tags = build_tags(tag, build_timestamp)
+        image_digests = row.get("image_digests", [])
+        if not isinstance(image_digests, list):
+            msg = f"components[{index}].image_digests must be a JSON array"
+            raise ValueError(msg)
+
+        logger.info(
+            "Processing index image %s (%d/%d)",
+            target_index,
+            index + 1,
+            len(components_in),
+        )
+        translated = image_ref.translate_delivery_repo(repository)
+        rh_registry_repo = translation_repo_url(translated, "redhat.io")
+        registry_access_repo = translation_repo_url(translated, "access.redhat.com")
+        repo_object = build_repo_object(
+            repository,
+            tags,
+            rh_registry_repo,
+            registry_access_repo,
+        )
+        snapshot_components.append(
+            build_index_component(
+                source_index=source_index,
+                repository=repository,
+                tags=tags,
+                image_digests=image_digests,
+                repo_object=repo_object,
+            ),
+        )
+
+    return {"components": snapshot_components}
+
+
+def run_collect_index_images(
+    *,
+    data_dir: Path,
+    internal_request_results_file: Path,
+    build_timestamp: str,
+    snapshot_path: Path,
+    index_image_snapshot_result_path: Path,
+) -> None:
+    """Load results, build the snapshot JSON, and write Tekton outputs."""
+    results_path = data_dir / internal_request_results_file
+    if not results_path.is_file():
+        msg = f"internal request results file not found: {results_path}"
+        raise FileNotFoundError(msg)
+
+    logger.info("Loading internal request results from %s", results_path)
+    results = file.load_json_dict(results_path)
+    snapshot = collect_index_image_components(results, build_timestamp)
+
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_path.write_text(json.dumps(snapshot) + "\n", encoding="utf-8")
+    index_image_snapshot_result_path.write_text(SNAPSHOT_FILENAME, encoding="utf-8")
+    logger.info("Wrote index image snapshot to %s", snapshot_path)
+
+
+def main() -> int:
+    """Run the collect-index-images workflow."""
+    data_dir = Path(tekton.require_env("PARAM_DATA_DIR"))
+    run_collect_index_images(
+        data_dir=data_dir,
+        internal_request_results_file=Path(
+            tekton.require_env("PARAM_INTERNAL_REQUEST_RESULTS_FILE"),
+        ),
+        build_timestamp=tekton.require_env("PARAM_BUILD_TIMESTAMP"),
+        snapshot_path=data_dir / SNAPSHOT_FILENAME,
+        index_image_snapshot_result_path=tekton.result_paths_from_env(
+            "RESULT_INDEX_IMAGE_SNAPSHOT_PATH",
+        )[0],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_collect_index_images.py
+++ b/scripts/python/tasks/managed/test_collect_index_images.py
@@ -1,0 +1,367 @@
+"""Test collect_index_images task logic."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+import collect_index_images
+
+_TRANSLATED_FBC = [
+    {
+        "repo": "redhat.io",
+        "url": "registry.redhat.io/redhat/fbc-target-index:v4.12",
+    },
+    {
+        "repo": "access.redhat.com",
+        "url": "registry.access.redhat.com/redhat/fbc-target-index:v4.12",
+    },
+]
+
+_TRANSLATED_PREVIEW = [
+    {
+        "repo": "redhat.io",
+        "url": "registry.redhat.io/redhat/preview-operator-index:v4.13",
+    },
+    {
+        "repo": "access.redhat.com",
+        "url": "registry.access.redhat.com/redhat/preview-operator-index:v4.13",
+    },
+]
+
+
+def _write_results(path: Path, components: list[dict[str, Any]]) -> None:
+    """Write an internal-request results JSON file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"components": components}) + "\n", encoding="utf-8")
+
+
+def test_split_target_index_parses_repository_and_tag() -> None:
+    """Split a target index reference at the last colon."""
+    assert collect_index_images.split_target_index(
+        "quay.io/redhat/redhat----fbc-target-index:v4.12",
+    ) == ("quay.io/redhat/redhat----fbc-target-index", "v4.12")
+
+
+def test_split_target_index_rejects_missing_tag() -> None:
+    """Reject target index values without a tag."""
+    with pytest.raises(ValueError, match="repository and tag"):
+        collect_index_images.split_target_index("quay.io/redhat/repo")
+
+
+def test_build_tags_appends_timestamp_for_bare_ocp_version() -> None:
+    """Append buildTimestamp for bare OCP version tags."""
+    assert collect_index_images.build_tags("v4.12", "2468") == [
+        "v4.12",
+        "v4.12-2468",
+    ]
+
+
+def test_build_tags_keeps_hotfix_tag_only() -> None:
+    """Do not append buildTimestamp for hotfix tags."""
+    assert collect_index_images.build_tags("v4.12-12345-6789", "9999") == [
+        "v4.12-12345-6789",
+    ]
+
+
+def test_build_tags_keeps_pre_ga_tag_only() -> None:
+    """Do not append buildTimestamp for pre-GA tags."""
+    tag = "v4.13-myproduct-1.0-20250220143022"
+    assert collect_index_images.build_tags(tag, "9999") == [tag]
+
+
+def test_translation_repo_url_strips_tag_suffix() -> None:
+    """Return the repository URL without the tag portion."""
+    url = collect_index_images.translation_repo_url(_TRANSLATED_FBC, "redhat.io")
+    assert url == "registry.redhat.io/redhat/fbc-target-index"
+
+
+def test_translation_repo_url_returns_empty_for_unknown_repo() -> None:
+    """Return an empty string when the repo key is absent."""
+    assert collect_index_images.translation_repo_url(_TRANSLATED_FBC, "missing") == ""
+
+
+def test_translation_repo_url_returns_empty_for_blank_url() -> None:
+    """Return an empty string when the matched entry has no URL."""
+    translated = [{"repo": "redhat.io", "url": ""}]
+    assert collect_index_images.translation_repo_url(translated, "redhat.io") == ""
+
+
+def test_build_repo_object_includes_optional_delivery_repos() -> None:
+    """Include translated delivery-repo fields when present."""
+    repo_object = collect_index_images.build_repo_object(
+        "quay.io/redhat/redhat----fbc-target-index",
+        ["v4.12", "v4.12-2468"],
+        "registry.redhat.io/redhat/fbc-target-index",
+        "registry.access.redhat.com/redhat/fbc-target-index",
+    )
+    assert repo_object["rh-registry-repo"] == "registry.redhat.io/redhat/fbc-target-index"
+    assert repo_object["registry-access-repo"] == (
+        "registry.access.redhat.com/redhat/fbc-target-index"
+    )
+
+
+def test_build_repo_object_omits_empty_delivery_repos() -> None:
+    """Omit optional delivery-repo fields when translation is blank."""
+    repo_object = collect_index_images.build_repo_object(
+        "quay.io/example/repo",
+        ["v1"],
+        "",
+        "",
+    )
+    assert "rh-registry-repo" not in repo_object
+    assert "registry-access-repo" not in repo_object
+
+
+def test_collect_index_image_components_single_version() -> None:
+    """Build one component with timestamp tag for a bare OCP version."""
+    results = {
+        "components": [
+            {
+                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk",
+            },
+        ],
+    }
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        return_value=_TRANSLATED_FBC,
+    ):
+        snapshot = collect_index_images.collect_index_image_components(results, "2468")
+
+    component = snapshot["components"][0]
+    assert component["containerImage"] == "redhat.com/rh-stage/iib@sha256:abcdefghijk"
+    assert component["repository"] == "quay.io/redhat/redhat----fbc-target-index"
+    assert component["tags"] == ["v4.12", "v4.12-2468"]
+    assert component["repositories"][0]["tags"] == ["v4.12", "v4.12-2468"]
+    assert "registry.redhat.io" in component["repositories"][0]["rh-registry-repo"]
+    assert "registry.access.redhat.com" in (
+        component["repositories"][0]["registry-access-repo"]
+    )
+
+
+def test_collect_index_image_components_multiple_versions() -> None:
+    """Build separate components for each bare OCP version."""
+    results = {
+        "components": [
+            {
+                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk",
+            },
+            {
+                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.13",
+                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:lmnopqrstuv",
+            },
+        ],
+    }
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        return_value=_TRANSLATED_FBC,
+    ):
+        snapshot = collect_index_images.collect_index_image_components(results, "1357")
+
+    assert len(snapshot["components"]) == 2
+    assert snapshot["components"][0]["tags"] == ["v4.12", "v4.12-1357"]
+    assert snapshot["components"][1]["tags"] == ["v4.13", "v4.13-1357"]
+
+
+def test_collect_index_image_components_hotfix_and_pre_ga() -> None:
+    """Keep hotfix and pre-GA tags without appending buildTimestamp."""
+    results = {
+        "components": [
+            {
+                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12-12345-6789",
+                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk",
+            },
+            {
+                "target_index": (
+                    "quay.io/redhat/redhat----preview-operator-index:"
+                    "v4.13-myproduct-1.0-20250220143022"
+                ),
+                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:lmnopqrstuv",
+            },
+        ],
+    }
+
+    def _translate(target_index: str) -> list[dict[str, Any]]:
+        if "preview-operator-index" in target_index:
+            return _TRANSLATED_PREVIEW
+        return _TRANSLATED_FBC
+
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        side_effect=_translate,
+    ):
+        snapshot = collect_index_images.collect_index_image_components(results, "9999")
+
+    assert snapshot["components"][0]["tags"] == ["v4.12-12345-6789"]
+    assert snapshot["components"][1]["tags"] == ["v4.13-myproduct-1.0-20250220143022"]
+
+
+def test_collect_index_image_components_includes_image_digests() -> None:
+    """Copy image_digests from the internal-request results when present."""
+    results = {
+        "components": [
+            {
+                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abc",
+                "image_digests": ["sha256:one", "sha256:two"],
+            },
+        ],
+    }
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        return_value=_TRANSLATED_FBC,
+    ):
+        snapshot = collect_index_images.collect_index_image_components(results, "2468")
+
+    assert snapshot["components"][0]["imageDigests"] == ["sha256:one", "sha256:two"]
+
+
+def test_collect_index_image_components_defaults_image_digests_to_empty() -> None:
+    """Use an empty imageDigests list when image_digests is absent."""
+    results = {
+        "components": [
+            {
+                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abc",
+            },
+        ],
+    }
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        return_value=_TRANSLATED_FBC,
+    ):
+        snapshot = collect_index_images.collect_index_image_components(results, "2468")
+
+    assert snapshot["components"][0]["imageDigests"] == []
+
+
+def test_collect_index_image_components_rejects_invalid_row() -> None:
+    """Fail when a components entry is not a JSON object."""
+    with pytest.raises(ValueError, match="components\\[0\\] must be a JSON object"):
+        collect_index_images.collect_index_image_components({"components": ["bad"]}, "1")
+
+
+def test_collect_index_image_components_rejects_missing_target_index() -> None:
+    """Fail when target_index is missing from a component row."""
+    row = {"index_image_resolved": "img@sha256:abc"}
+    with pytest.raises(ValueError, match="target_index must be a non-empty string"):
+        collect_index_images.collect_index_image_components({"components": [row]}, "1")
+
+
+def test_collect_index_image_components_rejects_missing_source_index() -> None:
+    """Fail when index_image_resolved is missing from a component row."""
+    row = {"target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12"}
+    with pytest.raises(ValueError, match="index_image_resolved must be a non-empty string"):
+        collect_index_images.collect_index_image_components({"components": [row]}, "1")
+
+
+def test_collect_index_image_components_rejects_invalid_image_digests() -> None:
+    """Fail when image_digests is not a JSON array."""
+    row = {
+        "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+        "index_image_resolved": "img@sha256:abc",
+        "image_digests": "bad",
+    }
+    with pytest.raises(ValueError, match="image_digests must be a JSON array"):
+        collect_index_images.collect_index_image_components({"components": [row]}, "1")
+
+
+def test_collect_index_image_components_rejects_invalid_components_type() -> None:
+    """Fail when the results components field is not an array."""
+    with pytest.raises(ValueError, match="components must be a JSON array"):
+        collect_index_images.collect_index_image_components(
+            {"components": "bad"},
+            "2468",
+        )
+
+
+def test_run_collect_index_images_writes_snapshot_and_result(
+    tmp_path: Path,
+) -> None:
+    """Write the snapshot JSON file and Tekton result path."""
+    _write_results(
+        tmp_path / "internal-requests-results.json",
+        [
+            {
+                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abc",
+            },
+        ],
+    )
+    result_path = tmp_path / "result.txt"
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        return_value=_TRANSLATED_FBC,
+    ):
+        collect_index_images.run_collect_index_images(
+            data_dir=tmp_path,
+            internal_request_results_file=Path("internal-requests-results.json"),
+            build_timestamp="2468",
+            snapshot_path=tmp_path / collect_index_images.SNAPSHOT_FILENAME,
+            index_image_snapshot_result_path=result_path,
+        )
+
+    snapshot = json.loads(
+        (tmp_path / collect_index_images.SNAPSHOT_FILENAME).read_text(encoding="utf-8"),
+    )
+    assert len(snapshot["components"]) == 1
+    assert result_path.read_text(encoding="utf-8") == collect_index_images.SNAPSHOT_FILENAME
+
+
+def test_run_collect_index_images_missing_results_file(tmp_path: Path) -> None:
+    """Fail when the internal request results file is missing."""
+    with pytest.raises(FileNotFoundError, match="internal request results file not found"):
+        collect_index_images.run_collect_index_images(
+            data_dir=tmp_path,
+            internal_request_results_file=Path("missing.json"),
+            build_timestamp="2468",
+            snapshot_path=tmp_path / collect_index_images.SNAPSHOT_FILENAME,
+            index_image_snapshot_result_path=tmp_path / "result.txt",
+        )
+
+
+def test_module_main_guard_propagates_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Executing the module as `__main__` propagates failures from main()."""
+    import runpy
+
+    monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PARAM_INTERNAL_REQUEST_RESULTS_FILE", "missing.json")
+    monkeypatch.setenv("PARAM_BUILD_TIMESTAMP", "2468")
+    monkeypatch.setenv("RESULT_INDEX_IMAGE_SNAPSHOT_PATH", str(tmp_path / "result.txt"))
+    with pytest.raises(FileNotFoundError, match="internal request results file not found"):
+        runpy.run_module("collect_index_images", run_name="__main__")
+
+
+def test_main_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exit zero after a successful run."""
+    _write_results(
+        tmp_path / "internal-requests-results.json",
+        [
+            {
+                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abc",
+            },
+        ],
+    )
+    monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PARAM_INTERNAL_REQUEST_RESULTS_FILE", "internal-requests-results.json")
+    monkeypatch.setenv("PARAM_BUILD_TIMESTAMP", "2468")
+    monkeypatch.setenv("RESULT_INDEX_IMAGE_SNAPSHOT_PATH", str(tmp_path / "result.txt"))
+
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        return_value=_TRANSLATED_FBC,
+    ):
+        assert collect_index_images.main() == 0


### PR DESCRIPTION
This commit adds a python script to replicate the functionality of the inline bash script in the collect-index-images managed task in the catalog repo. The task will be updated to use this python module instead.

Assisted-By: Cursor