### PR TITLE
fix(RELEASE-1993): fix missing result in update-fbc-catalog

### DIFF
--- a/scripts/python/tasks/internal/test_update_fbc_catalog.py
+++ b/scripts/python/tasks/internal/test_update_fbc_catalog.py
@@ -731,6 +731,9 @@ def test_poll_and_collect_complete_success() -> None:
         "internal_index_image_copy": "internal/img:v1",
         "index_image": "registry/idx:v4.12",
         "from_index": "registry/idx:v4.12",
+    }
+    full_build: iib.IIBBuild = {
+        **build,
         "logs": {"url": "https://logs/1"},
     }
     manifest = {
@@ -741,9 +744,12 @@ def test_poll_and_collect_complete_success() -> None:
             }
         ],
     }
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_skopeo_result(json.dumps(manifest)),
+    with (
+        mock.patch("iib.get_build", return_value=full_build),
+        mock.patch(
+            "skopeo.subprocess.run",
+            return_value=_skopeo_result(json.dumps(manifest)),
+        ),
     ):
         result = update_fbc_catalog._poll_and_collect(
             "https://iib",
@@ -765,13 +771,14 @@ def test_poll_and_collect_failed_build() -> None:
         "state": "failed",
         "state_reason": "something broke",
     }
-    result = update_fbc_catalog._poll_and_collect(
-        "https://iib",
-        build,
-        3600,
-        False,
-        False,
-    )
+    with mock.patch("iib.get_build", return_value=build):
+        result = update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            build,
+            3600,
+            False,
+            False,
+        )
     assert result.exit_code == 1
     assert result.state == "failed"
 
