### PR TITLE
feat(RELEASE-2482): convert collect-slack-notification-params to python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.coverage

--- a/scripts/python/tasks/managed/collect_slack_notification_params.py
+++ b/scripts/python/tasks/managed/collect_slack_notification_params.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Collect Slack notification parameters from Release CRs and the data file."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import tekton
+from file import load_json_dict
+from logger import logger
+
+
+class ReleaseMetadata(NamedTuple):
+    """Subset of release CR fields needed for the Slack message."""
+
+    origin_workspace: str
+    target_workspace: str
+    release_name: str
+    release_pipeline_name: str
+
+
+def validate_input_files(
+    data_file: Path,
+    snapshot_file: Path,
+    release_file: Path,
+) -> None:
+    """Raise RuntimeError when any required input file is missing."""
+    for label, path in [
+        ("data", data_file),
+        ("snapshot", snapshot_file),
+        ("release", release_file),
+    ]:
+        if not path.is_file():
+            raise RuntimeError(f"No valid {label} file was provided.")
+
+
+def _get_slack_field(data: dict[str, Any], key: str) -> str | None:
+    """Return a string value from data['slack'][key], or None if absent."""
+    slack = data.get("slack")
+    if isinstance(slack, dict) and key in slack:
+        return str(slack[key])
+    return None
+
+
+def extract_slack_secret(data: dict[str, Any]) -> str | None:
+    """Return the slack-notification-secret value, or None if absent."""
+    return _get_slack_field(data, "slack-notification-secret")
+
+
+def extract_slack_keyname(data: dict[str, Any]) -> str | None:
+    """Return the slack-webhook-notification-secret-keyname, or None."""
+    return _get_slack_field(data, "slack-webhook-notification-secret-keyname")
+
+
+def extract_release_metadata(release: dict[str, Any]) -> ReleaseMetadata:
+    """Extract release metadata needed for the Slack message."""
+    metadata = release.get("metadata", {})
+    status = release.get("status", {})
+
+    origin_namespace = metadata.get("namespace", "")
+    target_namespace = status.get("target", "")
+
+    return ReleaseMetadata(
+        origin_workspace=origin_namespace.replace("-tenant", ""),
+        target_workspace=target_namespace.replace("-tenant", ""),
+        release_name=metadata.get("name", ""),
+        release_pipeline_name=status.get("managedProcessing", {}).get("pipelineRun", ""),
+    )
+
+
+def build_urls(
+    hac_url: str,
+    meta: ReleaseMetadata,
+    component_group: str,
+) -> tuple[str, str]:
+    """Build the release detail and pipeline-run URLs."""
+    release_url = (
+        f"{hac_url}/{meta.origin_workspace}/applications"
+        f"/{component_group}/releases/{meta.release_name}"
+    )
+    release_plr_url = (
+        f"{hac_url}/{meta.target_workspace}/applications"
+        f"/{component_group}/pipelineruns"
+        f"/{meta.release_pipeline_name}"
+    )
+    return release_url, release_plr_url
+
+
+def build_slack_message(
+    meta: ReleaseMetadata,
+    component_group: str,
+    release_url: str,
+    release_plr_url: str,
+) -> str:
+    """Build a Slack Block Kit JSON message string."""
+    message: dict[str, Any] = {
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "RHTAP Release Service\n",
+                    "emoji": True,
+                },
+            },
+            {"type": "divider"},
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [
+                            {
+                                "type": "text",
+                                "text": "Release ",
+                                "style": {"bold": True},
+                            },
+                            {
+                                "type": "text",
+                                "text": (
+                                    f"{meta.origin_workspace}"
+                                    f"/{component_group}"
+                                    f"/{meta.release_name}"
+                                ),
+                            },
+                        ],
+                    }
+                ],
+            },
+            {"type": "divider"},
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [
+                            {
+                                "type": "emoji",
+                                "name": "@@CIRCLE_TYPE@@",
+                            },
+                            {"type": "text", "text": " "},
+                            {
+                                "type": "text",
+                                "text": " @@STATUS_TEXT@@ ",
+                                "style": {"bold": True},
+                            },
+                        ],
+                    }
+                ],
+            },
+            {"type": "divider"},
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"<{release_url}|Release Details>",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (f"<{release_plr_url}|Release PipelineRun Logs>"),
+                },
+            },
+            {"type": "divider"},
+        ]
+    }
+    return json.dumps(message)
+
+
+def _write_empty(
+    result_message: Path,
+    result_secret: Path,
+    result_keyname: Path,
+) -> None:
+    """Write empty strings to Tekton result files."""
+    result_message.write_text("", encoding="utf-8")
+    result_secret.write_text("", encoding="utf-8")
+    result_keyname.write_text("", encoding="utf-8")
+
+
+def collect_params(
+    *,
+    data_file: Path,
+    snapshot_file: Path,
+    release_file: Path,
+    hac_url: str,
+    result_message: Path,
+    result_secret: Path,
+    result_keyname: Path,
+) -> int:
+    """Collect Slack notification parameters and write result files."""
+    validate_input_files(data_file, snapshot_file, release_file)
+
+    data = load_json_dict(data_file)
+
+    secret = extract_slack_secret(data)
+    if secret is None:
+        logger.info(
+            "No secret name provided via 'slack.slack-notification-secret' key in Data."
+        )
+        _write_empty(result_message, result_secret, result_keyname)
+        return 0
+
+    result_secret.write_text(secret, encoding="utf-8")
+
+    keyname = extract_slack_keyname(data)
+    if keyname is None:
+        logger.info(
+            "No secret key name provided via"
+            " 'slack.slack-webhook-notification-secret-keyname'"
+            " key in Data."
+        )
+        _write_empty(result_message, result_secret, result_keyname)
+        return 0
+
+    result_keyname.write_text(keyname, encoding="utf-8")
+
+    release = load_json_dict(release_file)
+    snapshot = load_json_dict(snapshot_file)
+
+    meta = extract_release_metadata(release)
+    component_group = snapshot.get("componentGroup", "")
+    release_url, release_plr_url = build_urls(hac_url, meta, component_group)
+
+    message = build_slack_message(meta, component_group, release_url, release_plr_url)
+    result_message.write_text(message, encoding="utf-8")
+
+    return 0
+
+
+def main() -> int:
+    """Read environment, collect Slack notification params, write results."""
+    data_dir = Path(tekton.require_env("DATA_DIR"))
+    data_path = tekton.require_env("DATA_PATH")
+    snapshot_path = tekton.require_env("SNAPSHOT_PATH")
+    release_path = tekton.require_env("RELEASE_PATH")
+    hac_url = tekton.require_env("HAC_URL")
+
+    (
+        result_message,
+        result_secret,
+        result_keyname,
+    ) = tekton.result_paths_from_env(
+        "RESULT_MESSAGE",
+        "RESULT_SLACK_NOTIFICATION_SECRET",
+        "RESULT_SLACK_NOTIFICATION_SECRET_KEYNAME",
+    )
+
+    return collect_params(
+        data_file=data_dir / data_path,
+        snapshot_file=data_dir / snapshot_path,
+        release_file=data_dir / release_path,
+        hac_url=hac_url,
+        result_message=result_message,
+        result_secret=result_secret,
+        result_keyname=result_keyname,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_collect_slack_notification_params.py
+++ b/scripts/python/tasks/managed/test_collect_slack_notification_params.py
@@ -1,0 +1,424 @@
+"""Tests for collect_slack_notification_params."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from collect_slack_notification_params import (
+    ReleaseMetadata,
+    _write_empty,
+    build_slack_message,
+    build_urls,
+    collect_params,
+    extract_release_metadata,
+    extract_slack_keyname,
+    extract_slack_secret,
+    main,
+    validate_input_files,
+)
+
+
+def _write_json(path: Path, data: dict) -> None:
+    """Write a dict as JSON to path, creating parent dirs."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _sample_data() -> dict:
+    """Return a data dict with full slack configuration."""
+    return {
+        "slack": {
+            "slack-notification-secret": "my-slack-secret",
+            "slack-webhook-notification-secret-keyname": "webhook-key",
+        },
+    }
+
+
+def _sample_release() -> dict:
+    """Return a release dict with standard metadata."""
+    return {
+        "metadata": {
+            "namespace": "my-workspace-tenant",
+            "name": "my-release",
+        },
+        "status": {
+            "target": "target-workspace-tenant",
+            "managedProcessing": {
+                "pipelineRun": "my-pipeline-run",
+            },
+        },
+    }
+
+
+def _sample_snapshot() -> dict:
+    """Return a snapshot dict with componentGroup."""
+    return {"componentGroup": "my-app"}
+
+
+# -- validate_input_files --
+
+
+def test_validate_input_files_all_exist(tmp_path: Path) -> None:
+    """No exception when all three files exist."""
+    data = tmp_path / "data.json"
+    snapshot = tmp_path / "snapshot.json"
+    release = tmp_path / "release.json"
+    for f in (data, snapshot, release):
+        f.write_text("{}")
+
+    validate_input_files(data, snapshot, release)
+
+
+def test_validate_input_files_data_missing(tmp_path: Path) -> None:
+    """Raise RuntimeError when data file is missing."""
+    snapshot = tmp_path / "snapshot.json"
+    release = tmp_path / "release.json"
+    for f in (snapshot, release):
+        f.write_text("{}")
+
+    with pytest.raises(RuntimeError, match="No valid data file"):
+        validate_input_files(tmp_path / "missing.json", snapshot, release)
+
+
+def test_validate_input_files_snapshot_missing(tmp_path: Path) -> None:
+    """Raise RuntimeError when snapshot file is missing."""
+    data = tmp_path / "data.json"
+    release = tmp_path / "release.json"
+    for f in (data, release):
+        f.write_text("{}")
+
+    with pytest.raises(RuntimeError, match="No valid snapshot file"):
+        validate_input_files(data, tmp_path / "missing.json", release)
+
+
+def test_validate_input_files_release_missing(tmp_path: Path) -> None:
+    """Raise RuntimeError when release file is missing."""
+    data = tmp_path / "data.json"
+    snapshot = tmp_path / "snapshot.json"
+    for f in (data, snapshot):
+        f.write_text("{}")
+
+    with pytest.raises(RuntimeError, match="No valid release file"):
+        validate_input_files(data, snapshot, tmp_path / "missing.json")
+
+
+# -- extract_slack_secret --
+
+
+def test_extract_slack_secret_present() -> None:
+    """Return the secret value when present."""
+    data = {"slack": {"slack-notification-secret": "my-secret"}}
+    assert extract_slack_secret(data) == "my-secret"
+
+
+def test_extract_slack_secret_missing_key() -> None:
+    """Return None when the key is absent from the slack block."""
+    assert extract_slack_secret({"slack": {}}) is None
+
+
+def test_extract_slack_secret_no_slack_block() -> None:
+    """Return None when there is no slack block."""
+    assert extract_slack_secret({"other": "data"}) is None
+
+
+def test_extract_slack_secret_slack_not_dict() -> None:
+    """Return None when slack is not a dict."""
+    assert extract_slack_secret({"slack": "invalid"}) is None
+
+
+# -- extract_slack_keyname --
+
+
+def test_extract_slack_keyname_present() -> None:
+    """Return the keyname value when present."""
+    data = {
+        "slack": {
+            "slack-webhook-notification-secret-keyname": "wh-key",
+        }
+    }
+    assert extract_slack_keyname(data) == "wh-key"
+
+
+def test_extract_slack_keyname_missing() -> None:
+    """Return None when the key is absent."""
+    assert extract_slack_keyname({"slack": {}}) is None
+
+
+def test_extract_slack_keyname_no_slack_block() -> None:
+    """Return None when there is no slack block."""
+    assert extract_slack_keyname({}) is None
+
+
+# -- extract_release_metadata --
+
+
+def test_extract_release_metadata_full() -> None:
+    """Extract all fields and remove -tenant suffix."""
+    meta = extract_release_metadata(_sample_release())
+
+    assert meta.origin_workspace == "my-workspace"
+    assert meta.target_workspace == "target-workspace"
+    assert meta.release_name == "my-release"
+    assert meta.release_pipeline_name == "my-pipeline-run"
+
+
+def test_extract_release_metadata_missing_fields() -> None:
+    """Return empty strings when nested fields are absent."""
+    meta = extract_release_metadata({})
+
+    assert meta.origin_workspace == ""
+    assert meta.target_workspace == ""
+    assert meta.release_name == ""
+    assert meta.release_pipeline_name == ""
+
+
+# -- build_urls --
+
+
+def test_build_urls() -> None:
+    """Build correct release and pipeline-run URLs."""
+    meta = ReleaseMetadata(
+        origin_workspace="origin-ws",
+        target_workspace="target-ws",
+        release_name="rel-1",
+        release_pipeline_name="plr-1",
+    )
+    release_url, plr_url = build_urls("https://hac.example", meta, "app")
+
+    assert release_url == ("https://hac.example/origin-ws/applications" "/app/releases/rel-1")
+    assert plr_url == ("https://hac.example/target-ws/applications" "/app/pipelineruns/plr-1")
+
+
+# -- build_slack_message --
+
+
+def test_build_slack_message_valid_json() -> None:
+    """Output is valid JSON with expected block structure."""
+    meta = ReleaseMetadata("ws", "tws", "rel", "plr")
+    raw = build_slack_message(meta, "app", "http://r", "http://p")
+    parsed = json.loads(raw)
+
+    assert "blocks" in parsed
+    types = [b["type"] for b in parsed["blocks"]]
+    assert "header" in types
+    assert "divider" in types
+    assert "section" in types
+    assert "rich_text" in types
+
+
+def test_build_slack_message_contains_placeholders() -> None:
+    """Output contains status placeholders for downstream replacement."""
+    meta = ReleaseMetadata("ws", "tws", "rel", "plr")
+    raw = build_slack_message(meta, "app", "http://r", "http://p")
+
+    assert "@@CIRCLE_TYPE@@" in raw
+    assert "@@STATUS_TEXT@@" in raw
+
+
+def test_build_slack_message_contains_release_info() -> None:
+    """Output contains workspace, component group, and release name."""
+    meta = ReleaseMetadata("my-ws", "tgt-ws", "rel-42", "plr-7")
+    raw = build_slack_message(meta, "my-comp", "http://release", "http://plr")
+
+    assert "my-ws/my-comp/rel-42" in raw
+    assert "http://release" in raw
+    assert "http://plr" in raw
+
+
+# -- _write_empty --
+
+
+def test_write_empty(tmp_path: Path) -> None:
+    """Write empty strings to all three result files."""
+    msg = tmp_path / "msg"
+    secret = tmp_path / "secret"
+    keyname = tmp_path / "keyname"
+
+    _write_empty(msg, secret, keyname)
+
+    assert msg.read_text() == ""
+    assert secret.read_text() == ""
+    assert keyname.read_text() == ""
+
+
+# -- collect_params --
+
+
+def test_collect_params_happy_path(tmp_path: Path) -> None:
+    """Write secret, keyname, and message when all config is present."""
+    data_file = tmp_path / "data.json"
+    snapshot_file = tmp_path / "snapshot.json"
+    release_file = tmp_path / "release.json"
+    _write_json(data_file, _sample_data())
+    _write_json(snapshot_file, _sample_snapshot())
+    _write_json(release_file, _sample_release())
+
+    r_msg = tmp_path / "r_msg"
+    r_secret = tmp_path / "r_secret"
+    r_keyname = tmp_path / "r_keyname"
+
+    rc = collect_params(
+        data_file=data_file,
+        snapshot_file=snapshot_file,
+        release_file=release_file,
+        hac_url="https://hac.example",
+        result_message=r_msg,
+        result_secret=r_secret,
+        result_keyname=r_keyname,
+    )
+
+    assert rc == 0
+    assert r_secret.read_text() == "my-slack-secret"
+    assert r_keyname.read_text() == "webhook-key"
+
+    message = json.loads(r_msg.read_text())
+    assert "blocks" in message
+
+
+def test_collect_params_no_slack_secret(tmp_path: Path) -> None:
+    """Write empty results when slack secret is absent."""
+    data_file = tmp_path / "data.json"
+    snapshot_file = tmp_path / "snapshot.json"
+    release_file = tmp_path / "release.json"
+    _write_json(data_file, {"other": "data"})
+    _write_json(snapshot_file, _sample_snapshot())
+    _write_json(release_file, _sample_release())
+
+    r_msg = tmp_path / "r_msg"
+    r_secret = tmp_path / "r_secret"
+    r_keyname = tmp_path / "r_keyname"
+
+    rc = collect_params(
+        data_file=data_file,
+        snapshot_file=snapshot_file,
+        release_file=release_file,
+        hac_url="https://hac.example",
+        result_message=r_msg,
+        result_secret=r_secret,
+        result_keyname=r_keyname,
+    )
+
+    assert rc == 0
+    assert r_msg.read_text() == ""
+    assert r_secret.read_text() == ""
+    assert r_keyname.read_text() == ""
+
+
+def test_collect_params_no_slack_keyname(tmp_path: Path) -> None:
+    """Write secret but empty message and keyname when keyname is absent."""
+    data = {
+        "slack": {
+            "slack-notification-secret": "the-secret",
+        }
+    }
+    data_file = tmp_path / "data.json"
+    snapshot_file = tmp_path / "snapshot.json"
+    release_file = tmp_path / "release.json"
+    _write_json(data_file, data)
+    _write_json(snapshot_file, _sample_snapshot())
+    _write_json(release_file, _sample_release())
+
+    r_msg = tmp_path / "r_msg"
+    r_secret = tmp_path / "r_secret"
+    r_keyname = tmp_path / "r_keyname"
+
+    rc = collect_params(
+        data_file=data_file,
+        snapshot_file=snapshot_file,
+        release_file=release_file,
+        hac_url="https://hac.example",
+        result_message=r_msg,
+        result_secret=r_secret,
+        result_keyname=r_keyname,
+    )
+
+    assert rc == 0
+    assert r_msg.read_text() == ""
+    assert r_keyname.read_text() == ""
+
+
+def test_collect_params_missing_input_file(tmp_path: Path) -> None:
+    """Raise RuntimeError when an input file is missing."""
+    r_msg = tmp_path / "r_msg"
+    r_secret = tmp_path / "r_secret"
+    r_keyname = tmp_path / "r_keyname"
+
+    with pytest.raises(RuntimeError, match="No valid data file"):
+        collect_params(
+            data_file=tmp_path / "missing.json",
+            snapshot_file=tmp_path / "snapshot.json",
+            release_file=tmp_path / "release.json",
+            hac_url="https://hac.example",
+            result_message=r_msg,
+            result_secret=r_secret,
+            result_keyname=r_keyname,
+        )
+
+
+# -- main --
+
+
+def test_main_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return 0 and write all result files when fully configured."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_json(data_dir / "data.json", _sample_data())
+    _write_json(data_dir / "snapshot.json", _sample_snapshot())
+    _write_json(data_dir / "release.json", _sample_release())
+
+    r_msg = tmp_path / "r_msg"
+    r_secret = tmp_path / "r_secret"
+    r_keyname = tmp_path / "r_keyname"
+
+    monkeypatch.setenv("DATA_DIR", str(data_dir))
+    monkeypatch.setenv("DATA_PATH", "data.json")
+    monkeypatch.setenv("SNAPSHOT_PATH", "snapshot.json")
+    monkeypatch.setenv("RELEASE_PATH", "release.json")
+    monkeypatch.setenv("HAC_URL", "https://hac.example")
+    monkeypatch.setenv("RESULT_MESSAGE", str(r_msg))
+    monkeypatch.setenv("RESULT_SLACK_NOTIFICATION_SECRET", str(r_secret))
+    monkeypatch.setenv("RESULT_SLACK_NOTIFICATION_SECRET_KEYNAME", str(r_keyname))
+
+    rc = main()
+
+    assert rc == 0
+    assert r_secret.read_text() == "my-slack-secret"
+    assert r_keyname.read_text() == "webhook-key"
+    assert json.loads(r_msg.read_text())["blocks"]
+
+
+def test_main_missing_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exit with SystemExit when a required env var is missing."""
+    monkeypatch.delenv("DATA_DIR", raising=False)
+
+    with pytest.raises(SystemExit):
+        main()
+
+
+def test_main_missing_result_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exit with SystemExit when a result path env var is missing."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("DATA_PATH", "data.json")
+    monkeypatch.setenv("SNAPSHOT_PATH", "snapshot.json")
+    monkeypatch.setenv("RELEASE_PATH", "release.json")
+    monkeypatch.setenv("HAC_URL", "https://hac.example")
+    monkeypatch.delenv("RESULT_MESSAGE", raising=False)
+    monkeypatch.delenv("RESULT_SLACK_NOTIFICATION_SECRET", raising=False)
+    monkeypatch.delenv("RESULT_SLACK_NOTIFICATION_SECRET_KEYNAME", raising=False)
+
+    with pytest.raises(SystemExit):
+        main()
+
+
+def test_main_missing_hac_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exit with SystemExit when HAC_URL is not set."""
+    monkeypatch.delenv("HAC_URL", raising=False)
+    monkeypatch.delenv("DATA_DIR", raising=False)
+
+    with pytest.raises(SystemExit):
+        main()


### PR DESCRIPTION
Convert the collect-slack-notification-params managed task to python.

Assisted-by: Claude Code