### PR TITLE
feat(RELEASE-2496): convert filter-already-released-images to Python

### DIFF
--- a/scripts/python/helpers/authentication.py
+++ b/scripts/python/helpers/authentication.py
@@ -22,6 +22,14 @@ import retry
 from logger import logger
 
 
+def setup_ca_cert() -> None:
+    """Set SSL_CERT_FILE from CA_CERT_PATH if the file exists."""
+    ca_cert = os.environ.get("CA_CERT_PATH", "")
+    if ca_cert and Path(ca_cert).is_file():
+        os.environ["SSL_CERT_FILE"] = ca_cert
+        logger.info("Using CA certificate: %s", ca_cert)
+
+
 def read_mounted_text(mount: Path, filename: str) -> str:
     """Read a UTF-8 file (``mount / filename``) and return stripped text.
 

--- a/scripts/python/helpers/oras_utils.py
+++ b/scripts/python/helpers/oras_utils.py
@@ -12,17 +12,31 @@ import subprocess_cmd
 from subprocess_cmd import run_cmd
 
 
-def oras_resolve(reference: str) -> str:
+def oras_resolve(
+    reference: str,
+    *,
+    auth_ref: str | None = None,
+    check: bool = True,
+) -> str | None:
     """Resolve the digest of an OCI image reference using oras.
 
-    Obtains registry credentials via ``select-oci-auth``, writes them to a
-    temporary auth file, then runs ``oras resolve`` and returns the digest.
+    Obtains registry credentials via ``select-oci-auth`` and runs
+    ``oras resolve``.
 
