### PR TITLE
feat(RELEASE-2475): add close_advisory_issues.py script

### DIFF
--- a/scripts/python/tasks/managed/close_advisory_issues.py
+++ b/scripts/python/tasks/managed/close_advisory_issues.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Close Jira issues listed in releaseNotes after an advisory is published."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import advisory_data
+import authentication
+import file
+import http_client
+import requests
+import tekton
+from logger import logger
+from requests.auth import HTTPBasicAuth
+
+SUPPORTED_JIRA_SERVER = "redhat.atlassian.net"
+LEGACY_JIRA_SERVER = "issues.redhat.com"
+
+ISSUE_TRACKERS: dict[str, dict[str, Any]] = {
+    "Jira": {
+        "api": "rest/api/2/issue",
+        "servers": [
+            LEGACY_JIRA_SERVER,
+            "jira.atlassian.com",
+            SUPPORTED_JIRA_SERVER,
+        ],
+    },
+    "bugzilla": {
+        "api": "rest/bug",
+        "servers": ["bugzilla.redhat.com"],
+    },
+}
+
+_VALID_JIRA_ISSUE_ID = re.compile(r"^[A-Za-z][A-Za-z0-9_]+-\d+$|^\d+$")
+
+
+def normalize_issue_server(source: str) -> str:
+    """Map legacy issue tracker hostnames to the current Jira server."""
+    if source == LEGACY_JIRA_SERVER:
+        return SUPPORTED_JIRA_SERVER
+    return source
+
+
+def is_jira_eligible_issue(issue: dict[str, Any]) -> bool:
+    """Return whether *issue* will be processed against the Jira API."""
+    issue_id = issue.get("id")
+    source = issue.get("source")
+    if not isinstance(issue_id, str) or not issue_id.strip():
+        return False
+    if not isinstance(source, str) or not source.strip():
+        return False
+    server = normalize_issue_server(source.strip())
+    if server != SUPPORTED_JIRA_SERVER:
+        return False
+    return _VALID_JIRA_ISSUE_ID.fullmatch(issue_id.strip()) is not None
+
+
+def api_path_for_server(server: str) -> str:
+    """Return the REST API prefix for *server*."""
+    for tracker in ISSUE_TRACKERS.values():
+        servers = tracker.get("servers")
+        if isinstance(servers, list) and server in servers:
+            return str(tracker["api"])
+    msg = f"no API mapping for server: {server}"
+    raise ValueError(msg)
+
+
+def load_fixed_issues(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return fixed issues from releaseNotes, or an empty list when absent."""
+    fixed = advisory_data.content_array_from_decoded(
+        data,
+        ".releaseNotes.issues.fixed",
+    )
+    return [row for row in fixed if isinstance(row, dict)]
+
+
+def close_comment(advisory_url: str) -> str:
+    """Build the Jira comment posted when an issue is closed."""
+    return f"Fixed in Konflux Advisory {advisory_url}"
+
+
+def read_jira_credentials(secret_path: Path) -> tuple[str, str]:
+    """Read Jira basic-auth credentials from mounted secret files."""
+    email = authentication.read_mounted_text(secret_path, "email")
+    token = authentication.read_mounted_text(secret_path, "token")
+    if not email or not token:
+        msg = f"Jira secret at {secret_path} must include email and token"
+        raise ValueError(msg)
+    return email, token
+
+
+def jira_issue_url(server: str, issue_id: str) -> str:
+    """Build the Jira issue API URL for *issue_id* on *server*."""
+    api_path = api_path_for_server(server)
+    return f"https://{server}/{api_path}/{issue_id}"
+
+
+def jira_get_json(
+    session: requests.Session,
+    url: str,
+    auth: HTTPBasicAuth,
+) -> dict[str, Any]:
+    """Perform a GET request and return the parsed JSON object."""
+    response = session.get(url, auth=auth, timeout=60.0)
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        msg = f"expected JSON object from {url}"
+        raise ValueError(msg)
+    return data
+
+
+def jira_post_json(
+    session: requests.Session,
+    url: str,
+    auth: HTTPBasicAuth,
+    payload: dict[str, Any],
+) -> None:
+    """Perform a POST request and raise when the response is not successful."""
+    response = session.post(
+        url,
+        auth=auth,
+        json=payload,
+        headers={"Content-Type": "application/json"},
+        timeout=60.0,
+    )
+    response.raise_for_status()
+
+
+def issue_status_name(issue: dict[str, Any]) -> str:
+    """Return the human-readable Jira status name for *issue*."""
+    fields = issue.get("fields")
+    if not isinstance(fields, dict):
+        return ""
+    status = fields.get("status")
+    if not isinstance(status, dict):
+        return ""
+    name = status.get("name")
+    return name if isinstance(name, str) else ""
+
+
+def closed_transition_id(transitions: dict[str, Any]) -> str | None:
+    """Return the transition id for the Closed state, if present."""
+    items = transitions.get("transitions")
+    if not isinstance(items, list):
+        return None
+    for transition in items:
+        if not isinstance(transition, dict):
+            continue
+        if transition.get("name") != "Closed":
+            continue
+        transition_id = transition.get("id")
+        if transition_id is not None:
+            return str(transition_id)
+    return None
+
+
+def close_issue_with_comment(
+    session: requests.Session,
+    issue_url: str,
+    auth: HTTPBasicAuth,
+    transition_id: str,
+    comment: str,
+) -> None:
+    """Transition the issue to Closed and add *comment*."""
+    payload = {
+        "transition": {"id": transition_id},
+        "update": {"comment": [{"add": {"body": comment}}]},
+    }
+    jira_post_json(session, f"{issue_url}/transitions", auth, payload)
+
+
+def add_issue_comment(
+    session: requests.Session,
+    issue_url: str,
+    auth: HTTPBasicAuth,
+    comment: str,
+) -> None:
+    """Add *comment* to the issue without changing its state."""
+    jira_post_json(session, f"{issue_url}/comment", auth, {"body": comment})
+
+
+def process_fixed_issue(
+    issue: dict[str, Any],
+    *,
+    advisory_url: str,
+    auth: HTTPBasicAuth,
+    session: requests.Session,
+) -> None:
+    """Close one fixed issue or add an advisory comment when closing fails."""
+    issue_id = issue.get("id")
+    source = issue.get("source")
+    if not isinstance(issue_id, str) or not issue_id.strip():
+        logger.warning("Skipping issue with missing id: %s", issue)
+        return
+    if not isinstance(source, str) or not source.strip():
+        logger.warning("Skipping issue with missing source: %s", issue)
+        return
+
+    normalized_source = source.strip()
+    server = normalize_issue_server(normalized_source)
+    if server != SUPPORTED_JIRA_SERVER:
+        logger.warning(
+            "This task currently only supports closing issues on "
+            "issues.redhat.com and redhat.atlassian.net. Skipping issue %s "
+            "as it is on %s",
+            issue,
+            normalized_source,
+        )
+        return
+
+    normalized_id = issue_id.strip()
+    if _VALID_JIRA_ISSUE_ID.fullmatch(normalized_id) is None:
+        logger.warning(
+            "Skipping issue with invalid Jira id %r: %s",
+            normalized_id,
+            issue,
+        )
+        return
+
+    issue_url = jira_issue_url(server, normalized_id)
+    comment = close_comment(advisory_url)
+
+    issue_data = jira_get_json(session, issue_url, auth)
+    if issue_status_name(issue_data) == "Closed":
+        logger.info("Issue %s is already in Closed state. Skipping it.", issue)
+        return
+
+    logger.info("Closing issue %s", issue)
+    closing_failed = False
+    try:
+        transitions = jira_get_json(session, f"{issue_url}/transitions", auth)
+        transition_id = closed_transition_id(transitions)
+        if transition_id is None:
+            logger.warning(
+                "Warning: failed to fetch the closed state id for issue %s. "
+                "We most likely do not have permission to close it. Will try "
+                "to add a comment instead.",
+                issue,
+            )
+            closing_failed = True
+        else:
+            close_issue_with_comment(session, issue_url, auth, transition_id, comment)
+    except requests.RequestException as exc:
+        logger.warning(
+            "Warning: failed to close issue %s. Will try to add a comment " "instead. %s",
+            issue,
+            exc,
+        )
+        closing_failed = True
+
+    if not closing_failed:
+        return
+
+    try:
+        add_issue_comment(session, issue_url, auth, comment)
+    except requests.RequestException as exc:
+        logger.warning("Warning: failed to add comment to issue %s. %s", issue, exc)
+
+
+def close_advisory_issues(
+    *,
+    data_dir: Path,
+    data_path: Path,
+    advisory_url: str,
+    secret_path: Path,
+) -> None:
+    """Close fixed Jira issues referenced in the release data file."""
+    data_file = data_dir / data_path
+    if not data_file.is_file():
+        msg = "No data JSON was provided."
+        raise FileNotFoundError(msg)
+
+    logger.info("Loading release data from %s", data_file)
+    data = file.load_json_dict(data_file)
+    fixed_issues = load_fixed_issues(data)
+    if not any(is_jira_eligible_issue(issue) for issue in fixed_issues):
+        return
+
+    email, token = read_jira_credentials(secret_path)
+    auth = HTTPBasicAuth(email, token)
+    session = http_client.get_retry_session(
+        total=5,
+        connect=3,
+        read=3,
+        status=5,
+        backoff_factor=1.0,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=frozenset({"GET", "POST"}),
+    )
+
+    first_error: Exception | None = None
+    for issue in fixed_issues:
+        try:
+            process_fixed_issue(
+                issue,
+                advisory_url=advisory_url,
+                auth=auth,
+                session=session,
+            )
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+            logger.warning("Failed to process issue %s: %s", issue, exc)
+
+    if first_error is not None:
+        raise first_error
+
+
+def main() -> int:
+    """Run the close-advisory-issues workflow."""
+    close_advisory_issues(
+        data_dir=Path(tekton.require_env("PARAM_DATA_DIR")),
+        data_path=Path(tekton.require_env("PARAM_DATA_PATH")),
+        advisory_url=tekton.require_env("PARAM_ADVISORY_URL"),
+        secret_path=file.path_from_env_variable("JIRA_SECRET_PATH", "/etc/secrets"),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_close_advisory_issues.py
+++ b/scripts/python/tasks/managed/test_close_advisory_issues.py
@@ -1,0 +1,782 @@
+"""Verify close_advisory_issues task logic."""
+
+from __future__ import annotations
+
+import json
+import logging
+import runpy
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import close_advisory_issues
+import pytest
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+@pytest.fixture(autouse=True)
+def _propagate_release_logger() -> None:
+    """Allow caplog to capture records from the `release` logger."""
+    release_logger = logging.getLogger("release")
+    release_logger.propagate = True
+    yield
+    release_logger.propagate = False
+
+
+def _write_data(path: Path, data: dict[str, Any]) -> None:
+    """Write *data* as JSON to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data) + "\n", encoding="utf-8")
+
+
+def _write_jira_secret(path: Path) -> None:
+    """Write dummy Jira credentials under *path*."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "email").write_text("team@domain.com\n", encoding="utf-8")
+    (path / "token").write_text("abcdefg\n", encoding="utf-8")
+
+
+def _fixed_issue(
+    issue_id: str,
+    source: str = "redhat.atlassian.net",
+) -> dict[str, str]:
+    """Build one releaseNotes fixed-issue entry."""
+    return {"id": issue_id, "source": source}
+
+
+def test_normalize_issue_server_maps_legacy_host() -> None:
+    """Convert issues.redhat.com to redhat.atlassian.net."""
+    assert (
+        close_advisory_issues.normalize_issue_server("issues.redhat.com")
+        == "redhat.atlassian.net"
+    )
+
+
+def test_is_jira_eligible_issue_accepts_eligible_rows() -> None:
+    """Return true for supported Jira fixed-issue rows."""
+    assert close_advisory_issues.is_jira_eligible_issue(_fixed_issue("ISSUE-123"))
+    assert close_advisory_issues.is_jira_eligible_issue(
+        _fixed_issue("ISSUE-123", "issues.redhat.com"),
+    )
+    assert close_advisory_issues.is_jira_eligible_issue(_fixed_issue("123456"))
+    assert close_advisory_issues.is_jira_eligible_issue(_fixed_issue("RHOSP-12345"))
+    assert close_advisory_issues.is_jira_eligible_issue(
+        _fixed_issue("ISSUE-123", " redhat.atlassian.net "),
+    )
+
+
+def test_is_jira_eligible_issue_rejects_unsupported_tracker() -> None:
+    """Return false for non-Jira trackers."""
+    assert not close_advisory_issues.is_jira_eligible_issue(
+        _fixed_issue("12345", "bugzilla.redhat.com"),
+    )
+
+
+def test_is_jira_eligible_issue_rejects_missing_fields() -> None:
+    """Return false when id or source is missing."""
+    assert not close_advisory_issues.is_jira_eligible_issue(
+        {"source": "redhat.atlassian.net"},
+    )
+    assert not close_advisory_issues.is_jira_eligible_issue({"id": "ISSUE-123"})
+
+
+def test_is_jira_eligible_issue_rejects_invalid_id() -> None:
+    """Return false when the id would alter the Jira REST path."""
+    assert not close_advisory_issues.is_jira_eligible_issue(
+        _fixed_issue("ISSUE-123/extra"),
+    )
+    assert not close_advisory_issues.is_jira_eligible_issue(
+        _fixed_issue("ISSUE-123?query=1"),
+    )
+    assert not close_advisory_issues.is_jira_eligible_issue(_fixed_issue("../admin"))
+
+
+def test_load_fixed_issues_returns_empty_when_issues_not_object() -> None:
+    """Return an empty list when releaseNotes issues is not an object."""
+    data = {"releaseNotes": {"issues": []}}
+    assert close_advisory_issues.load_fixed_issues(data) == []
+
+
+def test_load_fixed_issues_returns_empty_when_fixed_not_array() -> None:
+    """Return an empty list when fixed issues is not an array."""
+    data = {"releaseNotes": {"issues": {"fixed": "bad"}}}
+    assert close_advisory_issues.load_fixed_issues(data) == []
+
+
+def test_issue_status_name_returns_empty_for_invalid_payload() -> None:
+    """Return an empty string when status fields are missing or invalid."""
+    assert close_advisory_issues.issue_status_name({}) == ""
+    assert close_advisory_issues.issue_status_name({"fields": []}) == ""
+    assert (
+        close_advisory_issues.issue_status_name(
+            {"fields": {"status": "bad"}},
+        )
+        == ""
+    )
+    assert (
+        close_advisory_issues.issue_status_name(
+            {"fields": {"status": {"name": 123}}},
+        )
+        == ""
+    )
+
+
+def test_closed_transition_id_ignores_invalid_entries() -> None:
+    """Skip invalid transition entries when searching for Closed."""
+    payload = {
+        "transitions": [
+            "bad",
+            {"id": "11", "name": "New"},
+            {"id": "91", "name": "Closed"},
+        ],
+    }
+    assert close_advisory_issues.closed_transition_id(payload) == "91"
+    assert close_advisory_issues.closed_transition_id({"transitions": "bad"}) is None
+
+
+def test_jira_get_json_returns_object_payload() -> None:
+    """Return parsed JSON objects from successful GET responses."""
+    session = mock.MagicMock()
+    response = mock.MagicMock()
+    response.json.return_value = {"fields": {"status": {"name": "Open"}}}
+    response.raise_for_status.return_value = None
+    session.get.return_value = response
+    auth = HTTPBasicAuth("user", "token")
+    payload = close_advisory_issues.jira_get_json(
+        session,
+        "https://example.test/issue",
+        auth,
+    )
+    assert payload["fields"]["status"]["name"] == "Open"
+
+
+def test_close_issue_with_comment_posts_transition_payload() -> None:
+    """POST a close transition with an advisory comment."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with mock.patch("close_advisory_issues.jira_post_json") as post_json:
+        close_advisory_issues.close_issue_with_comment(
+            session,
+            "https://example.test/issue/ISSUE-123",
+            auth,
+            "91",
+            "Fixed in Konflux Advisory https://example.test/advisory",
+        )
+    post_json.assert_called_once_with(
+        session,
+        "https://example.test/issue/ISSUE-123/transitions",
+        auth,
+        {
+            "transition": {"id": "91"},
+            "update": {
+                "comment": [
+                    {
+                        "add": {
+                            "body": (
+                                "Fixed in Konflux Advisory " "https://example.test/advisory"
+                            ),
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+
+def test_add_issue_comment_posts_body_payload() -> None:
+    """POST a standalone comment to the issue."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with mock.patch("close_advisory_issues.jira_post_json") as post_json:
+        close_advisory_issues.add_issue_comment(
+            session,
+            "https://example.test/issue/ISSUE-123",
+            auth,
+            "Fixed in Konflux Advisory https://example.test/advisory",
+        )
+    post_json.assert_called_once_with(
+        session,
+        "https://example.test/issue/ISSUE-123/comment",
+        auth,
+        {"body": "Fixed in Konflux Advisory https://example.test/advisory"},
+    )
+
+
+def test_process_fixed_issue_skips_missing_source(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Skip rows that do not include an issue source."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with caplog.at_level(logging.WARNING, logger="release"):
+        close_advisory_issues.process_fixed_issue(
+            {"id": "ISSUE-123"},
+            advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+            auth=auth,
+            session=session,
+        )
+    assert "missing source" in caplog.text
+
+
+def test_close_advisory_issues_skips_jira_setup_without_eligible_issues(
+    tmp_path: Path,
+) -> None:
+    """Do not read Jira secrets when there are no Jira-eligible fixed issues."""
+    _write_data(tmp_path / "data.json", {"foo": "bar"})
+    with mock.patch("close_advisory_issues.read_jira_credentials") as read_creds:
+        with mock.patch(
+            "close_advisory_issues.http_client.get_retry_session",
+        ) as create_session:
+            close_advisory_issues.close_advisory_issues(
+                data_dir=tmp_path,
+                data_path=Path("data.json"),
+                advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+                secret_path=tmp_path / "secrets",
+            )
+    read_creds.assert_not_called()
+    create_session.assert_not_called()
+
+
+def test_close_advisory_issues_skips_jira_setup_for_unsupported_trackers_only(
+    tmp_path: Path,
+) -> None:
+    """Do not read Jira secrets when every fixed issue is on an unsupported tracker."""
+    _write_data(
+        tmp_path / "data.json",
+        {
+            "releaseNotes": {
+                "issues": {
+                    "fixed": [_fixed_issue("12345", "bugzilla.redhat.com")],
+                },
+            },
+        },
+    )
+    with mock.patch("close_advisory_issues.read_jira_credentials") as read_creds:
+        with mock.patch(
+            "close_advisory_issues.http_client.get_retry_session",
+        ) as create_session:
+            close_advisory_issues.close_advisory_issues(
+                data_dir=tmp_path,
+                data_path=Path("data.json"),
+                advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+                secret_path=tmp_path / "secrets",
+            )
+    read_creds.assert_not_called()
+    create_session.assert_not_called()
+
+
+def test_close_advisory_issues_creates_retry_session_when_jira_issue_present(
+    tmp_path: Path,
+) -> None:
+    """Create a retry-enabled session when at least one Jira issue is eligible."""
+    _write_jira_secret(tmp_path / "secrets")
+    _write_data(
+        tmp_path / "data.json",
+        {"releaseNotes": {"issues": {"fixed": [_fixed_issue("ISSUE-123")]}}},
+    )
+    session = mock.MagicMock()
+    with mock.patch(
+        "close_advisory_issues.http_client.get_retry_session",
+        return_value=session,
+    ) as create_session:
+        with mock.patch("close_advisory_issues.process_fixed_issue") as process_issue:
+            close_advisory_issues.close_advisory_issues(
+                data_dir=tmp_path,
+                data_path=Path("data.json"),
+                advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+                secret_path=tmp_path / "secrets",
+            )
+    create_session.assert_called_once_with(
+        total=5,
+        connect=3,
+        read=3,
+        status=5,
+        backoff_factor=1.0,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=frozenset({"GET", "POST"}),
+    )
+    process_issue.assert_called_once()
+
+
+def test_load_fixed_issues_returns_empty_when_missing() -> None:
+    """Return an empty list when releaseNotes issues are absent."""
+    assert close_advisory_issues.load_fixed_issues({"foo": "bar"}) == []
+    assert (
+        close_advisory_issues.load_fixed_issues(
+            {"releaseNotes": {"issues": {}}},
+        )
+        == []
+    )
+
+
+def test_load_fixed_issues_returns_object_rows_only() -> None:
+    """Keep only JSON object entries from the fixed issues array."""
+    data = {
+        "releaseNotes": {
+            "issues": {
+                "fixed": [
+                    _fixed_issue("ISSUE-123"),
+                    "bad",
+                ],
+            },
+        },
+    }
+    assert close_advisory_issues.load_fixed_issues(data) == [_fixed_issue("ISSUE-123")]
+
+
+def test_close_comment_includes_advisory_url() -> None:
+    """Build the advisory comment with the provided URL."""
+    url = "https://access.redhat.com/errata/RHBA-2025:1111"
+    assert close_advisory_issues.close_comment(url) == (f"Fixed in Konflux Advisory {url}")
+
+
+def test_read_jira_credentials_reads_secret_files(tmp_path: Path) -> None:
+    """Load email and token from mounted secret files."""
+    _write_jira_secret(tmp_path)
+    assert close_advisory_issues.read_jira_credentials(tmp_path) == (
+        "team@domain.com",
+        "abcdefg",
+    )
+
+
+def test_read_jira_credentials_rejects_blank_values(tmp_path: Path) -> None:
+    """Reject secrets when email or token is blank."""
+    _write_jira_secret(tmp_path)
+    (tmp_path / "email").write_text(" \n", encoding="utf-8")
+    with pytest.raises(ValueError, match="must include email and token"):
+        close_advisory_issues.read_jira_credentials(tmp_path)
+
+
+def test_jira_issue_url_builds_atlassian_api_url() -> None:
+    """Build the REST URL for a Jira issue id."""
+    assert (
+        close_advisory_issues.jira_issue_url(
+            "redhat.atlassian.net",
+            "ISSUE-123",
+        )
+        == "https://redhat.atlassian.net/rest/api/2/issue/ISSUE-123"
+    )
+
+
+def test_api_path_for_server_rejects_unknown_host() -> None:
+    """Raise when no tracker mapping exists for the server."""
+    with pytest.raises(ValueError, match="no API mapping"):
+        close_advisory_issues.api_path_for_server("example.com")
+
+
+def test_issue_status_name_reads_nested_field() -> None:
+    """Extract the status name from a Jira issue payload."""
+    issue = {"fields": {"status": {"name": "Closed"}}}
+    assert close_advisory_issues.issue_status_name(issue) == "Closed"
+
+
+def test_closed_transition_id_returns_closed_id() -> None:
+    """Return the id for the Closed transition when present."""
+    payload = {
+        "transitions": [
+            {"id": "91", "name": "Closed"},
+            {"id": "11", "name": "New"},
+        ],
+    }
+    assert close_advisory_issues.closed_transition_id(payload) == "91"
+
+
+def test_closed_transition_id_returns_none_when_missing() -> None:
+    """Return None when no Closed transition exists."""
+    assert close_advisory_issues.closed_transition_id({"transitions": []}) is None
+
+
+def test_jira_get_json_rejects_non_object_payload() -> None:
+    """Raise when the response body is not a JSON object."""
+    session = mock.MagicMock()
+    response = mock.MagicMock()
+    response.json.return_value = []
+    response.raise_for_status.return_value = None
+    session.get.return_value = response
+    auth = HTTPBasicAuth("user", "token")
+    with pytest.raises(ValueError, match="expected JSON object"):
+        close_advisory_issues.jira_get_json(session, "https://example.test", auth)
+
+
+def test_process_fixed_issue_skips_invalid_jira_issue_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Skip Jira issues whose id would alter the REST path."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with caplog.at_level(logging.WARNING, logger="release"):
+        close_advisory_issues.process_fixed_issue(
+            _fixed_issue("ISSUE-123/extra"),
+            advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+            auth=auth,
+            session=session,
+        )
+    session.get.assert_not_called()
+    assert "invalid Jira id" in caplog.text
+
+
+def test_process_fixed_issue_skips_unsupported_tracker(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Skip Bugzilla issues without calling the Jira API."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with caplog.at_level(logging.WARNING, logger="release"):
+        close_advisory_issues.process_fixed_issue(
+            _fixed_issue("12345", "bugzilla.redhat.com"),
+            advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+            auth=auth,
+            session=session,
+        )
+    session.get.assert_not_called()
+    assert "Skipping issue" in caplog.text
+
+
+def test_process_fixed_issue_skips_already_closed_issue(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Skip closing when the issue is already Closed."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with mock.patch(
+        "close_advisory_issues.jira_get_json",
+        return_value={"fields": {"status": {"name": "Closed"}}},
+    ) as get_json:
+        with caplog.at_level(logging.INFO, logger="release"):
+            close_advisory_issues.process_fixed_issue(
+                _fixed_issue("CLOSED-987"),
+                advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+                auth=auth,
+                session=session,
+            )
+    get_json.assert_called_once()
+    session.post.assert_not_called()
+    assert "already in Closed state" in caplog.text
+
+
+def test_process_fixed_issue_closes_open_issue() -> None:
+    """Close an open issue when the Closed transition is available."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with mock.patch(
+        "close_advisory_issues.jira_get_json",
+        side_effect=[
+            {"fields": {"status": {"name": "Open"}}},
+            {"transitions": [{"id": "91", "name": "Closed"}]},
+        ],
+    ) as get_json:
+        with mock.patch(
+            "close_advisory_issues.close_issue_with_comment",
+        ) as close_issue:
+            close_advisory_issues.process_fixed_issue(
+                _fixed_issue("ISSUE-123"),
+                advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+                auth=auth,
+                session=session,
+            )
+    assert get_json.call_count == 2
+    close_issue.assert_called_once()
+
+
+def test_process_fixed_issue_adds_comment_when_no_closed_transition(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Add a comment when the Closed transition id cannot be resolved."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with mock.patch(
+        "close_advisory_issues.jira_get_json",
+        side_effect=[
+            {"fields": {"status": {"name": "Open"}}},
+            {"transitions": []},
+        ],
+    ):
+        with mock.patch("close_advisory_issues.add_issue_comment") as add_comment:
+            with caplog.at_level(logging.WARNING, logger="release"):
+                close_advisory_issues.process_fixed_issue(
+                    _fixed_issue("NOCLOSE-555"),
+                    advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+                    auth=auth,
+                    session=session,
+                )
+    add_comment.assert_called_once()
+    assert "failed to fetch the closed state id" in caplog.text
+
+
+def test_process_fixed_issue_adds_comment_when_close_request_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Add a comment when the close transition POST fails."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with mock.patch(
+        "close_advisory_issues.jira_get_json",
+        side_effect=[
+            {"fields": {"status": {"name": "Open"}}},
+            {"transitions": [{"id": "91", "name": "Closed"}]},
+        ],
+    ):
+        with mock.patch(
+            "close_advisory_issues.close_issue_with_comment",
+            side_effect=requests.HTTPError("close failed"),
+        ):
+            with mock.patch("close_advisory_issues.add_issue_comment") as add_comment:
+                with caplog.at_level(logging.WARNING, logger="release"):
+                    close_advisory_issues.process_fixed_issue(
+                        _fixed_issue("FAIL-999"),
+                        advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+                        auth=auth,
+                        session=session,
+                    )
+    add_comment.assert_called_once()
+    assert "failed to close issue" in caplog.text
+
+
+def test_process_fixed_issue_warns_when_comment_also_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Log a warning when both close and comment requests fail."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with mock.patch(
+        "close_advisory_issues.jira_get_json",
+        side_effect=[
+            {"fields": {"status": {"name": "Open"}}},
+            {"transitions": []},
+        ],
+    ):
+        with mock.patch(
+            "close_advisory_issues.add_issue_comment",
+            side_effect=requests.HTTPError("comment failed"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="release"):
+                close_advisory_issues.process_fixed_issue(
+                    _fixed_issue("FAIL-999"),
+                    advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+                    auth=auth,
+                    session=session,
+                )
+    assert "failed to add comment to issue" in caplog.text
+
+
+def test_process_fixed_issue_uses_atlassian_for_legacy_source() -> None:
+    """Query redhat.atlassian.net when the issue source is issues.redhat.com."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with mock.patch(
+        "close_advisory_issues.jira_get_json",
+        return_value={"fields": {"status": {"name": "Closed"}}},
+    ) as get_json:
+        close_advisory_issues.process_fixed_issue(
+            _fixed_issue("ISSUE-123", "issues.redhat.com"),
+            advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+            auth=auth,
+            session=session,
+        )
+    assert get_json.call_args.args[1].startswith(
+        "https://redhat.atlassian.net/rest/api/2/issue/ISSUE-123",
+    )
+
+
+def test_process_fixed_issue_strips_source_before_normalization() -> None:
+    """Normalize Jira hostnames after trimming surrounding whitespace."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with mock.patch(
+        "close_advisory_issues.jira_get_json",
+        return_value={"fields": {"status": {"name": "Closed"}}},
+    ) as get_json:
+        close_advisory_issues.process_fixed_issue(
+            _fixed_issue("ISSUE-123", " issues.redhat.com "),
+            advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+            auth=auth,
+            session=session,
+        )
+    assert get_json.call_args.args[1].startswith(
+        "https://redhat.atlassian.net/rest/api/2/issue/ISSUE-123",
+    )
+
+
+def test_process_fixed_issue_skips_missing_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Skip rows that do not include an issue id."""
+    session = mock.MagicMock()
+    auth = HTTPBasicAuth("user", "token")
+    with caplog.at_level(logging.WARNING, logger="release"):
+        close_advisory_issues.process_fixed_issue(
+            {"source": "redhat.atlassian.net"},
+            advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+            auth=auth,
+            session=session,
+        )
+    assert "missing id" in caplog.text
+
+
+def test_close_advisory_issues_happy_path(tmp_path: Path) -> None:
+    """Close supported Jira issues and skip unsupported trackers."""
+    _write_jira_secret(tmp_path / "secrets")
+    _write_data(
+        tmp_path / "data.json",
+        {
+            "releaseNotes": {
+                "issues": {
+                    "fixed": [
+                        _fixed_issue("ISSUE-123"),
+                        _fixed_issue("12345", "bugzilla.redhat.com"),
+                    ],
+                },
+            },
+        },
+    )
+    with mock.patch("close_advisory_issues.process_fixed_issue") as process_issue:
+        close_advisory_issues.close_advisory_issues(
+            data_dir=tmp_path,
+            data_path=Path("data.json"),
+            advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+            secret_path=tmp_path / "secrets",
+        )
+    assert process_issue.call_count == 2
+
+
+def test_close_advisory_issues_no_issues(tmp_path: Path) -> None:
+    """Succeed when release data has no fixed issues."""
+    _write_jira_secret(tmp_path / "secrets")
+    _write_data(tmp_path / "data.json", {"foo": "bar"})
+    with mock.patch("close_advisory_issues.process_fixed_issue") as process_issue:
+        close_advisory_issues.close_advisory_issues(
+            data_dir=tmp_path,
+            data_path=Path("data.json"),
+            advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+            secret_path=tmp_path / "secrets",
+        )
+    process_issue.assert_not_called()
+
+
+def test_close_advisory_issues_missing_data_file(tmp_path: Path) -> None:
+    """Fail when the release data file is missing."""
+    _write_jira_secret(tmp_path / "secrets")
+    with pytest.raises(FileNotFoundError, match="No data JSON was provided"):
+        close_advisory_issues.close_advisory_issues(
+            data_dir=tmp_path,
+            data_path=Path("missing.json"),
+            advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+            secret_path=tmp_path / "secrets",
+        )
+
+
+def test_close_advisory_issues_propagates_issue_lookup_failure(
+    tmp_path: Path,
+) -> None:
+    """Re-raise the first Jira failure after processing all fixed issues."""
+    _write_jira_secret(tmp_path / "secrets")
+    _write_data(
+        tmp_path / "data.json",
+        {
+            "releaseNotes": {
+                "issues": {
+                    "fixed": [
+                        _fixed_issue("ISSUE-123"),
+                        _fixed_issue("ISSUE-456"),
+                    ],
+                },
+            },
+        },
+    )
+    with mock.patch(
+        "close_advisory_issues.process_fixed_issue",
+        side_effect=[
+            requests.HTTPError("lookup failed"),
+            None,
+        ],
+    ) as process_issue:
+        with pytest.raises(requests.HTTPError, match="lookup failed"):
+            close_advisory_issues.close_advisory_issues(
+                data_dir=tmp_path,
+                data_path=Path("data.json"),
+                advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+                secret_path=tmp_path / "secrets",
+            )
+    assert process_issue.call_count == 2
+
+
+def test_close_advisory_issues_reraises_first_failure_only(
+    tmp_path: Path,
+) -> None:
+    """Keep the first unhandled error when multiple issues fail."""
+    _write_jira_secret(tmp_path / "secrets")
+    _write_data(
+        tmp_path / "data.json",
+        {
+            "releaseNotes": {
+                "issues": {
+                    "fixed": [
+                        _fixed_issue("ISSUE-123"),
+                        _fixed_issue("ISSUE-456"),
+                    ],
+                },
+            },
+        },
+    )
+    with mock.patch(
+        "close_advisory_issues.process_fixed_issue",
+        side_effect=[
+            requests.HTTPError("first failure"),
+            requests.HTTPError("second failure"),
+        ],
+    ) as process_issue:
+        with pytest.raises(requests.HTTPError, match="first failure"):
+            close_advisory_issues.close_advisory_issues(
+                data_dir=tmp_path,
+                data_path=Path("data.json"),
+                advisory_url="https://access.redhat.com/errata/RHBA-2025:1111",
+                secret_path=tmp_path / "secrets",
+            )
+    assert process_issue.call_count == 2
+
+
+def test_jira_post_json_raises_on_http_error() -> None:
+    """Raise when a Jira POST response is not successful."""
+    session = mock.MagicMock()
+    response = mock.MagicMock()
+    response.raise_for_status.side_effect = requests.HTTPError("bad request")
+    session.post.return_value = response
+    auth = HTTPBasicAuth("user", "token")
+    with pytest.raises(requests.HTTPError, match="bad request"):
+        close_advisory_issues.jira_post_json(
+            session,
+            "https://example.test/comment",
+            auth,
+            {"body": "hello"},
+        )
+
+
+def test_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exit zero after a successful run."""
+    monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PARAM_DATA_PATH", "data.json")
+    monkeypatch.setenv(
+        "PARAM_ADVISORY_URL",
+        "https://access.redhat.com/errata/RHBA-2025:1111",
+    )
+    monkeypatch.setenv("JIRA_SECRET_PATH", str(tmp_path / "secrets"))
+    with mock.patch("close_advisory_issues.close_advisory_issues") as run:
+        assert close_advisory_issues.main() == 0
+    run.assert_called_once()
+
+
+def test_module_main_guard_propagates_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Executing the module as `__main__` propagates failures from main()."""
+    monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PARAM_DATA_PATH", "missing.json")
+    monkeypatch.setenv(
+        "PARAM_ADVISORY_URL",
+        "https://access.redhat.com/errata/RHBA-2025:1111",
+    )
+    monkeypatch.setenv("JIRA_SECRET_PATH", str(tmp_path / "secrets"))
+    with pytest.raises(FileNotFoundError, match="No data JSON was provided"):
+        runpy.run_module("close_advisory_issues", run_name="__main__")


### PR DESCRIPTION
This commit adds a python script to replicate the functionality of the inline bash script in the close-advisory-issues managed task in the catalog repo. The task will be updated to use this python module instead.

Assisted-By: Cursor