### PR TITLE
fix(KONFLUX-12379): rework collect_index_images

### DIFF
--- a/scripts/python/tasks/managed/collect_index_images.py
+++ b/scripts/python/tasks/managed/collect_index_images.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 from typing import Any
 
@@ -14,7 +13,6 @@ import tekton
 from logger import logger
 
 SNAPSHOT_FILENAME = "index_image_snapshot.json"
-_BARE_OCP_TAG = re.compile(r"^v[0-9]+\.[0-9]+$")
 
 
 def split_target_index(target_index: str) -> tuple[str, str]:
@@ -24,14 +22,6 @@ def split_target_index(target_index: str) -> tuple[str, str]:
         msg = f"target_index must contain a repository and tag: {target_index!r}"
         raise ValueError(msg)
     return repository, tag
-
-
-def build_tags(tag: str, build_timestamp: str) -> list[str]:
-    """Return snapshot tags, appending a timestamp tag for bare OCP versions."""
-    tags = [tag]
-    if _BARE_OCP_TAG.fullmatch(tag):
-        tags.append(f"{tag}-{build_timestamp}")
-    return tags
 
 
 def translation_repo_url(translated: list[dict[str, Any]], repo_key: str) -> str:
@@ -48,14 +38,14 @@ def translation_repo_url(translated: list[dict[str, Any]], repo_key: str) -> str
 
 def build_repo_object(
     repository: str,
-    tags: list[str],
+    tag: str,
     rh_registry_repo: str,
     registry_access_repo: str,
 ) -> dict[str, Any]:
     """Build the repositories entry for one index image component."""
     repo_object: dict[str, Any] = {
         "url": repository,
-        "tags": tags,
+        "tags": [tag],
     }
     if rh_registry_repo:
         repo_object["rh-registry-repo"] = rh_registry_repo
@@ -68,7 +58,7 @@ def build_index_component(
     *,
     source_index: str,
     repository: str,
-    tags: list[str],
+    tag: str,
     image_digests: list[Any],
     repo_object: dict[str, Any],
 ) -> dict[str, Any]:
@@ -77,14 +67,13 @@ def build_index_component(
         "containerImage": source_index,
         "repository": repository,
         "repositories": [repo_object],
-        "tags": tags,
+        "tags": [tag],
         "imageDigests": image_digests,
     }
 
 
 def collect_index_image_components(
     results: dict[str, Any],
-    build_timestamp: str,
 ) -> dict[str, Any]:
     """Transform internal-request results into an index-image snapshot."""
     components_in = results.get("components")
