### PR TITLE
feat(RELEASE-2480): add collect_registry_token_secret script

### DIFF
--- a/scripts/python/helpers/snapshot.py
+++ b/scripts/python/helpers/snapshot.py
@@ -8,6 +8,11 @@ from typing import Any
 import file
 
 
+def _is_truthy(value: Any) -> bool:
+    """Return True for boolean ``True`` or the case-insensitive string ``"true"``."""
+    return value is True or str(value).lower() == "true"
+
+
 def first_component(snapshot_path: Path) -> dict[str, str]:
     """Return fields from the first snapshot `components` entry.
 
@@ -65,3 +70,19 @@ def component_push_source_container(
     if "pushSourceContainer" not in component and default_push_source_container:
         return True
     return False
+
+
+def component_public(data: dict[str, Any], component: dict[str, Any]) -> bool:
+    """Return whether a component should be made public.
+
+    A component is public when its own `public` field is truthy, or when
+    `public` is absent and the mapping-level default (`mapping.defaults.public`)
+    is true.
+    """
+    mapping = data.get("mapping")
+    default = False
+    if isinstance(mapping, dict):
+        defaults = mapping.get("defaults")
+        if isinstance(defaults, dict):
+            default = _is_truthy(defaults.get("public", False))
+    return _is_truthy(component.get("public", default))

--- a/scripts/python/helpers/test_snapshot.py
+++ b/scripts/python/helpers/test_snapshot.py
@@ -9,6 +9,25 @@ import pytest
 import snapshot
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, True),
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        (False, False),
+        ("false", False),
+        (None, False),
+        (1, False),
+        ("yes", False),
+    ],
+)
+def test_is_truthy(value: object, expected: bool) -> None:
+    """Only boolean `True` or a case-insensitive `"true"` string is truthy."""
+    assert snapshot._is_truthy(value) is expected
+
+
 def test_first_component_missing_components(tmp_path: Path) -> None:
     """Reject snapshots with no `components` list."""
     path = tmp_path / "snapshot.json"
@@ -107,3 +126,28 @@ def test_component_push_source_container_explicit_false() -> None:
         {"pushSourceContainer": False},
         True,
     )
+
+
+def test_component_public_own_flag_true() -> None:
+    """A component's own public=true takes effect regardless of the default."""
+    assert snapshot.component_public({}, {"public": True}) is True
+    assert snapshot.component_public({}, {"public": "true"}) is True
+
+
+def test_component_public_falls_back_to_default() -> None:
+    """A component without its own public field falls back to the mapping default."""
+    data = {"mapping": {"defaults": {"public": True}}}
+    assert snapshot.component_public(data, {}) is True
+    assert snapshot.component_public({}, {}) is False
+
+
+def test_component_public_own_false_overrides_default() -> None:
+    """A component's own public=false overrides a true default."""
+    data = {"mapping": {"defaults": {"public": True}}}
+    assert snapshot.component_public(data, {"public": False}) is False
+
+
+def test_component_public_without_defaults_mapping() -> None:
+    """Default to false when mapping.defaults is missing or invalid."""
+    assert snapshot.component_public({"mapping": {"defaults": "not-a-mapping"}}, {}) is False
+    assert snapshot.component_public({"mapping": "not-a-mapping"}, {}) is False