@@ -830,6 +837,12 @@ def _setup_result_env(
     return paths
 
 
+def _assert_all_results_exist(paths: dict[str, Path]) -> None:
+    """Assert that all five Tekton result files exist."""
+    for name, path in paths.items():
+        assert path.exists(), f"{name} result file was not created"
+
+
 def test_main_invalid_fbc_fragments(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -848,6 +861,7 @@ def test_main_invalid_fbc_fragments(
     state = json.loads(paths["RESULT_BUILD_STATE"].read_text(encoding="utf-8"))
     assert state["state"] == "failed"
     assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "1"
+    _assert_all_results_exist(paths)
 
 
 def test_main_empty_fbc_fragments(
@@ -866,6 +880,7 @@ def test_main_empty_fbc_fragments(
             ]
         )
     assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "1"
+    _assert_all_results_exist(paths)
 
 
 def test_main_writes_results_on_success(
@@ -924,6 +939,30 @@ def test_main_writes_results_on_success(
     )
 
 
+def test_main_writes_iib_log_when_url_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """All result files are written even when iib_log_url is empty."""
+    paths = _setup_result_env(monkeypatch, tmp_path)
+    _setup_mount_env(monkeypatch, tmp_path)
+
+    fake_result = update_fbc_catalog.RunResult(
+        build_info={"id": 1, "state": "complete"},
+        state="complete",
+        state_reason="ok",
+        index_image_digests="sha256:abc",
+        iib_log_url="",
+        exit_code=0,
+    )
+    with mock.patch("update_fbc_catalog.run", return_value=fake_result):
+        rc = update_fbc_catalog.main(["--fbc-fragments", '["frag"]', "--from-index", "idx:v1"])
+
+    assert rc == 0
+    _assert_all_results_exist(paths)
+    assert paths["RESULT_IIB_LOG"].read_text(encoding="utf-8") == ""
+
+
 def test_main_check_step_error_writes_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -961,6 +1000,7 @@ def test_main_check_step_error_writes_failure(
     assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "1"
     state = json.loads(paths["RESULT_BUILD_STATE"].read_text(encoding="utf-8"))
     assert state["state"] == "failed"
+    _assert_all_results_exist(paths)
 
 
 def test_main_missing_result_env_exits() -> None:
@@ -994,6 +1034,7 @@ def test_main_invalid_build_tags_json(
             ]
         )
     assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "1"
+    _assert_all_results_exist(paths)
 
 
 def test_main_returns_nonzero_on_failed_build(
@@ -1030,6 +1071,7 @@ def test_main_returns_nonzero_on_failed_build(
     state = json.loads(paths["RESULT_BUILD_STATE"].read_text(encoding="utf-8"))
     assert state["state"] == "failed"
     assert state["state_reason"] == "Build failed with exit code 1"
+    _assert_all_results_exist(paths)
 
 
 def test_main_timeout_returns_124(
@@ -1063,6 +1105,7 @@ def test_main_timeout_returns_124(
 
     assert rc == 124
     assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "124"
+    _assert_all_results_exist(paths)
 
 
 def _setup_mount_env(
@@ -1144,13 +1187,14 @@ def test_poll_and_collect_validation_error() -> None:
         "index_image": "registry/idx:wrong",
         "from_index": "registry/idx:v4.12",
     }
-    result = update_fbc_catalog._poll_and_collect(
-        "https://iib",
-        build,
-        3600,
-        True,
-        True,
-    )
+    with mock.patch("iib.get_build", return_value=build):
+        result = update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            build,
+            3600,
+            True,
+            True,
+        )
     assert result.exit_code == 1
     assert result.state == "failed"
     assert "Index image mismatch" in result.state_reason
@@ -1164,13 +1208,14 @@ def test_poll_and_collect_missing_internal_copy() -> None:
         "index_image": "registry/idx:v4.12",
         "from_index": "registry/idx:v4.12",
     }
-    result = update_fbc_catalog._poll_and_collect(
-        "https://iib",
-        build,
-        3600,
-        True,
-        True,
-    )
+    with mock.patch("iib.get_build", return_value=build):
+        result = update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            build,
+            3600,
+            True,
+            True,
+        )
     assert result.exit_code == 1
     assert "Missing internal_index_image_copy" in result.state_reason
 
@@ -1182,9 +1227,12 @@ def test_poll_and_collect_digest_extraction_fails() -> None:
         "state": "complete",
         "internal_index_image_copy": "internal/img:v1",
     }
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_skopeo_result(returncode=1),
+    with (
+        mock.patch("iib.get_build", return_value=build),
+        mock.patch(
+            "skopeo.subprocess.run",
+            return_value=_skopeo_result(returncode=1),
+        ),
     ):
         result = update_fbc_catalog._poll_and_collect(
             "https://iib",
@@ -1241,26 +1289,28 @@ def test_poll_and_collect_failed_state_reason() -> None:
         "state": "failed",
         "state_reason": "IIB internal error",
     }
-    result = update_fbc_catalog._poll_and_collect(
-        "https://iib",
-        build_with_reason,
-        3600,
-        False,
-        False,
-    )
+    with mock.patch("iib.get_build", return_value=build_with_reason):
+        result = update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            build_with_reason,
+            3600,
+            False,
+            False,
+        )
     assert result.state_reason == "IIB internal error"
 
     build_no_reason: iib.IIBBuild = {
         "id": 2,
         "state": "failed",
     }
-    result2 = update_fbc_catalog._poll_and_collect(
-        "https://iib",
-        build_no_reason,
-        3600,
-        False,
-        False,
-    )
+    with mock.patch("iib.get_build", return_value=build_no_reason):
+        result2 = update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            build_no_reason,
+            3600,
+            False,
+            False,
+        )
     assert result2.state_reason == "Build failed with exit code 1"
 
 
@@ -1627,6 +1677,7 @@ def test_main_empty_from_index(
             ]
         )
     assert paths["RESULT_EXIT_CODE"].read_text(encoding="utf-8") == "1"
+    _assert_all_results_exist(paths)
 
 
 def test_poll_and_collect_removes_state_history_without_polling() -> None:
@@ -1637,6 +1688,13 @@ def test_poll_and_collect_removes_state_history_without_polling() -> None:
         "internal_index_image_copy": "internal/img:v1",
         "state_history": [{"state": "in_progress"}],
     }
+    full_build: iib.IIBBuild = {
+        "id": 1,
+        "state": "complete",
+        "internal_index_image_copy": "internal/img:v1",
+        "state_history": [{"state": "in_progress"}],
+        "logs": {"url": "https://logs/1"},
+    }
     manifest = {
         "manifests": [
             {
@@ -1645,9 +1703,12 @@ def test_poll_and_collect_removes_state_history_without_polling() -> None:
             }
         ],
     }
