### PR TITLE
feat(RELEASE-2495): convert filter-advisory-rpms to python

### DIFF
--- a/scripts/python/helpers/advisory_data.py
+++ b/scripts/python/helpers/advisory_data.py
@@ -11,6 +11,16 @@ from typing import Any
 
 import yaml
 
+ADVISORY_SECRET_STAGE = "create-advisory-stage-secret"
+ADVISORY_SECRET_PROD = "create-advisory-prod-secret"
+
+
+def advisory_secret_name(environment: str) -> str:
+    """Return the advisory secret name for *environment* (``"stage"`` or ``"production"``)."""
+    if environment == "stage":
+        return ADVISORY_SECRET_STAGE
+    return ADVISORY_SECRET_PROD
+
 
 def _strip_checksum_from_purl(purl: str) -> str:
     """Strip `checksum` query/fragment parts from a package URL for comparison."""

--- a/scripts/python/helpers/pulp_client.py
+++ b/scripts/python/helpers/pulp_client.py
@@ -1,0 +1,241 @@
+"""Pulp REST API client with TOML-based configuration and auth.
+
+Parse ``cli.toml`` files, authenticate via Basic or OAuth2
+client-credentials, and query the Pulp REST API for distributions,
+repository versions, and RPM content digests.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import requests
+import requests.auth
+import tomllib
+
+import retry
+
+TOKEN_URL = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+
+
+class PulpDigestStatus(Enum):
+    """Outcome of a Pulp digest check."""
+
+    MATCH = "match"
+    NOT_FOUND = "not_found"
+    MISMATCH = "mismatch"
+
+
+def parse_pulp_config(config_path: Path) -> dict[str, str]:
+    """Parse a Pulp cli.toml file and return the ``[cli]`` section values.
+
+    Return a flat dict with keys: ``base_url``, ``client_id``,
+    ``client_secret``, ``username``, ``password``.  Credentials default
+    to empty strings; ``base_url`` is required and raises
+    ``RuntimeError`` when missing or blank.
+    """
+    raw = config_path.read_text(encoding="utf-8")
+    if not raw.strip():
+        raise RuntimeError(f"Missing cli.toml content in {config_path}")
+    parsed = tomllib.loads(raw)
+    cli = parsed.get("cli", {})
+    base_url = str(cli.get("base_url", "")).rstrip("/")
+    if not base_url:
+        raise RuntimeError(f"Missing required 'base_url' in [cli] section of {config_path}")
+    return {
+        "base_url": base_url,
+        "client_id": str(cli.get("client_id", "")),
+        "client_secret": str(cli.get("client_secret", "")),
+        "username": str(cli.get("username", "")),
+        "password": str(cli.get("password", "")),
+    }
+
+
+def _get_access_token(
+    client_id: str,
+    client_secret: str,
+) -> str:
+    """Fetch an OAuth2 access token from the Red Hat SSO endpoint."""
+
+    def _fetch() -> str:
+        resp = requests.post(
+            TOKEN_URL,
+            auth=(client_id, client_secret),
+            data={"grant_type": "client_credentials", "scope": "api.console"},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return str(resp.json()["access_token"])
+
+    return retry.retry_with_exponential_backoff(
+        _fetch,
+        max_attempts=3,
+        retry_on=requests.RequestException,
+    )
+
+
+class PulpAuth(requests.auth.AuthBase):
+    """Attach Pulp credentials to every request on a ``Session``.
+
+    Prefer Basic auth when username/password are present; fall back to
+    OAuth2 client-credentials.  OAuth2 tokens are fetched on every
+    request so that long-running tasks never hit an expired token
+    (matches the bash ``curl_auth`` -> ``get_auth_header`` behaviour).
+    """
+
+    def __init__(
+        self,
+        config: dict[str, str],
+    ) -> None:
+        """Initialize auth from *config*; validate credentials eagerly."""
+        username = config.get("username", "")
+        password = config.get("password", "")
+        if username and password:
+            self._basic_auth: requests.auth.HTTPBasicAuth | None = requests.auth.HTTPBasicAuth(
+                username, password
+            )
+            self._client_id = ""
+            self._client_secret = ""
+            return
+
+        client_id = config.get("client_id", "")
+        client_secret = config.get("client_secret", "")
+        if client_id and client_secret:
+            self._basic_auth = None
+            self._client_id = client_id
+            self._client_secret = client_secret
+            _get_access_token(client_id, client_secret)
+            return
+
+        raise RuntimeError(
+            "No valid credentials in cli.toml "
+            "(need username/password or client_id/client_secret)"
+        )
+
+    def __call__(self, r: requests.PreparedRequest) -> requests.PreparedRequest:
+        """Set the Authorization header on the outgoing request."""
+        if self._basic_auth:
+            return self._basic_auth(r)
+        token = _get_access_token(self._client_id, self._client_secret)
+        r.headers["Authorization"] = f"Bearer {token}"
+        return r
+
+
+class PulpClient:
+    """Thin wrapper around Pulp REST API calls."""
+
+    def __init__(self, session: requests.Session, base_url: str, domain: str) -> None:
+        """Create a client bound to *base_url* and Pulp *domain*."""
+        self._session = session
+        self._base_url = base_url
+        self._domain = domain
+
+    def get_json(self, url: str) -> dict[str, Any]:
+        """GET *url* and return parsed JSON."""
+        resp = self._session.get(url, timeout=60)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_published_version_href(self, repo_name: str) -> str:
+        """Return the published repository-version href for *repo_name*.
+
+        Check the distribution's ``repository_version``, then its
+        ``publication``, then the repository's ``latest_version_href``.
+        Return an empty string when nothing is published.
+        """
+        dist_url = (
+            f"{self._base_url}/api/pulp/{self._domain}"
+            f"/api/v3/distributions/rpm/rpm/?name={repo_name}"
+        )
+        dist_data = self.get_json(dist_url)
+
+        results = dist_data.get("results") or []
+        if not results:
+            return ""
+        dist = results[0]
+
+        rv = dist.get("repository_version")
+        if rv:
+            return str(rv)
+
+        pub_href = dist.get("publication")
+        if pub_href:
+            rv = self.get_json(f"{self._base_url}{pub_href}").get("repository_version")
+            if rv:
+                return str(rv)
+
+        repo_href = dist.get("repository")
+        if repo_href:
+            rv = self.get_json(f"{self._base_url}{repo_href}").get("latest_version_href")
+            if rv:
+                return str(rv)
+
+        return ""
+
+    def check_digest(
+        self,
+        repo_name: str,
+        name: str,
+        epoch: str,
+        version: str,
+        release: str,
+        arch: str,
+        expected_sha: str,
+    ) -> PulpDigestStatus:
+        """Check Pulp for an RPM digest in published content.
+
+        Return ``MATCH`` when the digest matches, ``NOT_FOUND`` when
+        no published version or no matching RPM exists, and ``MISMATCH``
+        when a different digest is found.
+
+        Raise ``requests.RequestException`` on API failures.
+        """
+        from logger import logger
+
+        rv_href = self.get_published_version_href(repo_name)
+
+        if not rv_href:
+            logger.info(
+                "  -> No published version for %s. RPM not accessible to users.",
+                repo_name,
+            )
+            return PulpDigestStatus.NOT_FOUND
+
+        query_url = (
+            f"{self._base_url}/api/pulp/{self._domain}"
+            f"/api/v3/content/rpm/packages/"
+            f"?repository_version={quote(rv_href, safe='')}"
+            f"&name={quote(name, safe='')}"
+            f"&epoch={quote(epoch, safe='')}"
+            f"&version={quote(version, safe='')}"
+            f"&release={quote(release, safe='')}"
+            f"&arch={quote(arch, safe='')}"
+        )
+
+        resp = self._session.get(query_url, timeout=60)
+        resp.raise_for_status()
+
+        data = resp.json()
+        if data.get("count", 0) == 0:
+            return PulpDigestStatus.NOT_FOUND
+
+        for result in data.get("results", []):
+            chref = result.get("pulp_href")
+            if not chref:
+                continue
+            content_data = self.get_json(f"{self._base_url}{chref}")
+
+            artifact_href = content_data.get("artifact") or (
+                (content_data.get("artifacts") or [None])[0]
+            )
+            if not artifact_href:
+                continue
+
+            server_sha = self.get_json(f"{self._base_url}{artifact_href}").get("sha256", "")
+            if server_sha and server_sha == expected_sha:
+                return PulpDigestStatus.MATCH
+
+        return PulpDigestStatus.MISMATCH

--- a/scripts/python/helpers/test_advisory_data.py
+++ b/scripts/python/helpers/test_advisory_data.py
@@ -19,6 +19,18 @@ def _gzip_b64(obj: dict) -> str:
     return base64.standard_b64encode(gz).decode("ascii")
 
 
+def test_advisory_secret_name_stage() -> None:
+    """Return the stage secret name for the 'stage' environment."""
+    assert advisory_data.advisory_secret_name("stage") == advisory_data.ADVISORY_SECRET_STAGE
+
+
+def test_advisory_secret_name_production() -> None:
+    """Return the prod secret name for the 'production' environment."""
+    assert (
+        advisory_data.advisory_secret_name("production") == advisory_data.ADVISORY_SECRET_PROD
+    )
+
+
 def test_spec_content_json_pointer_image() -> None:
     """Map `image` content type to `.content.images`."""
     assert advisory_data.spec_content_json_pointer("image") == ".content.images"

--- a/scripts/python/helpers/test_pulp_client.py
+++ b/scripts/python/helpers/test_pulp_client.py
@@ -1,0 +1,522 @@
+"""Tests for ``pulp_client`` helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pulp_client
+import pytest
+import requests
+
+
+def _toml_content(
+    base_url: str = "https://pulp.example.com",
+    username: str = "",
+    password: str = "",
+    client_id: str = "",
+    client_secret: str = "",
+) -> str:
+    lines = ["[cli]", f'base_url = "{base_url}"']
+    if username:
+        lines.append(f'username = "{username}"')
+    if password:
+        lines.append(f'password = "{password}"')
+    if client_id:
+        lines.append(f'client_id = "{client_id}"')
+    if client_secret:
+        lines.append(f'client_secret = "{client_secret}"')
+    return "\n".join(lines) + "\n"
+
+
+class TestParsePulpConfig:
+    """Test TOML parsing of Pulp cli.toml."""
+
+    def test_basic_auth(self, tmp_path: Path) -> None:
+        """Parse username/password credentials."""
+        f = tmp_path / "cli.toml"
+        f.write_text(
+            _toml_content(
+                base_url="https://pulp.test",
+                username="admin",
+                password="secret",
+            ),
+            encoding="utf-8",
+        )
+        cfg = pulp_client.parse_pulp_config(f)
+        assert cfg["base_url"] == "https://pulp.test"
+        assert cfg["username"] == "admin"
+        assert cfg["password"] == "secret"
+
+    def test_oauth_credentials(self, tmp_path: Path) -> None:
+        """Parse client_id/client_secret credentials."""
+        f = tmp_path / "cli.toml"
+        f.write_text(
+            _toml_content(client_id="cid", client_secret="csecret"),
+            encoding="utf-8",
+        )
+        cfg = pulp_client.parse_pulp_config(f)
+        assert cfg["client_id"] == "cid"
+        assert cfg["client_secret"] == "csecret"
+
+    def test_strips_trailing_slash(self, tmp_path: Path) -> None:
+        """Trailing slashes on base_url are removed."""
+        f = tmp_path / "cli.toml"
+        f.write_text(
+            _toml_content(base_url="https://pulp.test///"),
+            encoding="utf-8",
+        )
+        cfg = pulp_client.parse_pulp_config(f)
+        assert cfg["base_url"] == "https://pulp.test"
+
+    def test_missing_cli_section_raises(self, tmp_path: Path) -> None:
+        """Missing [cli] section raises because base_url is required."""
+        f = tmp_path / "cli.toml"
+        f.write_text("[other]\nfoo = 1\n", encoding="utf-8")
+        with pytest.raises(RuntimeError, match="Missing required.*base_url"):
+            pulp_client.parse_pulp_config(f)
+
+    def test_missing_base_url_raises(self, tmp_path: Path) -> None:
+        """Explicit [cli] section without base_url raises."""
+        f = tmp_path / "cli.toml"
+        f.write_text(
+            '[cli]\nusername = "u"\npassword = "p"\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(RuntimeError, match="Missing required.*base_url"):
+            pulp_client.parse_pulp_config(f)
+
+    def test_empty_file_raises(self, tmp_path: Path) -> None:
+        """Empty cli.toml raises RuntimeError."""
+        f = tmp_path / "cli.toml"
+        f.write_text("", encoding="utf-8")
+        with pytest.raises(RuntimeError, match="Missing cli.toml"):
+            pulp_client.parse_pulp_config(f)
+
+
+class TestPulpAuth:
+    """Test PulpAuth request authenticator."""
+
+    def test_basic_auth_preferred(self) -> None:
+        """Username/password produces Basic header."""
+        config = {
+            "username": "admin",
+            "password": "pass",
+            "client_id": "cid",
+            "client_secret": "csec",
+        }
+        auth = pulp_client.PulpAuth(config)
+        req = requests.Request("GET", "https://example.com").prepare()
+        auth(req)
+        assert req.headers["Authorization"].startswith("Basic ")
+
+    def test_oauth_fallback(self) -> None:
+        """When no username, uses client credentials with per-request refresh."""
+        config = {
+            "username": "",
+            "password": "",
+            "client_id": "cid",
+            "client_secret": "csec",
+        }
+        mock_post = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"access_token": "tok123"}
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        with patch("pulp_client.requests.post", mock_post):
+            auth = pulp_client.PulpAuth(config)
+            assert mock_post.call_count == 1
+
+            req = requests.Request("GET", "https://example.com").prepare()
+            auth(req)
+            assert req.headers["Authorization"] == "Bearer tok123"
+            assert mock_post.call_count == 2
+
+    def test_oauth_refreshes_per_request(self) -> None:
+        """OAuth2 token is fetched fresh on every request."""
+        config = {
+            "username": "",
+            "password": "",
+            "client_id": "cid",
+            "client_secret": "csec",
+        }
+        call_count = 0
+
+        def mock_post_fn(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            resp.json.return_value = {"access_token": f"tok{call_count}"}
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        with patch("pulp_client.requests.post", mock_post_fn):
+            auth = pulp_client.PulpAuth(config)
+            assert call_count == 1
+
+            req1 = requests.Request("GET", "https://example.com/1").prepare()
+            auth(req1)
+            assert req1.headers["Authorization"] == "Bearer tok2"
+
+            req2 = requests.Request("GET", "https://example.com/2").prepare()
+            auth(req2)
+            assert req2.headers["Authorization"] == "Bearer tok3"
+            assert call_count == 3
+
+    def test_no_credentials_raises(self) -> None:
+        """Raise RuntimeError when no credentials are available."""
+        config = {
+            "username": "",
+            "password": "",
+            "client_id": "",
+            "client_secret": "",
+        }
+        with pytest.raises(RuntimeError, match="No valid credentials"):
+            pulp_client.PulpAuth(config)
+
+
+class TestGetAccessToken:
+    """Test OAuth2 token fetch."""
+
+    @patch("time.sleep")
+    def test_success(self, _mock_sleep: MagicMock) -> None:
+        """Return access token from response."""
+        mock_post = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = {"access_token": "mytoken"}
+        resp.raise_for_status = MagicMock()
+        mock_post.return_value = resp
+
+        with patch("pulp_client.requests.post", mock_post):
+            token = pulp_client._get_access_token("cid", "csec")
+        assert token == "mytoken"
+
+    @patch("time.sleep")
+    def test_failure_raises_after_retries(self, _mock_sleep: MagicMock) -> None:
+        """HTTP error propagates after all retry attempts are exhausted."""
+        mock_post = MagicMock()
+        mock_post.return_value.raise_for_status.side_effect = requests.HTTPError("401")
+        with patch("pulp_client.requests.post", mock_post):
+            with pytest.raises(requests.HTTPError):
+                pulp_client._get_access_token("cid", "csec")
+        assert mock_post.call_count == 3
+
+    @patch("time.sleep")
+    def test_retries_on_transient_failure(self, _mock_sleep: MagicMock) -> None:
+        """Succeed after transient failures are retried."""
+        fail_resp = MagicMock()
+        fail_resp.raise_for_status.side_effect = requests.ConnectionError("timeout")
+
+        ok_resp = MagicMock()
+        ok_resp.json.return_value = {"access_token": "recovered"}
+        ok_resp.raise_for_status = MagicMock()
+
+        mock_post = MagicMock(side_effect=[fail_resp, ok_resp])
+
+        with patch("pulp_client.requests.post", mock_post):
+            token = pulp_client._get_access_token("cid", "csec")
+        assert token == "recovered"
+        assert mock_post.call_count == 2
+
+
+class TestPulpClient:
+    """Test PulpClient: published version href resolution and digest checks."""
+
+    def _session(self, responses: list[dict | Exception]) -> MagicMock:
+        session = MagicMock(spec=requests.Session)
+        resps = []
+        for r in responses:
+            if isinstance(r, Exception):
+                resps.append(r)
+            else:
+                resp = MagicMock()
+                resp.json.return_value = r
+                resp.raise_for_status = MagicMock()
+                resps.append(resp)
+        session.get.side_effect = resps
+        return session
+
+    def _client(self, responses: list[dict | Exception]) -> pulp_client.PulpClient:
+        return pulp_client.PulpClient(self._session(responses), "https://pulp.test", "dom")
+
+    def test_direct_repository_version(self) -> None:
+        """Return repository_version from distribution directly."""
+        client = self._client(
+            [
+                {
+                    "results": [
+                        {
+                            "repository_version": "/v3/rv/1/",
+                            "publication": None,
+                            "repository": None,
+                        }
+                    ]
+                }
+            ]
+        )
+        assert client.get_published_version_href("myrepo") == "/v3/rv/1/"
+
+    def test_via_publication(self) -> None:
+        """Resolve via publication href."""
+        client = self._client(
+            [
+                {
+                    "results": [
+                        {
+                            "repository_version": None,
+                            "publication": "/pub/1/",
+                            "repository": None,
+                        }
+                    ]
+                },
+                {"repository_version": "/v3/rv/2/"},
+            ]
+        )
+        assert client.get_published_version_href("myrepo") == "/v3/rv/2/"
+
+    def test_via_repository_latest(self) -> None:
+        """Fallback to repository latest_version_href."""
+        client = self._client(
+            [
+                {
+                    "results": [
+                        {
+                            "repository_version": None,
+                            "publication": None,
+                            "repository": "/repo/1/",
+                        }
+                    ]
+                },
+                {"latest_version_href": "/v3/rv/3/"},
+            ]
+        )
+        assert client.get_published_version_href("myrepo") == "/v3/rv/3/"
+
+    def test_no_results(self) -> None:
+        """Empty distribution results return empty string."""
+        client = self._client([{"results": []}])
+        assert client.get_published_version_href("myrepo") == ""
+
+    def test_no_published_version(self) -> None:
+        """All fields None returns empty string."""
+        client = self._client(
+            [
+                {
+                    "results": [
+                        {
+                            "repository_version": None,
+                            "publication": None,
+                            "repository": None,
+                        }
+                    ]
+                }
+            ]
+        )
+        assert client.get_published_version_href("myrepo") == ""
+
+    def test_repository_latest_none(self) -> None:
+        """Repository exists but latest_version_href is None."""
+        client = self._client(
+            [
+                {
+                    "results": [
+                        {
+                            "repository_version": None,
+                            "publication": None,
+                            "repository": "/repo/1/",
+                        }
+                    ]
+                },
+                {"latest_version_href": None},
+            ]
+        )
+        assert client.get_published_version_href("myrepo") == ""
+
+    def test_publication_rv_none(self) -> None:
+        """Publication exists but repository_version is None -> falls through to repo."""
+        client = self._client(
+            [
+                {
+                    "results": [
+                        {
+                            "repository_version": None,
+                            "publication": "/pub/1/",
+                            "repository": "/repo/1/",
+                        }
+                    ]
+                },
+                {"repository_version": None},
+                {"latest_version_href": "/v3/rv/4/"},
+            ]
+        )
+        assert client.get_published_version_href("myrepo") == "/v3/rv/4/"
+
+    def test_http_error_propagates(self) -> None:
+        """HTTP error from the distribution API propagates."""
+        session = MagicMock(spec=requests.Session)
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = requests.HTTPError("500 Server Error")
+        session.get.return_value = resp
+
+        client = pulp_client.PulpClient(session, "https://pulp.test", "dom")
+        with pytest.raises(requests.HTTPError, match="500"):
+            client.get_published_version_href("myrepo")
+
+    def test_publication_http_error_propagates(self) -> None:
+        """HTTP error when fetching publication href propagates."""
+        session = MagicMock(spec=requests.Session)
+        dist_resp = MagicMock()
+        dist_resp.json.return_value = {
+            "results": [
+                {
+                    "repository_version": None,
+                    "publication": "/pub/1/",
+                    "repository": None,
+                }
+            ]
+        }
+        dist_resp.raise_for_status = MagicMock()
+        pub_resp = MagicMock()
+        pub_resp.raise_for_status.side_effect = requests.HTTPError("502")
+        session.get.side_effect = [dist_resp, pub_resp]
+
+        client = pulp_client.PulpClient(session, "https://pulp.test", "dom")
+        with pytest.raises(requests.HTTPError, match="502"):
+            client.get_published_version_href("myrepo")
+
+    def test_digest_match(self) -> None:
+        """Matching digest returns MATCH."""
+        client = self._client(
+            [
+                {"results": [{"repository_version": "/rv/1/"}]},
+                {"count": 1, "results": [{"pulp_href": "/pkg/1/"}]},
+                {"artifact": "/art/1/"},
+                {"sha256": "abc123"},
+            ]
+        )
+        assert (
+            client.check_digest("myrepo", "hello", "0", "1.0", "1.el9", "x86_64", "abc123")
+            == pulp_client.PulpDigestStatus.MATCH
+        )
+
+    def test_digest_not_found_no_published(self) -> None:
+        """No published version returns NOT_FOUND."""
+        client = self._client(
+            [
+                {
+                    "results": [
+                        {
+                            "repository_version": None,
+                            "publication": None,
+                            "repository": None,
+                        }
+                    ]
+                }
+            ]
+        )
+        assert (
+            client.check_digest("myrepo", "hello", "0", "1.0", "1.el9", "x86_64", "abc123")
+            == pulp_client.PulpDigestStatus.NOT_FOUND
+        )
+
+    def test_digest_not_found_zero_count(self) -> None:
+        """Zero count in packages query returns NOT_FOUND."""
+        client = self._client(
+            [
+                {"results": [{"repository_version": "/rv/1/"}]},
+                {"count": 0, "results": []},
+            ]
+        )
+        assert (
+            client.check_digest("myrepo", "hello", "0", "1.0", "1.el9", "x86_64", "abc123")
+            == pulp_client.PulpDigestStatus.NOT_FOUND
+        )
+
+    def test_digest_mismatch(self) -> None:
+        """Different digest returns MISMATCH."""
+        client = self._client(
+            [
+                {"results": [{"repository_version": "/rv/1/"}]},
+                {"count": 1, "results": [{"pulp_href": "/pkg/1/"}]},
+                {"artifact": "/art/1/"},
+                {"sha256": "different_hash"},
+            ]
+        )
+        assert (
+            client.check_digest("myrepo", "hello", "0", "1.0", "1.el9", "x86_64", "abc123")
+            == pulp_client.PulpDigestStatus.MISMATCH
+        )
+
+    def test_digest_error_on_published_version(self) -> None:
+        """Request error during published version check propagates."""
+        session = MagicMock(spec=requests.Session)
+        session.get.side_effect = requests.ConnectionError("fail")
+        client = pulp_client.PulpClient(session, "https://pulp.test", "dom")
+        with pytest.raises(requests.ConnectionError):
+            client.check_digest("myrepo", "hello", "0", "1.0", "1.el9", "x86_64", "abc123")
+
+    def test_digest_error_on_packages_query(self) -> None:
+        """Request error during packages query propagates."""
+        client = self._client(
+            [
+                {"results": [{"repository_version": "/rv/1/"}]},
+                requests.ConnectionError("fail"),
+            ]
+        )
+        with pytest.raises(requests.ConnectionError):
+            client.check_digest("myrepo", "hello", "0", "1.0", "1.el9", "x86_64", "abc123")
+
+    def test_digest_error_on_content_fetch(self) -> None:
+        """Request error during content href fetch propagates."""
+        client = self._client(
+            [
+                {"results": [{"repository_version": "/rv/1/"}]},
+                {"count": 1, "results": [{"pulp_href": "/pkg/1/"}]},
+                requests.ConnectionError("fail"),
+            ]
+        )
+        with pytest.raises(requests.ConnectionError):
+            client.check_digest("myrepo", "hello", "0", "1.0", "1.el9", "x86_64", "abc123")
+
+    def test_digest_no_artifact_href(self) -> None:
+        """Content without artifact href returns MISMATCH."""
+        client = self._client(
+            [
+                {"results": [{"repository_version": "/rv/1/"}]},
+                {"count": 1, "results": [{"pulp_href": "/pkg/1/"}]},
+                {"artifact": None, "artifacts": []},
+            ]
+        )
+        assert (
+            client.check_digest("myrepo", "hello", "0", "1.0", "1.el9", "x86_64", "abc123")
+            == pulp_client.PulpDigestStatus.MISMATCH
+        )
+
+    def test_digest_no_pulp_href_skipped(self) -> None:
+        """Result with no pulp_href is skipped -> MISMATCH."""
+        client = self._client(
+            [
+                {"results": [{"repository_version": "/rv/1/"}]},
+                {"count": 1, "results": [{"pulp_href": ""}]},
+            ]
+        )
+        assert (
+            client.check_digest("myrepo", "hello", "0", "1.0", "1.el9", "x86_64", "abc123")
+            == pulp_client.PulpDigestStatus.MISMATCH
+        )
+
+    def test_digest_artifacts_list_fallback(self) -> None:
+        """Use artifacts[0] when artifact is None."""
+        client = self._client(
+            [
+                {"results": [{"repository_version": "/rv/1/"}]},
+                {"count": 1, "results": [{"pulp_href": "/pkg/1/"}]},
+                {"artifact": None, "artifacts": ["/art/1/"]},
+                {"sha256": "abc123"},
+            ]
+        )
+        assert (
+            client.check_digest("myrepo", "hello", "0", "1.0", "1.el9", "x86_64", "abc123")
+            == pulp_client.PulpDigestStatus.MATCH
+        )

--- a/scripts/python/tasks/managed/filter_already_released_advisory_rpms.py
+++ b/scripts/python/tasks/managed/filter_already_released_advisory_rpms.py
@@ -1,0 +1,799 @@
+#!/usr/bin/env python3
+"""Filter RPMs already published in advisories and reduce the snapshot.
+
+Pull RPM files from each component's OCI artifact, transform RPM metadata
+into purls for advisory matching, trigger an InternalRequest to check
+advisories, validate Pulp digests for RPMs in advisories (rebuild detection),
+write RPMs still needing publishing under ``.components[].rpmsToPublish``,
+remove components with an empty list, and overwrite the snapshot file.
+"""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import gzip
+import json
+import os
+import re
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import requests
+
+import advisory_data
+import file as file_helper
+import http_client
+import oras_utils
+import subprocess_cmd
+import tekton
+from logger import logger
+from pulp_client import PulpAuth, PulpClient, PulpDigestStatus, parse_pulp_config
+
+
+@dataclasses.dataclass(frozen=True)
+class RpmNevra:
+    """Name-Epoch-Version-Release-Architecture for an RPM."""
+
+    name: str
+    epoch: str
+    version: str
+    release: str
+    arch: str
+
+
+@dataclasses.dataclass(frozen=True)
+class RpmEntry:
+    """One RPM-to-repository mapping, fully resolved."""
+
+    component_name: str
+    rpm_filename: str
+    sha256: str
+    nevra: RpmNevra
+    purl: str
+    target_repo: dict[str, Any]
+
+
+@dataclasses.dataclass(frozen=True)
+class ResultPaths:
+    """Tekton result file paths written by the filtering workflow."""
+
+    skip_release: Path
+    environment: Path
+    latest_advisory_url: Path
+    latest_advisory_internal_url: Path
+
+
+@dataclasses.dataclass(frozen=True)
+class FilterConfig:
+    """Input configuration for the filtering workflow."""
+
+    snapshot_file: Path
+    data_file: Path
+    rpa_file: Path
+    pulp_config_file: Path
+    pulp_domain: str
+    default_excludes: list[str]
+    default_architectures: list[str]
+    pipeline_run_uid: str
+    oci_storage: str
+    oras_options: str
+    task_git_url: str
+    task_git_revision: str
+    synchronously: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class LoadedContext:
+    """Validated inputs loaded from disk."""
+
+    snapshot: dict[str, Any]
+    data: dict[str, Any]
+    origin: str
+    pulp_config: dict[str, str]
+    base_url: str
+    environment: str
+    advisory_secret_name: str
+
+
+@dataclasses.dataclass(frozen=True)
+class FilteringResult:
+    """Output of the advisory filtering phase."""
+
+    in_advisory_rpms: list[dict[str, Any]]
+    unreleased_rpms: list[dict[str, Any]]
+    advisory_url: str
+    advisory_internal_url: str
+
+
+def should_exclude_file(filename: str, patterns: list[str]) -> bool:
+    """Return True if *filename* contains any non-blank *pattern* as a substring."""
+    return any(p in filename for p in patterns if p.strip())
+
+
+def determine_environment(data: dict[str, Any]) -> str:
+    """Return ``"stage"`` or ``"production"`` based on data file content."""
+    intention = data.get("intention", "")
+    if intention == "staging":
+        return "stage"
+    if intention == "production":
+        return "production"
+
+    advisory_repo = (data.get("advisory") or {}).get("repo", "")
+    if "rhtap-release" in advisory_repo or "stage" in advisory_repo:
+        return "stage"
+    return "production"
+
+
+def extract_rpm_metadata(rpm_path: Path) -> RpmNevra | None:
+    """Run ``rpm -qp`` to extract NEVRA metadata from an RPM file.
+
+    Return an ``RpmNevra``, or ``None`` on failure.
+    """
+    try:
+        result = subprocess_cmd.run_cmd(
+            [
+                "rpm",
+                "-qp",
+                "--qf",
+                "%{NAME}|%{EPOCH}|%{VERSION}|%{RELEASE}|%{ARCH}\n",
+                str(rpm_path),
+            ],
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("extract_rpm_metadata: exception running rpm -qp: %s", exc)
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    line = result.stdout.strip().split("\n")[0]
+    parts = line.split("|")
+    if len(parts) != 5:
+        return None
+
+    epoch = parts[1]
+    if not epoch or epoch == "(none)":
+        epoch = "0"
+
+    return RpmNevra(
+        name=parts[0],
+        epoch=epoch,
+        version=parts[2],
+        release=parts[3],
+        arch=parts[4],
+    )
+
+
+def _build_arch_repo_cache(
+    rpm_repos: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Build a mapping from architecture to repository info."""
+    cache: dict[str, dict[str, Any]] = {}
+    for repo in rpm_repos:
+        arch = repo.get("arch", "")
+        if arch and arch not in cache:
+            cache[arch] = {
+                "repository_id": repo.get("repository_id", ""),
+                "repository_name": repo.get("repository_name", ""),
+                "distro": repo.get("distro", ""),
+            }
+    return cache
+
+
+def _build_purl(
+    rpmname: str,
+    version: str,
+    release: str,
+    arch: str,
+    distro: str,
+    repo_id: str,
+) -> str:
+    """Build a Package URL for an RPM."""
+    purl = f"pkg:rpm/redhat/{rpmname}@{version}-{release}?arch={arch}"
+    if distro:
+        purl += f"&distro={distro}"
+    if repo_id:
+        purl += f"&repository_id={repo_id}"
+    return purl
+
+
+def _pull_rpm_files(
+    image: str,
+    files_dir: Path,
+    excludes: list[str],
+) -> list[str]:
+    """Pull an OCI artifact and return filtered RPM filenames."""
+    oras_utils.oras_pull(image, files_dir)
+
+    kept = []
+    for f in sorted(files_dir.iterdir()):
+        if not f.is_file():
+            continue
+        if not f.name.endswith(".rpm"):
+            continue
+        if should_exclude_file(f.name, excludes):
+            continue
+        kept.append(f.name)
+
+    return kept
+
+
+def _resolve_target_repos(
+    nevra: RpmNevra,
+    arch_cache: dict[str, dict[str, Any]],
+    noarch_repos: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return target repositories for an RPM based on its NEVRA architecture."""
+    if nevra.arch == "src":
+        repo = arch_cache.get("src")
+        if repo:
+            return [repo]
+        logger.warning(
+            "No repository mapping for source arch (available: %s), skipping %s",
+            sorted(arch_cache.keys()),
+            nevra.name,
+        )
+        return []
+
+    if nevra.arch == "noarch":
+        return list(noarch_repos)
+
+    repo = arch_cache.get(nevra.arch)
+    return [repo] if repo else []
+
+
+def _process_component_rpms(
+    name: str,
+    files_dir: Path,
+    rpm_files: list[str],
+    arch_cache: dict[str, dict[str, Any]],
+    noarch_repos: list[dict[str, Any]],
+) -> list[RpmEntry]:
+    """Build resolved RPM entries for a single component."""
+    results: list[RpmEntry] = []
+
+    for f in rpm_files:
+        file_abs = files_dir / f
+        local_sha = file_helper.sha256(file_abs)
+        nevra = extract_rpm_metadata(file_abs)
+        if nevra is None:
+            continue
+
+        if f.endswith(".src.rpm"):
+            nevra = RpmNevra(
+                name=nevra.name,
+                epoch=nevra.epoch,
+                version=nevra.version,
+                release=nevra.release,
+                arch="src",
+            )
+
+        target_repos = _resolve_target_repos(nevra, arch_cache, noarch_repos)
+        if not target_repos:
+            continue
+
+        for repo_obj in target_repos:
+            repo_id = repo_obj.get("repository_id", "")
+            distro = repo_obj.get("distro", "")
+
+            purl = _build_purl(
+                nevra.name, nevra.version, nevra.release, nevra.arch, distro, repo_id
+            )
+
+            results.append(
+                RpmEntry(
+                    component_name=name,
+                    rpm_filename=f,
+                    sha256=local_sha,
+                    nevra=nevra,
+                    purl=purl,
+                    target_repo=repo_obj,
+                )
+            )
+
+    return results
+
+
+def entries_to_ir_payload(entries: list[RpmEntry]) -> list[dict[str, Any]]:
+    """Serialize RPM entries into the dict format expected by InternalRequest."""
+    return [
+        {
+            "name": e.component_name,
+            "purl": e.purl,
+            "repository_name": e.target_repo.get("repository_name", ""),
+            "rpm": e.rpm_filename,
+            "sha256": e.sha256,
+            "rpmname": e.nevra.name,
+            "epoch": e.nevra.epoch,
+            "version": e.nevra.version,
+            "release": e.nevra.release,
+            "arch": e.nevra.arch,
+            "targetRepo": e.target_repo,
+        }
+        for e in entries
+    ]
+
+
+def entries_to_rpms_map(
+    entries: list[RpmEntry],
+) -> dict[str, list[dict[str, Any]]]:
+    """Group RPM entries by component, one entry per (RPM, repo) pair.
+
+    Return a mapping from component name to its ``rpmsToPublish`` list.
+    Each RPM-to-repo combination produces a separate entry with a
+    single-element ``targetRepos`` array, matching the original bash
+    output format.
+    """
+    by_component: dict[str, list[dict[str, Any]]] = {}
+    for e in entries:
+        by_component.setdefault(e.component_name, []).append(
+            {
+                "rpm": e.rpm_filename,
+                "sha256": e.sha256,
+                "rpmname": e.nevra.name,
+                "epoch": e.nevra.epoch,
+                "version": e.nevra.version,
+                "release": e.nevra.release,
+                "arch": e.nevra.arch,
+                "targetRepos": [e.target_repo],
+            }
+        )
+
+    return by_component
+
+
+def build_rpm_entries(
+    snapshot: dict[str, Any],
+    data: dict[str, Any],
+    default_excludes: list[str],
+    default_architectures: list[str],
+) -> list[RpmEntry]:
+    """Extract RPMs from snapshot components and build resolved entries.
+
+    Return a flat list of ``RpmEntry`` objects, one per RPM-to-repo mapping.
+    """
+    rpm_repos = (data.get("mapping") or {}).get("rpm-repositories") or []
+
+    arch_cache = _build_arch_repo_cache(rpm_repos)
+    noarch_repos = [arch_cache[a] for a in default_architectures if a in arch_cache]
+
+    all_entries: list[RpmEntry] = []
+    components = snapshot.get("components", [])
+
+    for component in components:
+        image = component.get("containerImage", "")
+        name = component.get("name", "")
+        logger.info("Processing component '%s' (%s)", name, image)
+
+        with tempfile.TemporaryDirectory() as workdir_str:
+            files_dir = Path(workdir_str) / "files"
+            files_dir.mkdir()
+
+            rpm_files = _pull_rpm_files(image, files_dir, default_excludes)
+            if not rpm_files:
+                continue
+
+            entries = _process_component_rpms(
+                name, files_dir, rpm_files, arch_cache, noarch_repos
+            )
+            all_entries.extend(entries)
+
+    return all_entries
+
+
+def create_internal_request(
+    transformed_snapshot_b64: str,
+    origin: str,
+    advisory_secret_name: str,
+    pipeline_run_uid: str,
+    oci_storage: str,
+    oras_options: str,
+    task_git_url: str,
+    task_git_revision: str,
+    synchronously: bool,
+) -> dict[str, Any]:
+    """Create an InternalRequest and return its status results.
+
+    Call ``internal-request`` to create the IR, wait for it via
+    ``kubectl``, and return the parsed results dict.
+    """
+    pipelinerun_label = "internal-services.appstudio.openshift.io/pipelinerun-uid"
+
+    cmd = [
+        "internal-request",
+        "--pipeline",
+        "filter-already-released-advisory-rpms",
+        "-p",
+        f"transformedSnapshot={transformed_snapshot_b64}",
+        "-p",
+        f"origin={origin}",
+        "-p",
+        f"advisory_secret_name={advisory_secret_name}",
+        "-p",
+        f"internalRequestPipelineRunName={pipeline_run_uid}",
+        "-p",
+        f"ociStorage={oci_storage}",
+        "-p",
+        f"orasOptions={oras_options}",
+        "-p",
+        f"taskGitUrl={task_git_url}",
+        "-p",
+        f"taskGitRevision={task_git_revision}",
+        "-s",
+        str(synchronously).lower(),
+        "-l",
+        f"{pipelinerun_label}={pipeline_run_uid}",
+    ]
+
+    ir_result = subprocess_cmd.run_cmd(cmd, check=True)
+
+    ir_name = ""
+    for line in ir_result.stdout.splitlines():
+        if "created" in line:
+            match = re.search(r"'([^']+)'", line)
+            if match:
+                ir_name = match.group(1)
+                break
+
+    if not ir_name:
+        raise RuntimeError(
+            f"Could not parse InternalRequest name from output: {ir_result.stdout}"
+        )
+
+    logger.info("Internal request created: %s", ir_name)
+
+    results_out = subprocess_cmd.run_cmd(
+        [
+            "kubectl",
+            "get",
+            "internalrequest",
+            ir_name,
+            "-o=jsonpath={.status.results}",
+        ],
+        check=True,
+    )
+
+    results_text = results_out.stdout.strip()
+    if not results_text:
+        raise RuntimeError(f"No results found in internal request {ir_name}")
+
+    results: dict[str, Any] = json.loads(results_text)
+    if results.get("result") != "Success":
+        raise RuntimeError(f"Filtering failed: {json.dumps(results)}")
+
+    return results
+
+
+def pull_filter_results(
+    artifact_ref: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Pull filter results OCI artifact and extract the tarball.
+
+    Return ``(in_advisory_rpms, unreleased_rpms)`` lists.
+    """
+    oci_ref = artifact_ref.removeprefix("oci:")
+
+    with tempfile.TemporaryDirectory() as results_dir_str:
+        results_dir = Path(results_dir_str)
+        oras_utils.oras_pull(oci_ref, results_dir)
+
+        tarball = results_dir / "filter-results.tar.gz"
+
+        with tarfile.open(tarball, "r:gz") as tf:
+            tf.extractall(path=results_dir, filter="data")
+
+        in_advisory_file = results_dir / "in_advisory_rpms.json"
+        unreleased_file = results_dir / "unreleased_rpms.json"
+
+        in_advisory: list[dict[str, Any]] = []
+        if in_advisory_file.is_file():
+            in_advisory = json.loads(in_advisory_file.read_text(encoding="utf-8"))
+
+        if not unreleased_file.is_file():
+            raise RuntimeError("No unreleased_rpms.json found in filter results")
+        unreleased: list[dict[str, Any]] = json.loads(
+            unreleased_file.read_text(encoding="utf-8")
+        )
+
+        return in_advisory, unreleased
+
+
+def validate_pulp_digests(
+    in_advisory_rpms: list[dict[str, Any]],
+    pulp: PulpClient,
+) -> None:
+    """Validate Pulp digests for in-advisory RPMs.
+
+    Raise ``RuntimeError`` on digest mismatch or Pulp API failures.
+    """
+    logger.info(
+        "Validating Pulp digests for %d in-advisory RPMs...",
+        len(in_advisory_rpms),
+    )
+
+    for rpm_entry in in_advisory_rpms:
+        rpmname = rpm_entry["rpmname"]
+        epoch = rpm_entry["epoch"]
+        version = rpm_entry["version"]
+        release = rpm_entry["release"]
+        arch = rpm_entry["arch"]
+        sha256 = rpm_entry["sha256"]
+        repo_name = rpm_entry["repository_name"]
+
+        logger.info(
+            "Checking Pulp digest for %s-%s-%s.%s...",
+            rpmname,
+            version,
+            release,
+            arch,
+        )
+
+        try:
+            status = pulp.check_digest(
+                repo_name, rpmname, epoch, version, release, arch, sha256
+            )
+        except requests.RequestException as exc:
+            raise RuntimeError(
+                f"Pulp API error while checking digest "
+                f"for {rpmname}-{version}-{release}.{arch}"
+            ) from exc
+
+        if status == PulpDigestStatus.MATCH:
+            logger.info("  -> Published in Pulp with matching digest")
+        elif status == PulpDigestStatus.NOT_FOUND:
+            logger.info("  -> Not published in Pulp yet (advisory is authoritative)")
+        elif status == PulpDigestStatus.MISMATCH:
+            raise RuntimeError(
+                f"Cannot rebuild RPM with same NEVR but different digest. "
+                f"RPM: {rpmname}-{version}-{release}.{arch}, "
+                f"Snapshot sha256: {sha256}. "
+                f"Action required: Bump version or release number"
+            )
+
+
+def filter_snapshot(
+    snapshot: dict[str, Any],
+    unreleased_rpms: list[dict[str, Any]],
+    component_rpms_map: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
+    """Filter snapshot to keep only components with unreleased RPMs.
+
+    Attach ``rpmsToPublish`` to each retained component.
+    """
+    unreleased_names = sorted(set(r["name"] for r in unreleased_rpms))
+
+    components_by_name = {c["name"]: c for c in snapshot.get("components", []) if "name" in c}
+
+    filtered_components = []
+    for comp_name in unreleased_names:
+        original = components_by_name.get(comp_name)
+        if original is None:
+            continue
+
+        rpms = component_rpms_map.get(comp_name)
+        if not rpms:
+            continue
+
+        component = dict(original)
+        component["rpmsToPublish"] = rpms
+        filtered_components.append(component)
+
+    result = dict(snapshot)
+    result["components"] = filtered_components
+    return result
+
+
+def _write_results(
+    results: ResultPaths,
+    snapshot_file: Path,
+    snapshot: dict[str, Any],
+    *,
+    skip_release: bool,
+    advisory_url: str = "",
+    advisory_internal_url: str = "",
+) -> None:
+    """Write Tekton result files and the updated snapshot."""
+    results.skip_release.write_text("true" if skip_release else "false", encoding="utf-8")
+    results.latest_advisory_url.write_text(advisory_url, encoding="utf-8")
+    results.latest_advisory_internal_url.write_text(advisory_internal_url, encoding="utf-8")
+    snapshot_file.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+
+
+def load_and_validate(config: FilterConfig) -> LoadedContext:
+    """Load input files, parse Pulp config, and determine environment.
+
+    Raise ``FileNotFoundError`` on missing files, ``TypeError`` if
+    JSON root is not an object, or ``RuntimeError`` on invalid
+    configuration.
+    """
+    snapshot = file_helper.load_json_dict(config.snapshot_file)
+    data = file_helper.load_json_dict(config.data_file)
+    rpa = file_helper.load_json_dict(config.rpa_file)
+
+    origin = rpa["spec"]["origin"]
+    if not origin:
+        raise ValueError("'origin' in ReleasePlanAdmission spec is empty")
+
+    pulp_config = parse_pulp_config(config.pulp_config_file)
+    base_url = pulp_config["base_url"]
+
+    environment = determine_environment(data)
+
+    return LoadedContext(
+        snapshot=snapshot,
+        data=data,
+        origin=origin,
+        pulp_config=pulp_config,
+        base_url=base_url,
+        environment=environment,
+        advisory_secret_name=advisory_data.advisory_secret_name(environment),
+    )
+
+
+def submit_advisory_filter(
+    rpm_entries: list[RpmEntry],
+    config: FilterConfig,
+    ctx: LoadedContext,
+) -> FilteringResult:
+    """Compress RPM entries, submit InternalRequest, and pull back results."""
+    ir_payload = entries_to_ir_payload(rpm_entries)
+    entries_json = json.dumps(ir_payload).encode("utf-8")
+    compressed = gzip.compress(entries_json)
+    transformed_b64 = base64.b64encode(compressed).decode("ascii")
+
+    ir_results = create_internal_request(
+        transformed_b64,
+        ctx.origin,
+        ctx.advisory_secret_name,
+        config.pipeline_run_uid,
+        config.oci_storage,
+        config.oras_options,
+        config.task_git_url,
+        config.task_git_revision,
+        config.synchronously,
+    )
+
+    filter_artifact = ir_results.get("filter_results_artifact", "")
+    if not filter_artifact:
+        raise RuntimeError("No filter_results_artifact found in results")
+
+    logger.info("Pulling filter results from: %s", filter_artifact)
+    in_advisory_rpms, unreleased_rpms = pull_filter_results(filter_artifact)
+
+    return FilteringResult(
+        in_advisory_rpms=in_advisory_rpms,
+        unreleased_rpms=unreleased_rpms,
+        advisory_url=ir_results.get("advisory_url", ""),
+        advisory_internal_url=ir_results.get("advisory_internal_url", ""),
+    )
+
+
+def make_pulp_client(
+    ctx: LoadedContext,
+    domain: str,
+) -> PulpClient:
+    """Build a PulpClient with retry session and auth configured."""
+    session = http_client.get_retry_session(
+        total=3,
+        connect=3,
+        read=3,
+        status=2,
+        backoff_factor=0.4,
+        allowed_methods=frozenset({"GET", "POST"}),
+    )
+    session.auth = PulpAuth(ctx.pulp_config)
+    return PulpClient(session, ctx.base_url, domain)
+
+
+def run(
+    config: FilterConfig,
+    results: ResultPaths,
+) -> None:
+    """Orchestrate all filtering phases and write Tekton results."""
+    ctx = load_and_validate(config)
+    results.environment.write_text(ctx.environment, encoding="utf-8")
+    logger.info("Environment: %s", ctx.environment)
+
+    rpm_entries = build_rpm_entries(
+        ctx.snapshot,
+        ctx.data,
+        config.default_excludes,
+        config.default_architectures,
+    )
+    logger.info("Total transformed entries: %d", len(rpm_entries))
+
+    if not rpm_entries:
+        logger.info("No RPMs found in any component, skipping release")
+        ctx.snapshot["components"] = []
+        _write_results(results, config.snapshot_file, ctx.snapshot, skip_release=True)
+        return
+
+    filtering = submit_advisory_filter(rpm_entries, config, ctx)
+
+    pulp = make_pulp_client(ctx, config.pulp_domain)
+    if filtering.in_advisory_rpms:
+        validate_pulp_digests(filtering.in_advisory_rpms, pulp)
+
+    logger.info("Unreleased RPMs: %d", len(filtering.unreleased_rpms))
+
+    if not filtering.unreleased_rpms:
+        logger.info("All RPMs in the snapshot have already been released in advisories.")
+        ctx.snapshot["components"] = []
+        _write_results(
+            results,
+            config.snapshot_file,
+            ctx.snapshot,
+            skip_release=True,
+            advisory_url=filtering.advisory_url,
+            advisory_internal_url=filtering.advisory_internal_url,
+        )
+        return
+
+    component_rpms_map = entries_to_rpms_map(rpm_entries)
+    filtered = filter_snapshot(ctx.snapshot, filtering.unreleased_rpms, component_rpms_map)
+    logger.info(
+        "Filtered snapshot components: %d",
+        len(filtered.get("components", [])),
+    )
+    _write_results(results, config.snapshot_file, filtered, skip_release=False)
+
+
+def main() -> int:
+    """Read environment variables and run the filtering workflow."""
+    (
+        result_skip_release,
+        result_environment,
+        result_latest_advisory_url,
+        result_latest_advisory_internal_url,
+    ) = tekton.result_paths_from_env(
+        "RESULT_SKIP_RELEASE",
+        "RESULT_ENVIRONMENT",
+        "RESULT_LATEST_ADVISORY_URL",
+        "RESULT_LATEST_ADVISORY_INTERNAL_URL",
+    )
+
+    config = FilterConfig(
+        snapshot_file=Path(tekton.require_env("SNAPSHOT_FILE")),
+        data_file=Path(tekton.require_env("DATA_FILE")),
+        rpa_file=Path(tekton.require_env("RPA_FILE")),
+        pulp_config_file=Path(tekton.require_env("PULP_CONFIG_FILE")),
+        pulp_domain=tekton.require_env("PULP_DOMAIN"),
+        default_excludes=[
+            x.strip()
+            for x in os.environ.get("DEFAULT_EXCLUDES", "-debuginfo-, -debugsource-").split(
+                ","
+            )
+            if x.strip()
+        ],
+        default_architectures=[
+            x.strip()
+            for x in os.environ.get(
+                "DEFAULT_ARCHITECTURES", "x86_64,aarch64,s390x,ppc64le"
+            ).split(",")
+            if x.strip()
+        ],
+        pipeline_run_uid=tekton.require_env("PIPELINE_RUN_UID"),
+        oci_storage=os.environ.get("OCI_STORAGE", "empty"),
+        oras_options=os.environ.get("ORAS_OPTIONS", ""),
+        task_git_url=tekton.require_env("TASK_GIT_URL"),
+        task_git_revision=tekton.require_env("TASK_GIT_REVISION"),
+        synchronously=os.environ.get("SYNCHRONOUSLY", "true").lower() == "true",
+    )
+    result_paths = ResultPaths(
+        skip_release=result_skip_release,
+        environment=result_environment,
+        latest_advisory_url=result_latest_advisory_url,
+        latest_advisory_internal_url=result_latest_advisory_internal_url,
+    )
+
+    run(config, result_paths)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_filter_already_released_advisory_rpms.py
+++ b/scripts/python/tasks/managed/test_filter_already_released_advisory_rpms.py
@@ -1,0 +1,1408 @@
+"""Tests for ``filter_already_released_advisory_rpms``."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import filter_already_released_advisory_rpms as filt
+import pytest
+import requests
+
+
+def _write_json(path: Path, data: dict | list) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _snapshot(components: list[dict] | None = None) -> dict:
+    return {"components": components or []}
+
+
+def _data(
+    rpm_repos: list[dict] | None = None,
+    intention: str = "",
+    advisory_repo: str = "",
+) -> dict:
+    d: dict = {"mapping": {}}
+    if rpm_repos is not None:
+        d["mapping"]["rpm-repositories"] = rpm_repos
+    if intention:
+        d["intention"] = intention
+    if advisory_repo:
+        d["advisory"] = {"repo": advisory_repo}
+    return d
+
+
+def _rpa(origin: str = "test-origin") -> dict:
+    return {"spec": {"origin": origin}}
+
+
+def _toml_content(
+    base_url: str = "https://pulp.example.com",
+    username: str = "",
+    password: str = "",
+    client_id: str = "",
+    client_secret: str = "",
+) -> str:
+    lines = ["[cli]", f'base_url = "{base_url}"']
+    if username:
+        lines.append(f'username = "{username}"')
+    if password:
+        lines.append(f'password = "{password}"')
+    if client_id:
+        lines.append(f'client_id = "{client_id}"')
+    if client_secret:
+        lines.append(f'client_secret = "{client_secret}"')
+    return "\n".join(lines) + "\n"
+
+
+def _rpm_repos() -> list[dict]:
+    return [
+        {
+            "arch": "x86_64",
+            "repository_id": "rpm-x86_64",
+            "repository_name": "x86_64",
+            "distro": "el9",
+        },
+        {
+            "arch": "aarch64",
+            "repository_id": "rpm-aarch64",
+            "repository_name": "aarch64",
+            "distro": "el9",
+        },
+        {
+            "arch": "src",
+            "repository_id": "rpm-src",
+            "repository_name": "source",
+            "distro": "el9",
+        },
+    ]
+
+
+def _setup_base_files(
+    tmp_path: Path,
+    data: dict | None = None,
+    snapshot: dict | None = None,
+    rpa: dict | None = None,
+    toml: str | None = None,
+) -> tuple[Path, Path, Path, Path]:
+    """Create JSON files and return (snapshot, data, rpa, pulp_config)."""
+    snap_file = tmp_path / "snapshot.json"
+    data_file = tmp_path / "data.json"
+    rpa_file = tmp_path / "rpa.json"
+    toml_file = tmp_path / "cli.toml"
+
+    _write_json(snap_file, snapshot or _snapshot())
+    _write_json(data_file, data or _data())
+    _write_json(rpa_file, rpa or _rpa())
+    toml_file.write_text(
+        toml or _toml_content(username="user", password="pass"),
+        encoding="utf-8",
+    )
+    return snap_file, data_file, rpa_file, toml_file
+
+
+def _result_paths(tmp_path: Path) -> filt.ResultPaths:
+    """Create result paths and return a ``ResultPaths``."""
+    return filt.ResultPaths(
+        skip_release=tmp_path / "skip_release",
+        environment=tmp_path / "environment",
+        latest_advisory_url=tmp_path / "advisory_url",
+        latest_advisory_internal_url=tmp_path / "advisory_internal_url",
+    )
+
+
+def _make_config_and_results(
+    tmp_path: Path,
+    *,
+    data: dict | None = None,
+    snapshot: dict | None = None,
+    rpa: dict | None = None,
+    toml: str | None = None,
+    default_excludes: list[str] | None = None,
+    default_architectures: list[str] | None = None,
+) -> tuple[filt.FilterConfig, filt.ResultPaths]:
+    """Build a ``FilterConfig`` and ``ResultPaths``, writing files to *tmp_path*."""
+    snap_file, data_file, rpa_file, toml_file = _setup_base_files(
+        tmp_path,
+        data=data,
+        snapshot=snapshot,
+        rpa=rpa,
+        toml=toml,
+    )
+    cfg = filt.FilterConfig(
+        snapshot_file=snap_file,
+        data_file=data_file,
+        rpa_file=rpa_file,
+        pulp_config_file=toml_file,
+        pulp_domain="dom",
+        default_excludes=default_excludes if default_excludes is not None else [],
+        default_architectures=default_architectures or ["x86_64"],
+        pipeline_run_uid="uid",
+        oci_storage="oci",
+        oras_options="",
+        task_git_url="git",
+        task_git_revision="rev",
+        synchronously=True,
+    )
+    return cfg, _result_paths(tmp_path)
+
+
+def _make_filter_tarball(
+    tmp_path: Path,
+    unreleased: list[dict],
+    in_advisory: list[dict] | None = None,
+) -> Path:
+    """Create a filter-results.tar.gz in *tmp_path* and return its path."""
+    src_dir = tmp_path / "tar_src"
+    src_dir.mkdir(exist_ok=True)
+    _write_json(src_dir / "unreleased_rpms.json", unreleased)
+    _write_json(
+        src_dir / "in_advisory_rpms.json",
+        in_advisory if in_advisory is not None else [],
+    )
+    tarball = tmp_path / "filter-results.tar.gz"
+    with tarfile.open(tarball, "w:gz") as tf:
+        tf.add(src_dir / "unreleased_rpms.json", arcname="unreleased_rpms.json")
+        tf.add(src_dir / "in_advisory_rpms.json", arcname="in_advisory_rpms.json")
+    return tarball
+
+
+def _nevra_from_filename(fname: str) -> tuple[str, str, str, str]:
+    """Parse an RPM filename into (name, version, release, arch).
+
+    Used by mock runners to generate realistic ``rpm -qp`` output.
+    Real ``rpm -qp --qf '%{ARCH}'`` returns the build architecture for
+    source RPMs (e.g. ``x86_64``), **not** ``src``.  The production code
+    must override the arch to ``src`` based on the ``.src.rpm`` suffix.
+    """
+    is_src = fname.endswith(".src.rpm")
+    base = Path(fname).stem
+    if is_src:
+        base = Path(base).stem
+    parts = base.rsplit(".", 1)
+    arch = parts[1] if len(parts) > 1 else "x86_64"
+    nvr = parts[0]
+    if is_src:
+        arch = "x86_64"
+    release = nvr.rsplit("-", 1)[1] if "-" in nvr else "1"
+    namever = nvr.rsplit("-", 1)[0] if "-" in nvr else nvr
+    version = namever.rsplit("-", 1)[1] if "-" in namever else "1.0"
+    name = namever.rsplit("-", 1)[0] if "-" in namever else namever
+    return name, version, release, arch
+
+
+def _mock_run_cmd_for_oras_and_rpm(
+    rpm_files: list[str],
+    ir_results: dict | None = None,
+    filter_tarball: Path | None = None,
+) -> MagicMock:
+    """Return a mock for ``subprocess_cmd.run_cmd`` handling oras, rpm, IR, and kubectl."""
+    if ir_results is None:
+        ir_results = {
+            "result": "Success",
+            "filter_results_artifact": "oci:quay.io/r@sha256:abc",
+            "advisory_url": "",
+            "advisory_internal_url": "",
+        }
+
+    filter_artifact = ir_results.get("filter_results_artifact", "")
+    filter_ref = filter_artifact.removeprefix("oci:")
+
+    def side_effect(cmd, **kwargs):
+        if cmd[0] == "select-oci-auth":
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="auth")
+        if cmd[0] == "oras" and "pull" in cmd:
+            cwd = kwargs.get("cwd")
+            if cwd is not None:
+                out_dir = Path(cwd)
+            elif "-o" in cmd:
+                out_dir = Path(cmd[cmd.index("-o") + 1])
+            else:
+                out_dir = Path(".")
+            out_dir.mkdir(parents=True, exist_ok=True)
+            pull_spec = cmd[-1]
+            is_filter = filter_ref and pull_spec == filter_ref
+            if is_filter and filter_tarball:
+                shutil.copy2(filter_tarball, out_dir / "filter-results.tar.gz")
+            elif not is_filter and rpm_files:
+                for f in rpm_files:
+                    (out_dir / f).touch()
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+        if cmd[0] == "rpm":
+            fname = cmd[-1]
+            name, version, release, arch = _nevra_from_filename(fname)
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout=f"{name}|0|{version}|{release}|{arch}\n",
+            )
+        if cmd[0] == "internal-request":
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout="ir/'my-ir' created\n",
+            )
+        if cmd[0] == "kubectl":
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout=json.dumps(ir_results),
+            )
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+
+    return MagicMock(side_effect=side_effect)
+
+
+class TestShouldExcludeFile:
+    """Test file exclusion by pattern."""
+
+    def test_matches_pattern(self) -> None:
+        """File containing an exclude pattern is excluded."""
+        assert filt.should_exclude_file(
+            "hello-debuginfo-1.0.rpm", ["-debuginfo-", "-debugsource-"]
+        )
+
+    def test_no_match(self) -> None:
+        """Normal file is not excluded."""
+        assert not filt.should_exclude_file("hello-1.0.rpm", ["-debuginfo-", "-debugsource-"])
+
+    def test_empty_patterns(self) -> None:
+        """Empty pattern list excludes nothing."""
+        assert not filt.should_exclude_file("hello-1.0.rpm", [])
+
+    def test_whitespace_pattern(self) -> None:
+        """Whitespace-only patterns are skipped."""
+        assert not filt.should_exclude_file("hello-1.0.rpm", ["", " "])
+
+
+class TestDetermineEnvironment:
+    """Test environment determination."""
+
+    def test_staging_intention(self) -> None:
+        """Intention 'staging' -> 'stage'."""
+        assert filt.determine_environment({"intention": "staging"}) == "stage"
+
+    def test_production_intention(self) -> None:
+        """Intention 'production' -> 'production'."""
+        assert filt.determine_environment({"intention": "production"}) == "production"
+
+    def test_stage_advisory_repo(self) -> None:
+        """Advisory repo containing 'stage' -> 'stage'."""
+        d = {"advisory": {"repo": "https://stage.example.com"}}
+        assert filt.determine_environment(d) == "stage"
+
+    def test_rhtap_release_repo(self) -> None:
+        """Advisory repo containing 'rhtap-release' -> 'stage'."""
+        d = {"advisory": {"repo": "https://rhtap-release.example.com"}}
+        assert filt.determine_environment(d) == "stage"
+
+    def test_default_production(self) -> None:
+        """No matching signals -> 'production'."""
+        assert filt.determine_environment({}) == "production"
+
+
+class TestExtractRpmMetadata:
+    """Test RPM metadata extraction."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        """Parse rpm -qp output into RpmNevra."""
+        mock_run = MagicMock(
+            return_value=subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="hello|0|2.12|1.fc44|x86_64\n",
+            )
+        )
+        with patch.object(filt.subprocess_cmd, "run_cmd", mock_run):
+            result = filt.extract_rpm_metadata(tmp_path / "hello.rpm")
+        assert result == filt.RpmNevra(
+            name="hello",
+            epoch="0",
+            version="2.12",
+            release="1.fc44",
+            arch="x86_64",
+        )
+
+    def test_none_epoch(self, tmp_path: Path) -> None:
+        """(none) epoch normalizes to '0'."""
+        mock_run = MagicMock(
+            return_value=subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="hello|(none)|2.12|1.fc44|x86_64\n",
+            )
+        )
+        with patch.object(filt.subprocess_cmd, "run_cmd", mock_run):
+            result = filt.extract_rpm_metadata(tmp_path / "hello.rpm")
+        assert result is not None
+        assert result.epoch == "0"
+
+    def test_failure_returns_none(self, tmp_path: Path) -> None:
+        """Non-zero return code returns None."""
+        mock_run = MagicMock(
+            return_value=subprocess.CompletedProcess(args=[], returncode=1, stdout="")
+        )
+        with patch.object(filt.subprocess_cmd, "run_cmd", mock_run):
+            assert filt.extract_rpm_metadata(tmp_path / "bad.rpm") is None
+
+    def test_bad_output_returns_none(self, tmp_path: Path) -> None:
+        """Malformed output returns None."""
+        mock_run = MagicMock(
+            return_value=subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="bad-output\n",
+            )
+        )
+        with patch.object(filt.subprocess_cmd, "run_cmd", mock_run):
+            assert filt.extract_rpm_metadata(tmp_path / "bad.rpm") is None
+
+    def test_os_error_returns_none(self, tmp_path: Path) -> None:
+        """OSError (missing binary) returns None."""
+        mock_run = MagicMock(side_effect=OSError("not found"))
+        with patch.object(filt.subprocess_cmd, "run_cmd", mock_run):
+            assert filt.extract_rpm_metadata(tmp_path / "bad.rpm") is None
+
+
+class TestBuildPurl:
+    """Test purl construction."""
+
+    def test_full_purl(self) -> None:
+        """Build purl with distro and repo_id."""
+        result = filt._build_purl("hello", "1.0", "1.el9", "x86_64", "el9", "repo-1")
+        assert (
+            result
+            == "pkg:rpm/redhat/hello@1.0-1.el9?arch=x86_64&distro=el9&repository_id=repo-1"
+        )
+
+    def test_purl_no_distro(self) -> None:
+        """Build purl without distro."""
+        result = filt._build_purl("hello", "1.0", "1.el9", "x86_64", "", "repo-1")
+        assert "distro" not in result
+
+    def test_purl_no_repo_id(self) -> None:
+        """Build purl without repository_id."""
+        result = filt._build_purl("hello", "1.0", "1.el9", "x86_64", "el9", "")
+        assert "repository_id" not in result
+
+
+class TestBuildRpmEntries:
+    """Test Phase 1: RPM extraction and entry building."""
+
+    def _run_build(
+        self,
+        rpm_files: list[str],
+        rpm_repos: list[dict] | None = None,
+        default_excludes: list[str] | None = None,
+        default_architectures: list[str] | None = None,
+        components: list[dict] | None = None,
+    ) -> list[filt.RpmEntry]:
+        if components is None:
+            components = [{"containerImage": "quay.io/test/img@sha256:abc", "name": "comp1"}]
+        snapshot = _snapshot(components)
+        data = _data(rpm_repos=_rpm_repos() if rpm_repos is None else rpm_repos)
+        mock_run = _mock_run_cmd_for_oras_and_rpm(rpm_files)
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", mock_run),
+            patch.object(filt.file_helper, "sha256", return_value="sha_abc"),
+        ):
+            return filt.build_rpm_entries(
+                snapshot,
+                data,
+                ["-debuginfo-"] if default_excludes is None else default_excludes,
+                (
+                    ["x86_64", "aarch64"]
+                    if default_architectures is None
+                    else default_architectures
+                ),
+            )
+
+    def test_single_component(self) -> None:
+        """Build entries for a single component."""
+        entries = self._run_build(["hello-1.0-1.el9.x86_64.rpm"])
+
+        assert len(entries) == 1
+        assert entries[0].component_name == "comp1"
+        assert entries[0].sha256 == "sha_abc"
+
+        rpms_map = filt.entries_to_rpms_map(entries)
+        assert "comp1" in rpms_map
+
+    def test_noarch_rpm(self) -> None:
+        """Noarch RPMs are published to all default arch repos."""
+        entries = self._run_build(
+            ["hello-docs-1.0-1.el9.noarch.rpm"],
+            default_excludes=[],
+        )
+
+        assert len(entries) == 2
+        repo_names = [e.target_repo.get("repository_name", "") for e in entries]
+        assert "x86_64" in repo_names
+        assert "aarch64" in repo_names
+
+    def test_src_rpm(self) -> None:
+        """Source RPMs target the src repo despite rpm -qp returning build arch."""
+        entries = self._run_build(
+            ["hello-1.0-1.el9.src.rpm"],
+            default_excludes=[],
+        )
+
+        assert len(entries) == 1
+        assert entries[0].target_repo.get("repository_name") == "source"
+        assert entries[0].nevra.arch == "src"
+        assert "arch=src" in entries[0].purl
+
+    def test_excludes_debuginfo(self) -> None:
+        """Debug RPMs are excluded."""
+        entries = self._run_build(
+            ["hello-debuginfo-1.0-1.el9.x86_64.rpm"],
+            default_excludes=["-debuginfo-"],
+            default_architectures=["x86_64"],
+        )
+        assert entries == []
+
+    def test_no_rpm_files(self) -> None:
+        """Component with no RPM files is skipped."""
+        entries = self._run_build(
+            [],
+            default_excludes=[],
+            default_architectures=["x86_64"],
+        )
+        assert entries == []
+
+    def test_non_rpm_files_and_directories_skipped(self) -> None:
+        """Non-RPM files and subdirectories in the pull directory are ignored."""
+        rpm_files = ["hello-1.0-1.el9.x86_64.rpm"]
+
+        def mock_run(cmd, **kwargs):
+            if cmd[0] == "select-oci-auth":
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="auth")
+            if cmd[0] == "oras" and "pull" in cmd:
+                cwd = kwargs.get("cwd")
+                out_dir = Path(cwd) if cwd else Path(".")
+                out_dir.mkdir(parents=True, exist_ok=True)
+                for f in rpm_files:
+                    (out_dir / f).touch()
+                (out_dir / "manifest.json").touch()
+                (out_dir / "logs").mkdir(exist_ok=True)
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+            if cmd[0] == "rpm":
+                fname = cmd[-1]
+                name, version, release, arch = _nevra_from_filename(fname)
+                return subprocess.CompletedProcess(
+                    args=cmd,
+                    returncode=0,
+                    stdout=f"{name}|0|{version}|{release}|{arch}\n",
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+
+        components = [{"containerImage": "quay.io/test/img@sha256:abc", "name": "comp1"}]
+        snapshot = _snapshot(components)
+        data = _data(rpm_repos=_rpm_repos())
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", MagicMock(side_effect=mock_run)),
+            patch.object(filt.file_helper, "sha256", return_value="sha_abc"),
+        ):
+            entries = filt.build_rpm_entries(snapshot, data, [], ["x86_64", "aarch64"])
+
+        assert len(entries) == 1
+        assert entries[0].nevra.name == "hello"
+
+    def test_no_repo_mapping_for_arch(self) -> None:
+        """RPMs for unmapped architectures are skipped."""
+        entries = self._run_build(
+            ["hello-1.0-1.el9.x86_64.rpm"],
+            rpm_repos=[],
+            default_excludes=[],
+            default_architectures=["x86_64"],
+        )
+        assert entries == []
+
+    def test_rpm_metadata_failure_skipped(self) -> None:
+        """RPMs that fail metadata extraction are skipped."""
+
+        def bad_run(cmd, **kwargs):
+            if cmd[0] == "select-oci-auth":
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="auth")
+            if cmd[0] == "oras" and "pull" in cmd:
+                cwd = kwargs.get("cwd")
+                out_dir = Path(cwd) if cwd else Path(".")
+                out_dir.mkdir(parents=True, exist_ok=True)
+                (out_dir / "hello-1.0-1.el9.x86_64.rpm").touch()
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+            if cmd[0] == "rpm":
+                return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+
+        snapshot = _snapshot(
+            [{"containerImage": "quay.io/test/img@sha256:abc", "name": "comp1"}]
+        )
+        data = _data(rpm_repos=_rpm_repos())
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", MagicMock(side_effect=bad_run)),
+            patch.object(filt.file_helper, "sha256", return_value="sha_abc"),
+        ):
+            entries = filt.build_rpm_entries(snapshot, data, [], ["x86_64"])
+
+        assert entries == []
+
+    def test_noarch_no_target_repos(self) -> None:
+        """Noarch RPMs with no matching default arch repos are skipped."""
+        entries = self._run_build(
+            ["hello-docs-1.0-1.el9.noarch.rpm"],
+            rpm_repos=[],
+            default_excludes=[],
+            default_architectures=["x86_64"],
+        )
+        assert entries == []
+
+    def test_src_rpm_no_repo_mapping(self) -> None:
+        """Source RPMs without a src repo mapping are skipped."""
+        repos = [r for r in _rpm_repos() if r["arch"] != "src"]
+        entries = self._run_build(
+            ["hello-1.0-1.el9.src.rpm"],
+            rpm_repos=repos,
+            default_excludes=[],
+            default_architectures=["x86_64"],
+        )
+        assert entries == []
+
+    def test_mixed_binary_and_src_rpms(self) -> None:
+        """Binary and source RPMs from the same component route correctly."""
+        entries = self._run_build(
+            [
+                "hello-1.0-1.el9.x86_64.rpm",
+                "hello-1.0-1.el9.src.rpm",
+                "hello-data-1.0-1.el9.noarch.rpm",
+            ],
+            default_excludes=[],
+            default_architectures=["x86_64", "aarch64"],
+        )
+
+        src_entries = [e for e in entries if e.nevra.arch == "src"]
+        assert len(src_entries) == 1
+        assert src_entries[0].target_repo.get("repository_name") == "source"
+        assert src_entries[0].rpm_filename == "hello-1.0-1.el9.src.rpm"
+
+        binary_entries = [e for e in entries if e.nevra.arch == "x86_64"]
+        assert len(binary_entries) == 1
+        assert binary_entries[0].target_repo.get("repository_name") == "x86_64"
+
+        noarch_entries = [e for e in entries if e.nevra.arch == "noarch"]
+        assert len(noarch_entries) == 2
+        noarch_repos = sorted(e.target_repo.get("repository_name", "") for e in noarch_entries)
+        assert noarch_repos == ["aarch64", "x86_64"]
+
+        assert len(entries) == 4
+
+    def test_multiple_components(self) -> None:
+        """Build entries for multiple components, one with RPMs and one without."""
+        oras_call_count = 0
+
+        def side_effect(cmd, **kwargs):
+            nonlocal oras_call_count
+            if cmd[0] == "select-oci-auth":
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="auth")
+            if cmd[0] == "oras" and "pull" in cmd:
+                oras_call_count += 1
+                cwd = kwargs.get("cwd")
+                out_dir = Path(cwd) if cwd else Path(".")
+                out_dir.mkdir(parents=True, exist_ok=True)
+                if oras_call_count == 1:
+                    (out_dir / "hello-1.0-1.el9.x86_64.rpm").touch()
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+            if cmd[0] == "rpm":
+                fname = cmd[-1]
+                name, version, release, arch = _nevra_from_filename(fname)
+                return subprocess.CompletedProcess(
+                    args=cmd,
+                    returncode=0,
+                    stdout=f"{name}|0|{version}|{release}|{arch}\n",
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+
+        snapshot = _snapshot(
+            [
+                {"containerImage": "quay.io/test/img1@sha256:aaa", "name": "comp1"},
+                {"containerImage": "quay.io/test/img2@sha256:bbb", "name": "comp2"},
+            ]
+        )
+        data = _data(rpm_repos=_rpm_repos())
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", MagicMock(side_effect=side_effect)),
+            patch.object(filt.file_helper, "sha256", return_value="sha_abc"),
+        ):
+            entries = filt.build_rpm_entries(
+                snapshot,
+                data,
+                ["-debuginfo-"],
+                ["x86_64", "aarch64"],
+            )
+
+        assert len(entries) == 1
+        assert entries[0].component_name == "comp1"
+
+        rpms_map = filt.entries_to_rpms_map(entries)
+        assert "comp1" in rpms_map
+        assert "comp2" not in rpms_map
+
+
+class TestEntriesToIrPayload:
+    """Test IR payload serialization from RpmEntry."""
+
+    def test_serializes_all_fields(self) -> None:
+        """All RpmEntry fields appear in the serialized dict."""
+        entry = filt.RpmEntry(
+            component_name="comp1",
+            rpm_filename="hello-1.0-1.el9.x86_64.rpm",
+            sha256="abc123",
+            nevra=filt.RpmNevra("hello", "0", "1.0", "1.el9", "x86_64"),
+            purl="pkg:rpm/redhat/hello@1.0-1.el9?arch=x86_64",
+            target_repo={
+                "repository_name": "x86_64",
+                "repository_id": "repo-1",
+                "distro": "el9",
+            },
+        )
+        payload = filt.entries_to_ir_payload([entry])
+        assert len(payload) == 1
+        d = payload[0]
+        assert d["name"] == "comp1"
+        assert d["rpm"] == "hello-1.0-1.el9.x86_64.rpm"
+        assert d["sha256"] == "abc123"
+        assert d["rpmname"] == "hello"
+        assert d["epoch"] == "0"
+        assert d["version"] == "1.0"
+        assert d["release"] == "1.el9"
+        assert d["arch"] == "x86_64"
+        assert d["purl"] == "pkg:rpm/redhat/hello@1.0-1.el9?arch=x86_64"
+        assert d["repository_name"] == "x86_64"
+        assert d["targetRepo"] == entry.target_repo
+
+    def test_empty_list(self) -> None:
+        """Empty input produces empty output."""
+        assert filt.entries_to_ir_payload([]) == []
+
+
+class TestEntriesToRpmsMap:
+    """Test rpmsToPublish grouping from RpmEntry."""
+
+    def _entry(
+        self,
+        component: str = "comp1",
+        rpm: str = "hello-1.0-1.el9.x86_64.rpm",
+        sha: str = "abc",
+        repo_name: str = "x86_64",
+    ) -> filt.RpmEntry:
+        return filt.RpmEntry(
+            component_name=component,
+            rpm_filename=rpm,
+            sha256=sha,
+            nevra=filt.RpmNevra("hello", "0", "1.0", "1.el9", "x86_64"),
+            purl="pkg:rpm/redhat/hello@1.0-1.el9?arch=x86_64",
+            target_repo={"repository_name": repo_name},
+        )
+
+    def test_single_entry(self) -> None:
+        """Single entry produces a single-element map."""
+        rpms_map = filt.entries_to_rpms_map([self._entry()])
+        assert "comp1" in rpms_map
+        assert len(rpms_map["comp1"]) == 1
+        assert rpms_map["comp1"][0]["rpm"] == "hello-1.0-1.el9.x86_64.rpm"
+        assert rpms_map["comp1"][0]["targetRepos"] == [{"repository_name": "x86_64"}]
+
+    def test_separate_entries_per_repo(self) -> None:
+        """Multiple entries for the same RPM produce separate items."""
+        entries = [
+            self._entry(repo_name="x86_64"),
+            self._entry(repo_name="aarch64"),
+        ]
+        rpms_map = filt.entries_to_rpms_map(entries)
+        assert len(rpms_map["comp1"]) == 2
+        repos = [item["targetRepos"] for item in rpms_map["comp1"]]
+        assert [{"repository_name": "x86_64"}] in repos
+        assert [{"repository_name": "aarch64"}] in repos
+
+    def test_multiple_components(self) -> None:
+        """Entries from different components are grouped separately."""
+        entries = [
+            self._entry(component="comp1"),
+            self._entry(component="comp2", rpm="world-2.0-1.el9.x86_64.rpm"),
+        ]
+        rpms_map = filt.entries_to_rpms_map(entries)
+        assert "comp1" in rpms_map
+        assert "comp2" in rpms_map
+
+    def test_empty_list(self) -> None:
+        """Empty input produces empty map."""
+        assert filt.entries_to_rpms_map([]) == {}
+
+
+class TestCreateInternalRequest:
+    """Test InternalRequest creation and result parsing."""
+
+    def test_success(self) -> None:
+        """Parse IR name and return results."""
+        mock_run = _mock_run_cmd_for_oras_and_rpm([])
+        with patch.object(filt.subprocess_cmd, "run_cmd", mock_run):
+            results = filt.create_internal_request(
+                "b64data",
+                "origin",
+                "secret",
+                "uid",
+                "oci-storage",
+                "",
+                "git-url",
+                "rev",
+                True,
+            )
+        assert results["result"] == "Success"
+
+    def test_unparseable_name(self) -> None:
+        """Raise when IR name cannot be parsed."""
+        mock_run = MagicMock(
+            return_value=subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="unexpected output\n",
+            )
+        )
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", mock_run),
+            pytest.raises(RuntimeError, match="Could not parse"),
+        ):
+            filt.create_internal_request(
+                "b64data",
+                "origin",
+                "secret",
+                "uid",
+                "oci-storage",
+                "",
+                "git-url",
+                "rev",
+                True,
+            )
+
+    def test_empty_results(self) -> None:
+        """Raise when no results in IR status."""
+        call_count = 0
+
+        def mock_run(cmd, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if cmd[0] == "internal-request":
+                return subprocess.CompletedProcess(
+                    args=cmd,
+                    returncode=0,
+                    stdout="ir/'my-ir' created\n",
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", MagicMock(side_effect=mock_run)),
+            pytest.raises(RuntimeError, match="No results found"),
+        ):
+            filt.create_internal_request(
+                "b64data",
+                "origin",
+                "secret",
+                "uid",
+                "oci-storage",
+                "",
+                "git-url",
+                "rev",
+                True,
+            )
+
+    def test_failed_result(self) -> None:
+        """Raise when IR result is not Success."""
+        mock_run = _mock_run_cmd_for_oras_and_rpm(
+            [],
+            ir_results={"result": "Failure"},
+        )
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", mock_run),
+            pytest.raises(RuntimeError, match="Filtering failed"),
+        ):
+            filt.create_internal_request(
+                "b64data",
+                "origin",
+                "secret",
+                "uid",
+                "oci-storage",
+                "",
+                "git-url",
+                "rev",
+                True,
+            )
+
+
+class TestPullFilterResults:
+    """Test filter results artifact pulling and extraction."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        """Extract in_advisory and unreleased from tarball."""
+        tarball = _make_filter_tarball(
+            tmp_path,
+            unreleased=[{"name": "comp1"}],
+            in_advisory=[{"name": "comp2"}],
+        )
+
+        def mock_run(cmd, **kwargs):
+            if cmd[0] == "select-oci-auth":
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="auth")
+            if cmd[0] == "oras" and "pull" in cmd:
+                cwd = kwargs.get("cwd")
+                out_dir = Path(cwd) if cwd else Path(".")
+                out_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(tarball, out_dir / "filter-results.tar.gz")
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+
+        with patch.object(filt.subprocess_cmd, "run_cmd", MagicMock(side_effect=mock_run)):
+            in_adv, unreleased = filt.pull_filter_results(
+                "oci:quay.io/mock/results@sha256:abc",
+            )
+        assert len(in_adv) == 1
+        assert len(unreleased) == 1
+
+    def test_missing_unreleased_file(self, tmp_path: Path) -> None:
+        """Raise when unreleased_rpms.json is missing."""
+        src_dir = tmp_path / "tar_src"
+        src_dir.mkdir()
+        _write_json(src_dir / "in_advisory_rpms.json", [])
+        tarball = tmp_path / "filter-results.tar.gz"
+        with tarfile.open(tarball, "w:gz") as tf:
+            tf.add(src_dir / "in_advisory_rpms.json", arcname="in_advisory_rpms.json")
+
+        def mock_run(cmd, **kwargs):
+            if cmd[0] == "select-oci-auth":
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="auth")
+            if cmd[0] == "oras" and "pull" in cmd:
+                cwd = kwargs.get("cwd")
+                out_dir = Path(cwd) if cwd else Path(".")
+                out_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(tarball, out_dir / "filter-results.tar.gz")
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="")
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", MagicMock(side_effect=mock_run)),
+            pytest.raises(RuntimeError, match="No unreleased_rpms.json"),
+        ):
+            filt.pull_filter_results("oci:quay.io/mock/results@sha256:abc")
+
+
+class TestValidatePulpDigests:
+    """Test Pulp digest validation loop."""
+
+    def _rpm_entry(self) -> dict:
+        return {
+            "rpmname": "hello",
+            "epoch": "0",
+            "version": "1.0",
+            "release": "1.el9",
+            "arch": "x86_64",
+            "sha256": "abc",
+            "repository_name": "myrepo",
+        }
+
+    def test_all_match(self) -> None:
+        """No error when all digests match."""
+        pulp = MagicMock(spec=filt.PulpClient)
+        pulp.check_digest.return_value = filt.PulpDigestStatus.MATCH
+        filt.validate_pulp_digests([self._rpm_entry()], pulp)
+
+    def test_mismatch_raises(self) -> None:
+        """Raise on digest mismatch."""
+        pulp = MagicMock(spec=filt.PulpClient)
+        pulp.check_digest.return_value = filt.PulpDigestStatus.MISMATCH
+        with pytest.raises(RuntimeError, match="Cannot rebuild RPM"):
+            filt.validate_pulp_digests([self._rpm_entry()], pulp)
+
+    def test_error_raises(self) -> None:
+        """Pulp API error propagates as RuntimeError with context."""
+        pulp = MagicMock(spec=filt.PulpClient)
+        pulp.check_digest.side_effect = requests.ConnectionError("timeout")
+        with pytest.raises(RuntimeError, match="Pulp API error"):
+            filt.validate_pulp_digests([self._rpm_entry()], pulp)
+
+    def test_not_found_is_ok(self) -> None:
+        """NOT_FOUND is acceptable (advisory is authoritative)."""
+        pulp = MagicMock(spec=filt.PulpClient)
+        pulp.check_digest.return_value = filt.PulpDigestStatus.NOT_FOUND
+        filt.validate_pulp_digests([self._rpm_entry()], pulp)
+
+
+class TestFilterSnapshot:
+    """Test snapshot filtering."""
+
+    def test_keeps_unreleased_components(self) -> None:
+        """Only components with unreleased RPMs are kept."""
+        snapshot = _snapshot(
+            [
+                {"name": "comp1", "containerImage": "img1"},
+                {"name": "comp2", "containerImage": "img2"},
+            ]
+        )
+        unreleased = [{"name": "comp1"}]
+        rpms_map = {"comp1": [{"rpm": "hello.rpm"}]}
+
+        result = filt.filter_snapshot(snapshot, unreleased, rpms_map)
+        assert len(result["components"]) == 1
+        assert result["components"][0]["name"] == "comp1"
+        assert result["components"][0]["rpmsToPublish"] == [{"rpm": "hello.rpm"}]
+
+    def test_empty_unreleased(self) -> None:
+        """No unreleased RPMs results in empty components."""
+        snapshot = _snapshot([{"name": "comp1"}])
+        result = filt.filter_snapshot(snapshot, [], {})
+        assert result["components"] == []
+
+    def test_missing_component_skipped(self) -> None:
+        """Unreleased name not in snapshot is skipped."""
+        snapshot = _snapshot([{"name": "comp1"}])
+        unreleased = [{"name": "missing"}]
+        result = filt.filter_snapshot(snapshot, unreleased, {})
+        assert result["components"] == []
+
+    def test_no_rpms_in_map_skipped(self) -> None:
+        """Component in unreleased but not in rpms_map is skipped."""
+        snapshot = _snapshot([{"name": "comp1"}])
+        unreleased = [{"name": "comp1"}]
+        result = filt.filter_snapshot(snapshot, unreleased, {})
+        assert result["components"] == []
+
+
+class TestRun:
+    """Test the run() orchestration."""
+
+    def test_no_rpms_skip_release(self, tmp_path: Path) -> None:
+        """Skip release when no RPMs are found."""
+        cfg, res = _make_config_and_results(
+            tmp_path,
+            snapshot=_snapshot([{"containerImage": "quay.io/t/i@sha256:a", "name": "c1"}]),
+            data=_data(rpm_repos=_rpm_repos()),
+        )
+        mock_run = _mock_run_cmd_for_oras_and_rpm(rpm_files=[])
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", mock_run),
+            patch.object(filt.file_helper, "sha256", return_value="sha"),
+        ):
+            filt.run(cfg, res)
+
+        assert res.skip_release.read_text(encoding="utf-8") == "true"
+        snap = json.loads(cfg.snapshot_file.read_text(encoding="utf-8"))
+        assert snap["components"] == []
+
+    def test_all_released_skip(self, tmp_path: Path) -> None:
+        """Skip release when all RPMs are already released."""
+        tarball = _make_filter_tarball(tmp_path, unreleased=[], in_advisory=[])
+        cfg, res = _make_config_and_results(
+            tmp_path,
+            snapshot=_snapshot([{"containerImage": "quay.io/t/i@sha256:a", "name": "c1"}]),
+            data=_data(rpm_repos=_rpm_repos()),
+        )
+        ir_results = {
+            "result": "Success",
+            "filter_results_artifact": "oci:quay.io/r@sha256:abc",
+            "advisory_url": "https://adv.example.com",
+            "advisory_internal_url": "https://int.example.com",
+        }
+        mock_run = _mock_run_cmd_for_oras_and_rpm(
+            ["hello-1.0-1.el9.x86_64.rpm"],
+            ir_results=ir_results,
+            filter_tarball=tarball,
+        )
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", mock_run),
+            patch.object(filt.file_helper, "sha256", return_value="sha"),
+            patch.object(filt, "make_pulp_client", return_value=MagicMock()),
+        ):
+            filt.run(cfg, res)
+
+        assert res.skip_release.read_text(encoding="utf-8") == "true"
+        assert res.latest_advisory_url.read_text(encoding="utf-8") == "https://adv.example.com"
+
+    def test_unreleased_rpms_filter(self, tmp_path: Path) -> None:
+        """Unreleased RPMs produce a filtered snapshot."""
+        tarball = _make_filter_tarball(
+            tmp_path,
+            unreleased=[{"name": "c1"}],
+            in_advisory=[],
+        )
+        cfg, res = _make_config_and_results(
+            tmp_path,
+            snapshot=_snapshot([{"containerImage": "quay.io/t/i@sha256:a", "name": "c1"}]),
+            data=_data(rpm_repos=_rpm_repos()),
+        )
+        mock_run = _mock_run_cmd_for_oras_and_rpm(
+            ["hello-1.0-1.el9.x86_64.rpm"],
+            filter_tarball=tarball,
+        )
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", mock_run),
+            patch.object(filt.file_helper, "sha256", return_value="sha"),
+            patch.object(filt, "make_pulp_client", return_value=MagicMock()),
+        ):
+            filt.run(cfg, res)
+
+        assert res.skip_release.read_text(encoding="utf-8") == "false"
+        snap = json.loads(cfg.snapshot_file.read_text(encoding="utf-8"))
+        assert len(snap["components"]) == 1
+        assert "rpmsToPublish" in snap["components"][0]
+
+    def test_in_advisory_rpms_validated(self, tmp_path: Path) -> None:
+        """In-advisory RPMs trigger Pulp digest validation."""
+        in_advisory = [
+            {
+                "name": "c1",
+                "rpmname": "hello",
+                "epoch": "0",
+                "version": "1.0",
+                "release": "1.el9",
+                "arch": "x86_64",
+                "sha256": "sha",
+                "repository_name": "x86_64",
+            }
+        ]
+        tarball = _make_filter_tarball(
+            tmp_path,
+            unreleased=[{"name": "c1"}],
+            in_advisory=in_advisory,
+        )
+        cfg, res = _make_config_and_results(
+            tmp_path,
+            snapshot=_snapshot([{"containerImage": "quay.io/t/i@sha256:a", "name": "c1"}]),
+            data=_data(rpm_repos=_rpm_repos()),
+        )
+        mock_run = _mock_run_cmd_for_oras_and_rpm(
+            ["hello-1.0-1.el9.x86_64.rpm"],
+            filter_tarball=tarball,
+        )
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", mock_run),
+            patch.object(filt.file_helper, "sha256", return_value="sha"),
+            patch.object(filt, "make_pulp_client", return_value=MagicMock()),
+            patch.object(filt, "validate_pulp_digests") as mock_validate,
+        ):
+            filt.run(cfg, res)
+
+        mock_validate.assert_called_once()
+        assert mock_validate.call_args[0][0] == in_advisory
+
+    def test_in_advisory_all_released_skip(self, tmp_path: Path) -> None:
+        """Validate digests then skip when in-advisory but unreleased is empty."""
+        in_advisory = [
+            {
+                "name": "c1",
+                "rpmname": "hello",
+                "epoch": "0",
+                "version": "1.0",
+                "release": "1.el9",
+                "arch": "x86_64",
+                "sha256": "sha",
+                "repository_name": "x86_64",
+            }
+        ]
+        tarball = _make_filter_tarball(
+            tmp_path,
+            unreleased=[],
+            in_advisory=in_advisory,
+        )
+        cfg, res = _make_config_and_results(
+            tmp_path,
+            snapshot=_snapshot([{"containerImage": "quay.io/t/i@sha256:a", "name": "c1"}]),
+            data=_data(rpm_repos=_rpm_repos()),
+        )
+        ir_results = {
+            "result": "Success",
+            "filter_results_artifact": "oci:quay.io/r@sha256:abc",
+            "advisory_url": "https://adv.example.com",
+            "advisory_internal_url": "https://int.example.com",
+        }
+        mock_run = _mock_run_cmd_for_oras_and_rpm(
+            ["hello-1.0-1.el9.x86_64.rpm"],
+            ir_results=ir_results,
+            filter_tarball=tarball,
+        )
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", mock_run),
+            patch.object(filt.file_helper, "sha256", return_value="sha"),
+            patch.object(filt, "make_pulp_client", return_value=MagicMock()),
+            patch.object(filt, "validate_pulp_digests") as mock_validate,
+        ):
+            filt.run(cfg, res)
+
+        mock_validate.assert_called_once()
+        assert mock_validate.call_args[0][0] == in_advisory
+        assert res.skip_release.read_text(encoding="utf-8") == "true"
+        assert res.latest_advisory_url.read_text(encoding="utf-8") == "https://adv.example.com"
+        assert (
+            res.latest_advisory_internal_url.read_text(encoding="utf-8")
+            == "https://int.example.com"
+        )
+        snap = json.loads(cfg.snapshot_file.read_text(encoding="utf-8"))
+        assert snap["components"] == []
+
+    def test_missing_snapshot_raises(self, tmp_path: Path) -> None:
+        """Raise when snapshot file is missing."""
+        cfg, res = _make_config_and_results(tmp_path)
+        cfg = dataclasses.replace(cfg, snapshot_file=tmp_path / "missing.json")
+        with pytest.raises(FileNotFoundError):
+            filt.run(cfg, res)
+
+    def test_missing_data_raises(self, tmp_path: Path) -> None:
+        """Raise when data file is missing."""
+        cfg, res = _make_config_and_results(tmp_path)
+        cfg = dataclasses.replace(cfg, data_file=tmp_path / "missing.json")
+        with pytest.raises(FileNotFoundError):
+            filt.run(cfg, res)
+
+    def test_missing_rpa_raises(self, tmp_path: Path) -> None:
+        """Raise when RPA file is missing."""
+        cfg, res = _make_config_and_results(tmp_path)
+        cfg = dataclasses.replace(cfg, rpa_file=tmp_path / "missing.json")
+        with pytest.raises(FileNotFoundError):
+            filt.run(cfg, res)
+
+    def test_missing_origin_key_raises(self, tmp_path: Path) -> None:
+        """Raise when origin key is absent from RPA."""
+        cfg, res = _make_config_and_results(tmp_path, rpa={"spec": {}})
+        with pytest.raises(KeyError):
+            filt.run(cfg, res)
+
+    def test_empty_origin_raises(self, tmp_path: Path) -> None:
+        """Raise when origin is empty in RPA."""
+        cfg, res = _make_config_and_results(tmp_path, rpa={"spec": {"origin": ""}})
+        with pytest.raises(ValueError, match="origin.*empty"):
+            filt.run(cfg, res)
+
+    def test_empty_toml_raises(self, tmp_path: Path) -> None:
+        """Raise when cli.toml content is empty."""
+        cfg, res = _make_config_and_results(tmp_path)
+        empty_toml = tmp_path / "empty.toml"
+        empty_toml.write_text("", encoding="utf-8")
+        cfg = dataclasses.replace(cfg, pulp_config_file=empty_toml)
+        with pytest.raises(RuntimeError, match="Missing cli.toml"):
+            filt.run(cfg, res)
+
+    def test_missing_base_url_raises(self, tmp_path: Path) -> None:
+        """Raise when base_url is missing in cli.toml."""
+        cfg, res = _make_config_and_results(
+            tmp_path,
+            toml='[cli]\nusername = "u"\npassword = "p"\n',
+        )
+        with pytest.raises(RuntimeError, match="Missing required.*base_url"):
+            filt.load_and_validate(cfg)
+
+    def test_staging_environment(self, tmp_path: Path) -> None:
+        """Staging intention sets environment to 'stage'."""
+        cfg, res = _make_config_and_results(
+            tmp_path,
+            data=_data(intention="staging"),
+            snapshot=_snapshot([]),
+        )
+        filt.run(cfg, res)
+        assert res.environment.read_text(encoding="utf-8") == "stage"
+
+    def test_pulp_digest_mismatch_propagates(self, tmp_path: Path) -> None:
+        """Pulp digest mismatch in validate_pulp_digests propagates from run()."""
+        in_advisory = [
+            {
+                "name": "c1",
+                "rpmname": "hello",
+                "epoch": "0",
+                "version": "1.0",
+                "release": "1.el9",
+                "arch": "x86_64",
+                "sha256": "sha",
+                "repository_name": "x86_64",
+            }
+        ]
+        tarball = _make_filter_tarball(
+            tmp_path,
+            unreleased=[{"name": "c1"}],
+            in_advisory=in_advisory,
+        )
+        cfg, res = _make_config_and_results(
+            tmp_path,
+            snapshot=_snapshot([{"containerImage": "quay.io/t/i@sha256:a", "name": "c1"}]),
+            data=_data(rpm_repos=_rpm_repos()),
+        )
+        mock_run = _mock_run_cmd_for_oras_and_rpm(
+            ["hello-1.0-1.el9.x86_64.rpm"],
+            filter_tarball=tarball,
+        )
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", mock_run),
+            patch.object(filt.file_helper, "sha256", return_value="sha"),
+            patch.object(filt, "make_pulp_client", return_value=MagicMock()),
+            patch.object(
+                filt,
+                "validate_pulp_digests",
+                side_effect=RuntimeError("Cannot rebuild RPM"),
+            ),
+            pytest.raises(RuntimeError, match="Cannot rebuild RPM"),
+        ):
+            filt.run(cfg, res)
+
+    def test_no_filter_artifact_raises(self, tmp_path: Path) -> None:
+        """Raise when filter_results_artifact is missing."""
+        cfg, res = _make_config_and_results(
+            tmp_path,
+            snapshot=_snapshot([{"containerImage": "quay.io/t/i@sha256:a", "name": "c1"}]),
+            data=_data(rpm_repos=_rpm_repos()),
+        )
+        ir_results = {"result": "Success", "filter_results_artifact": ""}
+        mock_run = _mock_run_cmd_for_oras_and_rpm(
+            ["hello-1.0-1.el9.x86_64.rpm"],
+            ir_results=ir_results,
+        )
+
+        with (
+            patch.object(filt.subprocess_cmd, "run_cmd", mock_run),
+            patch.object(filt.file_helper, "sha256", return_value="sha"),
+            pytest.raises(RuntimeError, match="No filter_results_artifact"),
+        ):
+            filt.run(cfg, res)
+
+
+class TestMakePulpClient:
+    """Test PulpClient construction."""
+
+    def test_builds_client_with_basic_auth(self, tmp_path: Path) -> None:
+        """Build a PulpClient using basic auth credentials."""
+        pulp_config = {
+            "base_url": "https://pulp.example.com",
+            "username": "user",
+            "password": "pass",
+            "client_id": "",
+            "client_secret": "",
+        }
+        ctx = filt.LoadedContext(
+            snapshot={},
+            data={},
+            origin="test",
+            pulp_config=pulp_config,
+            base_url="https://pulp.example.com",
+            environment="production",
+            advisory_secret_name="secret",
+        )
+
+        mock_session = MagicMock()
+        with (
+            patch.object(
+                filt.http_client, "get_retry_session", return_value=mock_session
+            ) as mock_get_session,
+            patch("filter_already_released_advisory_rpms.PulpAuth") as mock_auth_cls,
+        ):
+            client = filt.make_pulp_client(ctx, "test-domain")
+
+        mock_get_session.assert_called_once_with(
+            total=3,
+            connect=3,
+            read=3,
+            status=2,
+            backoff_factor=0.4,
+            allowed_methods=frozenset({"GET", "POST"}),
+        )
+        mock_auth_cls.assert_called_once_with(pulp_config)
+        assert mock_session.auth == mock_auth_cls.return_value
+        assert isinstance(client, filt.PulpClient)
+
+
+class TestMain:
+    """Test the CLI entry point."""
+
+    def test_success(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Return 0 on success with all env vars set."""
+        snap_file, data_file, rpa_file, toml_file = _setup_base_files(
+            tmp_path,
+            snapshot=_snapshot([]),
+        )
+        res = _result_paths(tmp_path)
+
+        monkeypatch.setenv("SNAPSHOT_FILE", str(snap_file))
+        monkeypatch.setenv("DATA_FILE", str(data_file))
+        monkeypatch.setenv("RPA_FILE", str(rpa_file))
+        monkeypatch.setenv("PULP_CONFIG_FILE", str(toml_file))
+        monkeypatch.setenv("PULP_DOMAIN", "dom")
+        monkeypatch.setenv("PIPELINE_RUN_UID", "uid")
+        monkeypatch.setenv("TASK_GIT_URL", "git-url")
+        monkeypatch.setenv("TASK_GIT_REVISION", "rev")
+        monkeypatch.setenv("RESULT_SKIP_RELEASE", str(res.skip_release))
+        monkeypatch.setenv("RESULT_ENVIRONMENT", str(res.environment))
+        monkeypatch.setenv("RESULT_LATEST_ADVISORY_URL", str(res.latest_advisory_url))
+        monkeypatch.setenv(
+            "RESULT_LATEST_ADVISORY_INTERNAL_URL", str(res.latest_advisory_internal_url)
+        )
+
+        assert filt.main() == 0
+        assert res.skip_release.read_text(encoding="utf-8") == "true"
+
+    def test_missing_env_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SystemExit when required env var is missing."""
+        monkeypatch.delenv("SNAPSHOT_FILE", raising=False)
+        monkeypatch.delenv("DATA_FILE", raising=False)
+        monkeypatch.delenv("RPA_FILE", raising=False)
+        monkeypatch.delenv("PULP_CONFIG_FILE", raising=False)
+        monkeypatch.delenv("PULP_DOMAIN", raising=False)
+        monkeypatch.delenv("PIPELINE_RUN_UID", raising=False)
+        monkeypatch.delenv("TASK_GIT_URL", raising=False)
+        monkeypatch.delenv("TASK_GIT_REVISION", raising=False)
+        monkeypatch.delenv("RESULT_SKIP_RELEASE", raising=False)
+        monkeypatch.delenv("RESULT_ENVIRONMENT", raising=False)
+        monkeypatch.delenv("RESULT_LATEST_ADVISORY_URL", raising=False)
+        monkeypatch.delenv("RESULT_LATEST_ADVISORY_INTERNAL_URL", raising=False)
+
+        with pytest.raises(SystemExit):
+            filt.main()
+
+    def test_dunder_main_block(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Exercise the ``if __name__ == "__main__"`` block."""
+        snap_file, data_file, rpa_file, toml_file = _setup_base_files(
+            tmp_path,
+            snapshot=_snapshot([]),
+        )
+        res = _result_paths(tmp_path)
+
+        monkeypatch.setenv("SNAPSHOT_FILE", str(snap_file))
+        monkeypatch.setenv("DATA_FILE", str(data_file))
+        monkeypatch.setenv("RPA_FILE", str(rpa_file))
+        monkeypatch.setenv("PULP_CONFIG_FILE", str(toml_file))
+        monkeypatch.setenv("PULP_DOMAIN", "dom")
+        monkeypatch.setenv("PIPELINE_RUN_UID", "uid")
+        monkeypatch.setenv("TASK_GIT_URL", "git-url")
+        monkeypatch.setenv("TASK_GIT_REVISION", "rev")
+        monkeypatch.setenv("RESULT_SKIP_RELEASE", str(res.skip_release))
+        monkeypatch.setenv("RESULT_ENVIRONMENT", str(res.environment))
+        monkeypatch.setenv("RESULT_LATEST_ADVISORY_URL", str(res.latest_advisory_url))
+        monkeypatch.setenv(
+            "RESULT_LATEST_ADVISORY_INTERNAL_URL", str(res.latest_advisory_internal_url)
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            import runpy
+
+            runpy.run_module(
+                "filter_already_released_advisory_rpms",
+                run_name="__main__",
+            )
+        assert exc_info.value.code == 0


### PR DESCRIPTION
Replace the inline bash script with a standalone Python implementation
that handles RPM advisory filtering, Pulp digest validation, and
InternalRequest orchestration. Includes comprehensive unit tests.
A new helper has been created for Pulp interaction.

Assisted-by: Cursor