@@ -99,45 +88,81 @@ def collect_index_image_components(
             raise ValueError(msg)
 
         target_index = row.get("target_index")
+        target_index_with_timestamp = row.get("target_index_with_timestamp")
         source_index = row.get("index_image_resolved")
-        if not isinstance(target_index, str) or not target_index.strip():
-            msg = f"components[{index}].target_index must be a non-empty string"
-            raise ValueError(msg)
+
         if not isinstance(source_index, str) or not source_index.strip():
-            msg = f"components[{index}].index_image_resolved must be a non-empty string"
+            msg = (
+                f"components[{index}].index_image_resolved must be a non-empty string, "
+                f"got {type(source_index).__name__}: {source_index!r}"
+            )
             raise ValueError(msg)
 
-        repository, tag = split_target_index(target_index)
-        tags = build_tags(tag, build_timestamp)
         image_digests = row.get("image_digests", [])
         if not isinstance(image_digests, list):
-            msg = f"components[{index}].image_digests must be a JSON array"
+            msg = (
+                f"components[{index}].image_digests must be a JSON array, "
+                f"got {type(image_digests).__name__}: {image_digests!r}"
+            )
             raise ValueError(msg)
 
-        logger.info(
-            "Processing index image %s (%d/%d)",
-            target_index,
-            index + 1,
-            len(components_in),
-        )
-        translated = image_ref.translate_delivery_repo(repository)
-        rh_registry_repo = translation_repo_url(translated, "redhat.io")
-        registry_access_repo = translation_repo_url(translated, "access.redhat.com")
-        repo_object = build_repo_object(
-            repository,
-            tags,
-            rh_registry_repo,
-            registry_access_repo,
-        )
-        snapshot_components.append(
-            build_index_component(
-                source_index=source_index,
-                repository=repository,
-                tags=tags,
-                image_digests=image_digests,
-                repo_object=repo_object,
-            ),
-        )
+        # Validate target index fields are strings or missing
+        if target_index is not None and not isinstance(target_index, str):
+            msg = (
+                f"components[{index}].target_index must be a string, "
+                f"got {type(target_index).__name__}: {target_index!r}"
+            )
+            raise ValueError(msg)
+        if target_index_with_timestamp is not None and not isinstance(
+            target_index_with_timestamp, str
+        ):
+            msg = (
+                f"components[{index}].target_index_with_timestamp must be a string, "
+                f"got {type(target_index_with_timestamp).__name__}: "
+                f"{target_index_with_timestamp!r}"
+            )
+            raise ValueError(msg)
+
+        # Normalize missing to empty string
+        target_index = (target_index or "").strip()
+        target_index_with_timestamp = (target_index_with_timestamp or "").strip()
+
+        # Build list of targets to process, filtering empty values
+        targets = []
+        if target_index:
+            targets.append(target_index)
+        if target_index_with_timestamp and target_index_with_timestamp != target_index:
+            targets.append(target_index_with_timestamp)
+
+        # Create one component per target
+        for target in targets:
+            repository, tag = split_target_index(target)
+
+            logger.info(
+                "Processing index image %s (%d/%d)",
+                target,
+                index + 1,
+                len(components_in),
+            )
+
+            translated = image_ref.translate_delivery_repo(repository)
+            rh_registry_repo = translation_repo_url(translated, "redhat.io")
+            registry_access_repo = translation_repo_url(translated, "access.redhat.com")
+            repo_object = build_repo_object(
+                repository,
+                tag,
+                rh_registry_repo,
+                registry_access_repo,
+            )
+            snapshot_components.append(
+                build_index_component(
+                    source_index=source_index,
+                    repository=repository,
+                    tag=tag,
+                    image_digests=image_digests,
+                    repo_object=repo_object,
+                ),
+            )
 
     return {"components": snapshot_components}
 
@@ -146,7 +171,6 @@ def run_collect_index_images(
     *,
     data_dir: Path,
     internal_request_results_file: Path,
-    build_timestamp: str,
     snapshot_path: Path,
     index_image_snapshot_result_path: Path,
 ) -> None:
@@ -158,7 +182,7 @@ def run_collect_index_images(
 
     logger.info("Loading internal request results from %s", results_path)
     results = file.load_json_dict(results_path)
-    snapshot = collect_index_image_components(results, build_timestamp)
+    snapshot = collect_index_image_components(results)
 
     snapshot_path.parent.mkdir(parents=True, exist_ok=True)
     snapshot_path.write_text(json.dumps(snapshot) + "\n", encoding="utf-8")
@@ -174,7 +198,6 @@ def main() -> int:
         internal_request_results_file=Path(
             tekton.require_env("PARAM_INTERNAL_REQUEST_RESULTS_FILE"),
         ),
-        build_timestamp=tekton.require_env("PARAM_BUILD_TIMESTAMP"),
         snapshot_path=data_dir / SNAPSHOT_FILENAME,
         index_image_snapshot_result_path=tekton.result_paths_from_env(
             "RESULT_INDEX_IMAGE_SNAPSHOT_PATH",

--- a/scripts/python/tasks/managed/test_collect_index_images.py
+++ b/scripts/python/tasks/managed/test_collect_index_images.py
@@ -53,27 +53,6 @@ def test_split_target_index_rejects_missing_tag() -> None:
         collect_index_images.split_target_index("quay.io/redhat/repo")
 
 
-def test_build_tags_appends_timestamp_for_bare_ocp_version() -> None:
-    """Append buildTimestamp for bare OCP version tags."""
-    assert collect_index_images.build_tags("v4.12", "2468") == [
-        "v4.12",
-        "v4.12-2468",
-    ]
-
-
-def test_build_tags_keeps_hotfix_tag_only() -> None:
-    """Do not append buildTimestamp for hotfix tags."""
-    assert collect_index_images.build_tags("v4.12-12345-6789", "9999") == [
-        "v4.12-12345-6789",
-    ]
-
-
-def test_build_tags_keeps_pre_ga_tag_only() -> None:
-    """Do not append buildTimestamp for pre-GA tags."""
-    tag = "v4.13-myproduct-1.0-20250220143022"
-    assert collect_index_images.build_tags(tag, "9999") == [tag]
-
-
 def test_translation_repo_url_strips_tag_suffix() -> None:
     """Return the repository URL without the tag portion."""
     url = collect_index_images.translation_repo_url(_TRANSLATED_FBC, "redhat.io")
@@ -95,10 +74,11 @@ def test_build_repo_object_includes_optional_delivery_repos() -> None:
     """Include translated delivery-repo fields when present."""
     repo_object = collect_index_images.build_repo_object(
         "quay.io/redhat/redhat----fbc-target-index",
-        ["v4.12", "v4.12-2468"],
+        "v4.12",
         "registry.redhat.io/redhat/fbc-target-index",
         "registry.access.redhat.com/redhat/fbc-target-index",
     )
+    assert repo_object["tags"] == ["v4.12"]
     assert repo_object["rh-registry-repo"] == "registry.redhat.io/redhat/fbc-target-index"
     assert repo_object["registry-access-repo"] == (
         "registry.access.redhat.com/redhat/fbc-target-index"
@@ -109,7 +89,7 @@ def test_build_repo_object_omits_empty_delivery_repos() -> None:
     """Omit optional delivery-repo fields when translation is blank."""
     repo_object = collect_index_images.build_repo_object(
         "quay.io/example/repo",
-        ["v1"],
+        "v1",
         "",
         "",
     )
@@ -117,12 +97,15 @@ def test_build_repo_object_omits_empty_delivery_repos() -> None:
     assert "registry-access-repo" not in repo_object
 
 
-def test_collect_index_image_components_single_version() -> None:
-    """Build one component with timestamp tag for a bare OCP version."""
+def test_collect_index_image_components_creates_two_components() -> None:
+    """Build two separate components for floating and timestamped tags."""
     results = {
         "components": [
             {
                 "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                "target_index_with_timestamp": (
+                    "quay.io/redhat/redhat----fbc-target-index:v4.12-1234567890"
+                ),
                 "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk",
             },
         ],
@@ -131,75 +114,124 @@ def test_collect_index_image_components_single_version() -> None:
         "collect_index_images.image_ref.translate_delivery_repo",
         return_value=_TRANSLATED_FBC,
     ):
-        snapshot = collect_index_images.collect_index_image_components(results, "2468")
+        snapshot = collect_index_images.collect_index_image_components(results)
 
-    component = snapshot["components"][0]
-    assert component["containerImage"] == "redhat.com/rh-stage/iib@sha256:abcdefghijk"
-    assert component["repository"] == "quay.io/redhat/redhat----fbc-target-index"
-    assert component["tags"] == ["v4.12", "v4.12-2468"]
-    assert component["repositories"][0]["tags"] == ["v4.12", "v4.12-2468"]
-    assert "registry.redhat.io" in component["repositories"][0]["rh-registry-repo"]
-    assert "registry.access.redhat.com" in (
-        component["repositories"][0]["registry-access-repo"]
+    assert len(snapshot["components"]) == 2
+    # First component: floating tag
+    assert (
+        snapshot["components"][0]["containerImage"]
+        == "redhat.com/rh-stage/iib@sha256:abcdefghijk"
     )
+    assert (
+        snapshot["components"][0]["repository"] == "quay.io/redhat/redhat----fbc-target-index"
+    )
+    assert snapshot["components"][0]["tags"] == ["v4.12"]
+    # Second component: timestamped tag
+    assert (
+        snapshot["components"][1]["containerImage"]
+        == "redhat.com/rh-stage/iib@sha256:abcdefghijk"
+    )
+    assert (
+        snapshot["components"][1]["repository"] == "quay.io/redhat/redhat----fbc-target-index"
+    )
+    assert snapshot["components"][1]["tags"] == ["v4.12-1234567890"]
 
 
 def test_collect_index_image_components_multiple_versions() -> None:
-    """Build separate components for each bare OCP version."""
+    """Build separate components for each index image."""
     results = {
         "components": [
             {
                 "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                "target_index_with_timestamp": (
+                    "quay.io/redhat/redhat----fbc-target-index:v4.12-1111111111"
+                ),
                 "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk",
             },
             {
                 "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.13",
-                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:lmnopqrstuv",
-            },
-        ],
-    }
-    with mock.patch(
-        "collect_index_images.image_ref.translate_delivery_repo",
-        return_value=_TRANSLATED_FBC,
-    ):
-        snapshot = collect_index_images.collect_index_image_components(results, "1357")
-
-    assert len(snapshot["components"]) == 2
-    assert snapshot["components"][0]["tags"] == ["v4.12", "v4.12-1357"]
-    assert snapshot["components"][1]["tags"] == ["v4.13", "v4.13-1357"]
-
-
-def test_collect_index_image_components_hotfix_and_pre_ga() -> None:
-    """Keep hotfix and pre-GA tags without appending buildTimestamp."""
-    results = {
-        "components": [
-            {
-                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12-12345-6789",
-                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk",
-            },
-            {
-                "target_index": (
-                    "quay.io/redhat/redhat----preview-operator-index:"
-                    "v4.13-myproduct-1.0-20250220143022"
+                "target_index_with_timestamp": (
+                    "quay.io/redhat/redhat----fbc-target-index:v4.13-2222222222"
                 ),
                 "index_image_resolved": "redhat.com/rh-stage/iib@sha256:lmnopqrstuv",
             },
         ],
     }
-
-    def _translate(target_index: str) -> list[dict[str, Any]]:
-        if "preview-operator-index" in target_index:
-            return _TRANSLATED_PREVIEW
-        return _TRANSLATED_FBC
-
     with mock.patch(
         "collect_index_images.image_ref.translate_delivery_repo",
-        side_effect=_translate,
+        return_value=_TRANSLATED_FBC,
     ):
-        snapshot = collect_index_images.collect_index_image_components(results, "9999")
+        snapshot = collect_index_images.collect_index_image_components(results)
 
+    assert len(snapshot["components"]) == 4
+    assert snapshot["components"][0]["tags"] == ["v4.12"]
+    assert snapshot["components"][1]["tags"] == ["v4.12-1111111111"]
+    assert snapshot["components"][2]["tags"] == ["v4.13"]
+    assert snapshot["components"][3]["tags"] == ["v4.13-2222222222"]
+
+
+def test_collect_index_image_components_hotfix_single_component() -> None:
+    """Keep hotfix tag only (no separate timestamped component when they match)."""
+    results = {
+        "components": [
+            {
+                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12-12345-6789",
+                "target_index_with_timestamp": (
+                    "quay.io/redhat/redhat----fbc-target-index:v4.12-12345-6789"
+                ),
+                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk",
+            },
+        ],
+    }
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        return_value=_TRANSLATED_FBC,
+    ):
+        snapshot = collect_index_images.collect_index_image_components(results)
+
+    assert len(snapshot["components"]) == 1
     assert snapshot["components"][0]["tags"] == ["v4.12-12345-6789"]
-    assert snapshot["components"][1]["tags"] == ["v4.13-myproduct-1.0-20250220143022"]
+
+
+def test_collect_index_image_components_pre_ga_single_component() -> None:
+    """Keep pre-GA tag only (no separate timestamped component when they match)."""
+    tag = "v4.13-myproduct-1.0-20250220143022"
+    results = {
+        "components": [
+            {
+                "target_index": f"quay.io/redhat/redhat----preview-operator-index:{tag}",
+                "target_index_with_timestamp": (
+                    f"quay.io/redhat/redhat----preview-operator-index:{tag}"
+                ),
+                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:lmnopqrstuv",
+            },
+        ],
+    }
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        return_value=_TRANSLATED_PREVIEW,
+    ):
+        snapshot = collect_index_images.collect_index_image_components(results)
+
+    assert len(snapshot["components"]) == 1
+    assert snapshot["components"][0]["tags"] == [tag]
+
+
+def test_collect_index_image_components_staged_release_empty_target() -> None:
+    """Skip empty target_index for staged releases."""
+    results = {
+        "components": [
+            {
+                "target_index": "",
+                "target_index_with_timestamp": "",
+                "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk",
+            },
+        ],
+    }
+    snapshot = collect_index_images.collect_index_image_components(results)
+
+    # No components created when both target indices are empty
+    assert len(snapshot["components"]) == 0
 
 
 def test_collect_index_image_components_includes_image_digests() -> None:
@@ -208,6 +240,9 @@ def test_collect_index_image_components_includes_image_digests() -> None:
         "components": [
             {
                 "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                "target_index_with_timestamp": (
+                    "quay.io/redhat/redhat----fbc-target-index:v4.12-1234567890"
+                ),
                 "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abc",
                 "image_digests": ["sha256:one", "sha256:two"],
             },
@@ -217,9 +252,11 @@ def test_collect_index_image_components_includes_image_digests() -> None:
         "collect_index_images.image_ref.translate_delivery_repo",
         return_value=_TRANSLATED_FBC,
     ):
-        snapshot = collect_index_images.collect_index_image_components(results, "2468")
+        snapshot = collect_index_images.collect_index_image_components(results)
 
+    # Both components should have the same image_digests
     assert snapshot["components"][0]["imageDigests"] == ["sha256:one", "sha256:two"]
+    assert snapshot["components"][1]["imageDigests"] == ["sha256:one", "sha256:two"]
 
 
 def test_collect_index_image_components_defaults_image_digests_to_empty() -> None:
@@ -228,6 +265,9 @@ def test_collect_index_image_components_defaults_image_digests_to_empty() -> Non
         "components": [
             {
                 "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                "target_index_with_timestamp": (
+                    "quay.io/redhat/redhat----fbc-target-index:v4.12-1234567890"
+                ),
                 "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abc",
             },
         ],
