### PR TITLE
fix: use full shallow clone in process_file_updates

### DIFF
--- a/scripts/python/helpers/vcs/git.py
+++ b/scripts/python/helpers/vcs/git.py
@@ -96,8 +96,9 @@ def clone(
 ) -> Path:
     """Clone *clone_url* into *parent_dir*.
 
-    When *shallow* is true, perform a blob-filtered shallow clone and optional
-    sparse checkout of *sparse_dirs* at *revision*.
+    When *shallow* is true, perform a shallow clone at *revision*. With
+    *sparse_dirs*, use blob-filtered sparse checkout; otherwise clone the full
+    tree at depth 1 (legacy bash ``git_clone_and_checkout`` without ``--sparse-dir``).
 
     Creates *parent_dir* when it does not exist yet.
     """
@@ -111,35 +112,48 @@ def clone(
         if revision is None:
             msg = "revision is required for a shallow clone"
             raise ValueError(msg)
-        if not sparse_dirs:
-            msg = "sparse_dirs is required for a shallow clone"
-            raise ValueError(msg)
-        _run_git_cmd(
-            [
-                "git",
-                "clone",
-                "--filter=blob:none",
-                "--no-checkout",
-                "--depth",
-                "1",
-                "--branch",
-                revision,
-                clone_url,
-                str(repo_dir),
-            ],
-            cwd=parent_dir,
-            stderr_path=stderr_path,
-        )
-        _run_git_cmd(
-            ["git", "sparse-checkout", "set", *sparse_dirs],
-            cwd=repo_dir,
-            stderr_path=stderr_path,
-        )
-        _run_git_cmd(
-            ["git", "checkout", revision],
-            cwd=repo_dir,
-            stderr_path=stderr_path,
-        )
+        if sparse_dirs:
+            _run_git_cmd(
+                [
+                    "git",
+                    "clone",
+                    "--filter=blob:none",
+                    "--no-checkout",
+                    "--depth",
+                    "1",
+                    "--branch",
+                    revision,
+                    clone_url,
+                    str(repo_dir),
+                ],
+                cwd=parent_dir,
+                stderr_path=stderr_path,
+            )
+            _run_git_cmd(
+                ["git", "sparse-checkout", "set", *sparse_dirs],
+                cwd=repo_dir,
+                stderr_path=stderr_path,
+            )
+            _run_git_cmd(
+                ["git", "checkout", revision],
+                cwd=repo_dir,
+                stderr_path=stderr_path,
+            )
+        else:
+            _run_git_cmd(
+                [
+                    "git",
+                    "clone",
+                    "--depth",
+                    "1",
+                    "--branch",
+                    revision,
+                    clone_url,
+                    str(repo_dir),
+                ],
+                cwd=parent_dir,
+                stderr_path=stderr_path,
+            )
     else:
         _run_git_cmd(
             ["git", "clone", clone_url, str(repo_dir)],

--- a/scripts/python/helpers/vcs/test_git.py
+++ b/scripts/python/helpers/vcs/test_git.py
@@ -144,10 +144,38 @@ def test_clone_shallow_sparse(tmp_path: Path) -> None:
     assert run_cmd.call_count == 3
 
 
+def test_clone_shallow_full(tmp_path: Path) -> None:
+    """Shallow clone without sparse dirs checks out the full tree at depth 1."""
+    repo_dir = tmp_path / "proj"
+    with mock.patch.object(git, "_run_git_cmd") as run_cmd:
+        out = git.clone(
+            tmp_path,
+            "https://x/proj.git",
+            directory_name="proj",
+            revision="main",
+            shallow=True,
+        )
+    assert out == repo_dir
+    run_cmd.assert_called_once_with(
+        [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            "main",
+            "https://x/proj.git",
+            str(repo_dir),
+        ],
+        cwd=tmp_path,
+        stderr_path=None,
+    )
+
+
 def test_clone_shallow_requires_revision(tmp_path: Path) -> None:
     """Shallow clones require a revision."""
     with pytest.raises(ValueError, match="revision"):
-        git.clone(tmp_path, "https://x/p.git", shallow=True, sparse_dirs=["a"])
+        git.clone(tmp_path, "https://x/p.git", shallow=True)
 
 
 def test_clone_appends_stderr(tmp_path: Path) -> None:

--- a/scripts/python/tasks/internal/process_file_updates.py
+++ b/scripts/python/tasks/internal/process_file_updates.py
@@ -300,21 +300,6 @@ def write_paths_manifest(paths_json: str, temp_dir: Path) -> tuple[Path, list[di
     return update_paths_file, json.loads(paths_json)
 
 
-def sparse_dirs_from_paths(paths_data: list[dict[str, Any]]) -> list[str]:
-    """Return sparse-checkout paths covering every ``path`` entry in *paths_data*."""
-    sparse_dirs: set[str] = set()
-    for entry in paths_data:
-        entry_path = entry.get("path")
-        if not entry_path:
-            continue
-        path = Path(str(entry_path))
-        if path.parent == Path("."):
-            sparse_dirs.add(path.as_posix())
-        else:
-            sparse_dirs.add(path.parent.as_posix())
-    return sorted(sparse_dirs)
-
-
 def prepare_repository(
     repo: str,
     revision: str,
@@ -324,8 +309,7 @@ def prepare_repository(
 ) -> Path:
     """Clone *repo* at *revision*, rebase on *upstream_repo*, and return the repo cwd."""
     logger.info("=== UPDATING %s ON BRANCH %s ===", repo, revision)
-    sparse_dirs = sparse_dirs_from_paths(paths_data)
-    if not sparse_dirs:
+    if not any(entry.get("path") for entry in paths_data):
         raise tekton.CheckStepError(
             "cloning repository",
             ValueError("paths JSON must include at least one path entry"),
@@ -334,7 +318,6 @@ def prepare_repository(
         temp_dir,
         repo,
         revision=revision,
-        sparse_dirs=sparse_dirs,
         shallow=True,
     )
     vcs_git.rebase_onto_remote(

--- a/scripts/python/tasks/internal/test_process_file_updates.py
+++ b/scripts/python/tasks/internal/test_process_file_updates.py
@@ -470,27 +470,8 @@ def test_git_functions_init_configures_identity() -> None:
     cfg.assert_called_once_with("Author", "a@example.com")
 
 
-def test_sparse_dirs_from_paths() -> None:
-    """Sparse checkout paths cover parent dirs and root-level files."""
-    paths = [
-        {"path": "deploy/overlays/prod/kustomization.yaml"},
-        {"path": "version.yaml"},
-        {"path": "deploy/base/kustomization.yaml"},
-    ]
-    assert process_file_updates.sparse_dirs_from_paths(paths) == [
-        "deploy/base",
-        "deploy/overlays/prod",
-        "version.yaml",
-    ]
-
-
-def test_sparse_dirs_from_paths_skips_missing_path() -> None:
-    """Entries without a path are ignored."""
-    assert process_file_updates.sparse_dirs_from_paths([{"seed": "x"}]) == []
-
-
 def test_prepare_repository(tmp_path: Path) -> None:
-    """Repository is sparse-cloned and rebased on upstream via ``vcs.git``."""
+    """Repository is shallow-cloned and rebased on upstream via ``vcs.git``."""
     repo_cwd = tmp_path / "cloned"
     repo_cwd.mkdir()
     paths = [{"path": "deploy/image.yaml", "replacements": []}]
@@ -514,7 +495,6 @@ def test_prepare_repository(tmp_path: Path) -> None:
         tmp_path,
         "https://gitlab.com/org/repo.git",
         revision="main",
-        sparse_dirs=["deploy"],
         shallow=True,
     )
     rebase.assert_called_once()


### PR DESCRIPTION
## Describe your changes
The python port from #775 used sparse shallow clone, but the bash task does a full shallow clone. 
e2e file updates failed because the target file wasn’t present after sparse checkout (yq → exit 1). 

This change makes prepare_repository() use a full shallow clone to match bash. git.clone() still supports sparse shallow clone when sparse_dirs is provided for other callers.

## Relevant Jira
[RELEASE-1988](https://redhat.atlassian.net/browse/RELEASE-1988)


[RELEASE-1988]: https://redhat.atlassian.net/browse/RELEASE-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