--- a/scripts/python/tasks/managed/collect_registry_token_secret.py
+++ b/scripts/python/tasks/managed/collect_registry_token_secret.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Collect the registry token secret name from the release data file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import file
+import snapshot
+import tekton
+from logger import logger
+
+
+def is_secret_required(data: dict[str, Any]) -> bool:
+    """Return True when defaults or any component require making repos public.
+
+    An empty component (no ``public`` override) resolves to the mapping-level
+    default, so this also covers the case of ``mapping.defaults.public`` being
+    true with no components at all.
+    """
+    if snapshot.component_public(data, {}):
+        return True
+
+    mapping = data.get("mapping") or {}
+    for component in mapping.get("components") or []:
+        if isinstance(component, dict) and snapshot.component_public(data, component):
+            return True
+
+    return False
+
+
+def collect_registry_token_secret(data: dict[str, Any]) -> str:
+    """Return the registry secret name, or an empty string when not required.
+
+    Raises:
+        KeyError: When a secret is required but ``mapping.registrySecret``
+            is absent.
+
+    """
+    if not is_secret_required(data):
+        logger.info("No repos to make public, so no secret is required. Exiting...")
+        return ""
+
+    mapping = data.get("mapping") or {}
+    return str(mapping["registrySecret"]).strip()
+
+
+def run(data_file: Path) -> str:
+    """Load *data_file* and return the registry secret name (or empty)."""
+    data = file.load_json_dict(data_file)
+    return collect_registry_token_secret(data)
+
+
+def main() -> int:
+    """Read Tekton env vars, resolve the secret name, and write the result."""
+    data_dir = Path(tekton.require_env("PARAM_DATA_DIR"))
+    data_path = Path(tekton.require_env("PARAM_DATA_PATH"))
+    (result_path,) = tekton.result_paths_from_env("RESULT_REGISTRY_SECRET")
+
+    secret = run(data_dir / data_path)
+    result_path.write_text(secret, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_collect_registry_token_secret.py
+++ b/scripts/python/tasks/managed/test_collect_registry_token_secret.py
@@ -1,0 +1,224 @@
+"""Tests for collect_registry_token_secret."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from collect_registry_token_secret import (
+    collect_registry_token_secret,
+    is_secret_required,
+    main,
+    run,
+)
+
+
+def test_is_secret_required_when_defaults_public() -> None:
+    """defaults.public=true requires a registry secret, even with no components."""
+    data = {"mapping": {"defaults": {"public": True}, "components": []}}
+    assert is_secret_required(data) is True
+
+
+def test_is_secret_required_default_public_short_circuits_component_overrides() -> None:
+    """A true mapping default requires a secret regardless of component overrides."""
+    data = {
+        "mapping": {
+            "defaults": {"public": True},
+            "components": [{"name": "a", "public": False}],
+        }
+    }
+    assert is_secret_required(data) is True
+
+
+def test_is_secret_required_when_component_public() -> None:
+    """Any component with public=true requires a registry secret."""
+    data = {
+        "mapping": {
+            "defaults": {},
+            "components": [{"name": "a"}, {"name": "b", "public": True}],
+        }
+    }
+    assert is_secret_required(data) is True
+
+
+def test_is_secret_required_false_when_nothing_public() -> None:
+    """No secret is required when nothing is marked public."""
+    data = {
+        "mapping": {
+            "defaults": {},
+            "components": [{"name": "a"}, {"name": "b", "public": False}],
+        }
+    }
+    assert is_secret_required(data) is False
+
+
+def test_is_secret_required_when_component_public_string() -> None:
+    """Component with public='true' (string) also requires a registry secret."""
+    data = {
+        "mapping": {
+            "defaults": {},
+            "components": [{"name": "a", "public": "true"}],
+        }
+    }
+    assert is_secret_required(data) is True
+
+
+def test_is_secret_required_skips_non_dict_components() -> None:
+    """Non-dict entries in the components list are skipped gracefully."""
+    data = {
+        "mapping": {
+            "defaults": {},
+            "components": ["not-a-dict", None, {"name": "a"}],
+        }
+    }
+    assert is_secret_required(data) is False
+
+
+def test_is_secret_required_with_empty_mapping() -> None:
+    """Empty mapping dict returns False."""
+    assert is_secret_required({"mapping": {}}) is False
+
+
+def test_is_secret_required_with_null_mapping() -> None:
+    """Missing mapping key returns False."""
+    assert is_secret_required({}) is False
+
+
+def test_collect_returns_secret_when_required() -> None:
+    """Return mapping.registrySecret when public repos need a token."""
+    data = {
+        "mapping": {
+            "defaults": {},
+            "components": [{"name": "c", "public": True}],
+            "registrySecret": "mysecret",
+        }
+    }
+    assert collect_registry_token_secret(data) == "mysecret"
+
+
+def test_collect_returns_empty_when_not_required() -> None:
+    """Return an empty string when no repos are public."""
+    data = {
+        "mapping": {
+            "defaults": {},
+            "components": [{"name": "c"}],
+            "registrySecret": "mysecret",
+        }
+    }
+    assert collect_registry_token_secret(data) == ""
+
+
+def test_collect_raises_when_secret_missing() -> None:
+    """Raise KeyError when public=true but mapping.registrySecret is absent."""
+    data = {
+        "mapping": {
+            "defaults": {"public": True},
+            "components": [],
+        }
+    }
+    with pytest.raises(KeyError):
+        collect_registry_token_secret(data)
+
+
+def test_collect_strips_secret_whitespace() -> None:
+    """Leading and trailing whitespace is stripped from the secret name."""
+    data = {
+        "mapping": {
+            "defaults": {},
+            "components": [{"name": "c", "public": True}],
+            "registrySecret": "  mysecret  ",
+        }
+    }
+    assert collect_registry_token_secret(data) == "mysecret"
+
+
+def test_run_reads_file(tmp_path: Path) -> None:
+    """Load JSON from disk and return the registry secret name."""
+    data_file = tmp_path / "data.json"
+    data_file.write_text(
+        json.dumps(
+            {
+                "mapping": {
+                    "components": [{"name": "c", "public": True}],
+                    "defaults": {},
+                    "registrySecret": "token-secret",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert run(data_file) == "token-secret"
+
+
+def test_main_writes_secret(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write the secret name to the Tekton result file."""
+    data_dir = tmp_path / "release"
+    data_dir.mkdir()
+    (data_dir / "data.json").write_text(
+        json.dumps(
+            {
+                "mapping": {
+                    "components": [{"name": "c", "public": True}],
+                    "defaults": {},
+                    "registrySecret": "mysecret",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    result_file = tmp_path / "registrySecret"
+    monkeypatch.setenv("PARAM_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("PARAM_DATA_PATH", "data.json")
+    monkeypatch.setenv("RESULT_REGISTRY_SECRET", str(result_file))
+
+    assert main() == 0
+    assert result_file.read_text(encoding="utf-8") == "mysecret"
+
+
+def test_main_writes_empty_when_not_required(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Write an empty result when no secret is required."""
+    data_dir = tmp_path / "release"
+    data_dir.mkdir()
+    (data_dir / "data.json").write_text(
+        json.dumps({"mapping": {"components": [{"name": "c"}], "defaults": {}}}),
+        encoding="utf-8",
+    )
+    result_file = tmp_path / "registrySecret"
+    monkeypatch.setenv("PARAM_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("PARAM_DATA_PATH", "data.json")
+    monkeypatch.setenv("RESULT_REGISTRY_SECRET", str(result_file))
+
+    assert main() == 0
+    assert result_file.read_text(encoding="utf-8") == ""
+
+
+def test_main_raises_when_secret_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Propagate KeyError when registrySecret is missing but required."""
+    data_dir = tmp_path / "release"
+    data_dir.mkdir()
+    (data_dir / "data.json").write_text(
+        json.dumps(
+            {
+                "mapping": {
+                    "components": [],
+                    "defaults": {"public": True},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    result_file = tmp_path / "registrySecret"
+    monkeypatch.setenv("PARAM_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("PARAM_DATA_PATH", "data.json")
+    monkeypatch.setenv("RESULT_REGISTRY_SECRET", str(result_file))
+
+    with pytest.raises(KeyError):
+        main()
+
+    assert not result_file.exists()


### PR DESCRIPTION
This commit adds a python script to replicate the inline bash in the
collect-registry-token-secret managed task in the catalog repo. The task
will be updated to use this python module instead.
- collect_registry_token_secret.py: read data JSON, detect public repos,
  return registry secret name (or empty) via Tekton result
- test_collect_registry_token_secret.py: 11 pytest cases

Assisted-by: Cursor