-    with mock.patch(
-        "skopeo.subprocess.run",
-        return_value=_skopeo_result(json.dumps(manifest)),
+    with (
+        mock.patch("iib.get_build", return_value=full_build),
+        mock.patch(
+            "skopeo.subprocess.run",
+            return_value=_skopeo_result(json.dumps(manifest)),
+        ),
     ):
         result = update_fbc_catalog._poll_and_collect(
             "https://iib",
@@ -1658,3 +1719,79 @@ def test_poll_and_collect_removes_state_history_without_polling() -> None:
         )
     assert result.exit_code == 0
     assert "state_history" not in result.build_info
+
+
+def test_poll_and_collect_fetches_full_details_for_reused_build() -> None:
+    """Reused completed build is re-fetched via the detail endpoint."""
+    list_build: iib.IIBBuild = {
+        "id": 42,
+        "state": "complete",
+        "internal_index_image_copy": "internal/img:v1",
+    }
+    detail_build: iib.IIBBuild = {
+        "id": 42,
+        "state": "complete",
+        "internal_index_image_copy": "internal/img:v1",
+        "logs": {"url": "https://logs/42"},
+    }
+    manifest = {
+        "manifests": [
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "digest": "sha256:abc",
+            }
+        ],
+    }
+    with (
+        mock.patch("iib.get_build", return_value=detail_build) as get_mock,
+        mock.patch(
+            "skopeo.subprocess.run",
+            return_value=_skopeo_result(json.dumps(manifest)),
+        ),
+    ):
+        result = update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            list_build,
+            3600,
+            False,
+            False,
+        )
+    get_mock.assert_called_once_with("https://iib", 42)
+    assert result.iib_log_url == "https://logs/42"
+    assert result.exit_code == 0
+
+
+def test_poll_and_collect_detail_fetch_failure_is_non_fatal() -> None:
+    """Failure to fetch full details does not break the flow."""
+    list_build: iib.IIBBuild = {
+        "id": 42,
+        "state": "complete",
+        "internal_index_image_copy": "internal/img:v1",
+    }
+    manifest = {
+        "manifests": [
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "digest": "sha256:abc",
+            }
+        ],
+    }
+    with (
+        mock.patch(
+            "iib.get_build",
+            side_effect=requests.ConnectionError("timeout"),
+        ),
+        mock.patch(
+            "skopeo.subprocess.run",
+            return_value=_skopeo_result(json.dumps(manifest)),
+        ),
+    ):
+        result = update_fbc_catalog._poll_and_collect(
+            "https://iib",
+            list_build,
+            3600,
+            False,
+            False,
+        )
+    assert result.exit_code == 0
+    assert result.iib_log_url == ""

--- a/scripts/python/tasks/internal/update_fbc_catalog.py
+++ b/scripts/python/tasks/internal/update_fbc_catalog.py
@@ -17,16 +17,15 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-import requests
-from requests_kerberos import HTTPKerberosAuth, OPTIONAL
-
 import authentication
 import file
 import http_client
 import iib
+import requests
 import skopeo
 import tekton
 from logger import logger
+from requests_kerberos import OPTIONAL, HTTPKerberosAuth
 
 PROG = "update_fbc_catalog.py"
 POLL_INTERVAL_SECONDS = 30