@@ -236,29 +276,23 @@ def test_collect_index_image_components_defaults_image_digests_to_empty() -> Non
         "collect_index_images.image_ref.translate_delivery_repo",
         return_value=_TRANSLATED_FBC,
     ):
-        snapshot = collect_index_images.collect_index_image_components(results, "2468")
+        snapshot = collect_index_images.collect_index_image_components(results)
 
     assert snapshot["components"][0]["imageDigests"] == []
+    assert snapshot["components"][1]["imageDigests"] == []
 
 
 def test_collect_index_image_components_rejects_invalid_row() -> None:
     """Fail when a components entry is not a JSON object."""
     with pytest.raises(ValueError, match="components\\[0\\] must be a JSON object"):
-        collect_index_images.collect_index_image_components({"components": ["bad"]}, "1")
-
-
-def test_collect_index_image_components_rejects_missing_target_index() -> None:
-    """Fail when target_index is missing from a component row."""
-    row = {"index_image_resolved": "img@sha256:abc"}
-    with pytest.raises(ValueError, match="target_index must be a non-empty string"):
-        collect_index_images.collect_index_image_components({"components": [row]}, "1")
+        collect_index_images.collect_index_image_components({"components": ["bad"]})
 
 
 def test_collect_index_image_components_rejects_missing_source_index() -> None:
     """Fail when index_image_resolved is missing from a component row."""
     row = {"target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12"}
     with pytest.raises(ValueError, match="index_image_resolved must be a non-empty string"):
