### PR TITLE
feat(RELEASE-2488): convert embargo-check task logic to python

### DIFF
--- a/scripts/python/helpers/jira.py
+++ b/scripts/python/helpers/jira.py
@@ -1,0 +1,98 @@
+"""Jira REST API helpers shared across task scripts.
+
+Provides constants and functions for interacting with Jira Cloud and legacy
+issue tracker APIs: server normalization, API URL construction, credential
+reading, and authenticated JSON requests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import authentication
+import requests
+from requests.auth import HTTPBasicAuth
+
+SUPPORTED_JIRA_SERVER = "redhat.atlassian.net"
+LEGACY_JIRA_SERVER = "issues.redhat.com"
+
+ISSUE_TRACKERS: dict[str, dict[str, Any]] = {
+    "Jira": {
+        "api": "rest/api/2/issue",
+        "servers": [
+            LEGACY_JIRA_SERVER,
+            "jira.atlassian.com",
+            SUPPORTED_JIRA_SERVER,
+        ],
+    },
+    "bugzilla": {
+        "api": "rest/bug",
+        "servers": ["bugzilla.redhat.com"],
+    },
+}
+
+
+def normalize_issue_server(source: str) -> str:
+    """Map legacy issue tracker hostnames to the current Jira server."""
+    if source == LEGACY_JIRA_SERVER:
+        return SUPPORTED_JIRA_SERVER
+    return source
+
+
+def api_path_for_server(server: str) -> str:
+    """Return the REST API prefix for *server*."""
+    for tracker in ISSUE_TRACKERS.values():
+        servers = tracker.get("servers")
+        if isinstance(servers, list) and server in servers:
+            return str(tracker["api"])
+    msg = f"no API mapping for server: {server}"
+    raise ValueError(msg)
+
+
+def read_jira_credentials(secret_path: Path) -> tuple[str, str]:
+    """Read Jira basic-auth credentials from mounted secret files."""
+    email = authentication.read_mounted_text(secret_path, "email")
+    token = authentication.read_mounted_text(secret_path, "token")
+    if not email or not token:
+        msg = f"Jira secret at {secret_path} must include email and token"
+        raise ValueError(msg)
+    return email, token
+
+
+def jira_issue_url(server: str, issue_id: str) -> str:
+    """Build the Jira issue API URL for *issue_id* on *server*."""
+    api_path = api_path_for_server(server)
+    return f"https://{server}/{api_path}/{issue_id}"
+
+
+def jira_get_json(
+    session: requests.Session,
+    url: str,
+    auth: HTTPBasicAuth,
+) -> dict[str, Any]:
+    """Perform a GET request and return the parsed JSON object."""
+    response = session.get(url, auth=auth, timeout=60.0)
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        msg = f"expected JSON object from {url}"
+        raise ValueError(msg)
+    return data
+
+
+def jira_post_json(
+    session: requests.Session,
+    url: str,
+    auth: HTTPBasicAuth,
+    payload: dict[str, Any],
+) -> None:
+    """Perform a POST request and raise when the response is not successful."""
+    response = session.post(
+        url,
+        auth=auth,
+        json=payload,
+        headers={"Content-Type": "application/json"},
+        timeout=60.0,
+    )
+    response.raise_for_status()

--- a/scripts/python/helpers/test_jira.py
+++ b/scripts/python/helpers/test_jira.py
@@ -1,0 +1,160 @@
+"""Tests for the jira helper module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import jira
+import pytest
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+class TestNormalizeIssueServer:
+    """Test legacy server name normalization."""
+
+    def test_maps_legacy_host(self) -> None:
+        """Convert issues.redhat.com to redhat.atlassian.net."""
+        assert jira.normalize_issue_server("issues.redhat.com") == "redhat.atlassian.net"
+
+    def test_passes_through_other_servers(self) -> None:
+        """Return non-legacy servers unchanged."""
+        assert jira.normalize_issue_server("redhat.atlassian.net") == "redhat.atlassian.net"
+        assert jira.normalize_issue_server("jira.atlassian.com") == "jira.atlassian.com"
+        assert jira.normalize_issue_server("bugzilla.redhat.com") == "bugzilla.redhat.com"
+
+
+class TestApiPathForServer:
+    """Test REST API path resolution from server names."""
+
+    def test_returns_jira_api_path(self) -> None:
+        """Return the Jira REST path for known Jira servers."""
+        assert jira.api_path_for_server("redhat.atlassian.net") == "rest/api/2/issue"
+        assert jira.api_path_for_server("jira.atlassian.com") == "rest/api/2/issue"
+        assert jira.api_path_for_server("issues.redhat.com") == "rest/api/2/issue"
+
+    def test_returns_bugzilla_api_path(self) -> None:
+        """Return the Bugzilla REST path for bugzilla.redhat.com."""
+        assert jira.api_path_for_server("bugzilla.redhat.com") == "rest/bug"
+
+    def test_raises_for_unknown_server(self) -> None:
+        """Raise ValueError for servers not in the tracker map."""
+        with pytest.raises(ValueError, match="no API mapping"):
+            jira.api_path_for_server("example.com")
+
+
+class TestReadJiraCredentials:
+    """Test reading credentials from mounted secret files."""
+
+    def test_reads_email_and_token(self, tmp_path: Path) -> None:
+        """Load email and token from mounted secret files."""
+        (tmp_path / "email").write_text("team@domain.com\n", encoding="utf-8")
+        (tmp_path / "token").write_text("abcdefg\n", encoding="utf-8")
+        assert jira.read_jira_credentials(tmp_path) == ("team@domain.com", "abcdefg")
+
+    def test_rejects_blank_email(self, tmp_path: Path) -> None:
+        """Raise when email is blank."""
+        (tmp_path / "email").write_text(" \n", encoding="utf-8")
+        (tmp_path / "token").write_text("abcdefg\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="must include email and token"):
+            jira.read_jira_credentials(tmp_path)
+
+    def test_rejects_blank_token(self, tmp_path: Path) -> None:
+        """Raise when token is blank."""
+        (tmp_path / "email").write_text("team@domain.com\n", encoding="utf-8")
+        (tmp_path / "token").write_text(" \n", encoding="utf-8")
+        with pytest.raises(ValueError, match="must include email and token"):
+            jira.read_jira_credentials(tmp_path)
+
+
+class TestJiraIssueUrl:
+    """Test API URL construction."""
+
+    def test_builds_atlassian_url(self) -> None:
+        """Build the REST URL for a Jira issue."""
+        assert (
+            jira.jira_issue_url("redhat.atlassian.net", "ISSUE-123")
+            == "https://redhat.atlassian.net/rest/api/2/issue/ISSUE-123"
+        )
+
+    def test_builds_bugzilla_url(self) -> None:
+        """Build the REST URL for a Bugzilla bug."""
+        assert (
+            jira.jira_issue_url("bugzilla.redhat.com", "12345")
+            == "https://bugzilla.redhat.com/rest/bug/12345"
+        )
+
+
+class TestJiraGetJson:
+    """Test authenticated JSON GET requests."""
+
+    def test_returns_parsed_json(self) -> None:
+        """Return the parsed JSON object from a successful response."""
+        session = mock.MagicMock(spec=requests.Session)
+        response = mock.MagicMock()
+        response.json.return_value = {"fields": {"status": {"name": "Open"}}}
+        response.raise_for_status.return_value = None
+        session.get.return_value = response
+        auth = HTTPBasicAuth("user", "token")
+
+        result = jira.jira_get_json(session, "https://example.test/issue", auth)
+        assert result == {"fields": {"status": {"name": "Open"}}}
+        session.get.assert_called_once_with(
+            "https://example.test/issue", auth=auth, timeout=60.0
+        )
+
+    def test_raises_on_non_object_response(self) -> None:
+        """Raise ValueError when the response is not a JSON object."""
+        session = mock.MagicMock(spec=requests.Session)
+        response = mock.MagicMock()
+        response.json.return_value = []
+        response.raise_for_status.return_value = None
+        session.get.return_value = response
+        auth = HTTPBasicAuth("user", "token")
+
+        with pytest.raises(ValueError, match="expected JSON object"):
+            jira.jira_get_json(session, "https://example.test", auth)
+
+    def test_raises_on_http_error(self) -> None:
+        """Propagate HTTP errors from raise_for_status."""
+        session = mock.MagicMock(spec=requests.Session)
+        response = mock.MagicMock()
+        response.raise_for_status.side_effect = requests.HTTPError("401 Unauthorized")
+        session.get.return_value = response
+        auth = HTTPBasicAuth("user", "token")
+
+        with pytest.raises(requests.HTTPError, match="401 Unauthorized"):
+            jira.jira_get_json(session, "https://example.test", auth)
+
+
+class TestJiraPostJson:
+    """Test authenticated JSON POST requests."""
+
+    def test_posts_payload(self) -> None:
+        """POST the payload with correct headers."""
+        session = mock.MagicMock(spec=requests.Session)
+        response = mock.MagicMock()
+        response.raise_for_status.return_value = None
+        session.post.return_value = response
+        auth = HTTPBasicAuth("user", "token")
+
+        jira.jira_post_json(session, "https://example.test/comment", auth, {"body": "hi"})
+        session.post.assert_called_once_with(
+            "https://example.test/comment",
+            auth=auth,
+            json={"body": "hi"},
+            headers={"Content-Type": "application/json"},
+            timeout=60.0,
+        )
+
+    def test_raises_on_http_error(self) -> None:
+        """Propagate HTTP errors from raise_for_status."""
+        session = mock.MagicMock(spec=requests.Session)
+        response = mock.MagicMock()
+        response.raise_for_status.side_effect = requests.HTTPError("bad request")
+        session.post.return_value = response
+        auth = HTTPBasicAuth("user", "token")
+
+        with pytest.raises(requests.HTTPError, match="bad request"):
+            jira.jira_post_json(session, "https://example.test/comment", auth, {"body": "hi"})

--- a/scripts/python/tasks/managed/close_advisory_issues.py
+++ b/scripts/python/tasks/managed/close_advisory_issues.py
@@ -8,40 +8,22 @@ from pathlib import Path
 from typing import Any
 
 import advisory_data
-import authentication
 import file
 import http_client
 import requests
 import tekton
+from jira import (
+    SUPPORTED_JIRA_SERVER,
+    jira_get_json,
+    jira_issue_url,
+    jira_post_json,
+    normalize_issue_server,
+    read_jira_credentials,
+)
 from logger import logger
 from requests.auth import HTTPBasicAuth
 
-SUPPORTED_JIRA_SERVER = "redhat.atlassian.net"
-LEGACY_JIRA_SERVER = "issues.redhat.com"
-
-ISSUE_TRACKERS: dict[str, dict[str, Any]] = {
-    "Jira": {
-        "api": "rest/api/2/issue",
-        "servers": [
-            LEGACY_JIRA_SERVER,
-            "jira.atlassian.com",
-            SUPPORTED_JIRA_SERVER,
-        ],
-    },
-    "bugzilla": {
-        "api": "rest/bug",
-        "servers": ["bugzilla.redhat.com"],
-    },
-}
-
 _VALID_JIRA_ISSUE_ID = re.compile(r"^[A-Za-z][A-Za-z0-9_]+-\d+$|^\d+$")
-
-
-def normalize_issue_server(source: str) -> str:
-    """Map legacy issue tracker hostnames to the current Jira server."""
-    if source == LEGACY_JIRA_SERVER:
-        return SUPPORTED_JIRA_SERVER
-    return source
 
 
 def is_jira_eligible_issue(issue: dict[str, Any]) -> bool:
@@ -58,16 +40,6 @@ def is_jira_eligible_issue(issue: dict[str, Any]) -> bool:
     return _VALID_JIRA_ISSUE_ID.fullmatch(issue_id.strip()) is not None
 
 
-def api_path_for_server(server: str) -> str:
-    """Return the REST API prefix for *server*."""
-    for tracker in ISSUE_TRACKERS.values():
-        servers = tracker.get("servers")
-        if isinstance(servers, list) and server in servers:
-            return str(tracker["api"])
-    msg = f"no API mapping for server: {server}"
-    raise ValueError(msg)
-
-
 def load_fixed_issues(data: dict[str, Any]) -> list[dict[str, Any]]:
     """Return fixed issues from releaseNotes, or an empty list when absent."""
     fixed = advisory_data.content_array_from_decoded(
@@ -80,54 +52,6 @@ def load_fixed_issues(data: dict[str, Any]) -> list[dict[str, Any]]:
 def close_comment(advisory_url: str) -> str:
     """Build the Jira comment posted when an issue is closed."""
     return f"Fixed in Konflux Advisory {advisory_url}"
-
-
-def read_jira_credentials(secret_path: Path) -> tuple[str, str]:
-    """Read Jira basic-auth credentials from mounted secret files."""
-    email = authentication.read_mounted_text(secret_path, "email")
-    token = authentication.read_mounted_text(secret_path, "token")
-    if not email or not token:
-        msg = f"Jira secret at {secret_path} must include email and token"
-        raise ValueError(msg)
-    return email, token
-
-
-def jira_issue_url(server: str, issue_id: str) -> str:
-    """Build the Jira issue API URL for *issue_id* on *server*."""
-    api_path = api_path_for_server(server)
-    return f"https://{server}/{api_path}/{issue_id}"
-
-
-def jira_get_json(
-    session: requests.Session,
-    url: str,
-    auth: HTTPBasicAuth,
-) -> dict[str, Any]:
-    """Perform a GET request and return the parsed JSON object."""
-    response = session.get(url, auth=auth, timeout=60.0)
-    response.raise_for_status()
-    data = response.json()
-    if not isinstance(data, dict):
-        msg = f"expected JSON object from {url}"
-        raise ValueError(msg)
-    return data
-
-
-def jira_post_json(
-    session: requests.Session,
-    url: str,
-    auth: HTTPBasicAuth,
-    payload: dict[str, Any],
-) -> None:
-    """Perform a POST request and raise when the response is not successful."""
-    response = session.post(
-        url,
-        auth=auth,
-        json=payload,
-        headers={"Content-Type": "application/json"},
-        timeout=60.0,
-    )
-    response.raise_for_status()
 
 
 def issue_status_name(issue: dict[str, Any]) -> str:

--- a/scripts/python/tasks/managed/embargo_check.py
+++ b/scripts/python/tasks/managed/embargo_check.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Check if issues or CVEs in releaseNotes are embargoed.
+
+Validates Jira/Bugzilla issues from ``releaseNotes.issues.fixed`` by querying
+their REST APIs, injects a ``public`` boolean into each issue entry, validates
+that Vulnerability-type Jira issues have their CVE listed in the content section,
+and delegates CVE embargo checking to an InternalRequest running
+``check-embargoed-cves``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from pathlib import Path
+from typing import Any
+
+import file
+import http_client
+import requests
+import tekton
+from internal_request import SPAWN_OVERHEAD_SECONDS, InternalRequestWaitError, create
+from internal_request.internal_request import PIPELINERUN_UID_LABEL
+from jira import (
+    SUPPORTED_JIRA_SERVER,
+    jira_issue_url,
+    normalize_issue_server,
+    read_jira_credentials,
+)
+from logger import logger
+from requests.auth import HTTPBasicAuth
+from subprocess_cmd import run_cmd
+
+PROG = "embargo_check.py"
+
+CVE_FIELD = "customfield_10667"
+
+MAX_JIRA_404_RETRIES = 3
+
+
+def _get_with_jira_404_retry(
+    session: requests.Session,
+    url: str,
+    auth: HTTPBasicAuth,
+) -> dict[str, Any]:
+    """GET a Jira URL, retrying on transient 404s (RELEASE-2386).
+
+    Jira Cloud occasionally returns spurious 404 responses for issues that
+    exist.  This wrapper retries those with exponential backoff and jitter,
+    then returns the parsed JSON object (matching the ``jira_get_json``
+    contract).  Rate-limit (429) and server-error retries are handled by the
+    session's urllib3 Retry adapter.
+    """
+    retries = 0
+    while True:
+        resp = session.get(url, auth=auth, timeout=60.0)
+        if resp.status_code == 404:
+            retries += 1
+            if retries < MAX_JIRA_404_RETRIES:
+                delay = 1.0 * (2 ** (retries - 1)) + random.randint(0, 2)
+                logger.warning(
+                    "Received 404 for %s (attempt %d/%d), retrying in %.1fs",
+                    url,
+                    retries,
+                    MAX_JIRA_404_RETRIES,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+        resp.raise_for_status()
+        data = resp.json()
+        if not isinstance(data, dict):
+            msg = f"expected JSON object from {url}"
+            raise ValueError(msg)
+        return data
+
+
+def _get_content_items(data: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """Return the content items list from releaseNotes, or None if absent.
+
+    Checks ``images`` first, then ``artifacts``.  Returns the list even when
+    empty (an empty list is valid content); returns ``None`` only when neither
+    key is present.
+    """
+    release_notes = data.get("releaseNotes", {})
+    content = release_notes.get("content", {})
+    if content.get("images") is not None:
+        return content["images"]
+    if content.get("artifacts") is not None:
+        return content["artifacts"]
+    return None
+
+
+def _extract_cves(data: dict[str, Any]) -> list[str]:
+    """Extract unique CVE IDs from releaseNotes.content."""
+    items = _get_content_items(data)
+    if items is None:
+        return []
+    cves: set[str] = set()
+    for item in items:
+        fixed = item.get("cves", {}).get("fixed", {})
+        cves.update(fixed.keys())
+    return sorted(cves)
+
+
+def _check_issue_visibility(session: requests.Session, url: str) -> bool:
+    """Return True if the issue is accessible without authentication."""
+    try:
+        resp = session.get(url, auth=None, timeout=60.0)
+        resp.raise_for_status()
+        return True
+    except requests.RequestException:
+        return False
+
+
+def _process_issue(
+    issue: dict[str, Any],
+    *,
+    session: requests.Session,
+    auth: HTTPBasicAuth,
+    content_items: list[dict[str, Any]] | None,
+) -> str | None:
+    """Validate a single issue and inject the ``public`` key.
+
+    Return an error message if the issue fails validation, or ``None`` on
+    success.  The *issue* dict is mutated in place to add the ``public`` key.
+    """
+    server = normalize_issue_server(issue.get("source", ""))
+    issue_id = issue.get("id", "")
+
+    try:
+        api_url = jira_issue_url(server, issue_id)
+    except ValueError:
+        return (
+            f"Error: {issue_id} uses unsupported issue tracker '{server}'. "
+            "Cannot verify embargo status; assuming embargoed."
+        )
+
+    try:
+        if server == SUPPORTED_JIRA_SERVER:
+            output = _get_with_jira_404_retry(session, api_url, auth)
+        else:
+            resp = session.get(api_url, auth=None, timeout=60.0)
+            resp.raise_for_status()
+            output = resp.json()
+            if not isinstance(output, dict):
+                return (
+                    f"Error: {issue_id} returned unexpected JSON from {api_url}. "
+                    "Cannot verify embargo status; assuming embargoed."
+                )
+    except requests.RequestException:
+        return (
+            f"Error: {issue_id} is not visible. "
+            "Assuming it is embargoed and stopping pipelineRun execution."
+        )
+
+    public = False
+    security_value = output.get("fields", {}).get("security")
+    if security_value is None:
+        if server == SUPPORTED_JIRA_SERVER:
+            public = _check_issue_visibility(session, api_url)
+        else:
+            public = True
+
+    issue["public"] = public
+
+    if server != SUPPORTED_JIRA_SERVER:
+        return None
+
+    issue_type = (output.get("fields") or {}).get("issuetype", {}).get("name", "")
+    if issue_type != "Vulnerability":
+        return None
+
+    if content_items is None:
+        logger.info("No content found under releaseNotes.content.images or .artifacts;")
+        return None
+
+    cve_id = (output.get("fields") or {}).get(CVE_FIELD, "")
+    cve_found = any(
+        cve_id in (item.get("cves", {}).get("fixed", {})) for item in content_items
+    )
+    if not cve_found:
+        return (
+            f"Error: Issue {issue_id} lists 'CVE ID' {cve_id} "
+            f"but that CVE is not present in the releaseNotes.content section "
+            f"for any image or artifact. This is likely due to CVE {cve_id} "
+            f"not being provided in the releaseNotes.cves part of your Release object."
+        )
+
+    return None
+
+
+def check_issues(
+    data: dict[str, Any],
+    *,
+    secret_path: Path,
+    session: requests.Session,
+) -> tuple[dict[str, Any], list[str]]:
+    """Validate issues and inject the ``public`` key.
+
+    Return the modified data dict and a list of error messages.
+    """
+    issues = (data.get("releaseNotes") or {}).get("issues", {}).get("fixed", [])
+    if not issues:
+        return data, []
+
+    email, token = read_jira_credentials(secret_path)
+    auth = HTTPBasicAuth(email, token)
+    content_items = _get_content_items(data)
+
+    errors: list[str] = []
+    for issue in issues:
+        error = _process_issue(
+            issue,
+            session=session,
+            auth=auth,
+            content_items=content_items,
+        )
+        if error:
+            errors.append(error)
+
+    return data, errors
+
+
+def _format_timeout(seconds: int) -> str:
+    """Format seconds as HHhMMmSSs for Tekton timeouts."""
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+    secs = seconds % 60
+    return f"{hours:02d}h{minutes:02d}m{secs:02d}s"
+
+
+def check_cves(
+    data: dict[str, Any],
+    *,
+    pipeline_run_uid: str,
+    request_timeout: int,
+    task_git_url: str,
+    task_git_revision: str,
+) -> list[str]:
+    """Check CVEs for embargo status via an InternalRequest.
+
+    Return a list of error messages (empty on success).
+    """
+    cves = _extract_cves(data)
+    if not cves:
+        logger.info("No CVEs found to check")
+        return []
+
+    cves_str = " ".join(cves)
+    logger.info("Checking the following CVEs: %s", cves_str)
+
+    pipeline_timeout = _format_timeout(request_timeout + SPAWN_OVERHEAD_SECONDS)
+    task_timeout = _format_timeout(request_timeout)
+    wait_timeout = request_timeout + SPAWN_OVERHEAD_SECONDS
+
+    try:
+        ir_name = create(
+            "check-embargoed-cves",
+            params={
+                "cves": cves_str,
+                "taskGitUrl": task_git_url,
+                "taskGitRevision": task_git_revision,
+            },
+            labels={PIPELINERUN_UID_LABEL: pipeline_run_uid},
+            sync=True,
+            timeout=wait_timeout,
+            pipeline_timeout=pipeline_timeout,
+            task_timeout=task_timeout,
+        )
+    except InternalRequestWaitError as e:
+        return [f"internal-request failed: {e}"]
+
+    logger.info("done (%s)", ir_name)
+
+    result = run_cmd(
+        [
+            "kubectl",
+            "get",
+            "internalrequest",
+            ir_name,
+            "-o=jsonpath={.status.results}",
+        ],
+        check=True,
+    )
+
+    try:
+        results = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return [f"Could not parse InternalRequest results: {result.stdout.strip()}"]
+
+    if results.get("result") == "Success":
+        logger.info("No embargoed CVEs found")
+        return []
+
+    embargoed = results.get("embargoed_cves", "")
+    return [f"The following CVEs are marked as embargoed: {embargoed}"]
+
+
+def run(
+    data_file: Path,
+    *,
+    secret_path: Path,
+    pipeline_run_uid: str,
+    request_timeout: int,
+    task_git_url: str,
+    task_git_revision: str,
+) -> None:
+    """Orchestrate the embargo check: validate issues and check CVEs."""
+    if not data_file.is_file():
+        raise RuntimeError("No data JSON was provided.")
+
+    data = file.load_json_dict(data_file)
+
+    session = http_client.get_retry_session(
+        total=5,
+        connect=3,
+        read=3,
+        status=5,
+        backoff_factor=1.0,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=frozenset({"GET"}),
+    )
+
+    data, issue_errors = check_issues(
+        data,
+        secret_path=secret_path,
+        session=session,
+    )
+
+    data_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    if issue_errors:
+        for err in issue_errors:
+            logger.error(err)
+        raise RuntimeError("\n".join(issue_errors))
+
+    cve_errors = check_cves(
+        data,
+        pipeline_run_uid=pipeline_run_uid,
+        request_timeout=request_timeout,
+        task_git_url=task_git_url,
+        task_git_revision=task_git_revision,
+    )
+
+    if cve_errors:
+        for err in cve_errors:
+            logger.error(err)
+        raise RuntimeError("\n".join(cve_errors))
+
+
+def main() -> int:
+    """Read environment variables and execute the embargo check."""
+    data_file_str = tekton.require_env("DATA_FILE")
+    secret_path = file.path_from_env_variable("JIRA_SECRET_PATH", "/etc/secrets")
+    pipeline_run_uid = tekton.require_env("PIPELINE_RUN_UID")
+    request_timeout = int(os.environ.get("REQUEST_TIMEOUT", "2700").strip())
+    task_git_url = tekton.require_env("TASK_GIT_URL")
+    task_git_revision = tekton.require_env("TASK_GIT_REVISION")
+
+    run(
+        Path(data_file_str),
+        secret_path=secret_path,
+        pipeline_run_uid=pipeline_run_uid,
+        request_timeout=request_timeout,
+        task_git_url=task_git_url,
+        task_git_revision=task_git_revision,
+    )
+
+    logger.info("embargo-check completed successfully")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_close_advisory_issues.py
+++ b/scripts/python/tasks/managed/test_close_advisory_issues.py
@@ -45,14 +45,6 @@ def _fixed_issue(
     return {"id": issue_id, "source": source}
 
 
-def test_normalize_issue_server_maps_legacy_host() -> None:
-    """Convert issues.redhat.com to redhat.atlassian.net."""
-    assert (
-        close_advisory_issues.normalize_issue_server("issues.redhat.com")
-        == "redhat.atlassian.net"
-    )
-
-
 def test_is_jira_eligible_issue_accepts_eligible_rows() -> None:
     """Return true for supported Jira fixed-issue rows."""
     assert close_advisory_issues.is_jira_eligible_issue(_fixed_issue("ISSUE-123"))
@@ -133,22 +125,6 @@ def test_closed_transition_id_ignores_invalid_entries() -> None:
     }
     assert close_advisory_issues.closed_transition_id(payload) == "91"
     assert close_advisory_issues.closed_transition_id({"transitions": "bad"}) is None
-
-
-def test_jira_get_json_returns_object_payload() -> None:
-    """Return parsed JSON objects from successful GET responses."""
-    session = mock.MagicMock()
-    response = mock.MagicMock()
-    response.json.return_value = {"fields": {"status": {"name": "Open"}}}
-    response.raise_for_status.return_value = None
-    session.get.return_value = response
-    auth = HTTPBasicAuth("user", "token")
-    payload = close_advisory_issues.jira_get_json(
-        session,
-        "https://example.test/issue",
-        auth,
-    )
-    assert payload["fields"]["status"]["name"] == "Open"
 
 
 def test_close_issue_with_comment_posts_transition_payload() -> None:
@@ -331,40 +307,6 @@ def test_close_comment_includes_advisory_url() -> None:
     assert close_advisory_issues.close_comment(url) == (f"Fixed in Konflux Advisory {url}")
 
 
-def test_read_jira_credentials_reads_secret_files(tmp_path: Path) -> None:
-    """Load email and token from mounted secret files."""
-    _write_jira_secret(tmp_path)
-    assert close_advisory_issues.read_jira_credentials(tmp_path) == (
-        "team@domain.com",
-        "abcdefg",
-    )
-
-
-def test_read_jira_credentials_rejects_blank_values(tmp_path: Path) -> None:
-    """Reject secrets when email or token is blank."""
-    _write_jira_secret(tmp_path)
-    (tmp_path / "email").write_text(" \n", encoding="utf-8")
-    with pytest.raises(ValueError, match="must include email and token"):
-        close_advisory_issues.read_jira_credentials(tmp_path)
-
-
-def test_jira_issue_url_builds_atlassian_api_url() -> None:
-    """Build the REST URL for a Jira issue id."""
-    assert (
-        close_advisory_issues.jira_issue_url(
-            "redhat.atlassian.net",
-            "ISSUE-123",
-        )
-        == "https://redhat.atlassian.net/rest/api/2/issue/ISSUE-123"
-    )
-
-
-def test_api_path_for_server_rejects_unknown_host() -> None:
-    """Raise when no tracker mapping exists for the server."""
-    with pytest.raises(ValueError, match="no API mapping"):
-        close_advisory_issues.api_path_for_server("example.com")
-
-
 def test_issue_status_name_reads_nested_field() -> None:
     """Extract the status name from a Jira issue payload."""
     issue = {"fields": {"status": {"name": "Closed"}}}
@@ -385,18 +327,6 @@ def test_closed_transition_id_returns_closed_id() -> None:
 def test_closed_transition_id_returns_none_when_missing() -> None:
     """Return None when no Closed transition exists."""
     assert close_advisory_issues.closed_transition_id({"transitions": []}) is None
-
-
-def test_jira_get_json_rejects_non_object_payload() -> None:
-    """Raise when the response body is not a JSON object."""
-    session = mock.MagicMock()
-    response = mock.MagicMock()
-    response.json.return_value = []
-    response.raise_for_status.return_value = None
-    session.get.return_value = response
-    auth = HTTPBasicAuth("user", "token")
-    with pytest.raises(ValueError, match="expected JSON object"):
-        close_advisory_issues.jira_get_json(session, "https://example.test", auth)
 
 
 def test_process_fixed_issue_skips_invalid_jira_issue_id(
@@ -734,22 +664,6 @@ def test_close_advisory_issues_reraises_first_failure_only(
                 secret_path=tmp_path / "secrets",
             )
     assert process_issue.call_count == 2
-
-
-def test_jira_post_json_raises_on_http_error() -> None:
-    """Raise when a Jira POST response is not successful."""
-    session = mock.MagicMock()
-    response = mock.MagicMock()
-    response.raise_for_status.side_effect = requests.HTTPError("bad request")
-    session.post.return_value = response
-    auth = HTTPBasicAuth("user", "token")
-    with pytest.raises(requests.HTTPError, match="bad request"):
-        close_advisory_issues.jira_post_json(
-            session,
-            "https://example.test/comment",
-            auth,
-            {"body": "hello"},
-        )
 
 
 def test_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/scripts/python/tasks/managed/test_embargo_check.py
+++ b/scripts/python/tasks/managed/test_embargo_check.py
@@ -1,0 +1,796 @@
+"""Tests for embargo_check task logic."""
+
+from __future__ import annotations
+
+import json
+import runpy
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import embargo_check
+import pytest
+import requests
+from internal_request import InternalRequestWaitError
+
+
+def _write_data(path: Path, data: dict[str, Any]) -> None:
+    """Write *data* as JSON to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _write_jira_secret(path: Path) -> None:
+    """Write dummy Jira credentials under *path*."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "email").write_text("team@domain.com\n", encoding="utf-8")
+    (path / "token").write_text("abcdefg\n", encoding="utf-8")
+
+
+@pytest.fixture()
+def jira_secret_path(tmp_path: Path) -> Path:
+    """Write dummy Jira credentials and return the secret directory."""
+    secret_dir = tmp_path / "secrets"
+    _write_jira_secret(secret_dir)
+    return secret_dir
+
+
+def _mock_jira_response(json_data: dict[str, Any]) -> mock.MagicMock:
+    """Build a mock requests.Response with status 200 and *json_data*."""
+    response = mock.MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.json.return_value = json_data
+    return response
+
+
+def _data_with_issues(
+    issues: list[dict[str, Any]],
+    content_type: str = "images",
+    content_items: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal data dict with fixed issues and optional content."""
+    data: dict[str, Any] = {
+        "releaseNotes": {
+            "issues": {"fixed": issues},
+            "content": {},
+        },
+    }
+    if content_items is not None:
+        data["releaseNotes"]["content"][content_type] = content_items
+    return data
+
+
+def _data_with_cves(
+    cve_ids: list[str],
+    content_type: str = "images",
+) -> dict[str, Any]:
+    """Build a minimal data dict with CVEs in content."""
+    items = [{"cves": {"fixed": {cve: {} for cve in cve_ids}}}]
+    return {
+        "releaseNotes": {
+            "issues": {},
+            "content": {content_type: items},
+        },
+    }
+
+
+class TestGetContentItems:
+    """Test _get_content_items."""
+
+    def test_returns_images(self) -> None:
+        """Return images list when images content exists."""
+        data = {"releaseNotes": {"content": {"images": [{"name": "img1"}]}}}
+        assert embargo_check._get_content_items(data) == [{"name": "img1"}]
+
+    def test_returns_artifacts(self) -> None:
+        """Return artifacts list when only artifacts content exists."""
+        data = {"releaseNotes": {"content": {"artifacts": [{"name": "art1"}]}}}
+        assert embargo_check._get_content_items(data) == [{"name": "art1"}]
+
+    def test_returns_empty_list_for_empty_content(self) -> None:
+        """Return empty list when the key exists but is empty."""
+        data = {"releaseNotes": {"content": {"images": []}}}
+        assert embargo_check._get_content_items(data) == []
+
+    def test_returns_none(self) -> None:
+        """Return None when no content exists."""
+        assert embargo_check._get_content_items({}) is None
+        assert embargo_check._get_content_items({"releaseNotes": {}}) is None
+        assert embargo_check._get_content_items({"releaseNotes": {"content": {}}}) is None
+
+
+class TestExtractCves:
+    """Test _extract_cves."""
+
+    def test_extracts_cves_from_images(self) -> None:
+        """Extract unique CVE IDs from images content."""
+        data = _data_with_cves(["CVE-2024-001", "CVE-2024-002"])
+        assert embargo_check._extract_cves(data) == ["CVE-2024-001", "CVE-2024-002"]
+
+    def test_extracts_cves_from_artifacts(self) -> None:
+        """Extract unique CVE IDs from artifacts content."""
+        data = _data_with_cves(["CVE-2024-001"], content_type="artifacts")
+        assert embargo_check._extract_cves(data) == ["CVE-2024-001"]
+
+    def test_returns_empty_no_content(self) -> None:
+        """Return empty list when no content exists."""
+        assert embargo_check._extract_cves({}) == []
+
+    def test_deduplicates_cves(self) -> None:
+        """Return unique sorted CVEs."""
+        data = {
+            "releaseNotes": {
+                "content": {
+                    "images": [
+                        {"cves": {"fixed": {"CVE-2024-001": {}}}},
+                        {"cves": {"fixed": {"CVE-2024-001": {}, "CVE-2024-002": {}}}},
+                    ],
+                },
+            },
+        }
+        assert embargo_check._extract_cves(data) == ["CVE-2024-001", "CVE-2024-002"]
+
+
+class TestCheckIssueVisibility:
+    """Test _check_issue_visibility."""
+
+    def test_returns_true_on_success(self) -> None:
+        """Return True when GET succeeds with 2xx."""
+        session = mock.MagicMock(spec=requests.Session)
+        success = mock.MagicMock()
+        success.status_code = 200
+        session.get.return_value = success
+        assert embargo_check._check_issue_visibility(session, "https://example.test") is True
+
+    def test_returns_false_on_non_2xx(self) -> None:
+        """Return False when GET returns non-2xx."""
+        session = mock.MagicMock(spec=requests.Session)
+        unauthorized = mock.MagicMock()
+        unauthorized.status_code = 401
+        unauthorized.raise_for_status.side_effect = requests.HTTPError("401")
+        session.get.return_value = unauthorized
+        assert embargo_check._check_issue_visibility(session, "https://example.test") is False
+
+    def test_returns_false_on_exception(self) -> None:
+        """Return False when GET raises an exception."""
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.side_effect = requests.ConnectionError("timeout")
+        assert embargo_check._check_issue_visibility(session, "https://example.test") is False
+
+
+class TestGetWithJira404Retry:
+    """Test _get_with_jira_404_retry."""
+
+    @mock.patch("embargo_check.time.sleep")
+    def test_retries_on_transient_404(self, mock_sleep: mock.MagicMock) -> None:
+        """Retry on 404 and succeed on next attempt."""
+        session = mock.MagicMock(spec=requests.Session)
+        auth = mock.MagicMock()
+        not_found = mock.MagicMock()
+        not_found.status_code = 404
+        success = mock.MagicMock()
+        success.status_code = 200
+        expected = {"fields": {"security": None}}
+        success.json.return_value = expected
+        session.get.side_effect = [not_found, success]
+
+        result = embargo_check._get_with_jira_404_retry(
+            session, "https://jira.test/issue/X-1", auth
+        )
+        assert result == expected
+        assert session.get.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @mock.patch("embargo_check.time.sleep")
+    def test_raises_after_exhausting_404_retries(self, mock_sleep: mock.MagicMock) -> None:
+        """Raise HTTPError when all retry attempts return 404."""
+        session = mock.MagicMock(spec=requests.Session)
+        auth = mock.MagicMock()
+        not_found = mock.MagicMock()
+        not_found.status_code = 404
+        not_found.raise_for_status.side_effect = requests.HTTPError("404")
+        session.get.return_value = not_found
+
+        with pytest.raises(requests.HTTPError):
+            embargo_check._get_with_jira_404_retry(
+                session, "https://jira.test/issue/X-1", auth
+            )
+        assert session.get.call_count == embargo_check.MAX_JIRA_404_RETRIES
+
+    def test_no_retry_on_non_retryable_error(self) -> None:
+        """Do not retry when status is not 404."""
+        session = mock.MagicMock(spec=requests.Session)
+        auth = mock.MagicMock()
+        forbidden = mock.MagicMock()
+        forbidden.status_code = 403
+        forbidden.raise_for_status.side_effect = requests.HTTPError("403")
+        session.get.return_value = forbidden
+
+        with pytest.raises(requests.HTTPError):
+            embargo_check._get_with_jira_404_retry(
+                session, "https://jira.test/issue/X-1", auth
+            )
+        assert session.get.call_count == 1
+
+    def test_returns_immediately_on_success(self) -> None:
+        """Return parsed JSON on 200 without retrying."""
+        session = mock.MagicMock(spec=requests.Session)
+        auth = mock.MagicMock()
+        success = mock.MagicMock()
+        success.status_code = 200
+        expected = {"fields": {"security": None}}
+        success.json.return_value = expected
+        session.get.return_value = success
+
+        result = embargo_check._get_with_jira_404_retry(
+            session, "https://jira.test/issue/X-1", auth
+        )
+        assert result == expected
+        assert session.get.call_count == 1
+
+    def test_raises_on_non_dict_json(self) -> None:
+        """Raise ValueError when Jira returns non-dict JSON."""
+        session = mock.MagicMock(spec=requests.Session)
+        auth = mock.MagicMock()
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = ["not", "a", "dict"]
+        session.get.return_value = resp
+
+        with pytest.raises(ValueError, match="expected JSON object"):
+            embargo_check._get_with_jira_404_retry(
+                session, "https://jira.test/issue/X-1", auth
+            )
+
+
+class TestFormatTimeout:
+    """Test _format_timeout."""
+
+    def test_formats_seconds_only(self) -> None:
+        """Format 45 seconds as 00h00m45s."""
+        assert embargo_check._format_timeout(45) == "00h00m45s"
+
+    def test_formats_minutes_and_seconds(self) -> None:
+        """Format 3000 seconds as 00h50m00s."""
+        assert embargo_check._format_timeout(3000) == "00h50m00s"
+
+    def test_formats_hours(self) -> None:
+        """Format 3661 seconds as 01h01m01s."""
+        assert embargo_check._format_timeout(3661) == "01h01m01s"
+
+
+class TestCheckIssues:
+    """Test check_issues function."""
+
+    def test_no_issues(self, jira_secret_path: Path) -> None:
+        """Return empty errors when no issues exist."""
+        data: dict[str, Any] = {"releaseNotes": {"issues": {}}}
+        session = mock.MagicMock(spec=requests.Session)
+        result_data, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert errors == []
+        assert result_data == data
+
+    def test_jira_issue_visible_public(self, jira_secret_path: Path) -> None:
+        """Mark issue as public when security is null and unauthenticated access works."""
+        data = _data_with_issues([{"id": "ISSUE-123", "source": "redhat.atlassian.net"}])
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_jira_response(
+            {"fields": {"security": None, "issuetype": {"name": "Bug"}}}
+        )
+
+        result_data, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert errors == []
+        assert result_data["releaseNotes"]["issues"]["fixed"][0]["public"] is True
+
+    def test_jira_issue_not_public(self, jira_secret_path: Path) -> None:
+        """Mark issue as not public when security field has a value."""
+        data = _data_with_issues([{"id": "ISSUE-123", "source": "redhat.atlassian.net"}])
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_jira_response(
+            {"fields": {"security": {"name": "Red Hat"}, "issuetype": {"name": "Bug"}}}
+        )
+
+        result_data, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert errors == []
+        assert result_data["releaseNotes"]["issues"]["fixed"][0]["public"] is False
+
+    def test_jira_issue_not_visible(self, jira_secret_path: Path) -> None:
+        """Return error when issue is not visible."""
+        data = _data_with_issues([{"id": "ISSUE-123", "source": "redhat.atlassian.net"}])
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.side_effect = requests.HTTPError("401 Unauthorized")
+
+        _, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert len(errors) == 1
+        assert "not visible" in errors[0]
+
+    def test_bugzilla_issue_not_visible(self, jira_secret_path: Path) -> None:
+        """Return error when Bugzilla issue is not visible."""
+        data = _data_with_issues([{"id": "12345", "source": "bugzilla.redhat.com"}])
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.side_effect = requests.HTTPError("404")
+
+        _, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert len(errors) == 1
+        assert "not visible" in errors[0]
+
+    def test_bugzilla_issue_visible(self, jira_secret_path: Path) -> None:
+        """Mark Bugzilla issue as public=False (security field check)."""
+        data = _data_with_issues([{"id": "12345", "source": "bugzilla.redhat.com"}])
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_jira_response(
+            {"fields": {"security": {"name": "embargo"}}}
+        )
+
+        result_data, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert errors == []
+        assert result_data["releaseNotes"]["issues"]["fixed"][0]["public"] is False
+
+    def test_bugzilla_issue_null_security_is_public(self, jira_secret_path: Path) -> None:
+        """Mark Bugzilla issue as public when security is null."""
+        data = _data_with_issues([{"id": "12345", "source": "bugzilla.redhat.com"}])
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_jira_response({"fields": {"security": None}})
+
+        result_data, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert errors == []
+        assert result_data["releaseNotes"]["issues"]["fixed"][0]["public"] is True
+        assert session.get.call_count == 1
+
+    def test_bugzilla_non_dict_json_returns_error(self, jira_secret_path: Path) -> None:
+        """Return error when a non-Jira server responds with non-dict JSON."""
+        data = _data_with_issues([{"id": "12345", "source": "bugzilla.redhat.com"}])
+        session = mock.MagicMock(spec=requests.Session)
+        response = mock.MagicMock()
+        response.status_code = 200
+        response.raise_for_status.return_value = None
+        response.json.return_value = []
+        session.get.return_value = response
+
+        _, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert len(errors) == 1
+        assert "returned unexpected JSON" in errors[0]
+
+    def test_issues_redhat_com_normalized(self, jira_secret_path: Path) -> None:
+        """Normalize issues.redhat.com to redhat.atlassian.net."""
+        data = _data_with_issues([{"id": "ISSUE-123", "source": "issues.redhat.com"}])
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_jira_response(
+            {"fields": {"security": {"name": "Red Hat"}, "issuetype": {"name": "Bug"}}}
+        )
+
+        result_data, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert errors == []
+        session.get.assert_called_once()
+        call_url = session.get.call_args[0][0]
+        assert "redhat.atlassian.net" in call_url
+
+    def test_vulnerability_cve_present(self, jira_secret_path: Path) -> None:
+        """No error when Vulnerability issue CVE is in content."""
+        data = _data_with_issues(
+            [{"id": "VULN-123", "source": "redhat.atlassian.net"}],
+            content_type="images",
+            content_items=[{"cves": {"fixed": {"CVE-2024-001": {}}}}],
+        )
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_jira_response(
+            {
+                "fields": {
+                    "security": {"name": "public"},
+                    "issuetype": {"name": "Vulnerability"},
+                    "customfield_10667": "CVE-2024-001",
+                },
+            }
+        )
+
+        _, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert errors == []
+
+    def test_vulnerability_cve_missing(self, jira_secret_path: Path) -> None:
+        """Error when Vulnerability issue CVE is not in content."""
+        data = _data_with_issues(
+            [{"id": "VULN-123", "source": "redhat.atlassian.net"}],
+            content_type="images",
+            content_items=[{"cves": {"fixed": {"CVE-OTHER": {}}}}],
+        )
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_jira_response(
+            {
+                "fields": {
+                    "security": {"name": "public"},
+                    "issuetype": {"name": "Vulnerability"},
+                    "customfield_10667": "CVE-2024-001",
+                },
+            }
+        )
+
+        _, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert len(errors) == 1
+        assert "CVE-2024-001" in errors[0]
+
+    def test_vulnerability_no_content(self, jira_secret_path: Path) -> None:
+        """No error when Vulnerability but no content section."""
+        data = _data_with_issues(
+            [{"id": "VULN-123", "source": "redhat.atlassian.net"}],
+        )
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_jira_response(
+            {
+                "fields": {
+                    "security": {"name": "public"},
+                    "issuetype": {"name": "Vulnerability"},
+                    "customfield_10667": "CVE-2024-001",
+                },
+            }
+        )
+
+        _, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert errors == []
+
+    def test_unknown_server_errors(self, jira_secret_path: Path) -> None:
+        """Fail closed for issues from unknown servers."""
+        data = _data_with_issues([{"id": "ISSUE-123", "source": "unknown.example.com"}])
+        session = mock.MagicMock(spec=requests.Session)
+        _, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert len(errors) == 1
+        assert "unsupported issue tracker" in errors[0]
+        session.get.assert_not_called()
+
+    def test_non_vulnerability_skips_cve_check(self, jira_secret_path: Path) -> None:
+        """Non-vulnerability issues skip CVE validation."""
+        data = _data_with_issues(
+            [{"id": "ISSUE-123", "source": "redhat.atlassian.net"}],
+            content_type="images",
+            content_items=[{"cves": {"fixed": {"CVE-2024-001": {}}}}],
+        )
+        session = mock.MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_jira_response(
+            {
+                "fields": {
+                    "security": {"name": "public"},
+                    "issuetype": {"name": "Bug"},
+                },
+            }
+        )
+
+        _, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert errors == []
+
+    def test_empty_fixed_list(self, jira_secret_path: Path) -> None:
+        """Return empty errors when fixed list is empty."""
+        data = _data_with_issues([])
+        session = mock.MagicMock(spec=requests.Session)
+        _, errors = embargo_check.check_issues(
+            data, secret_path=jira_secret_path, session=session
+        )
+        assert errors == []
+
+
+def _kubectl_result(stdout: str) -> subprocess.CompletedProcess[str]:
+    """Build a CompletedProcess mimicking run_cmd output."""
+    return subprocess.CompletedProcess(args=["kubectl"], returncode=0, stdout=stdout)
+
+
+class TestCheckCves:
+    """Test check_cves function."""
+
+    def test_no_cves(self) -> None:
+        """Return empty errors when no CVEs exist."""
+        data: dict[str, Any] = {"releaseNotes": {"content": {}}}
+        errors = embargo_check.check_cves(
+            data,
+            pipeline_run_uid="uid-123",
+            request_timeout=2700,
+            task_git_url="https://github.com/test/repo",
+            task_git_revision="main",
+        )
+        assert errors == []
+
+    @mock.patch("embargo_check.create")
+    def test_internal_request_fails(self, mock_create: mock.MagicMock) -> None:
+        """Return error when internal-request creation or wait fails."""
+        data = _data_with_cves(["CVE-2024-001"])
+        mock_create.side_effect = InternalRequestWaitError(
+            "At least one InternalRequest failed", 21
+        )
+        errors = embargo_check.check_cves(
+            data,
+            pipeline_run_uid="uid-123",
+            request_timeout=2700,
+            task_git_url="https://github.com/test/repo",
+            task_git_revision="main",
+        )
+        assert len(errors) == 1
+        assert "internal-request failed" in errors[0]
+
+    @mock.patch("embargo_check.run_cmd")
+    @mock.patch("embargo_check.create", return_value="ir-abc")
+    def test_kubectl_invalid_json(
+        self,
+        mock_create: mock.MagicMock,
+        mock_run: mock.MagicMock,
+    ) -> None:
+        """Return error when kubectl output is not valid JSON."""
+        data = _data_with_cves(["CVE-2024-001"])
+        mock_run.return_value = _kubectl_result("not json")
+        errors = embargo_check.check_cves(
+            data,
+            pipeline_run_uid="uid-123",
+            request_timeout=2700,
+            task_git_url="https://github.com/test/repo",
+            task_git_revision="main",
+        )
+        assert len(errors) == 1
+        assert "Could not parse InternalRequest results" in errors[0]
+
+    @mock.patch("embargo_check.run_cmd")
+    @mock.patch("embargo_check.create", return_value="ir-abc")
+    def test_success_no_embargoed_cves(
+        self,
+        mock_create: mock.MagicMock,
+        mock_run: mock.MagicMock,
+    ) -> None:
+        """Return empty errors when result is Success."""
+        data = _data_with_cves(["CVE-2024-001"])
+        mock_run.return_value = _kubectl_result(json.dumps({"result": "Success"}))
+        errors = embargo_check.check_cves(
+            data,
+            pipeline_run_uid="uid-123",
+            request_timeout=2700,
+            task_git_url="https://github.com/test/repo",
+            task_git_revision="main",
+        )
+        assert errors == []
+
+    @mock.patch("embargo_check.run_cmd")
+    @mock.patch("embargo_check.create", return_value="ir-abc")
+    def test_embargoed_cves_found(
+        self,
+        mock_create: mock.MagicMock,
+        mock_run: mock.MagicMock,
+    ) -> None:
+        """Return error listing embargoed CVEs."""
+        data = _data_with_cves(["CVE-2024-001", "CVE-2024-002"])
+        mock_run.return_value = _kubectl_result(
+            json.dumps({"result": "Failure", "embargoed_cves": "CVE-2024-001"})
+        )
+        errors = embargo_check.check_cves(
+            data,
+            pipeline_run_uid="uid-123",
+            request_timeout=2700,
+            task_git_url="https://github.com/test/repo",
+            task_git_revision="main",
+        )
+        assert len(errors) == 1
+        assert "CVE-2024-001" in errors[0]
+
+    @mock.patch("embargo_check.run_cmd")
+    @mock.patch("embargo_check.create", return_value="ir-abc")
+    def test_create_called_with_correct_args(
+        self,
+        mock_create: mock.MagicMock,
+        mock_run: mock.MagicMock,
+    ) -> None:
+        """Verify correct arguments are passed to internal_request.create."""
+        data = _data_with_cves(["CVE-2024-001"])
+        mock_run.return_value = _kubectl_result(json.dumps({"result": "Success"}))
+        embargo_check.check_cves(
+            data,
+            pipeline_run_uid="uid-123",
+            request_timeout=2700,
+            task_git_url="https://github.com/test/repo",
+            task_git_revision="v1",
+        )
+        mock_create.assert_called_once_with(
+            "check-embargoed-cves",
+            params={
+                "cves": "CVE-2024-001",
+                "taskGitUrl": "https://github.com/test/repo",
+                "taskGitRevision": "v1",
+            },
+            labels={
+                "internal-services.appstudio.openshift.io/pipelinerun-uid": "uid-123",
+            },
+            sync=True,
+            timeout=3000,
+            pipeline_timeout="00h50m00s",
+            task_timeout="00h45m00s",
+        )
+
+
+class TestRun:
+    """Test the run() orchestrator."""
+
+    def test_missing_data_file(self, tmp_path: Path) -> None:
+        """Raise RuntimeError when data file is missing."""
+        _write_jira_secret(tmp_path / "secrets")
+        with pytest.raises(RuntimeError, match="No data JSON"):
+            embargo_check.run(
+                tmp_path / "missing.json",
+                secret_path=tmp_path / "secrets",
+                pipeline_run_uid="uid",
+                request_timeout=2700,
+                task_git_url="https://example.test",
+                task_git_revision="main",
+            )
+
+    @mock.patch("embargo_check.check_cves", return_value=[])
+    @mock.patch("embargo_check.check_issues")
+    @mock.patch("embargo_check.http_client.get_retry_session")
+    def test_success(
+        self,
+        mock_session: mock.MagicMock,
+        mock_check_issues: mock.MagicMock,
+        mock_check_cves: mock.MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Complete successfully when no errors occur."""
+        data = {"releaseNotes": {"issues": {}}}
+        _write_data(tmp_path / "data.json", data)
+        _write_jira_secret(tmp_path / "secrets")
+        mock_check_issues.return_value = (data, [])
+
+        embargo_check.run(
+            tmp_path / "data.json",
+            secret_path=tmp_path / "secrets",
+            pipeline_run_uid="uid",
+            request_timeout=2700,
+            task_git_url="https://example.test",
+            task_git_revision="main",
+        )
+        mock_check_issues.assert_called_once()
+        mock_check_cves.assert_called_once()
+
+    @mock.patch("embargo_check.check_cves", return_value=[])
+    @mock.patch("embargo_check.check_issues")
+    @mock.patch("embargo_check.http_client.get_retry_session")
+    def test_writes_modified_data(
+        self,
+        mock_session: mock.MagicMock,
+        mock_check_issues: mock.MagicMock,
+        mock_check_cves: mock.MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Write modified data back to the file."""
+        original = {"releaseNotes": {"issues": {}}}
+        modified = {"releaseNotes": {"issues": {}, "modified": True}}
+        _write_data(tmp_path / "data.json", original)
+        _write_jira_secret(tmp_path / "secrets")
+        mock_check_issues.return_value = (modified, [])
+
+        embargo_check.run(
+            tmp_path / "data.json",
+            secret_path=tmp_path / "secrets",
+            pipeline_run_uid="uid",
+            request_timeout=2700,
+            task_git_url="https://example.test",
+            task_git_revision="main",
+        )
+        written = json.loads((tmp_path / "data.json").read_text())
+        assert written.get("releaseNotes", {}).get("modified") is True
+
+    @mock.patch("embargo_check.check_cves")
+    @mock.patch("embargo_check.check_issues")
+    @mock.patch("embargo_check.http_client.get_retry_session")
+    def test_issue_errors_skip_cve_check(
+        self,
+        mock_session: mock.MagicMock,
+        mock_check_issues: mock.MagicMock,
+        mock_check_cves: mock.MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Raise on issue errors without running CVE check."""
+        data = {"releaseNotes": {"issues": {}}}
+        _write_data(tmp_path / "data.json", data)
+        _write_jira_secret(tmp_path / "secrets")
+        mock_check_issues.return_value = (data, ["issue error"])
+
+        with pytest.raises(RuntimeError, match="issue error"):
+            embargo_check.run(
+                tmp_path / "data.json",
+                secret_path=tmp_path / "secrets",
+                pipeline_run_uid="uid",
+                request_timeout=2700,
+                task_git_url="https://example.test",
+                task_git_revision="main",
+            )
+        mock_check_cves.assert_not_called()
+
+    @mock.patch("embargo_check.check_cves", return_value=["CVE error"])
+    @mock.patch("embargo_check.check_issues")
+    @mock.patch("embargo_check.http_client.get_retry_session")
+    def test_raises_on_cve_errors(
+        self,
+        mock_session: mock.MagicMock,
+        mock_check_issues: mock.MagicMock,
+        mock_check_cves: mock.MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Raise RuntimeError when CVE check finds errors."""
+        data = {"releaseNotes": {"issues": {}}}
+        _write_data(tmp_path / "data.json", data)
+        _write_jira_secret(tmp_path / "secrets")
+        mock_check_issues.return_value = (data, [])
+
+        with pytest.raises(RuntimeError, match="CVE error"):
+            embargo_check.run(
+                tmp_path / "data.json",
+                secret_path=tmp_path / "secrets",
+                pipeline_run_uid="uid",
+                request_timeout=2700,
+                task_git_url="https://example.test",
+                task_git_revision="main",
+            )
+
+
+class TestMain:
+    """Test the main() entry point."""
+
+    def test_success(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Exit zero on success."""
+        data = {"releaseNotes": {"issues": {}}}
+        _write_data(tmp_path / "data.json", data)
+        _write_jira_secret(tmp_path / "secrets")
+        monkeypatch.setenv("DATA_FILE", str(tmp_path / "data.json"))
+        monkeypatch.setenv("JIRA_SECRET_PATH", str(tmp_path / "secrets"))
+        monkeypatch.setenv("PIPELINE_RUN_UID", "uid-123")
+        monkeypatch.setenv("REQUEST_TIMEOUT", "2700")
+        monkeypatch.setenv("TASK_GIT_URL", "https://github.com/test/repo")
+        monkeypatch.setenv("TASK_GIT_REVISION", "main")
+
+        with mock.patch("embargo_check.run") as mock_run:
+            assert embargo_check.main() == 0
+        mock_run.assert_called_once()
+
+    def test_missing_required_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Exit non-zero when required env vars are missing."""
+        monkeypatch.delenv("DATA_FILE", raising=False)
+        with pytest.raises(SystemExit):
+            embargo_check.main()
+
+    def test_module_main_guard(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Executing as __main__ calls main()."""
+        data = {"releaseNotes": {"issues": {}}}
+        _write_data(tmp_path / "data.json", data)
+        _write_jira_secret(tmp_path / "secrets")
+        monkeypatch.setenv("DATA_FILE", str(tmp_path / "data.json"))
+        monkeypatch.setenv("JIRA_SECRET_PATH", str(tmp_path / "secrets"))
+        monkeypatch.setenv("PIPELINE_RUN_UID", "uid-123")
+        monkeypatch.setenv("REQUEST_TIMEOUT", "2700")
+        monkeypatch.setenv("TASK_GIT_URL", "https://github.com/test/repo")
+        monkeypatch.setenv("TASK_GIT_REVISION", "main")
+
+        with mock.patch("embargo_check.run"):
+            with pytest.raises(SystemExit) as exc_info:
+                runpy.run_module("embargo_check", run_name="__main__")
+            assert exc_info.value.code == 0


### PR DESCRIPTION
Add embargo_check.py merging the check-issues and check-cves
tekton steps into a single Python script. Extract shared
Jira helpers (server normalization, URL construction,
credentials, REST operations) into a new jira.py helper
module and refactor close_advisory_issues.py to use it.

Assisted-by: Cursor