@@ -168,7 +167,7 @@ def is_build_newer_than_index(
         try:
             upstream_ts = iib.parse_date_to_epoch(from_index_created)
             if new_catalog_ts < upstream_ts:
-                logger.warning("Completed build is older than from_index, " "skipping reuse")
+                logger.warning("Completed build is older than from_index, skipping reuse")
                 return False
             return True
         except (ValueError, OSError) as e:
@@ -382,7 +381,7 @@ def poll_build_status(
         elapsed = clock_fn() - start
         if elapsed >= timeout_seconds:
             raise TimeoutError(
-                f"Timeout after {timeout_seconds}s waiting for " f"build {build_id}"
+                f"Timeout after {timeout_seconds}s waiting for build {build_id}"
             )
 
         now = clock_fn()
@@ -473,12 +472,12 @@ def get_manifest_digests(image_ref: str) -> str:
     """
     result = skopeo.inspect(image_ref, raw=True)
     if result.returncode != 0:
-        raise RuntimeError(f"skopeo inspect --raw failed for {image_ref}: " f"{result.stderr}")
+        raise RuntimeError(f"skopeo inspect --raw failed for {image_ref}: {result.stderr}")
     raw = json.loads(result.stdout)
     media = "application/vnd.docker.distribution.manifest.v2+json"
     digests = [m["digest"] for m in raw.get("manifests", []) if m.get("mediaType") == media]
     if not digests:
-        raise RuntimeError("Index image produced is not multi-arch with a manifest " "list")
+        raise RuntimeError("Index image produced is not multi-arch with a manifest list")
     return " ".join(digests)
 
 
@@ -652,6 +651,12 @@ def _poll_and_collect(
                 exit_code=124,
             )
         state = build_info.get("state", "")
+    else:
+        try:
+            build_info = iib.get_build(iib_url, build_id)
+            build_info.pop("state_history", None)  # type: ignore[misc]
+        except (requests.RequestException, OSError, json.JSONDecodeError) as e:
+            logger.warning("Failed to fetch full build details: %s", e)
 
     log_url = iib.extract_log_url(build_info)
     state_reason = build_info.get("state_reason", "")
@@ -730,20 +735,41 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     if not args.from_index.strip():
-        _write_failure(build_state_path, exit_code_path, "from-index is required")
+        _write_failure(
+            build_state_path,
+            exit_code_path,
+            "from-index is required",
+            json_build_info_path,
+            index_image_digests_path,
+            iib_log_path,
+        )
         raise SystemExit(f"{PROG}: from-index is required")
 
     try:
         fbc_fragments = parse_fbc_fragments(args.fbc_fragments)
     except (json.JSONDecodeError, ValueError) as e:
-        _write_failure(build_state_path, exit_code_path, str(e))
+        _write_failure(
+            build_state_path,
+            exit_code_path,
+            str(e),
+            json_build_info_path,
+            index_image_digests_path,
+            iib_log_path,
+        )
         raise SystemExit(f"{PROG}: {e}") from e
 
     try:
         build_tags: list[str] = json.loads(args.build_tags)
         add_arches: list[str] = json.loads(args.add_arches)
     except json.JSONDecodeError as e:
-        _write_failure(build_state_path, exit_code_path, str(e))
+        _write_failure(
+            build_state_path,
+            exit_code_path,
+            str(e),
+            json_build_info_path,
+            index_image_digests_path,
+            iib_log_path,
+        )
         raise SystemExit(f"{PROG}: Invalid JSON: {e}") from e
 
     input = FBCCatalogInput(
@@ -781,7 +807,14 @@ def main(argv: list[str] | None = None) -> int:
             iib_log_path=iib_log_path,
         )
     except tekton.CheckStepError as e:
-        _write_failure(build_state_path, exit_code_path, str(e))
+        _write_failure(
+            build_state_path,
+            exit_code_path,
+            str(e),
+            json_build_info_path,
+            index_image_digests_path,
+            iib_log_path,
+        )
         raise SystemExit(f"{PROG}: {e}") from e
 
     json_build_info_path.write_text(
@@ -797,8 +830,10 @@ def main(argv: list[str] | None = None) -> int:
         encoding="utf-8",
     )
     index_image_digests_path.write_text(result.index_image_digests, encoding="utf-8")
-    if result.iib_log_url:
-        iib_log_path.write_text(f"IIB log url is: {result.iib_log_url}", encoding="utf-8")
+    iib_log_path.write_text(
+        f"IIB log url is: {result.iib_log_url}" if result.iib_log_url else "",
+        encoding="utf-8",
+    )
     exit_code_path.write_text(str(result.exit_code), encoding="utf-8")
 
     if result.iib_log_url:
@@ -815,13 +850,24 @@ def _write_failure(
     build_state_path: Path,
     exit_code_path: Path,
     reason: str,
+    json_build_info_path: Path,
+    index_image_digests_path: Path,
+    iib_log_path: Path,
 ) -> None:
-    """Write failure state to Tekton result files."""
+    """Write failure state to Tekton result files.
+
+    All declared Tekton result files must exist by the time the Task
+    finishes or the TaskRun fails. Results that have no data on early
+    failure paths are written empty.
+    """
     build_state_path.write_text(
         json.dumps({"state": "failed", "state_reason": reason}),
         encoding="utf-8",
     )
     exit_code_path.write_text("1", encoding="utf-8")
+    json_build_info_path.write_text("", encoding="utf-8")
+    index_image_digests_path.write_text("", encoding="utf-8")
+    iib_log_path.write_text("", encoding="utf-8")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Always write the iibLog result file even when the log URL is empty, write all five result files on early failure paths, and fetch full build details for reused builds so the logs field is populated.

Assisted-by: Claude Code