-    Raises ``RuntimeError`` if oras resolve exits non-zero.
+    *auth_ref* overrides the reference passed to ``select-oci-auth`` —
+    useful when resolving a tagged reference (``repo:tag``) but the
+    auth credentials should be obtained for the bare repository URL.
+    Defaults to *reference* when not given.
+
+    When *check* is ``True`` (the default), ``RuntimeError`` is raised on
+    a non-zero exit code.  When ``False``, ``None`` is returned instead,
+    which is convenient for "try to resolve, treat failure as not-found"
+    callers.
     """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as auth_file:
-        select_auth = run_cmd(["select-oci-auth", reference])
-        auth_file.write(select_auth.stdout)
+        select_auth = run_cmd(["select-oci-auth", auth_ref or reference], check=False)
+        auth_content = select_auth.stdout.strip()
+        auth_file.write(auth_content if auth_content else "{}")
         auth_file.flush()
 
         result = run_cmd(
@@ -31,11 +45,14 @@ def oras_resolve(reference: str) -> str:
         )
 
     if result.returncode != 0:
-        raise RuntimeError(
-            f"oras resolve failed for {reference!r} (exit {result.returncode}):"
-            f" {result.stderr.strip()}"
-        )
-    return result.stdout.strip()
+        if check:
+            raise RuntimeError(
+                f"oras resolve failed for {reference!r}"
+                f" (exit {result.returncode}): {result.stderr.strip()}"
+            )
+        return None
+    digest = result.stdout.strip()
+    return digest or None
 
 
 def oras_login(registry: str, username: str, password: str) -> None:

--- a/scripts/python/helpers/test_authentication.py
+++ b/scripts/python/helpers/test_authentication.py
@@ -311,3 +311,54 @@ def test_kerberos_login_cleans_up_on_kinit_failure() -> None:
 
     for f in created_files:
         assert not f.exists()
+
+
+# ---------------------------------------------------------------------------
+# setup_ca_cert
+# ---------------------------------------------------------------------------
+
+
+def test_setup_ca_cert_sets_ssl_cert_file_when_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SSL_CERT_FILE is set when CA cert file exists."""
+    ca_file = tmp_path / "ca-bundle.crt"
+    ca_file.write_text("CERT", encoding="utf-8")
+    monkeypatch.setenv("CA_CERT_PATH", str(ca_file))
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+
+    authentication.setup_ca_cert()
+    assert os.environ["SSL_CERT_FILE"] == str(ca_file)
+
+
+def test_setup_ca_cert_noop_when_file_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No action when CA cert file does not exist."""
+    monkeypatch.setenv("CA_CERT_PATH", str(tmp_path / "missing.crt"))
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+
+    authentication.setup_ca_cert()
+    assert "SSL_CERT_FILE" not in os.environ
+
+
+def test_setup_ca_cert_noop_when_env_not_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No action when CA_CERT_PATH is not set."""
+    monkeypatch.delenv("CA_CERT_PATH", raising=False)
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+
+    authentication.setup_ca_cert()
+    assert "SSL_CERT_FILE" not in os.environ
+
+
+def test_setup_ca_cert_noop_when_env_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No action when CA_CERT_PATH is empty string."""
+    monkeypatch.setenv("CA_CERT_PATH", "")
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+
+    authentication.setup_ca_cert()
+    assert "SSL_CERT_FILE" not in os.environ

--- a/scripts/python/helpers/test_oras_utils.py
+++ b/scripts/python/helpers/test_oras_utils.py
@@ -22,7 +22,7 @@ def test_oras_resolve_calls_select_oci_auth_with_reference() -> None:
         oras_resolve("registry.io/repo:tag")
 
     first_call = mock_run.call_args_list[0]
-    assert first_call == call(["select-oci-auth", "registry.io/repo:tag"])
+    assert first_call == call(["select-oci-auth", "registry.io/repo:tag"], check=False)
 
 
 def test_oras_resolve_passes_auth_file_to_oras() -> None:
@@ -63,6 +63,71 @@ def test_oras_resolve_raises_on_nonzero_returncode() -> None:
         ]
         with pytest.raises(RuntimeError):
             oras_resolve("registry.io/repo:tag")
+
+
+def test_oras_resolve_returns_none_when_check_false() -> None:
+    """Returns None instead of raising when check=False."""
+    with patch("oras_utils.run_cmd") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(stdout="{}"),
+            MagicMock(returncode=1, stdout="", stderr="not found"),
+        ]
+        result = oras_resolve("registry.io/repo:tag", check=False)
+
+    assert result is None
+
+
+def test_oras_resolve_returns_none_on_empty_output_when_check_false() -> None:
+    """Returns None when oras outputs only whitespace (check=False)."""
+    with patch("oras_utils.run_cmd") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(stdout="{}"),
+            MagicMock(returncode=0, stdout="  \n"),
+        ]
+        result = oras_resolve("registry.io/repo:tag", check=False)
+
+    assert result is None
+
+
+def test_oras_resolve_uses_auth_ref_for_select_oci_auth() -> None:
+    """auth_ref overrides reference for select-oci-auth."""
+    with patch("oras_utils.run_cmd") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(stdout="{}"),
+            MagicMock(returncode=0, stdout="sha256:abc\n"),
+        ]
+        oras_resolve("registry.io/repo:v1", auth_ref="registry.io/repo")
+
+    auth_call = mock_run.call_args_list[0]
+    assert auth_call == call(["select-oci-auth", "registry.io/repo"], check=False)
+    resolve_call = mock_run.call_args_list[1]
+    assert "registry.io/repo:v1" in resolve_call.args[0]
+
+
+def test_oras_resolve_falls_back_to_empty_auth_on_select_oci_auth_failure() -> None:
+    """select-oci-auth failure falls back to empty auth and still resolves."""
+    with patch("oras_utils.run_cmd") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=1, stdout="", stderr="no creds"),
+            MagicMock(returncode=0, stdout="sha256:abc\n"),
+        ]
+        result = oras_resolve("registry.io/repo:tag")
+
+    assert result == "sha256:abc"
+    auth_call = mock_run.call_args_list[0]
+    assert auth_call == call(["select-oci-auth", "registry.io/repo:tag"], check=False)
+
+
+def test_oras_resolve_falls_back_to_empty_auth_on_empty_stdout() -> None:
+    """select-oci-auth returning empty stdout falls back to empty auth."""
+    with patch("oras_utils.run_cmd") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="  \n"),
+            MagicMock(returncode=0, stdout="sha256:abc\n"),
+        ]
+        result = oras_resolve("registry.io/repo:tag")
+
+    assert result == "sha256:abc"
 
 
 def test_oras_pull_runs_select_oci_auth_and_oras(

--- a/scripts/python/tasks/managed/filter_already_released_images.py
+++ b/scripts/python/tasks/managed/filter_already_released_images.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Filter already-released images from a snapshot before downstream validation.
+
+Check target registries to determine if push-snapshot has completed successfully
+for each component by validating that ALL required tags exist with the correct
+digest.  Components that are fully released (all tags present in at least one
+target repository) are filtered out.  The snapshot file is overwritten in place.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import tekton
+from authentication import setup_ca_cert
+from logger import logger
+from oras_utils import oras_resolve
+
+PROG = "filter_already_released_images.py"
+
+
+def _check_tag(repo_url: str, tag: str, expected_digest: str) -> bool:
+    """Return True when *repo_url*:*tag* resolves to *expected_digest*."""
+    actual = oras_resolve(f"{repo_url}:{tag}", auth_ref=repo_url, check=False)
+
+    if actual is None:
+        logger.info("    Tag %s: cannot resolve (treating as not found)", tag)
+        return False
+    if actual != expected_digest:
+        logger.info("    Tag %s: DIGEST MISMATCH", tag)
+        logger.info("      Expected: %s", expected_digest)
+        logger.info("      Found:    %s", actual)
+        return False
+
+    logger.info("    Tag %s: MATCH (%s)", tag, actual)
+    return True
+
+
+def is_component_released(component: dict, digest: str) -> bool:
+    """Return True when *component* is fully released to any target repository.
+
+    A component is considered released when at least one of its mapped
+    repositories has ALL required tags pointing to *digest*.  Components
+    without repositories or with only invalid repository entries return False.
+    """
+    repositories = component.get("repositories") or []
+    if not repositories:
+        return False
+
+    component_name = component.get("name", "?")
+    logger.info(
+        "Checking component: %s (%d target repositories)",
+        component_name,
+        len(repositories),
+    )
+
+    for j, repo_obj in enumerate(repositories):
+        repo_url = repo_obj.get("url") or ""
+        tags = repo_obj.get("tags") or []
+
+        if not repo_url:
+            logger.warning("  Repository #%d has empty URL, skipping", j + 1)
+            continue
+        if not tags:
+            logger.warning(
+                "  Repository %s has no tags specified, skipping",
+                repo_url,
+            )
+            continue
+
+        logger.info("  Checking repository: %s (%d tags)", repo_url, len(tags))
+
+        if all(_check_tag(repo_url, tag, digest) for tag in tags):
+            return True
+
+    return False
+
+
+def _partition_components(
+    components: list[dict],
+) -> tuple[list[dict], int]:
+    """Classify components as kept or already-released.
+
+    Return ``(kept_list, filtered_count)``.  Components that cannot be
+    resolved or have no target repositories are always kept.
+    """
+    kept: list[dict] = []
+    filtered = 0
+
+    for component in components:
+        component_name = component.get("name", "?")
+        container_image = component.get("containerImage", "")
+
+        digest = oras_resolve(container_image, check=False)
+        if digest is None:
+            logger.warning(
+                "Cannot resolve component image %s, treating as not yet released",
+                container_image,
+            )
+            kept.append(component)
+            continue
+
+        logger.info("  Component digest: %s", digest)
+
+        if is_component_released(component, digest):
+            logger.info("Component %s: FILTERED (already released)", component_name)
+            filtered += 1
+        else:
+            logger.info("Component %s: KEPT (needs to be released)", component_name)
+            kept.append(component)
+
+    return kept, filtered
+
+
+def filter_snapshot(snapshot_path: Path) -> tuple[int, int]:
+    """Filter already-released components from the snapshot file.
+
+    Overwrite *snapshot_path* in place with only the components that still
+    need to be released.  Return ``(total_count, filtered_count)``.
+    """
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    components = snapshot.get("components") or []
+    total = len(components)
+
+    kept, filtered = _partition_components(components)
+
+    snapshot["components"] = kept
+    snapshot_path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+
+    logger.info("SUMMARY:")
+    logger.info("  Total components: %d", total)
+    logger.info("  Filtered (already released): %d", filtered)
+    logger.info("  To be released: %d", total - filtered)
+
+    return total, filtered
+
+
+def run(snapshot_path: Path, result_skip_release: Path) -> None:
+    """Orchestrate filtering and write the skip_release result."""
+    if not snapshot_path.is_file():
+        raise RuntimeError(f"Snapshot file not found: {snapshot_path}")
+
+    total, filtered = filter_snapshot(snapshot_path)
+
+    skip = filtered == total and total > 0
+    result_skip_release.write_text("true" if skip else "false", encoding="utf-8")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__, prog=PROG)
+    parser.add_argument(
+        "--snapshot-path",
+        required=True,
+        help="Path to the snapshot JSON file",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments, resolve Tekton result paths, and run the filter."""
+    setup_ca_cert()
+    args = _parse_args(argv)
+    (result_skip_release,) = tekton.result_paths_from_env("RESULT_SKIP_RELEASE")
+    run(Path(args.snapshot_path), result_skip_release)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_filter_already_released_images.py
+++ b/scripts/python/tasks/managed/test_filter_already_released_images.py
@@ -1,0 +1,468 @@
+"""Test filtering of already-released images from a snapshot."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import filter_already_released_images
+import pytest
+
+
+def _write_snapshot(path: Path, components: list[dict]) -> None:
+    """Write a minimal snapshot JSON file."""
+    path.write_text(
+        json.dumps({"application": "test", "components": components}),
+        encoding="utf-8",
+    )
+
+
+def _component(
+    name: str,
+    image: str,
+    repositories: list[dict] | None = None,
+) -> dict:
+    """Build a component dict."""
+    c: dict = {"name": name, "containerImage": image}
+    if repositories is not None:
+        c["repositories"] = repositories
+    return c
+
+
+class TestCheckTag:
+    """Test _check_tag which verifies a single tag in a target repo."""
+
+    def test_matching_digest_returns_true(self) -> None:
+        """Tag resolving to expected digest returns True."""
+        with patch(
+            "filter_already_released_images.oras_resolve",
+            return_value="sha256:abc",
+        ):
+            assert filter_already_released_images._check_tag("reg.io/repo", "v1", "sha256:abc")
+
+    def test_mismatched_digest_returns_false(self) -> None:
+        """Tag resolving to wrong digest returns False."""
+        with patch(
+            "filter_already_released_images.oras_resolve",
+            return_value="sha256:wrong",
+        ):
+            assert not filter_already_released_images._check_tag(
+                "reg.io/repo", "v1", "sha256:abc"
+            )
+
+    def test_resolve_failure_returns_false(self) -> None:
+        """Tag that cannot be resolved returns False."""
+        with patch(
+            "filter_already_released_images.oras_resolve",
+            return_value=None,
+        ):
+            assert not filter_already_released_images._check_tag(
+                "reg.io/repo", "v1", "sha256:abc"
+            )
+
+    def test_passes_repo_url_as_auth_ref(self) -> None:
+        """_oras_resolve is called with repo_url as auth_ref."""
+        with patch(
+            "filter_already_released_images.oras_resolve",
+            return_value="sha256:abc",
+        ) as mock_resolve:
+            filter_already_released_images._check_tag("reg.io/repo", "v1", "sha256:abc")
+            mock_resolve.assert_called_once_with(
+                "reg.io/repo:v1", auth_ref="reg.io/repo", check=False
+            )
+
+
+class TestIsComponentReleased:
+    """Test is_component_released logic."""
+
+    def test_all_tags_match_returns_true(self) -> None:
+        """Component is released when all tags in a repo match."""
+        comp = _component(
+            "c1",
+            "reg.io/img@sha256:abc",
+            [{"url": "reg.io/target", "tags": ["v1", "latest"]}],
+        )
+        with patch(
+            "filter_already_released_images._check_tag",
+            return_value=True,
+        ):
+            assert filter_already_released_images.is_component_released(comp, "sha256:abc")
+
+    def test_partial_tags_returns_false(self) -> None:
+        """Component is not released when some tags are missing."""
+        comp = _component(
+            "c1",
+            "reg.io/img@sha256:abc",
+            [{"url": "reg.io/target", "tags": ["v1", "latest"]}],
+        )
+        with patch(
+            "filter_already_released_images._check_tag",
+            side_effect=[True, False],
+        ):
+            assert not filter_already_released_images.is_component_released(comp, "sha256:abc")
+
+    def test_no_repositories_returns_false(self) -> None:
+        """Component with no repositories is not considered released."""
+        comp = _component("c1", "reg.io/img@sha256:abc", [])
+        assert not filter_already_released_images.is_component_released(comp, "sha256:abc")
+
+    def test_none_repositories_returns_false(self) -> None:
+        """Component without repositories key returns False."""
+        comp = _component("c1", "reg.io/img@sha256:abc")
+        assert not filter_already_released_images.is_component_released(comp, "sha256:abc")
+
+    def test_empty_url_skipped(self) -> None:
+        """Repository with empty URL is skipped."""
+        comp = _component(
+            "c1",
+            "reg.io/img@sha256:abc",
+            [{"url": "", "tags": ["v1"]}],
+        )
+        assert not filter_already_released_images.is_component_released(comp, "sha256:abc")
+
+    def test_no_tags_skipped(self) -> None:
+        """Repository with no tags is skipped."""
+        comp = _component(
+            "c1",
+            "reg.io/img@sha256:abc",
+            [{"url": "reg.io/target", "tags": []}],
+        )
+        assert not filter_already_released_images.is_component_released(comp, "sha256:abc")
+
+    def test_any_repo_logic_first_incomplete_second_complete(self) -> None:
+        """Component released if ANY repository has all tags complete."""
+        comp = _component(
+            "c1",
+            "reg.io/img@sha256:abc",
+            [
+                {"url": "staging.io/target", "tags": ["v1"]},
+                {"url": "prod.io/target", "tags": ["v1"]},
+            ],
+        )
+        with patch(
+            "filter_already_released_images._check_tag",
+            side_effect=[False, True],
+        ):
+            assert filter_already_released_images.is_component_released(comp, "sha256:abc")
+
+    def test_first_complete_skips_remaining_repos(self) -> None:
+        """Early return when first repository has all tags complete."""
+        comp = _component(
+            "c1",
+            "reg.io/img@sha256:abc",
+            [
+                {"url": "first.io/target", "tags": ["v1"]},
+                {"url": "second.io/target", "tags": ["v1"]},
+            ],
+        )
+        with patch(
+            "filter_already_released_images._check_tag",
+            return_value=True,
+        ) as mock_check:
+            assert filter_already_released_images.is_component_released(comp, "sha256:abc")
+        mock_check.assert_called_once_with("first.io/target", "v1", "sha256:abc")
+
+    def test_all_repos_incomplete_returns_false(self) -> None:
+        """Component not released if no repository has all tags."""
+        comp = _component(
+            "c1",
+            "reg.io/img@sha256:abc",
+            [
+                {"url": "staging.io/t1", "tags": ["v1"]},
+                {"url": "prod.io/t2", "tags": ["v1"]},
+            ],
+        )
+        with patch(
+            "filter_already_released_images._check_tag",
+            return_value=False,
+        ):
+            assert not filter_already_released_images.is_component_released(comp, "sha256:abc")
+
+
+class TestPartitionComponents:
+    """Test _partition_components logic (core filtering without I/O)."""
+
+    def test_all_released(self) -> None:
+        """All components filtered when fully released."""
+        components = [
+            _component("c1", "r.io/i@sha256:a1", [{"url": "r.io/t1", "tags": ["v1"]}]),
+        ]
+        with (
+            patch(
+                "filter_already_released_images.oras_resolve",
+                return_value="sha256:a1",
+            ),
+            patch(
+                "filter_already_released_images.is_component_released",
+                return_value=True,
+            ),
+        ):
+            kept, filtered = filter_already_released_images._partition_components(components)
+        assert filtered == 1
+        assert kept == []
+
+    def test_none_released(self) -> None:
+        """No components filtered when none are released."""
+        components = [
+            _component("c1", "r.io/i@sha256:a1", [{"url": "r.io/t1", "tags": ["v1"]}]),
+        ]
+        with (
+            patch(
+                "filter_already_released_images.oras_resolve",
+                return_value="sha256:a1",
+            ),
+            patch(
+                "filter_already_released_images.is_component_released",
+                return_value=False,
+            ),
+        ):
+            kept, filtered = filter_already_released_images._partition_components(components)
+        assert filtered == 0
+        assert len(kept) == 1
+
+    def test_some_released(self) -> None:
+        """Only released components are filtered out."""
+        components = [
+            _component("released", "r.io/i@sha256:r1", [{"url": "r.io/t1", "tags": ["v1"]}]),
+            _component("kept", "r.io/i@sha256:k1", [{"url": "r.io/t2", "tags": ["v1"]}]),
+        ]
+        with (
+            patch(
+                "filter_already_released_images.oras_resolve",
+                side_effect=["sha256:r1", "sha256:k1"],
+            ),
+            patch(
+                "filter_already_released_images.is_component_released",
+                side_effect=[True, False],
+            ),
+        ):
+            kept, filtered = filter_already_released_images._partition_components(components)
+        assert filtered == 1
+        assert len(kept) == 1
+        assert kept[0]["name"] == "kept"
+
+    def test_unresolvable_image_kept(self) -> None:
+        """Component whose image cannot be resolved is kept."""
+        components = [
+            _component("c1", "r.io/i@sha256:bad", [{"url": "r.io/t1", "tags": ["v1"]}])
+        ]
+        with patch(
+            "filter_already_released_images.oras_resolve",
+            return_value=None,
+        ):
+            kept, filtered = filter_already_released_images._partition_components(components)
+        assert filtered == 0
+        assert len(kept) == 1
+
+    def test_no_repositories_kept(self) -> None:
+        """Component with no repositories is kept (is_component_released returns False)."""
+        components = [_component("c1", "r.io/i@sha256:a1", [])]
+        with patch(
+            "filter_already_released_images.oras_resolve",
+            return_value="sha256:a1",
+        ):
+            kept, filtered = filter_already_released_images._partition_components(components)
+        assert filtered == 0
+        assert len(kept) == 1
+
+    def test_empty_components(self) -> None:
+        """Empty components list produces zero counts."""
+        kept, filtered = filter_already_released_images._partition_components([])
+        assert filtered == 0
+        assert kept == []
+
+    def test_missing_repositories_key_kept(self) -> None:
+        """Component without a repositories key is kept."""
+        components = [_component("c1", "r.io/i@sha256:a1")]
+        with patch(
+            "filter_already_released_images.oras_resolve",
+            return_value="sha256:a1",
+        ):
+            kept, filtered = filter_already_released_images._partition_components(components)
+        assert filtered == 0
+        assert len(kept) == 1
+
+
+class TestFilterSnapshot:
+    """Test filter_snapshot file I/O and integration with _partition_components."""
+
+    def test_overwrites_snapshot_in_place(self, tmp_path: Path) -> None:
+        """Snapshot file is overwritten with only kept components."""
+        snap = tmp_path / "snap.json"
+        _write_snapshot(
+            snap,
+            [
+                _component(
+                    "released",
+                    "r.io/i@sha256:r1",
+                    [{"url": "r.io/t1", "tags": ["v1"]}],
+                ),
+                _component(
+                    "kept",
+                    "r.io/i@sha256:k1",
+                    [{"url": "r.io/t2", "tags": ["v1"]}],
+                ),
+            ],
+        )
+        kept_comps = [
+            _component("kept", "r.io/i@sha256:k1", [{"url": "r.io/t2", "tags": ["v1"]}])
+        ]
+        with patch(
+            "filter_already_released_images._partition_components",
+            return_value=(kept_comps, 1),
+        ):
+            total, filtered = filter_already_released_images.filter_snapshot(snap)
+
+        assert total == 2
+        assert filtered == 1
+        result = json.loads(snap.read_text(encoding="utf-8"))
+        assert len(result["components"]) == 1
+        assert result["components"][0]["name"] == "kept"
+
+    def test_empty_snapshot(self, tmp_path: Path) -> None:
+        """Empty components list produces zero counts."""
+        snap = tmp_path / "snap.json"
+        _write_snapshot(snap, [])
+        with patch(
+            "filter_already_released_images._partition_components",
+            return_value=([], 0),
+        ):
+            total, filtered = filter_already_released_images.filter_snapshot(snap)
+        assert total == 0
+        assert filtered == 0
+
+    def test_preserves_non_component_keys(self, tmp_path: Path) -> None:
+        """Non-component keys in the snapshot survive the round-trip."""
+        snap = tmp_path / "snap.json"
+        snap.write_text(
+            json.dumps(
+                {
+                    "application": "my-app",
+                    "customField": {"nested": True},
+                    "components": [
+                        _component(
+                            "c1", "r.io/i@sha256:a1", [{"url": "r.io/t", "tags": ["v1"]}]
+                        )
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        kept_comps = [
+            _component("c1", "r.io/i@sha256:a1", [{"url": "r.io/t", "tags": ["v1"]}])
+        ]
+        with patch(
+            "filter_already_released_images._partition_components",
+            return_value=(kept_comps, 0),
+        ):
+            filter_already_released_images.filter_snapshot(snap)
+
+        result = json.loads(snap.read_text(encoding="utf-8"))
+        assert result["application"] == "my-app"
+        assert result["customField"] == {"nested": True}
+        assert len(result["components"]) == 1
+
+
+class TestRun:
+    """Test the run() orchestration."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        """Run writes 'false' when not all components are filtered."""
+        snap = tmp_path / "snap.json"
+        result_file = tmp_path / "skip_release"
+        _write_snapshot(
+            snap,
+            [
+                _component(
+                    "c1",
+                    "r.io/i@sha256:a1",
+                    [{"url": "r.io/t1", "tags": ["v1"]}],
+                ),
+            ],
+        )
+        with patch(
+            "filter_already_released_images.filter_snapshot",
+            return_value=(1, 0),
+        ):
+            filter_already_released_images.run(snap, result_file)
+        assert result_file.read_text(encoding="utf-8") == "false"
+
+    def test_all_filtered_writes_true(self, tmp_path: Path) -> None:
+        """Run writes 'true' when all components are filtered."""
+        snap = tmp_path / "snap.json"
+        result_file = tmp_path / "skip_release"
+        _write_snapshot(snap, [_component("c1", "r.io/i@sha256:a1")])
+        with patch(
+            "filter_already_released_images.filter_snapshot",
+            return_value=(2, 2),
+        ):
+            filter_already_released_images.run(snap, result_file)
+        assert result_file.read_text(encoding="utf-8") == "true"
+
+    def test_empty_snapshot_writes_false(self, tmp_path: Path) -> None:
+        """Run writes 'false' when snapshot has zero components."""
+        snap = tmp_path / "snap.json"
+        result_file = tmp_path / "skip_release"
+        _write_snapshot(snap, [])
+        with patch(
+            "filter_already_released_images.filter_snapshot",
+            return_value=(0, 0),
+        ):
+            filter_already_released_images.run(snap, result_file)
+        assert result_file.read_text(encoding="utf-8") == "false"
+
+    def test_missing_snapshot_raises(self, tmp_path: Path) -> None:
+        """RuntimeError when snapshot file does not exist."""
+        result_file = tmp_path / "skip_release"
+        with pytest.raises(RuntimeError, match="Snapshot file not found"):
+            filter_already_released_images.run(tmp_path / "missing.json", result_file)
+
+
+class TestParseArgs:
+    """Test CLI argument parsing."""
+
+    def test_snapshot_path_required(self) -> None:
+        """--snapshot-path is required."""
+        with pytest.raises(SystemExit):
+            filter_already_released_images._parse_args([])
+
+    def test_parses_snapshot_path(self) -> None:
+        """--snapshot-path is correctly parsed."""
+        args = filter_already_released_images._parse_args(
+            ["--snapshot-path", "/data/snap.json"]
+        )
+        assert args.snapshot_path == "/data/snap.json"
+
+
+class TestMain:
+    """Test the main() entry point."""
+
+    def test_success(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Return 0 on successful run."""
+        snap = tmp_path / "snap.json"
+        result_file = tmp_path / "skip_release"
+        _write_snapshot(snap, [])
+        monkeypatch.setenv("RESULT_SKIP_RELEASE", str(result_file))
+        with patch(
+            "filter_already_released_images.filter_snapshot",
+            return_value=(0, 0),
+        ):
+            assert filter_already_released_images.main(["--snapshot-path", str(snap)]) == 0
+
+    def test_missing_env_var_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SystemExit when RESULT_SKIP_RELEASE is not set."""
+        monkeypatch.delenv("RESULT_SKIP_RELEASE", raising=False)
+        with pytest.raises(SystemExit):
+            filter_already_released_images.main(["--snapshot-path", "/tmp/s.json"])
+
+    def test_runtime_error_propagates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """RuntimeError from run() propagates."""
+        result_file = tmp_path / "skip_release"
+        monkeypatch.setenv("RESULT_SKIP_RELEASE", str(result_file))
+        with pytest.raises(RuntimeError, match="Snapshot file not found"):
+            filter_already_released_images.main(
+                ["--snapshot-path", str(tmp_path / "missing.json")]
+            )


### PR DESCRIPTION
Add filter_already_released_images.py managed task script and unit
tests. Extend oras_utils helper with flexible oras_resolve options
(auth_ref, check=False).

Assisted-by: Cursor