-        collect_index_images.collect_index_image_components({"components": [row]}, "1")
+        collect_index_images.collect_index_image_components({"components": [row]})
 
 
 def test_collect_index_image_components_rejects_invalid_image_digests() -> None:
@@ -269,16 +303,106 @@ def test_collect_index_image_components_rejects_invalid_image_digests() -> None:
         "image_digests": "bad",
     }
     with pytest.raises(ValueError, match="image_digests must be a JSON array"):
-        collect_index_images.collect_index_image_components({"components": [row]}, "1")
+        collect_index_images.collect_index_image_components({"components": [row]})
 
 
 def test_collect_index_image_components_rejects_invalid_components_type() -> None:
     """Fail when the results components field is not an array."""
     with pytest.raises(ValueError, match="components must be a JSON array"):
-        collect_index_images.collect_index_image_components(
-            {"components": "bad"},
-            "2468",
+        collect_index_images.collect_index_image_components({"components": "bad"})
+
+
+def test_collect_index_image_components_rejects_non_string_target_index() -> None:
+    """Fail when target_index is not a string."""
+    row = {
+        "target_index": 123,
+        "target_index_with_timestamp": "quay.io/redhat/repo:v1-123",
+        "index_image_resolved": "img@sha256:abc",
+    }
+    with pytest.raises(ValueError, match="target_index must be a string"):
+        collect_index_images.collect_index_image_components({"components": [row]})
+
+
+def test_collect_index_image_components_rejects_non_string_target_index_with_ts() -> None:
+    """Fail when target_index_with_timestamp is not a string."""
+    row = {
+        "target_index": "quay.io/redhat/repo:v1",
+        "target_index_with_timestamp": 456,
+        "index_image_resolved": "img@sha256:abc",
+    }
+    with pytest.raises(ValueError, match="target_index_with_timestamp must be a string"):
+        collect_index_images.collect_index_image_components({"components": [row]})
+
+
+def test_collect_index_image_components_only_target_index_populated() -> None:
+    """Create one component when only target_index is present."""
+    row = {
+        "target_index": "quay.io/redhat/redhat----preview-operator-index:v4.13",
+        "target_index_with_timestamp": "",
+        "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abc",
+    }
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        return_value=_TRANSLATED_PREVIEW,
+    ):
+        snapshot = collect_index_images.collect_index_image_components(
+            {"components": [row]},
         )
