### PR TITLE
feat(RELEASE-2678): add internal_request python module

### DIFF
--- a/docs/tasks/internal/get_advisory_severity.md
+++ b/docs/tasks/internal/get_advisory_severity.md
@@ -67,7 +67,7 @@ When the catalog step runs this script (same contract as [`get-advisory-severity
 | `PARAM_TASK_RUN_NAME` | `$(context.taskRun.name)` |
 | OSIDB mount | `/mnt/osidb-service-account` (secret `osidb-service-account`) |
 
-[`internal_request.write_result_paths`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/internal_request.py#L9-L22) writes the pipeline and task run names at the start of [`run_get_advisory_severity`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L310-L314).
+[`internal_request_results.write_result_paths`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/internal_request_results.py#L9-L21) writes the pipeline and task run names at the start of [`run_get_advisory_severity`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/get_advisory_severity.py#L310-L314).
 
 ---
 
@@ -217,4 +217,4 @@ If `internal-request` fails before the pipeline finishes, `set-severity` may fai
 |------|------|
 | Unit tests | [`test_get_advisory_severity.py`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/tasks/internal/test_get_advisory_severity.py) |
 | Purl matching | [`find_matching_purl.py`](https://github.com/konflux-ci/release-service-utils/blob/main/utils/find_matching_purl.py) |
-| Helpers | [`authentication`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/authentication.py), [`osidb`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/osidb.py), [`http_client`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/http_client.py), [`tekton`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/tekton.py), [`internal_request`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/internal_request.py) |
+| Helpers | [`authentication`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/authentication.py), [`osidb`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/osidb.py), [`http_client`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/http_client.py), [`tekton`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/tekton.py), [`internal_request_results`](https://github.com/konflux-ci/release-service-utils/blob/main/scripts/python/helpers/internal_request_results.py) |

--- a/scripts/python/helpers/internal_request/__init__.py
+++ b/scripts/python/helpers/internal_request/__init__.py
@@ -1,0 +1,7 @@
+"""Create and wait for InternalRequest resources."""
+
+from __future__ import annotations
+
+from .internal_request import InternalRequestWaitError, SPAWN_OVERHEAD_SECONDS, create
+
+__all__ = ["InternalRequestWaitError", "SPAWN_OVERHEAD_SECONDS", "create"]

--- a/scripts/python/helpers/internal_request/internal_request.py
+++ b/scripts/python/helpers/internal_request/internal_request.py
@@ -1,0 +1,501 @@
+"""Create and wait for InternalRequest resources in Kubernetes.
+
+This module creates an InternalRequest resource in a Kubernetes cluster using
+`kubectl`. Parameters are passed as Python mappings rather than CLI flags.
+
+
+Sync and async behavior
+-----------------------
+
+In sync mode (the default), `create()` waits for the InternalRequest to reach
+a completed status. On failure it raises `InternalRequestWaitError` with an
+`exit_code` that mirrors the bash utilities:
+
+    Succeeded          returns the InternalRequest name (no exception)
+    Failed or rejected `exit_code` 21
+    Timeout            `exit_code` 124
+
+In async mode (`sync=False`), the InternalRequest is created and the function
+returns immediately without waiting for status updates.
+
+
+Usage
+-----
+
+::
+
+    from internal_request import create
+
+    ir_name = create(
+        "create-advisory",
+        params={
+            "taskGitUrl": "https://github.com/konflux-ci/release-service-catalog.git",
+            "taskGitRevision": "development",
+            "advisory_name": "RHSA-2024:1234",
+        },
+        labels={
+            "internal-services.appstudio.openshift.io/pipelinerun-uid": "<uid>",
+        },
+        sync=True,
+        timeout=3600,
+        service_account="release-service-account",
+        pipeline_timeout="1h0m0s",
+        task_timeout="0h55m0s",
+        finally_timeout="0h5m0s",
+    )
+
+
+`create()` parameters
+-------------------
+
+`pipeline`
+    Name of the pipeline under `internal/pipelines` in release-service-catalog.
+
+`params`
+    Mapping of parameter names to string values. Each entry becomes a
+    `spec.params` field on the InternalRequest. Values may be valid JSON objects
+    or arrays when serialized. `taskGitUrl` and `taskGitRevision` are required.
+
+`labels`
+    Optional mapping added to `metadata.labels`. When
+    `internal-services.appstudio.openshift.io/pipelinerun-uid` is present,
+    prior InternalRequests for the same pipeline run and pipeline name are
+    deleted before creating a new one.
+
+`sync`
+    When true (default), block until the InternalRequest completes.
+
+`timeout`
+    Seconds to wait in sync mode. Defaults to 3600. Callers should allow at
+    least ``duration_to_seconds(pipeline_timeout) + SPAWN_OVERHEAD_SECONDS`` so
+    the poll loop outlives operator delay before the PipelineRun starts.
+
+`service_account`
+    Optional service account for the PipelineRun.
+
+`pipeline_timeout`
+    Total PipelineRun timeout in `XhYmZs` format. Defaults to `1h0m0s`.
+
+`task_timeout`
+    Task timeout in `XhYmZs` format. Defaults to `0h55m0s`.
+
+`finally_timeout`
+    Finally-task timeout in `XhYmZs` format. Defaults to `0h5m0s`.
+
+
+Prerequisites
+-------------
+
+* `kubectl` must be installed and configured to communicate with the cluster.
+
+
+Note:
+----
+Intended for clusters whose API includes the `InternalRequest` resource type
+(`appstudio.redhat.com/v1alpha1`).
+
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import retry
+from logger import logger
+from subprocess_cmd import run_cmd
+
+PIPELINE_NAME_LABEL = "internal-services.appstudio.openshift.io/pipeline-name"
+PIPELINERUN_UID_LABEL = "internal-services.appstudio.openshift.io/pipelinerun-uid"
+CLEANUP_PROPAGATION_SLEEP_SECONDS = 5
+# Extra poll budget before the PipelineRun starts (operator reconcile and scheduling).
+SPAWN_OVERHEAD_SECONDS = 300
+EXIT_FAILED = 21
+EXIT_TIMEOUT = 124
+_DURATION_RE = re.compile(r"^(\d+)h(\d+)m(\d+)s$")
+
+
+class InternalRequestWaitError(RuntimeError):
+    """Raised when waiting for InternalRequests fails or times out."""
+
+    def __init__(self, message: str, exit_code: int) -> None:
+        """Store *message* and *exit_code* on the exception instance."""
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+class _InternalRequestNotComplete(Exception):
+    """Raised when InternalRequests have not yet reached a terminal state."""
+
+
+def duration_to_seconds(duration: str) -> int:
+    """Convert an `XhYmZs` duration string to seconds."""
+    match = _DURATION_RE.fullmatch(duration)
+    if match is None:
+        msg = f"duration must use XhYmZs format: {duration!r}"
+        raise ValueError(msg)
+    hours, minutes, seconds = (int(match.group(i)) for i in range(1, 4))
+    return (hours * 3600) + (minutes * 60) + seconds
+
+
+def validate_timeouts(
+    *,
+    timeout: int,
+    pipeline_timeout: str,
+    task_timeout: str,
+    finally_timeout: str,
+) -> None:
+    """Validate timeout strings and their relationships."""
+    for label, value in (
+        ("pipeline_timeout", pipeline_timeout),
+        ("task_timeout", task_timeout),
+        ("finally_timeout", finally_timeout),
+    ):
+        if _DURATION_RE.fullmatch(value) is None:
+            msg = f"{label} must use XhYmZs format, where X, Y, and Z are integers"
+            raise ValueError(msg)
+
+    pipeline_timeout_secs = duration_to_seconds(pipeline_timeout)
+    task_timeout_secs = duration_to_seconds(task_timeout)
+    finally_timeout_secs = duration_to_seconds(finally_timeout)
+    all_tasks_timeout = task_timeout_secs + finally_timeout_secs
+    if all_tasks_timeout > pipeline_timeout_secs:
+        msg = (
+            "The sum of the task and finally timeout cannot exceed the pipeline "
+            f"timeout. Pipeline timeout is {pipeline_timeout_secs} and the sum "
+            f"of the others is {all_tasks_timeout}."
+        )
+        raise ValueError(msg)
+
+    if pipeline_timeout_secs > timeout:
+        logger.warning(
+            "The passed pipeline timeout is greater than the script timeout. "
+            "This means the script can fail before the pipeline times out, "
+            "should it take that long.",
+        )
+
+
+def build_payload(
+    *,
+    pipeline: str,
+    params: Mapping[str, str],
+    labels: Mapping[str, str],
+    pipeline_git_url: str,
+    pipeline_git_revision: str,
+    pipeline_timeout: str,
+    task_timeout: str,
+    finally_timeout: str,
+    service_account: str | None,
+) -> dict[str, Any]:
+    """Build the InternalRequest manifest payload."""
+    merged_labels = dict(labels)
+    merged_labels[PIPELINE_NAME_LABEL] = pipeline
+
+    payload: dict[str, Any] = {
+        "apiVersion": "appstudio.redhat.com/v1alpha1",
+        "kind": "InternalRequest",
+        "metadata": {
+            "generateName": f"{pipeline}-",
+            "labels": merged_labels,
+        },
+        "spec": {
+            "pipeline": {
+                "pipelineRef": {
+                    "resolver": "git",
+                    "params": [
+                        {"name": "url", "value": pipeline_git_url},
+                        {"name": "revision", "value": pipeline_git_revision},
+                        {
+                            "name": "pathInRepo",
+                            "value": f"pipelines/internal/{pipeline}/{pipeline}.yaml",
+                        },
+                    ],
+                },
+            },
+            "params": dict(params),
+            "timeouts": {
+                "pipeline": pipeline_timeout,
+                "tasks": task_timeout,
+                "finally": finally_timeout,
+            },
+        },
+    }
+    if service_account:
+        payload["spec"]["serviceAccount"] = service_account
+    return payload
+
+
+def _pipelinerun_uid_from_labels(labels: Mapping[str, str]) -> str:
+    """Return the pipelinerun-uid label value when present."""
+    return labels.get(PIPELINERUN_UID_LABEL, "")
+
+
+def _fetch_internal_requests(
+    *,
+    name: str | None,
+    label_selector: str | None,
+) -> list[dict[str, Any]]:
+    """Return InternalRequest objects as a list of parsed JSON dicts."""
+    if name is not None:
+        result = run_cmd(
+            ["kubectl", "get", "internalrequest", name, "-o", "json"],
+            check=True,
+        )
+        item = json.loads(result.stdout)
+        return [item]
+
+    result = run_cmd(
+        [
+            "kubectl",
+            "get",
+            "internalrequest",
+            "-l",
+            label_selector or "",
+            "-o",
+            "json",
+        ],
+        check=True,
+    )
+    data = json.loads(result.stdout)
+    items = data.get("items")
+    return items if isinstance(items, list) else []
+
+
+def _print_conditions(internal_requests: Sequence[dict[str, Any]]) -> None:
+    """Log InternalRequest condition summaries."""
+    logger.info("Conditions:")
+    for item in internal_requests:
+        ir_name = item.get("metadata", {}).get("name", "")
+        conditions = item.get("status", {}).get("conditions", [])
+        logger.info("  %s: %s", ir_name, json.dumps(conditions, separators=(",", ":")))
+
+
+def _ir_output_path(ir_name: str) -> Path:
+    """Return the wait-sidecar output path for an InternalRequest name."""
+    return Path(f"/tmp/{ir_name}-output.json")
+
+
+def _append_ir_output(ir_name: str, pipeline_run: str) -> None:
+    """Append InternalRequest completion metadata to the output file."""
+    output_path = _ir_output_path(ir_name)
+    payload = json.dumps({"name": ir_name, "pipelineRun": pipeline_run})
+    logger.info("writing results to %s", output_path)
+    with output_path.open("a", encoding="utf-8") as output_file:
+        output_file.write(f"{payload}\n")
+
+
+def wait_for_completion(
+    *,
+    name: str | None = None,
+    label_selector: str | None = None,
+    timeout: int = 600,
+) -> None:
+    """Block until InternalRequests complete or *timeout* seconds elapse.
+
+    One of *name* or *label_selector* must be set, but not both.
+
+    Raises:
+        ValueError: When neither or both selectors are provided.
+        InternalRequestWaitError: When an IR fails or the wait times out.
+
+    """
+    has_name = bool(name)
+    has_labels = bool(label_selector)
+    if has_name == has_labels:
+        msg = "exactly one of name or label_selector must be set"
+        raise ValueError(msg)
+
+    end_time = time.time() + timeout
+    written_outputs: set[str] = set()
+
+    def _poll_once() -> None:
+        logger.info("Checking IR statuses...")
+        internal_requests = _fetch_internal_requests(
+            name=name,
+            label_selector=label_selector,
+        )
+        logger.info(
+            "Found %d InternalRequests matching the name or label",
+            len(internal_requests),
+        )
+
+        done_count = 0
+        all_succeeded = True
+        for item in internal_requests:
+            ir_name = item.get("metadata", {}).get("name", "")
+            conditions = item.get("status", {}).get("conditions") or []
+            reason = ""
+            if conditions and isinstance(conditions[0], dict):
+                reason = str(conditions[0].get("reason") or "")
+            pipeline_run = item.get("status", {}).get("pipelineRun") or ""
+
+            if not reason:
+                logger.info("  %s: no condition yet", ir_name)
+            elif reason == "Running":
+                logger.info("  %s: running - pipelineRun: %s", ir_name, pipeline_run)
+            elif reason == "Succeeded":
+                logger.info("  %s: succeeded - pipelineRun: %s", ir_name, pipeline_run)
+                if ir_name and ir_name not in written_outputs:
+                    _append_ir_output(ir_name, pipeline_run)
+                    written_outputs.add(ir_name)
+                done_count += 1
+            else:
+                logger.info("  %s: %s", ir_name, reason)
+                if ir_name and ir_name not in written_outputs:
+                    _append_ir_output(ir_name, pipeline_run)
+                    written_outputs.add(ir_name)
+                done_count += 1
+                all_succeeded = False
+
+        if internal_requests and done_count == len(internal_requests):
+            if all_succeeded:
+                _print_conditions(internal_requests)
+                logger.info("Result: success")
+                return
+            _print_conditions(internal_requests)
+            raise InternalRequestWaitError(
+                "At least one InternalRequest failed",
+                EXIT_FAILED,
+            )
+
+        if time.time() > end_time:
+            _print_conditions(internal_requests)
+            raise InternalRequestWaitError(
+                "Timeout while waiting for the InternalRequests to complete",
+                EXIT_TIMEOUT,
+            )
+
+        raise _InternalRequestNotComplete()
+
+    # Enough attempts for the full timeout at the minimum 5s backoff interval.
+    max_attempts = max(timeout // 5 + 1, 2)
+    retry.retry_with_exponential_backoff(
+        _poll_once,
+        max_attempts=max_attempts,
+        retry_on=_InternalRequestNotComplete,
+        base_sleep_seconds=5,
+    )
+
+
+def cleanup_existing_requests(
+    *,
+    pipeline: str,
+    labels: Mapping[str, str],
+) -> None:
+    """Delete prior InternalRequests for the same pipeline run and pipeline name."""
+    pipelinerun_uid = _pipelinerun_uid_from_labels(labels)
+    if not pipelinerun_uid:
+        return
+
+    label_selector = (
+        f"{PIPELINERUN_UID_LABEL}={pipelinerun_uid}," f"{PIPELINE_NAME_LABEL}={pipeline}"
+    )
+    items = _fetch_internal_requests(name=None, label_selector=label_selector)
+    if not items:
+        return
+
+    logger.info("Found existing InternalRequests from prior attempts. Cleaning up...")
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        ir_name = item.get("metadata", {}).get("name")
+        if not isinstance(ir_name, str) or not ir_name:
+            continue
+        logger.info("Deleting InternalRequest %s...", ir_name)
+        run_cmd(
+            [
+                "kubectl",
+                "delete",
+                "internalrequest",
+                ir_name,
+                "--wait=true",
+                "--timeout=60s",
+            ],
+            check=True,
+        )
+
+    logger.info(
+        "Cleanup complete. Waiting %ds for PipelineRun cancellation to propagate...",
+        CLEANUP_PROPAGATION_SLEEP_SECONDS,
+    )
+    time.sleep(CLEANUP_PROPAGATION_SLEEP_SECONDS)
+
+
+def create_internal_request(payload: dict[str, Any]) -> str:
+    """Create an InternalRequest from *payload* and return its name."""
+    result = run_cmd(
+        ["kubectl", "create", "-f", "-", "-o", "json"],
+        stdin=json.dumps(payload),
+        check=True,
+    )
+    resource = json.loads(result.stdout)
+    name = resource.get("metadata", {}).get("name")
+    if not isinstance(name, str) or not name:
+        msg = "kubectl create did not return an InternalRequest name"
+        raise RuntimeError(msg)
+    return name
+
+
+def create(
+    pipeline: str,
+    *,
+    params: Mapping[str, str],
+    labels: Mapping[str, str] | None = None,
+    sync: bool = True,
+    timeout: int = 3600,
+    service_account: str | None = None,
+    pipeline_timeout: str = "1h0m0s",
+    task_timeout: str = "0h55m0s",
+    finally_timeout: str = "0h5m0s",
+) -> str:
+    """Create an InternalRequest and optionally wait for it to complete.
+
+    Returns the created InternalRequest name. When *sync* is true, blocks until
+    the InternalRequest completes using the same semantics as the bash utility.
+    """
+    if not pipeline:
+        msg = "pipeline is required"
+        raise ValueError(msg)
+
+    merged_labels = dict(labels or {})
+    merged_params = dict(params)
+    pipeline_git_url = merged_params.get("taskGitUrl")
+    pipeline_git_revision = merged_params.get("taskGitRevision")
+    if not pipeline_git_url or not pipeline_git_revision:
+        msg = (
+            "params must include taskGitUrl and taskGitRevision for the git "
+            "resolver pipeline reference"
+        )
+        raise ValueError(msg)
+
+    validate_timeouts(
+        timeout=timeout,
+        pipeline_timeout=pipeline_timeout,
+        task_timeout=task_timeout,
+        finally_timeout=finally_timeout,
+    )
+    cleanup_existing_requests(pipeline=pipeline, labels=merged_labels)
+
+    payload = build_payload(
+        pipeline=pipeline,
+        params=merged_params,
+        labels=merged_labels,
+        pipeline_git_url=pipeline_git_url,
+        pipeline_git_revision=pipeline_git_revision,
+        pipeline_timeout=pipeline_timeout,
+        task_timeout=task_timeout,
+        finally_timeout=finally_timeout,
+        service_account=service_account,
+    )
+    internal_request_name = create_internal_request(payload)
+    logger.info("InternalRequest '%s' created.", internal_request_name)
+
+    if sync:
+        logger.info("Sync flag set to true. Waiting for the InternalRequest to complete.")
+        wait_for_completion(name=internal_request_name, timeout=timeout)
+
+    return internal_request_name

--- a/scripts/python/helpers/internal_request/test_internal_request.py
+++ b/scripts/python/helpers/internal_request/test_internal_request.py
@@ -1,0 +1,444 @@
+"""Test internal_request helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+import retry
+from internal_request import internal_request as ir_module
+from internal_request.internal_request import (
+    EXIT_FAILED,
+    EXIT_TIMEOUT,
+    InternalRequestWaitError,
+    wait_for_completion,
+)
+
+
+def test_duration_to_seconds_parses_hms() -> None:
+    """Convert XhYmZs durations to seconds."""
+    assert ir_module.duration_to_seconds("1h0m0s") == 3600
+    assert ir_module.duration_to_seconds("0h55m0s") == 3300
+
+
+def test_duration_to_seconds_rejects_invalid_format() -> None:
+    """Reject durations that do not use XhYmZs format."""
+    with pytest.raises(ValueError, match="XhYmZs"):
+        ir_module.duration_to_seconds("60m")
+
+
+def test_validate_timeouts_rejects_task_plus_finally_exceeding_pipeline() -> None:
+    """Reject when task and finally timeouts exceed the pipeline timeout."""
+    with pytest.raises(ValueError, match="cannot exceed the pipeline timeout"):
+        ir_module.validate_timeouts(
+            timeout=3600,
+            pipeline_timeout="0h10m0s",
+            task_timeout="0h8m0s",
+            finally_timeout="0h5m0s",
+        )
+
+
+def test_validate_timeouts_rejects_invalid_format() -> None:
+    """Reject timeout values that do not use XhYmZs format."""
+    with pytest.raises(ValueError, match="task_timeout must use XhYmZs"):
+        ir_module.validate_timeouts(
+            timeout=3600,
+            pipeline_timeout="1h0m0s",
+            task_timeout="55m",
+            finally_timeout="0h5m0s",
+        )
+
+
+def test_validate_timeouts_warns_when_pipeline_exceeds_script_timeout() -> None:
+    """Log a warning when the pipeline timeout exceeds the script timeout."""
+    with mock.patch.object(ir_module.logger, "warning") as warning:
+        ir_module.validate_timeouts(
+            timeout=60,
+            pipeline_timeout="1h0m0s",
+            task_timeout="0h55m0s",
+            finally_timeout="0h5m0s",
+        )
+
+    warning.assert_called_once()
+    assert "pipeline timeout is greater than the script timeout" in warning.call_args[0][0]
+
+
+def test_build_payload_includes_required_fields() -> None:
+    """Build an InternalRequest manifest with git resolver metadata."""
+    payload = ir_module.build_payload(
+        pipeline="create-advisory",
+        params={
+            "taskGitUrl": "https://example.test/catalog",
+            "taskGitRevision": "main",
+            "advisory_json": "abc",
+        },
+        labels={"foo": "bar"},
+        pipeline_git_url="https://example.test/catalog",
+        pipeline_git_revision="main",
+        pipeline_timeout="1h0m0s",
+        task_timeout="0h55m0s",
+        finally_timeout="0h5m0s",
+        service_account="ir-sa",
+    )
+
+    assert payload["metadata"]["generateName"] == "create-advisory-"
+    assert payload["metadata"]["labels"]["foo"] == "bar"
+    assert payload["metadata"]["labels"][ir_module.PIPELINE_NAME_LABEL] == "create-advisory"
+    assert payload["spec"]["serviceAccount"] == "ir-sa"
+    assert payload["spec"]["params"]["advisory_json"] == "abc"
+    assert (
+        payload["spec"]["pipeline"]["pipelineRef"]["params"][2]["value"]
+        == "pipelines/internal/create-advisory/create-advisory.yaml"
+    )
+
+
+def _completed_process(stdout: str, returncode: int = 0) -> mock.MagicMock:
+    result = mock.MagicMock()
+    result.stdout = stdout
+    result.returncode = returncode
+    return result
+
+
+def test_cleanup_existing_requests_deletes_matching_irs() -> None:
+    """Delete existing InternalRequests before creating a new one."""
+    calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        calls.append(cmd)
+        if cmd[0:3] == ["kubectl", "get", "internalrequest"]:
+            body = {"items": [{"metadata": {"name": "old-ir-1"}}]}
+            return _completed_process(json.dumps(body))
+        return _completed_process("")
+
+    with (
+        mock.patch.object(ir_module, "run_cmd", side_effect=fake_run_cmd),
+        mock.patch.object(ir_module.time, "sleep"),
+    ):
+        ir_module.cleanup_existing_requests(
+            pipeline="create-advisory",
+            labels={ir_module.PIPELINERUN_UID_LABEL: "uid-123"},
+        )
+
+    assert calls[0] == [
+        "kubectl",
+        "get",
+        "internalrequest",
+        "-l",
+        (
+            f"{ir_module.PIPELINERUN_UID_LABEL}=uid-123,"
+            f"{ir_module.PIPELINE_NAME_LABEL}=create-advisory"
+        ),
+        "-o",
+        "json",
+    ]
+    assert calls[1][:4] == ["kubectl", "delete", "internalrequest", "old-ir-1"]
+
+
+def test_cleanup_existing_requests_skips_without_pipelinerun_uid() -> None:
+    """Skip cleanup when the pipelinerun-uid label is absent."""
+    with mock.patch.object(ir_module, "run_cmd") as fake_run_cmd:
+        ir_module.cleanup_existing_requests(
+            pipeline="create-advisory",
+            labels={"other": "value"},
+        )
+    fake_run_cmd.assert_not_called()
+
+
+def test_cleanup_existing_requests_skips_when_no_matching_items() -> None:
+    """Skip deletion when no existing InternalRequests are found."""
+    with mock.patch.object(ir_module, "run_cmd") as fake_run_cmd:
+        fake_run_cmd.return_value = _completed_process(json.dumps({"items": []}))
+        ir_module.cleanup_existing_requests(
+            pipeline="create-advisory",
+            labels={ir_module.PIPELINERUN_UID_LABEL: "uid-123"},
+        )
+
+    fake_run_cmd.assert_called_once()
+
+
+def test_cleanup_existing_requests_skips_non_dict_items() -> None:
+    """Ignore list entries that are not InternalRequest objects."""
+    calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        calls.append(cmd)
+        if cmd[0:3] == ["kubectl", "get", "internalrequest"]:
+            body = {"items": ["not-a-dict", {"metadata": {"name": "old-ir-1"}}]}
+            return _completed_process(json.dumps(body))
+        return _completed_process("")
+
+    with (
+        mock.patch.object(ir_module, "run_cmd", side_effect=fake_run_cmd),
+        mock.patch.object(ir_module.time, "sleep"),
+    ):
+        ir_module.cleanup_existing_requests(
+            pipeline="create-advisory",
+            labels={ir_module.PIPELINERUN_UID_LABEL: "uid-123"},
+        )
+
+    assert calls[1][:4] == ["kubectl", "delete", "internalrequest", "old-ir-1"]
+
+
+def test_cleanup_existing_requests_skips_invalid_ir_name() -> None:
+    """Ignore InternalRequests whose metadata name is missing or not a string."""
+    calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        calls.append(cmd)
+        if cmd[0:3] == ["kubectl", "get", "internalrequest"]:
+            body = {
+                "items": [
+                    {"metadata": {}},
+                    {"metadata": {"name": ""}},
+                    {"metadata": {"name": 123}},
+                ],
+            }
+            return _completed_process(json.dumps(body))
+        return _completed_process("")
+
+    with (
+        mock.patch.object(ir_module, "run_cmd", side_effect=fake_run_cmd),
+        mock.patch.object(ir_module.time, "sleep"),
+    ):
+        ir_module.cleanup_existing_requests(
+            pipeline="create-advisory",
+            labels={ir_module.PIPELINERUN_UID_LABEL: "uid-123"},
+        )
+
+    assert len(calls) == 1
+
+
+def test_create_creates_internal_request_without_waiting() -> None:
+    """Create an InternalRequest and return its name when sync is false."""
+    calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        calls.append(cmd)
+        if cmd[0:2] == ["kubectl", "create"]:
+            body = {"metadata": {"name": "create-advisory-abc"}}
+            return _completed_process(json.dumps(body))
+        return _completed_process(json.dumps({"items": []}))
+
+    with (
+        mock.patch.object(ir_module, "run_cmd", side_effect=fake_run_cmd),
+        mock.patch.object(ir_module.time, "sleep"),
+    ):
+        name = ir_module.create(
+            "create-advisory",
+            params={
+                "taskGitUrl": "https://example.test/catalog",
+                "taskGitRevision": "main",
+            },
+            sync=False,
+        )
+
+    assert name == "create-advisory-abc"
+    assert any(cmd[0:2] == ["kubectl", "create"] for cmd in calls)
+
+
+def test_create_requires_task_git_params() -> None:
+    """Reject creation when git resolver params are missing."""
+    with pytest.raises(ValueError, match="taskGitUrl and taskGitRevision"):
+        ir_module.create(
+            "create-advisory",
+            params={"componentGroup": "myapp"},
+            sync=False,
+        )
+
+
+def test_create_requires_pipeline() -> None:
+    """Reject creation when the pipeline name is empty."""
+    with pytest.raises(ValueError, match="pipeline is required"):
+        ir_module.create(
+            "",
+            params={
+                "taskGitUrl": "https://example.test/catalog",
+                "taskGitRevision": "main",
+            },
+            sync=False,
+        )
+
+
+def test_create_internal_request_raises_when_name_missing() -> None:
+    """Raise when kubectl create does not return an InternalRequest name."""
+    with (
+        mock.patch.object(
+            ir_module,
+            "run_cmd",
+            return_value=_completed_process(json.dumps({"metadata": {}})),
+        ),
+        pytest.raises(RuntimeError, match="did not return an InternalRequest name"),
+    ):
+        ir_module.create_internal_request({"kind": "InternalRequest"})
+
+
+def test_create_waits_when_sync_is_true() -> None:
+    """Wait for completion after creating the InternalRequest."""
+    with (
+        mock.patch.object(ir_module, "cleanup_existing_requests"),
+        mock.patch.object(
+            ir_module,
+            "create_internal_request",
+            return_value="create-advisory-abc",
+        ),
+        mock.patch.object(ir_module, "wait_for_completion") as wait,
+    ):
+        name = ir_module.create(
+            "create-advisory",
+            params={
+                "taskGitUrl": "https://example.test/catalog",
+                "taskGitRevision": "main",
+            },
+            sync=True,
+        )
+
+    assert name == "create-advisory-abc"
+    wait.assert_called_once_with(name="create-advisory-abc", timeout=3600)
+
+
+def test_wait_for_completion_requires_exactly_one_selector() -> None:
+    """Reject calls that provide both or neither selector."""
+    with pytest.raises(ValueError, match="exactly one"):
+        wait_for_completion()
+
+    with pytest.raises(ValueError, match="exactly one"):
+        wait_for_completion(name="ir-1", label_selector="foo=bar")
+
+
+def _patch_ir_output_path(tmp_path: Path, ir_name: str = "ir-1") -> tuple[mock._patch, Path]:
+    """Patch ``_ir_output_path`` to write under *tmp_path* for isolated tests."""
+    output_path = tmp_path / f"{ir_name}-output.json"
+    patch = mock.patch.object(ir_module, "_ir_output_path", return_value=output_path)
+    return patch, output_path
+
+
+def test_wait_for_completion_handles_running_before_success(tmp_path: Path) -> None:
+    """Poll again when an InternalRequest is still running."""
+    running_body = {
+        "metadata": {"name": "ir-1"},
+        "status": {
+            "conditions": [{"reason": "Running"}],
+            "pipelineRun": "pr-running",
+        },
+    }
+    succeeded_body = {
+        "metadata": {"name": "ir-1"},
+        "status": {
+            "conditions": [{"reason": "Succeeded"}],
+            "pipelineRun": "pr-1",
+        },
+    }
+    responses = [running_body, succeeded_body]
+    output_patch, output_path = _patch_ir_output_path(tmp_path)
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        return _completed_process(json.dumps(responses.pop(0)))
+
+    with (
+        output_patch,
+        mock.patch.object(ir_module, "run_cmd", side_effect=fake_run_cmd),
+        mock.patch.object(retry.time, "sleep") as sleep,
+        mock.patch.object(ir_module.time, "time", side_effect=[0, 1]),
+    ):
+        wait_for_completion(name="ir-1", timeout=600)
+
+    sleep.assert_called_once_with(5)
+    assert output_path.read_text(encoding="utf-8") == (
+        '{"name": "ir-1", "pipelineRun": "pr-1"}\n'
+    )
+
+
+def test_wait_for_completion_writes_output_json_on_success(tmp_path: Path) -> None:
+    """Write name and pipelineRun to the IR output file on success."""
+    ir_body = {
+        "metadata": {"name": "ir-1"},
+        "status": {
+            "conditions": [{"reason": "Succeeded"}],
+            "pipelineRun": "pr-1",
+        },
+    }
+    output_patch, output_path = _patch_ir_output_path(tmp_path)
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        return _completed_process(json.dumps(ir_body))
+
+    with (
+        output_patch,
+        mock.patch.object(ir_module, "run_cmd", side_effect=fake_run_cmd),
+        mock.patch.object(retry.time, "sleep"),
+    ):
+        wait_for_completion(name="ir-1", timeout=600)
+
+    assert output_path.read_text(encoding="utf-8") == (
+        '{"name": "ir-1", "pipelineRun": "pr-1"}\n'
+    )
+
+
+def test_wait_for_completion_raises_on_failure(tmp_path: Path) -> None:
+    """Raise InternalRequestWaitError when an IR completes unsuccessfully."""
+    ir_body = {
+        "metadata": {"name": "ir-1"},
+        "status": {
+            "conditions": [{"reason": "Failed"}],
+            "pipelineRun": "pr-1",
+        },
+    }
+    output_patch, output_path = _patch_ir_output_path(tmp_path)
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        return _completed_process(json.dumps(ir_body))
+
+    with (
+        output_patch,
+        mock.patch.object(ir_module, "run_cmd", side_effect=fake_run_cmd),
+        mock.patch.object(retry.time, "sleep"),
+        pytest.raises(InternalRequestWaitError) as exc_info,
+    ):
+        wait_for_completion(name="ir-1", timeout=600)
+
+    assert exc_info.value.exit_code == EXIT_FAILED
+    assert output_path.read_text(encoding="utf-8") == (
+        '{"name": "ir-1", "pipelineRun": "pr-1"}\n'
+    )
+
+
+def test_wait_for_completion_raises_on_timeout() -> None:
+    """Raise InternalRequestWaitError when the wait timeout elapses."""
+    ir_body = {
+        "metadata": {"name": "ir-1"},
+        "status": {"conditions": []},
+    }
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        return _completed_process(json.dumps(ir_body))
+
+    with (
+        mock.patch.object(ir_module, "run_cmd", side_effect=fake_run_cmd),
+        mock.patch.object(retry.time, "sleep"),
+        mock.patch.object(ir_module.time, "time", side_effect=[0, 601]),
+        pytest.raises(InternalRequestWaitError) as exc_info,
+    ):
+        wait_for_completion(name="ir-1", timeout=600)
+
+    assert exc_info.value.exit_code == EXIT_TIMEOUT
+
+
+def test_wait_for_completion_keeps_polling_when_label_selector_matches_nothing() -> None:
+    """Keep polling until timeout when a label selector matches no InternalRequests."""
+    empty_list_body = {"items": []}
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        return _completed_process(json.dumps(empty_list_body))
+
+    with (
+        mock.patch.object(ir_module, "run_cmd", side_effect=fake_run_cmd),
+        mock.patch.object(retry.time, "sleep"),
+        mock.patch.object(ir_module.time, "time", side_effect=[0, 601]),
+        pytest.raises(InternalRequestWaitError) as exc_info,
+    ):
+        wait_for_completion(label_selector="foo=bar", timeout=600)
+
+    assert exc_info.value.exit_code == EXIT_TIMEOUT

--- a/scripts/python/helpers/internal_request_results.py
+++ b/scripts/python/helpers/internal_request_results.py
@@ -1,4 +1,4 @@
-"""Helpers for interacting with InternalRequests."""
+"""Write Tekton result files for internal-request orchestration."""
 
 from __future__ import annotations
 
@@ -12,8 +12,7 @@ def write_result_paths(
     pipeline_run_name: str,
     task_run_name: str,
 ) -> None:
-    """
-    Write pipeline and task run names to the internal-request Tekton results.
+    """Write pipeline and task run names to the internal-request Tekton results.
 
     *result_paths* must include ``internal_pr_name`` and ``internal_task_run_name``
     keys mapping to the result file paths from the task step.

--- a/scripts/python/helpers/test_internal_request_results.py
+++ b/scripts/python/helpers/test_internal_request_results.py
@@ -1,16 +1,17 @@
-"""Tests for `internal_request`."""
+"""Test internal_request_results helpers."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-import internal_request
+import internal_request_results
 
 
 def test_write_result_paths(tmp_path: Path) -> None:
+    """Write pipeline and task run names to Tekton result files."""
     pr_path = tmp_path / "pr"
     tr_path = tmp_path / "tr"
-    internal_request.write_result_paths(
+    internal_request_results.write_result_paths(
         {"internal_pr_name": pr_path, "internal_task_run_name": tr_path},
         pipeline_run_name="pr-123",
         task_run_name="tr-456",

--- a/scripts/python/tasks/internal/create_advisory.py
+++ b/scripts/python/tasks/internal/create_advisory.py
@@ -31,7 +31,7 @@ import apply_template
 import authentication
 import file
 import http_client
-import internal_request
+import internal_request_results
 import requests
 import subprocess_cmd
 import tekton
@@ -470,7 +470,7 @@ def run_create_advisory(
     credentials = gitlab.read_credentials_from_mount(advisory_secret)
     # Internal-request child results are written before work begins so partial runs
     # still expose pipeline/task run names to the parent.
-    internal_request.write_result_paths(
+    internal_request_results.write_result_paths(
         result_paths,
         pipeline_run_name=params["internal_request_pr_name"],
         task_run_name=params["task_run_name"],

--- a/scripts/python/tasks/internal/filter_already_released_advisory_images.py
+++ b/scripts/python/tasks/internal/filter_already_released_advisory_images.py
@@ -25,7 +25,7 @@ from typing import Any
 from git.exc import GitCommandError
 
 import file
-import internal_request
+import internal_request_results
 import subprocess_cmd
 import tekton
 from logger import logger
@@ -320,7 +320,7 @@ def main(argv: list[str] | None = None) -> int:
         ADVISORY_SECRET_MOUNT_DEFAULT,
     )
     try:
-        internal_request.write_result_paths(
+        internal_request_results.write_result_paths(
             result_paths,
             pipeline_run_name=args.internal_request_pipeline_run_name,
             task_run_name=args.internal_request_task_run_name,

--- a/scripts/python/tasks/internal/get_advisory_severity.py
+++ b/scripts/python/tasks/internal/get_advisory_severity.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import authentication
 import file
-import internal_request
+import internal_request_results
 import osidb
 import requests
 import tekton
@@ -293,7 +293,7 @@ def run_get_advisory_severity(
     krb5_template: Path = Path("/etc/krb5.conf"),
 ) -> None:
     """Query OSIDB and write the highest advisory severity to *result_paths*."""
-    internal_request.write_result_paths(
+    internal_request_results.write_result_paths(
         result_paths,
         pipeline_run_name=pipeline_run_name,
         task_run_name=task_run_name,

--- a/utils/internal-request
+++ b/utils/internal-request
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# DEPRECATED - Use the python implementation in scripts/python/helpers/internal_request
+# when creating InternalRequests in python task scripts.
+#
 # This script creates an InternalRequest resource in a Kubernetes cluster
 # using the 'kubectl' command line tool. The resource is created with
 # parameters passed to the script.


### PR DESCRIPTION
This commit adds an internal_request python module to the helpers directory. Because we already have an internal_request.py helper for result writing, that was renamed to internal_request_results.py. This is meant to take the place of the bash utils/internal-request script so that we can use native python to create InternalRequests in python task scripts.

Assisted-By: Cursor