+    assert len(snapshot["components"]) == 1
+    assert snapshot["components"][0]["tags"] == ["v4.13"]
+
+
+def test_collect_index_image_components_only_target_index_with_ts_populated() -> None:
+    """Create one component when only target_index_with_timestamp is present."""
+    row = {
+        "target_index": "",
+        "target_index_with_timestamp": "quay.io/redhat/redhat----fbc-target-index:v4.12-123",
+        "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abc",
+    }
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        return_value=_TRANSLATED_FBC,
+    ):
+        snapshot = collect_index_images.collect_index_image_components(
+            {"components": [row]},
+        )
+    assert len(snapshot["components"]) == 1
+    assert snapshot["components"][0]["tags"] == ["v4.12-123"]
+
+
+def test_collect_index_image_components_missing_ts_field() -> None:
+    """Create one component when target_index_with_timestamp key is absent."""
+    row = {
+        "target_index": "quay.io/redhat/redhat----preview-operator-index:v4.13",
+        "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abc",
+    }
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        return_value=_TRANSLATED_PREVIEW,
+    ):
+        snapshot = collect_index_images.collect_index_image_components(
+            {"components": [row]},
+        )
+    assert len(snapshot["components"]) == 1
+    assert snapshot["components"][0]["tags"] == ["v4.13"]
+
+
+def test_collect_index_image_components_null_ts_with_populated_target() -> None:
+    """Create one component when target_index_with_timestamp is null."""
+    row = {
+        "target_index": "quay.io/redhat/redhat----preview-operator-index:v4.13",
+        "target_index_with_timestamp": None,
+        "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abc",
+    }
+    with mock.patch(
+        "collect_index_images.image_ref.translate_delivery_repo",
+        return_value=_TRANSLATED_PREVIEW,
+    ):
+        snapshot = collect_index_images.collect_index_image_components(
+            {"components": [row]},
+        )
+    assert len(snapshot["components"]) == 1
+    assert snapshot["components"][0]["tags"] == ["v4.13"]
 
 
 def test_run_collect_index_images_writes_snapshot_and_result(
@@ -290,6 +414,9 @@ def test_run_collect_index_images_writes_snapshot_and_result(
         [
             {
                 "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                "target_index_with_timestamp": (
+                    "quay.io/redhat/redhat----fbc-target-index:v4.12-1234567890"
+                ),
                 "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abc",
             },
         ],
@@ -302,7 +429,6 @@ def test_run_collect_index_images_writes_snapshot_and_result(
         collect_index_images.run_collect_index_images(
             data_dir=tmp_path,
             internal_request_results_file=Path("internal-requests-results.json"),
-            build_timestamp="2468",
             snapshot_path=tmp_path / collect_index_images.SNAPSHOT_FILENAME,
             index_image_snapshot_result_path=result_path,
         )
@@ -310,7 +436,7 @@ def test_run_collect_index_images_writes_snapshot_and_result(
     snapshot = json.loads(
         (tmp_path / collect_index_images.SNAPSHOT_FILENAME).read_text(encoding="utf-8"),
     )
-    assert len(snapshot["components"]) == 1
+    assert len(snapshot["components"]) == 2
     assert result_path.read_text(encoding="utf-8") == collect_index_images.SNAPSHOT_FILENAME
 
 
@@ -320,7 +446,6 @@ def test_run_collect_index_images_missing_results_file(tmp_path: Path) -> None:
         collect_index_images.run_collect_index_images(
             data_dir=tmp_path,
             internal_request_results_file=Path("missing.json"),
-            build_timestamp="2468",
             snapshot_path=tmp_path / collect_index_images.SNAPSHOT_FILENAME,
             index_image_snapshot_result_path=tmp_path / "result.txt",
         )
@@ -335,7 +460,6 @@ def test_module_main_guard_propagates_failure(
 
     monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("PARAM_INTERNAL_REQUEST_RESULTS_FILE", "missing.json")
-    monkeypatch.setenv("PARAM_BUILD_TIMESTAMP", "2468")
     monkeypatch.setenv("RESULT_INDEX_IMAGE_SNAPSHOT_PATH", str(tmp_path / "result.txt"))
     with pytest.raises(FileNotFoundError, match="internal request results file not found"):
         runpy.run_module("collect_index_images", run_name="__main__")
@@ -351,13 +475,15 @@ def test_main_success(
         [
             {
                 "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                "target_index_with_timestamp": (
+                    "quay.io/redhat/redhat----fbc-target-index:v4.12-1234567890"
+                ),
                 "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abc",
             },
         ],
     )
     monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("PARAM_INTERNAL_REQUEST_RESULTS_FILE", "internal-requests-results.json")
-    monkeypatch.setenv("PARAM_BUILD_TIMESTAMP", "2468")
     monkeypatch.setenv("RESULT_INDEX_IMAGE_SNAPSHOT_PATH", str(tmp_path / "result.txt"))
 
     with mock.patch(


### PR DESCRIPTION
Replace build_timestamp logic with direct reading of
target_index_with_timestamp from results. Create
separate components for floating and timestamped
target indexes instead of one component with multiple
tags. Skip duplicates when both values are equal
(hotfix/pre-ga releases). Filter empty values for
staged releases. Add type validation for target_index
fields to prevent silent data loss, while allowing
partial fields (target_index without timestamp).

Assisted-by: Claude