### PR TITLE
feat(RELEASE-2485): add create_advisory.py script

### DIFF
--- a/scripts/python/helpers/advisory_data.py
+++ b/scripts/python/helpers/advisory_data.py
@@ -11,8 +11,15 @@ from typing import Any
 
 import yaml
 
+DEFAULT_ADVISORY_TYPE = "RHBA"
+VALID_ADVISORY_TYPES = frozenset({"RHSA", "RHBA", "RHEA"})
+# "image" is the default content type and is intentionally omitted (uses .content.images).
+ARTIFACT_CONTENT_TYPES = frozenset({"binary", "generic", "disk-image", "rpm"})
+# Advisory GitLab instances (prod and staging) each have matching secrets.
 ADVISORY_SECRET_STAGE = "create-advisory-stage-secret"
 ADVISORY_SECRET_PROD = "create-advisory-prod-secret"
+ERRATA_SECRET_STAGE = "errata-stage-service-account"
+ERRATA_SECRET_PROD = "errata-prod-service-account"
 
 
 def advisory_secret_name(environment: str) -> str:
@@ -99,6 +106,32 @@ def decode_advisory_param(advisory_b64gzip: str) -> dict[str, Any]:
     b64_decoded = base64.standard_b64decode(advisory_b64gzip.strip())
     gzip_decoded = gzip.decompress(b64_decoded)
     return json.loads(gzip_decoded.decode("utf-8"))
+
+
+def encode_advisory_param(advisory: dict[str, Any]) -> str:
+    """Gzip and base64-encode advisory JSON for InternalRequest parameters."""
+    raw = json.dumps(advisory, separators=(",", ":")).encode("utf-8")
+    compressed = gzip.compress(raw)
+    return base64.standard_b64encode(compressed).decode("ascii")
+
+
+def first_mapping_content_type(data: dict[str, Any]) -> str:
+    """Return the first component content type from mapping.components."""
+    components = data.get("mapping", {}).get("components")
+    if not isinstance(components, list):
+        return ""
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        content_gateway = component.get("contentGateway")
+        if isinstance(content_gateway, dict):
+            content_type = content_gateway.get("contentType")
+            if content_type:
+                return str(content_type)
+        content_type = component.get("contentType")
+        if content_type:
+            return str(content_type)
+    return ""
 
 
 def content_array_from_decoded(root: dict[str, Any], content_list_path: str) -> list[Any]:
@@ -246,7 +279,7 @@ def spec_content_json_pointer(content_type: str) -> str:
     """Return the dotted *content_list_path* for *content_type* (under `spec` in YAML)."""
     if content_type == "image":
         return ".content.images"
-    if content_type in ("binary", "generic", "rpm", "disk-image"):
+    if content_type in ARTIFACT_CONTENT_TYPES:
         return ".content.artifacts"
     msg = f"Unsupported contentType: {content_type}"
     raise ValueError(msg)

--- a/scripts/python/helpers/compress_artifacts.py
+++ b/scripts/python/helpers/compress_artifacts.py
@@ -37,6 +37,7 @@ import zipfile
 from pathlib import Path
 
 import disk_image_utils
+import content_gateway
 import oras_utils
 
 PROG = "compress_artifacts.py"
@@ -94,15 +95,6 @@ def _restore_supplementary(component_dir: Path) -> None:
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.move(str(file), str(dest))
                 logger.info("  Restored supplementary file: %s/%s", os_name, rel)
-
-
-def _windows_filename(source_filename: str) -> str:
-    """Replace .tar.gz or .tar extension with .zip for Windows archives."""
-    if source_filename.endswith(".tar.gz"):
-        return source_filename[: -len(".tar.gz")] + ".zip"
-    if source_filename.endswith(".tar"):
-        return source_filename[: -len(".tar")] + ".zip"
-    return source_filename
 
 
 def _compress_file_entry(
@@ -168,7 +160,7 @@ def _compress_file_entry(
         logger.info("  Created (%s): %s", array_name, source_filename)
         return source
 
-    win_filename = _windows_filename(source_filename)
+    win_filename = content_gateway.windows_zip_filename(source_filename)
     out_path = ready_dir / win_filename
     with zipfile.ZipFile(str(out_path), "w", zipfile.ZIP_DEFLATED) as zf:
         for item in sorted(arch_dir.rglob("*")):

--- a/scripts/python/helpers/content_gateway/__init__.py
+++ b/scripts/python/helpers/content_gateway/__init__.py
@@ -1,0 +1,23 @@
+"""Content Gateway and CDN helpers for artifact delivery."""
+
+from __future__ import annotations
+
+from .content_gateway import (
+    cdn_base_urls,
+    cdn_base_urls_for_env,
+    cdn_env,
+    component_file_entries,
+    filename_for_binary_or_generic,
+    windows_archive_basename,
+    windows_zip_filename,
+)
+
+__all__ = [
+    "cdn_base_urls",
+    "cdn_base_urls_for_env",
+    "cdn_env",
+    "component_file_entries",
+    "filename_for_binary_or_generic",
+    "windows_archive_basename",
+    "windows_zip_filename",
+]

--- a/scripts/python/helpers/content_gateway/content_gateway.py
+++ b/scripts/python/helpers/content_gateway/content_gateway.py
@@ -1,0 +1,74 @@
+"""Content Gateway and CDN helpers for artifact filenames and download URLs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+_CGW_PRODUCTS_PROD = "https://developers.redhat.com/products"
+_CDN_DOWNLOADS_PROD = "https://access.redhat.com/downloads"
+_CGW_PRODUCTS_PREPROD = "https://developers.qa.redhat.com/products"
+_CDN_DOWNLOADS_PREPROD = "https://access.stage.redhat.com/downloads"
+
+
+def cdn_env(data: dict[str, Any]) -> str:
+    """Return the CDN environment from *data*, defaulting to production."""
+    return str(data.get("cdn", {}).get("env", "production"))
+
+
+def cdn_base_urls(data: dict[str, Any]) -> tuple[str, str]:
+    """Return CGW and CDN download base URLs for the data.json CDN environment."""
+    return cdn_base_urls_for_env(cdn_env(data))
+
+
+def cdn_base_urls_for_env(cdn_env_value: str) -> tuple[str, str]:
+    """Return CGW and CDN download base URLs for *cdn_env_value*."""
+    if cdn_env_value in {"stage", "qa"}:
+        return (_CGW_PRODUCTS_PREPROD, _CDN_DOWNLOADS_PREPROD)
+    return (_CGW_PRODUCTS_PROD, _CDN_DOWNLOADS_PROD)
+
+
+def component_file_entries(component: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return file rows from ``files[]``, falling back to ``staged.files[]`` when empty."""
+    files = component.get("files")
+    if isinstance(files, list) and files:
+        return [row for row in files if isinstance(row, dict)]
+    staged = component.get("staged")
+    if not isinstance(staged, dict):
+        return []
+    staged_files = staged.get("files")
+    if not isinstance(staged_files, list):
+        return []
+    return [row for row in staged_files if isinstance(row, dict)]
+
+
+def filename_for_binary_or_generic(
+    component: dict[str, Any],
+    *,
+    architecture: str,
+    operating_system: str,
+) -> str:
+    """Return ``source`` for binary/generic rows matching arch and operating_system."""
+    for file_row in component_file_entries(component):
+        if file_row.get("arch") == architecture and file_row.get("os") == operating_system:
+            source = file_row.get("source")
+            if isinstance(source, str):
+                return source
+    return ""
+
+
+def windows_zip_filename(filename: str) -> str:
+    """Replace ``.tar.gz`` or ``.tar`` extension with ``.zip`` for Windows archives."""
+    if filename.endswith(".tar.gz"):
+        return filename[: -len(".tar.gz")] + ".zip"
+    if filename.endswith(".tar"):
+        return filename[: -len(".tar")] + ".zip"
+    return filename
+
+
+def windows_archive_basename(filename: str, operating_system: str) -> str:
+    """Return basename with Windows archive extensions normalized to ``.zip``."""
+    basename = Path(filename).name
+    if operating_system == "windows":
+        return windows_zip_filename(basename)
+    return basename

--- a/scripts/python/helpers/content_gateway/test_content_gateway.py
+++ b/scripts/python/helpers/content_gateway/test_content_gateway.py
@@ -1,0 +1,117 @@
+"""Tests for content_gateway helpers."""
+
+from __future__ import annotations
+
+from content_gateway import content_gateway
+
+
+def test_cdn_base_urls_production() -> None:
+    """Production CDN env uses public CGW and CDN download hosts."""
+    data = {"cdn": {"env": "production"}}
+    assert content_gateway.cdn_base_urls(data) == (
+        "https://developers.redhat.com/products",
+        "https://access.redhat.com/downloads",
+    )
+
+
+def test_cdn_base_urls_stage() -> None:
+    """Stage CDN env uses preprod CGW and CDN download hosts."""
+    data = {"cdn": {"env": "stage"}}
+    assert content_gateway.cdn_base_urls(data) == (
+        "https://developers.qa.redhat.com/products",
+        "https://access.stage.redhat.com/downloads",
+    )
+
+
+def test_cdn_base_urls_defaults_to_production() -> None:
+    """Missing cdn.env defaults to production URLs."""
+    assert content_gateway.cdn_base_urls({}) == (
+        "https://developers.redhat.com/products",
+        "https://access.redhat.com/downloads",
+    )
+
+
+def test_filename_for_binary_or_generic_prefers_files_array() -> None:
+    """Binary/generic lookup prefers top-level files[] over staged.files[]."""
+    component = {
+        "files": [{"arch": "amd64", "os": "linux", "source": "app-linux.tgz"}],
+        "staged": {
+            "files": [{"arch": "amd64", "os": "linux", "source": "staged-linux.tgz"}],
+        },
+    }
+    assert (
+        content_gateway.filename_for_binary_or_generic(
+            component,
+            architecture="amd64",
+            operating_system="linux",
+        )
+        == "app-linux.tgz"
+    )
+
+
+def test_filename_for_binary_or_generic_falls_back_to_staged_files() -> None:
+    """Binary/generic lookup uses staged.files[] when files[] is empty."""
+    component = {
+        "staged": {
+            "files": [{"arch": "amd64", "os": "linux", "source": "staged-linux.tgz"}],
+        },
+    }
+    assert (
+        content_gateway.filename_for_binary_or_generic(
+            component,
+            architecture="amd64",
+            operating_system="linux",
+        )
+        == "staged-linux.tgz"
+    )
+
+
+def test_windows_zip_filename_tar_gz() -> None:
+    """A .tar.gz filename is converted to the equivalent .zip name."""
+    assert content_gateway.windows_zip_filename("binary-amd64.tar.gz") == "binary-amd64.zip"
+
+
+def test_windows_zip_filename_tar() -> None:
+    """A .tar filename is converted to the equivalent .zip name."""
+    assert content_gateway.windows_zip_filename("binary-amd64.tar") == "binary-amd64.zip"
+
+
+def test_windows_zip_filename_already_zip() -> None:
+    """Zip filenames are returned unchanged."""
+    assert content_gateway.windows_zip_filename("binary-amd64.zip") == "binary-amd64.zip"
+
+
+def test_windows_archive_basename_converts_windows_tar_gz() -> None:
+    """Windows archive basenames normalize tar.gz to zip for checksum lookup."""
+    out = content_gateway.windows_archive_basename("app.tar.gz", "windows")
+    assert out == "app.zip"
+
+
+def test_windows_archive_basename_skips_non_windows() -> None:
+    """Non-Windows operating systems keep the original basename."""
+    assert content_gateway.windows_archive_basename("app.tar.gz", "linux") == "app.tar.gz"
+
+
+def test_component_file_entries_empty_when_staged_not_dict() -> None:
+    """Return no rows when staged is not a mapping."""
+    assert content_gateway.component_file_entries({"staged": "invalid"}) == []
+
+
+def test_component_file_entries_empty_when_staged_files_not_list() -> None:
+    """Return no rows when staged.files is not a list."""
+    assert content_gateway.component_file_entries({"staged": {"files": "invalid"}}) == []
+
+
+def test_filename_for_binary_or_generic_empty_when_no_match() -> None:
+    """Return empty when no file row matches arch and operating system."""
+    component = {
+        "files": [{"arch": "amd64", "os": "linux", "source": "app-linux.tgz"}],
+    }
+    assert (
+        content_gateway.filename_for_binary_or_generic(
+            component,
+            architecture="aarch64",
+            operating_system="linux",
+        )
+        == ""
+    )

--- a/scripts/python/helpers/disk_image_utils.py
+++ b/scripts/python/helpers/disk_image_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 # Unambiguous disk-image file suffixes (simple and compound). Files matching
 # these are handled as raw binary blobs rather than tar archives, even when the
 # component does not carry contentType: disk-image.
@@ -11,6 +13,8 @@ from __future__ import annotations
 DISK_IMAGE_SUFFIXES: frozenset[str] = frozenset(
     {".qcow2", ".iso", ".iso.gz", ".raw.gz", ".vhd.gz"}
 )
+# Disk-image advisory rows always use linux; arch is sniffed from the filename.
+DISK_IMAGE_DEFAULT_OS = "linux"
 
 
 def is_disk_image_file(filename: str) -> bool:
@@ -29,3 +33,16 @@ def is_disk_image_component(component: dict) -> bool:
         component.get("contentType") == "disk-image"
         or (component.get("contentGateway") or {}).get("contentType") == "disk-image"
     )
+
+
+def architecture_from_filename(filename: str) -> str:
+    """Return ``aarch64`` / ``x86_64`` if present in the basename, else ``unknown``.
+
+    Check aarch64 before x86_64 so a name containing both prefers aarch64.
+    """
+    name = Path(filename).name
+    if "aarch64" in name:
+        return "aarch64"
+    if "x86_64" in name:
+        return "x86_64"
+    return "unknown"

--- a/scripts/python/helpers/internal_request/__init__.py
+++ b/scripts/python/helpers/internal_request/__init__.py
@@ -2,6 +2,20 @@
 
 from __future__ import annotations
 
-from .internal_request import InternalRequestWaitError, SPAWN_OVERHEAD_SECONDS, create
+from .internal_request import (
+    InternalRequestWaitError,
+    PIPELINERUN_UID_LABEL,
+    SPAWN_OVERHEAD_SECONDS,
+    create,
+    duration_to_seconds,
+    fetch_results,
+)
 
-__all__ = ["InternalRequestWaitError", "SPAWN_OVERHEAD_SECONDS", "create"]
+__all__ = [
+    "InternalRequestWaitError",
+    "PIPELINERUN_UID_LABEL",
+    "SPAWN_OVERHEAD_SECONDS",
+    "create",
+    "duration_to_seconds",
+    "fetch_results",
+]

--- a/scripts/python/helpers/internal_request/internal_request.py
+++ b/scripts/python/helpers/internal_request/internal_request.py
@@ -440,6 +440,25 @@ def create_internal_request(payload: dict[str, Any]) -> str:
     return name
 
 
+def fetch_results(internal_request_name: str) -> dict[str, Any]:
+    """Read InternalRequest ``status.results`` via kubectl."""
+    result = run_cmd(
+        [
+            "kubectl",
+            "get",
+            "internalrequest",
+            internal_request_name,
+            "-o=jsonpath={.status.results}",
+        ],
+        check=True,
+    )
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return {}
+    parsed = json.loads(raw)
+    return parsed if isinstance(parsed, dict) else {}
+
+
 def create(
     pipeline: str,
     *,

--- a/scripts/python/helpers/internal_request/test_internal_request.py
+++ b/scripts/python/helpers/internal_request/test_internal_request.py
@@ -442,3 +442,34 @@ def test_wait_for_completion_keeps_polling_when_label_selector_matches_nothing()
         wait_for_completion(label_selector="foo=bar", timeout=600)
 
     assert exc_info.value.exit_code == EXIT_TIMEOUT
+
+
+def test_fetch_results_handles_empty_stdout() -> None:
+    """Return an empty dict when kubectl prints no results."""
+    with mock.patch.object(
+        ir_module,
+        "run_cmd",
+        return_value=_completed_process(""),
+    ):
+        assert ir_module.fetch_results("ir-1") == {}
+
+
+def test_fetch_results_parses_json() -> None:
+    """Parse InternalRequest status.results JSON from kubectl."""
+    payload = {"result": "Success", "advisory_url": "url"}
+    with mock.patch.object(
+        ir_module,
+        "run_cmd",
+        return_value=_completed_process(json.dumps(payload)),
+    ):
+        assert ir_module.fetch_results("ir-1") == payload
+
+
+def test_fetch_results_ignores_non_dict_json() -> None:
+    """Return an empty dict when kubectl output is not a JSON object."""
+    with mock.patch.object(
+        ir_module,
+        "run_cmd",
+        return_value=_completed_process('["not","dict"]'),
+    ):
+        assert ir_module.fetch_results("ir-1") == {}

--- a/scripts/python/helpers/push_artifacts.py
+++ b/scripts/python/helpers/push_artifacts.py
@@ -47,6 +47,7 @@ import tempfile
 from pathlib import Path
 
 import disk_image_utils
+import content_gateway
 import publish_to_cgw_wrapper
 import pulp_push_wrapper
 import yaml  # type: ignore
@@ -188,16 +189,20 @@ def _push_component_to_pulp(
                 continue
 
             source_filename = Path(source_path).name
-            # Handle windows .tar.gz/.tar → .zip conversion
+            # Windows sources are declared as .tar.gz, but this pipeline repackages
+            # Windows binaries as .zip after signing (see compress_artifacts.py). Use the
+            # real .zip name on disk instead of the declared name so we copy the correct
+            # file and publish it to Pulp/Customer Portal under its actual extension.
             if "windows" in source_filename:
-                for old_ext, new_ext in [(".tar.gz", ".zip"), (".tar", ".zip")]:
-                    if source_filename.endswith(old_ext):
-                        candidate = source_filename[: -len(old_ext)] + new_ext
-                        if (component_dir / candidate).exists():
-                            source_filename = candidate
-                            if dest_filename.endswith(old_ext):
-                                dest_filename = dest_filename[: -len(old_ext)] + new_ext
-                        break
+                zip_filename = content_gateway.windows_zip_filename(source_filename)
+                zip_on_disk = component_dir / zip_filename
+                if zip_filename != source_filename and zip_on_disk.is_file():
+                    source_filename = zip_filename
+                    if dest_filename:
+                        dest_name = Path(dest_filename).name
+                        dest_zip = content_gateway.windows_zip_filename(dest_name)
+                        if dest_zip != dest_name:
+                            dest_filename = dest_zip
 
             if not dest_filename:
                 dest_filename = source_filename

--- a/scripts/python/helpers/release_notes_purl/__init__.py
+++ b/scripts/python/helpers/release_notes_purl/__init__.py
@@ -1,0 +1,7 @@
+"""Populate releaseNotes artifact PURLs from a checksum map OCI artifact."""
+
+from __future__ import annotations
+
+from .release_notes_purl import TA_DOCKERCONFIG_DEFAULT, update_artifact_purls
+
+__all__ = ["TA_DOCKERCONFIG_DEFAULT", "update_artifact_purls"]

--- a/scripts/python/helpers/release_notes_purl/release_notes_purl.py
+++ b/scripts/python/helpers/release_notes_purl/release_notes_purl.py
@@ -1,0 +1,549 @@
+"""Populate releaseNotes artifact PURLs from a checksum map OCI artifact."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import authentication
+import content_gateway
+import disk_image_utils
+import file
+import subprocess_cmd
+from logger import logger
+
+PURL_CONTENT_TYPES = frozenset({"binary", "generic", "disk-image"})
+TA_DOCKERCONFIG_DEFAULT = Path("/mnt/trusted_artifacts_dockerconfig/.dockerconfigjson")
+
+
+def _artifact_rows(release_notes: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return releaseNotes.content.artifacts as a list of dict rows."""
+    content = release_notes.get("content")
+    if not isinstance(content, dict):
+        return []
+    artifacts = content.get("artifacts")
+    if not isinstance(artifacts, list):
+        return []
+    return [row for row in artifacts if isinstance(row, dict)]
+
+
+def _all_artifacts_have_purls(artifacts: list[dict[str, Any]]) -> bool:
+    """Return true when every artifact row has a non-placeholder PURL."""
+    if not artifacts:
+        return False
+    for row in artifacts:
+        purl = row.get("purl")
+        if not isinstance(purl, str) or not purl or purl == "placeholder":
+            return False
+    return True
+
+
+def _component_content_type(component: dict[str, Any]) -> str:
+    """Return contentGateway.contentType, else top-level contentType, else empty."""
+    content_gateway_cfg = component.get("contentGateway")
+    if isinstance(content_gateway_cfg, dict):
+        content_type = content_gateway_cfg.get("contentType")
+        if content_type:
+            return str(content_type)
+    content_type = component.get("contentType")
+    return str(content_type) if content_type else ""
+
+
+def _first_purl_content_type(data: dict[str, Any]) -> str:
+    """Return the first mapping component content type that needs PURL updates.
+
+    A release can have mixed content types (e.g. binary + disk-image), so callers
+    scan across all components rather than stopping at the first one.
+    """
+    components = data.get("mapping", {}).get("components")
+    if not isinstance(components, list):
+        return ""
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        content_type = _component_content_type(component)
+        if content_type in PURL_CONTENT_TYPES:
+            return content_type
+    return ""
+
+
+def _staged_files_by_component(
+    snapshot: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]]:
+    """Build component-name → staged.files[] from the snapshot spec.
+
+    apply-mapping substitutes ``{{ release_timestamp }}`` (and other template vars)
+    in the snapshot's components but does NOT write those substitutions back to the
+    data file. Reading staged.files from data.json would produce filenames like
+    ``foo-{{ release_timestamp }}-x86_64.iso`` which Jinja2 would then render as
+    empty, giving ``foo--x86_64.iso`` in the advisory.
+    """
+    out: dict[str, list[dict[str, Any]]] = {}
+    components = snapshot.get("components")
+    if not isinstance(components, list):
+        return out
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        name = component.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        staged = component.get("staged")
+        files = staged.get("files") if isinstance(staged, dict) else None
+        if not isinstance(files, list):
+            out[name] = []
+            continue
+        out[name] = [row for row in files if isinstance(row, dict)]
+    return out
+
+
+def load_checksum_map(checksum_map_param: str) -> list[dict[str, Any]]:
+    """Pull checksum_map from OCI and return the decoded JSON list."""
+    pull_dir = Path(tempfile.mkdtemp(prefix="checksum-map-"))
+    try:
+        logger.info("Pulling checksum_map from OCI: %s", checksum_map_param)
+        subprocess_cmd.run_cmd(["oras", "pull", checksum_map_param], cwd=pull_dir, check=True)
+
+        # oras may leave a gzip tarball or a plain checksum_map.json depending on push format.
+        archive_path = pull_dir / "checksum_map"
+        json_path = pull_dir / "checksum_map.json"
+        if archive_path.is_file():
+            with tarfile.open(archive_path, "r:gz") as archive:
+                archive.extractall(path=pull_dir)
+        if not json_path.is_file():
+            msg = "checksum_map.json not found in OCI artifact"
+            raise FileNotFoundError(msg)
+
+        parsed = json.loads(json_path.read_text(encoding="utf-8"))
+        if not isinstance(parsed, list) or not parsed:
+            msg = "checksum map is empty or invalid JSON"
+            raise ValueError(msg)
+        logger.info("Checksum manifest loaded with %d component(s).", len(parsed))
+        return parsed
+    finally:
+        shutil.rmtree(pull_dir, ignore_errors=True)
+
+
+def _checksum_for_file(
+    checksum_map: list[dict[str, Any]],
+    *,
+    component_name: str,
+    filename_basename: str,
+) -> str:
+    """Look up a checksum for *component_name* and *filename_basename*."""
+    for row in checksum_map:
+        if not isinstance(row, dict):
+            continue
+        if row.get("component") != component_name:
+            continue
+        files = row.get("files")
+        if not isinstance(files, dict):
+            continue
+        checksum = files.get(filename_basename)
+        if isinstance(checksum, str) and checksum:
+            return checksum
+    logger.warning(
+        "No checksum found for %s/%s in manifest",
+        component_name,
+        filename_basename,
+    )
+    return ""
+
+
+def _build_purl(
+    *,
+    component_name: str,
+    version_name: str,
+    filename_basename: str,
+    checksum: str,
+    download_url: str,
+) -> str:
+    """Build a pkg:generic PURL with filename, checksum, and download_url params.
+
+    Filename is added first so it uniquely identifies the file in the PURL.
+    """
+    purl = f"pkg:generic/{component_name}@{version_name}"
+    query_parts: list[str] = []
+    if filename_basename:
+        query_parts.append(f"filename={quote(filename_basename, safe='')}")
+    if checksum:
+        query_parts.append(f"checksum={quote(checksum, safe='')}")
+    if download_url:
+        query_parts.append(f"download_url={quote(download_url, safe='')}")
+    if query_parts:
+        purl = f"{purl}?{'&'.join(query_parts)}"
+    return purl
+
+
+def _component_version_name(component: dict[str, Any]) -> str:
+    """Return CGW productVersionName, else staged.version, else empty."""
+    component_cgw = component.get("contentGateway")
+    if isinstance(component_cgw, dict):
+        version_name = str(component_cgw.get("productVersionName") or "")
+        if version_name:
+            return version_name
+    staged = component.get("staged")
+    if isinstance(staged, dict):
+        return str(staged.get("version") or "")
+    return ""
+
+
+def _download_url_for_component(
+    component: dict[str, Any],
+    *,
+    cgw_base_url: str,
+    cdn_base_url: str,
+) -> str:
+    """Return the canonical download_url base for a component.
+
+    When a component has both contentGateway (Developer Portal) and staged
+    (Customer Portal/CDN), CGW is used. If only staged is present, the CDN URL
+    is used instead.
+    """
+    component_cgw = component.get("contentGateway")
+    has_cgw = isinstance(component_cgw, dict) and bool(component_cgw)
+    return cgw_base_url if has_cgw else cdn_base_url
+
+
+def _dedupe_artifact_key(row: dict[str, Any]) -> str:
+    """Return the component|architecture|os deduplication key for an artifact row."""
+    return (
+        f"{row.get('component', '')}|" f"{row.get('architecture', '')}|" f"{row.get('os', '')}"
+    )
+
+
+def _updated_binary_or_generic_entries(
+    data: dict[str, Any],
+    component: dict[str, Any],
+    *,
+    checksum_map: list[dict[str, Any]],
+    cgw_base_url: str,
+    cdn_base_url: str,
+) -> list[dict[str, Any]]:
+    """Build updated artifact rows for one binary/generic mapping component."""
+    component_name = str(component.get("name", ""))
+    version_name = _component_version_name(component)
+    if not version_name:
+        logger.warning(
+            "No version found for component %s (checked contentGateway and staged)",
+            component_name,
+        )
+        return []
+
+    release_notes = data["releaseNotes"]
+    matching_entries = [
+        row for row in _artifact_rows(release_notes) if row.get("component") == component_name
+    ]
+    if not matching_entries:
+        logger.warning(
+            "no releaseNotes.content.artifacts entries found for component: %s",
+            component_name,
+        )
+        return []
+
+    download_url = _download_url_for_component(
+        component,
+        cgw_base_url=cgw_base_url,
+        cdn_base_url=cdn_base_url,
+    )
+    updated: list[dict[str, Any]] = []
+    for entry in matching_entries:
+        architecture = str(entry.get("architecture", ""))
+        operating_system = str(entry.get("os", ""))
+        # Match files by arch/os, falling back to staged.files for teams that use
+        # the CDN staged structure instead of a top-level files array.
+        filename = content_gateway.filename_for_binary_or_generic(
+            component,
+            architecture=architecture,
+            operating_system=operating_system,
+        )
+        # compress-artifacts renames Windows .tar.gz to .zip; checksum map keys use .zip.
+        filename_basename = content_gateway.windows_archive_basename(
+            filename,
+            operating_system,
+        )
+        checksum = _checksum_for_file(
+            checksum_map,
+            component_name=component_name,
+            filename_basename=filename_basename,
+        )
+        purl = _build_purl(
+            component_name=component_name,
+            version_name=version_name,
+            filename_basename=filename_basename,
+            checksum=checksum,
+            download_url=download_url,
+        )
+        updated.append({**entry, "purl": purl})
+    return updated
+
+
+def _updated_disk_image_entries(
+    data: dict[str, Any],
+    component: dict[str, Any],
+    *,
+    staged_files: list[dict[str, Any]],
+    checksum_map: list[dict[str, Any]],
+    cgw_base_url: str,
+    cdn_base_url: str,
+) -> list[dict[str, Any]]:
+    """Expand one advisory artifact row per snapshot staged file for a disk-image.
+
+    Multiple files can share the same os+arch (e.g. ISO + QCOW2 both linux/x86_64),
+    so iterating over advisory entries (one per os+arch) would produce malformed
+    PURLs. Instead, use the first advisory entry as a metadata template and expand
+    it per staged file.
+    """
+    component_name = str(component.get("name", ""))
+    version_name = _component_version_name(component)
+    if not version_name:
+        logger.warning(
+            "No version found for component %s (checked contentGateway and staged)",
+            component_name,
+        )
+        return []
+
+    release_notes = data["releaseNotes"]
+    matching_entries = [
+        row for row in _artifact_rows(release_notes) if row.get("component") == component_name
+    ]
+    if not matching_entries:
+        logger.warning(
+            "no releaseNotes.content.artifacts entries found for component: %s",
+            component_name,
+        )
+        return []
+
+    # Fail loudly instead of silently leaving placeholder PURLs if the snapshot
+    # has no staged.files[] (e.g. snapshot/mapping mismatch).
+    if not staged_files:
+        msg = (
+            f"disk-image component {component_name} has releaseNotes.content.artifacts "
+            "entries but no staged.files[] in the snapshot"
+        )
+        raise ValueError(msg)
+
+    template_entry = matching_entries[0]
+    download_url = _download_url_for_component(
+        component,
+        cgw_base_url=cgw_base_url,
+        cdn_base_url=cdn_base_url,
+    )
+    updated: list[dict[str, Any]] = []
+    for staged_file in staged_files:
+        filename = staged_file.get("filename")
+        # Reject missing/empty values and the literal "null" string (JSON null mishandling).
+        if not isinstance(filename, str) or not filename or filename == "null":
+            msg = (
+                f"staged.files[].filename is required for disk-image "
+                f"component {component_name}"
+            )
+            raise ValueError(msg)
+        filename_basename = Path(filename).name
+        # Disk-image architecture is encoded in the filename; os defaults to linux.
+        architecture = disk_image_utils.architecture_from_filename(filename_basename)
+        checksum = _checksum_for_file(
+            checksum_map,
+            component_name=component_name,
+            filename_basename=filename_basename,
+        )
+        purl = _build_purl(
+            component_name=component_name,
+            version_name=version_name,
+            filename_basename=filename_basename,
+            checksum=checksum,
+            download_url=download_url,
+        )
+        updated.append(
+            {
+                **template_entry,
+                "purl": purl,
+                "architecture": architecture,
+                "os": disk_image_utils.DISK_IMAGE_DEFAULT_OS,
+            },
+        )
+    return updated
+
+
+def _merge_updated_artifacts(
+    data: dict[str, Any],
+    *,
+    updated_entries: list[dict[str, Any]],
+    updated_disk_entries: list[dict[str, Any]],
+) -> None:
+    """Merge binary/generic and disk-image updates back into data.json."""
+    release_notes = data["releaseNotes"]
+    content = release_notes.setdefault("content", {})
+    if not isinstance(content, dict):
+        content = {}
+        release_notes["content"] = content
+    artifacts = content.get("artifacts")
+    if not isinstance(artifacts, list):
+        artifacts = []
+        content["artifacts"] = artifacts
+
+    # Disk-image replacements: drop existing entries for updated components and
+    # substitute the new per-file expanded entries. Cannot deduplicate by
+    # component|arch|os because multiple files (e.g. ISO + QCOW2) legitimately
+    # share the same arch/os.
+    disk_components = {
+        str(row.get("component", "")) for row in updated_disk_entries if row.get("component")
+    }
+    if updated_disk_entries:
+        kept = [
+            row
+            for row in artifacts
+            if isinstance(row, dict) and str(row.get("component", "")) not in disk_components
+        ]
+        artifacts = kept + updated_disk_entries
+        content["artifacts"] = artifacts
+
+    if not updated_entries:
+        return
+
+    # Merge binary/generic updated entries. Deduplicate by component|architecture|os
+    # when multiple files share the same arch/os. Disk-image components are excluded
+    # from this pass (and re-appended untouched) because they were already expanded
+    # above and can legitimately have multiple entries sharing the same
+    # component|architecture|os -- deduplicating them here would drop all but one
+    # file's PURL/checksum.
+    updated_map = {_dedupe_artifact_key(row): row for row in updated_entries}
+    disk_items = [
+        row
+        for row in artifacts
+        if isinstance(row, dict) and str(row.get("component", "")) in disk_components
+    ]
+    other_items = [
+        row
+        for row in artifacts
+        if isinstance(row, dict) and str(row.get("component", "")) not in disk_components
+    ]
+    merged_rows: dict[str, dict[str, Any]] = {}
+    for row in other_items:
+        key = _dedupe_artifact_key(row)
+        merged_rows[key] = updated_map.get(key, row)
+    for key, row in updated_map.items():
+        merged_rows.setdefault(key, row)
+    content["artifacts"] = list(merged_rows.values()) + disk_items
+
+
+def update_artifact_purls(
+    data_file: Path,
+    *,
+    checksum_map_param: str,
+    dockerconfig_path: Path = TA_DOCKERCONFIG_DEFAULT,
+    snapshot_path: Path | None = None,
+) -> None:
+    """Update releaseNotes artifact PURLs in *data_file* when a checksum map exists."""
+    data = file.load_json_dict(data_file)
+    # Marketplace releases ship pre-built PURLs; checksum map is not used.
+    marketplace_secret = data.get("mapping", {}).get("cloudMarketplacesSecret")
+    if marketplace_secret:
+        logger.info("Marketplace release detected. Skipping PURL updates.")
+        return
+
+    # Check whether any component requires PURL updates (binary/generic/disk-image).
+    # Mixed releases (e.g. binary + disk-image) must look across all components.
+    purl_content_type = _first_purl_content_type(data)
+    if not purl_content_type:
+        if "github" in data:
+            logger.info("Github release. Skipping update-purl.")
+            return
+        logger.info("No binary/generic/disk-image content type found, skipping update-purl")
+        return
+
+    release_notes = data["releaseNotes"]
+    artifacts = _artifact_rows(release_notes)
+    if _all_artifacts_have_purls(artifacts):
+        logger.info(
+            "All %d artifacts already have PURLs populated. Skipping update-purl.",
+            len(artifacts),
+        )
+        return
+
+    logger.info("Processing artifacts for PURL updates...")
+    cgw_base_url, cdn_base_url = content_gateway.cdn_base_urls(data)
+    logger.info(
+        "Using %s environment: CGW=%s, CDN=%s",
+        content_gateway.cdn_env(data),
+        cgw_base_url,
+        cdn_base_url,
+    )
+
+    authentication.setup_docker_config(dockerconfig_path, optional=True)
+    if not checksum_map_param or checksum_map_param in {"null", "empty"}:
+        msg = (
+            f"checksum map is required for content type '{purl_content_type}' "
+            "but was not provided."
+        )
+        raise ValueError(msg)
+    checksum_map = load_checksum_map(checksum_map_param)
+
+    # Snapshot staged.files (with template vars already substituted) — see
+    # _staged_files_by_component for why data.json must not be used here.
+    staged_by_component: dict[str, list[dict[str, Any]]] = {}
+    if snapshot_path is not None:
+        snapshot = file.load_json_dict(snapshot_path)
+        staged_by_component = _staged_files_by_component(snapshot)
+
+    components = data.get("mapping", {}).get("components")
+    if not isinstance(components, list):
+        components = []
+
+    updated_entries: list[dict[str, Any]] = []
+    updated_disk_entries: list[dict[str, Any]] = []
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        # Resolve content type per component so mixed releases (e.g. binary +
+        # disk-image) each go through the correct code path. Unspecified or
+        # container "image" types do not need PURL updates here.
+        content_type = _component_content_type(component)
+        if content_type not in PURL_CONTENT_TYPES:
+            logger.info(
+                "Component %s content type '%s'. Skipping.",
+                component.get("name", ""),
+                content_type,
+            )
+            continue
+        if content_type == "disk-image":
+            component_name = str(component.get("name", ""))
+            updated_disk_entries.extend(
+                _updated_disk_image_entries(
+                    data,
+                    component,
+                    staged_files=staged_by_component.get(component_name, []),
+                    checksum_map=checksum_map,
+                    cgw_base_url=cgw_base_url,
+                    cdn_base_url=cdn_base_url,
+                ),
+            )
+        else:
+            updated_entries.extend(
+                _updated_binary_or_generic_entries(
+                    data,
+                    component,
+                    checksum_map=checksum_map,
+                    cgw_base_url=cgw_base_url,
+                    cdn_base_url=cdn_base_url,
+                ),
+            )
+
+    if not updated_entries and not updated_disk_entries:
+        logger.info("No advisory entries were updated.")
+        return
+
+    _merge_updated_artifacts(
+        data,
+        updated_entries=updated_entries,
+        updated_disk_entries=updated_disk_entries,
+    )
+    data_file.write_text(
+        json.dumps(data, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )

--- a/scripts/python/helpers/release_notes_purl/test_release_notes_purl.py
+++ b/scripts/python/helpers/release_notes_purl/test_release_notes_purl.py
@@ -1,0 +1,1019 @@
+"""Tests for `release_notes_purl`."""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+from unittest import mock
+
+import pytest
+from release_notes_purl import release_notes_purl as rnp_module
+
+
+def _write_data(path: Path, data: dict[str, Any]) -> None:
+    """Write *data* as JSON to *path*."""
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _mock_checksum_pull(checksum_map: list[dict[str, Any]]):
+    """Return a fake oras pull that materializes checksum_map as a gz tarball."""
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        cwd = kwargs.get("cwd")
+        assert cwd is not None
+        json_path = Path(cwd) / "checksum_map.json"
+        json_path.write_text(json.dumps(checksum_map), encoding="utf-8")
+        archive_path = Path(cwd) / "checksum_map"
+        with tarfile.open(archive_path, "w:gz") as archive:
+            archive.add(json_path, arcname="checksum_map.json")
+        json_path.unlink()
+        return mock.Mock(stdout="", returncode=0)
+
+    return fake_run_cmd
+
+
+def _mock_checksum_pull_plain_json(checksum_map: list[dict[str, Any]]):
+    """Return a fake oras pull that leaves checksum_map.json in the pull directory."""
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        cwd = kwargs.get("cwd")
+        assert cwd is not None
+        json_path = Path(cwd) / "checksum_map.json"
+        json_path.write_text(json.dumps(checksum_map), encoding="utf-8")
+        return mock.Mock(stdout="", returncode=0)
+
+    return fake_run_cmd
+
+
+@contextmanager
+def _patch_oci_update(checksum_map: list[dict[str, Any]]) -> Iterator[None]:
+    """Patch OCI pull and docker setup for update_artifact_purls integration tests."""
+    with (
+        mock.patch.object(
+            rnp_module.subprocess_cmd,
+            "run_cmd",
+            side_effect=_mock_checksum_pull(checksum_map),
+        ),
+        mock.patch.object(rnp_module.authentication, "setup_docker_config"),
+    ):
+        yield
+
+
+def _generic_mapping_data(
+    *,
+    component_name: str = "app",
+    content_type: str = "generic",
+    component_extra: dict[str, Any] | None = None,
+    artifact_extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build minimal data.json for a single-component generic release."""
+    component: dict[str, Any] = {
+        "name": component_name,
+        "contentType": content_type,
+        "staged": {"version": "1.0"},
+        "files": [{"arch": "x86_64", "os": "linux", "source": "app.tgz"}],
+    }
+    if component_extra:
+        component.update(component_extra)
+    artifact: dict[str, Any] = {
+        "component": component_name,
+        "architecture": "x86_64",
+        "os": "linux",
+        "purl": "placeholder",
+    }
+    if artifact_extra:
+        artifact.update(artifact_extra)
+    return {
+        "cdn": {"env": "production"},
+        "mapping": {"components": [component]},
+        "releaseNotes": {"content": {"artifacts": [artifact]}},
+    }
+
+
+def test_artifact_rows_skips_invalid_shapes() -> None:
+    """Return only dict rows from a well-formed artifacts list."""
+    release_notes = {
+        "content": {
+            "artifacts": [
+                {"component": "app"},
+                "not-a-dict",
+                {"component": "other"},
+            ],
+        },
+    }
+    rows = rnp_module._artifact_rows(release_notes)
+    assert rows == [{"component": "app"}, {"component": "other"}]
+
+
+def test_artifact_rows_returns_empty_when_content_missing() -> None:
+    """Missing or non-dict content yields an empty artifact list."""
+    assert rnp_module._artifact_rows({}) == []
+    assert rnp_module._artifact_rows({"content": []}) == []
+
+
+def test_artifact_rows_returns_empty_when_artifacts_not_list() -> None:
+    """Non-list artifacts yields an empty artifact list."""
+    assert rnp_module._artifact_rows({"content": {"artifacts": "bad"}}) == []
+
+
+def test_all_artifacts_have_purls_requires_non_placeholder_values() -> None:
+    """Treat empty lists, placeholders, and missing PURLs as not fully populated."""
+    assert rnp_module._all_artifacts_have_purls([]) is False
+    assert (
+        rnp_module._all_artifacts_have_purls(
+            [{"purl": "placeholder"}],
+        )
+        is False
+    )
+    assert (
+        rnp_module._all_artifacts_have_purls(
+            [{"purl": "pkg:generic/app@1.0"}],
+        )
+        is True
+    )
+
+
+def test_build_purl_url_encodes_query_parameters() -> None:
+    """Build a pkg:generic PURL with URL-encoded filename, checksum, and download_url."""
+    purl = rnp_module._build_purl(
+        component_name="app",
+        version_name="1.0",
+        filename_basename="app.tgz",
+        checksum="sha256:abc",
+        download_url="https://developers.redhat.com/products",
+    )
+    assert purl.startswith("pkg:generic/app@1.0?")
+    assert "filename=app.tgz" in purl
+    assert "checksum=sha256%3Aabc" in purl
+    assert "download_url=https%3A%2F%2Fdevelopers.redhat.com%2Fproducts" in purl
+
+
+def test_checksum_for_file_returns_match_or_empty_string() -> None:
+    """Look up checksums by component and basename; warn and return empty when missing."""
+    checksum_map = [{"component": "app", "files": {"app.tgz": "sha256:abc"}}]
+    assert (
+        rnp_module._checksum_for_file(
+            checksum_map,
+            component_name="app",
+            filename_basename="app.tgz",
+        )
+        == "sha256:abc"
+    )
+    with mock.patch.object(rnp_module.logger, "warning") as warning:
+        missing = rnp_module._checksum_for_file(
+            checksum_map,
+            component_name="app",
+            filename_basename="missing.tgz",
+        )
+    assert missing == ""
+    warning.assert_called_once()
+
+
+def test_checksum_for_file_skips_malformed_checksum_map_rows() -> None:
+    """Ignore non-dict rows, other components, and rows whose files value is not a dict."""
+    checksum_map: list[Any] = [
+        "skip",
+        {"component": "other", "files": {"other.tgz": "sha256:1"}},
+        {"component": "app", "files": "not-a-dict"},
+        {"component": "app", "files": {"app.tgz": "sha256:abc"}},
+    ]
+    assert (
+        rnp_module._checksum_for_file(
+            checksum_map,
+            component_name="app",
+            filename_basename="app.tgz",
+        )
+        == "sha256:abc"
+    )
+
+
+def test_load_checksum_map_reads_plain_json_file() -> None:
+    """Accept a pull directory that already contains checksum_map.json."""
+    checksum_map = [{"component": "app", "files": {"app.tgz": "sha256:abc"}}]
+    with mock.patch.object(
+        rnp_module.subprocess_cmd,
+        "run_cmd",
+        side_effect=_mock_checksum_pull_plain_json(checksum_map),
+    ):
+        loaded = rnp_module.load_checksum_map("oci:checksum")
+    assert loaded == checksum_map
+
+
+def test_load_checksum_map_extracts_gzip_tarball() -> None:
+    """Unpack checksum_map tarball artifacts produced by build_checksum_map."""
+    checksum_map = [{"component": "app", "files": {"app.tgz": "sha256:abc"}}]
+    with mock.patch.object(
+        rnp_module.subprocess_cmd,
+        "run_cmd",
+        side_effect=_mock_checksum_pull(checksum_map),
+    ):
+        loaded = rnp_module.load_checksum_map("oci:checksum")
+    assert loaded == checksum_map
+
+
+def test_load_checksum_map_raises_when_json_missing() -> None:
+    """Fail when oras pull does not materialize checksum_map.json."""
+
+    def empty_pull(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        return mock.Mock(stdout="", returncode=0)
+
+    with (
+        mock.patch.object(rnp_module.subprocess_cmd, "run_cmd", side_effect=empty_pull),
+        pytest.raises(FileNotFoundError, match="checksum_map.json not found"),
+    ):
+        rnp_module.load_checksum_map("oci:checksum")
+
+
+def test_load_checksum_map_raises_when_manifest_empty() -> None:
+    """Fail when checksum_map.json decodes to an empty list."""
+
+    def empty_manifest_pull(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+        cwd = kwargs.get("cwd")
+        assert cwd is not None
+        (Path(cwd) / "checksum_map.json").write_text("[]", encoding="utf-8")
+        return mock.Mock(stdout="", returncode=0)
+
+    with (
+        mock.patch.object(
+            rnp_module.subprocess_cmd,
+            "run_cmd",
+            side_effect=empty_manifest_pull,
+        ),
+        pytest.raises(ValueError, match="checksum map is empty or invalid JSON"),
+    ):
+        rnp_module.load_checksum_map("oci:checksum")
+
+
+def test_merge_updated_artifacts_replaces_rows_by_component_arch_os() -> None:
+    """Updated PURLs replace placeholder rows without duplicating arch/os entries."""
+    data = {
+        "releaseNotes": {
+            "content": {
+                "artifacts": [
+                    {
+                        "component": "app",
+                        "architecture": "x86_64",
+                        "os": "linux",
+                        "purl": "placeholder",
+                    },
+                    {
+                        "component": "app",
+                        "architecture": "x86_64",
+                        "os": "windows",
+                        "purl": "placeholder",
+                    },
+                ],
+            },
+        },
+    }
+    updated_entries = [
+        {
+            "component": "app",
+            "architecture": "x86_64",
+            "os": "linux",
+            "purl": "pkg:generic/app@1.0?filename=linux.tgz",
+        },
+    ]
+    rnp_module._merge_updated_artifacts(
+        data,
+        updated_entries=updated_entries,
+        updated_disk_entries=[],
+    )
+    artifacts = data["releaseNotes"]["content"]["artifacts"]
+    linux = next(row for row in artifacts if row["os"] == "linux")
+    windows = next(row for row in artifacts if row["os"] == "windows")
+    assert "linux.tgz" in linux["purl"]
+    assert windows["purl"] == "placeholder"
+
+
+def test_merge_updated_artifacts_normalizes_invalid_content_and_artifact_rows() -> None:
+    """Repair non-dict content, non-list artifacts, and skip invalid artifact rows."""
+    data: dict[str, Any] = {
+        "releaseNotes": {
+            "content": "not-a-dict",
+        },
+    }
+    updated_entries = [
+        {
+            "component": "app",
+            "architecture": "x86_64",
+            "os": "linux",
+            "purl": "pkg:generic/app@1.0",
+        },
+    ]
+    rnp_module._merge_updated_artifacts(
+        data,
+        updated_entries=updated_entries,
+        updated_disk_entries=[],
+    )
+    content = data["releaseNotes"]["content"]
+    assert isinstance(content, dict)
+    assert content["artifacts"] == updated_entries
+
+    data = {
+        "releaseNotes": {
+            "content": {
+                "artifacts": [
+                    "skip",
+                    {
+                        "component": "app",
+                        "architecture": "x86_64",
+                        "os": "linux",
+                        "purl": "placeholder",
+                    },
+                ],
+            },
+        },
+    }
+    rnp_module._merge_updated_artifacts(
+        data,
+        updated_entries=updated_entries,
+        updated_disk_entries=[],
+    )
+    artifacts = data["releaseNotes"]["content"]["artifacts"]
+    assert len(artifacts) == 1
+    assert artifacts[0]["purl"] == "pkg:generic/app@1.0"
+
+
+def test_updated_binary_or_generic_entries_uses_content_gateway_version_and_url() -> None:
+    """CGW components use productVersionName and the Developer Portal download base."""
+    data = {
+        "releaseNotes": {
+            "content": {
+                "artifacts": [
+                    {
+                        "component": "helm",
+                        "architecture": "x86_64",
+                        "os": "linux",
+                        "purl": "placeholder",
+                    },
+                ],
+            },
+        },
+    }
+    component = {
+        "name": "helm",
+        "contentGateway": {"productVersionName": "1.5.0"},
+        "files": [{"arch": "x86_64", "os": "linux", "source": "helm-linux.tgz"}],
+    }
+    checksum_map = [{"component": "helm", "files": {"helm-linux.tgz": "sha256:abc"}}]
+    updated = rnp_module._updated_binary_or_generic_entries(
+        data,
+        component,
+        checksum_map=checksum_map,
+        cgw_base_url="https://developers.redhat.com/products",
+        cdn_base_url="https://access.redhat.com/downloads",
+    )
+    purl = updated[0]["purl"]
+    assert "pkg:generic/helm@1.5.0" in purl
+    assert "download_url=https%3A%2F%2Fdevelopers.redhat.com%2Fproducts" in purl
+
+
+def test_updated_binary_or_generic_entries_returns_empty_when_version_missing() -> None:
+    """Skip a component that has neither contentGateway nor staged version metadata."""
+    data = {"releaseNotes": {"content": {"artifacts": [{"component": "app"}]}}}
+    component = {"name": "app", "files": []}
+    updated = rnp_module._updated_binary_or_generic_entries(
+        data,
+        component,
+        checksum_map=[],
+        cgw_base_url="https://developers.redhat.com/products",
+        cdn_base_url="https://access.redhat.com/downloads",
+    )
+    assert updated == []
+
+
+def test_updated_disk_image_entries_requires_staged_files() -> None:
+    """Fail when a disk-image has artifact rows but no snapshot staged.files[]."""
+    data = {
+        "releaseNotes": {
+            "content": {
+                "artifacts": [
+                    {
+                        "component": "iso",
+                        "architecture": "x86_64",
+                        "os": "linux",
+                        "purl": "placeholder",
+                    },
+                ],
+            },
+        },
+    }
+    component = {"name": "iso", "staged": {"version": "1.0"}}
+    with pytest.raises(ValueError, match="no staged.files"):
+        rnp_module._updated_disk_image_entries(
+            data,
+            component,
+            staged_files=[],
+            checksum_map=[],
+            cgw_base_url="https://developers.redhat.com/products",
+            cdn_base_url="https://access.redhat.com/downloads",
+        )
+
+
+@pytest.mark.parametrize("filename", ["", "null", None])
+def test_updated_disk_image_entries_requires_filename(filename: str | None) -> None:
+    """Fail when a staged file has a missing, empty, or literal null filename."""
+    data = {
+        "releaseNotes": {
+            "content": {
+                "artifacts": [
+                    {
+                        "component": "iso",
+                        "architecture": "x86_64",
+                        "os": "linux",
+                        "purl": "placeholder",
+                    },
+                ],
+            },
+        },
+    }
+    component = {"name": "iso", "staged": {"version": "1.0"}}
+    with pytest.raises(ValueError, match="filename is required"):
+        rnp_module._updated_disk_image_entries(
+            data,
+            component,
+            staged_files=[{"filename": filename}],
+            checksum_map=[],
+            cgw_base_url="https://developers.redhat.com/products",
+            cdn_base_url="https://access.redhat.com/downloads",
+        )
+
+
+def test_updated_disk_image_entries_uses_cdn_when_content_gateway_empty() -> None:
+    """Disk-image PURLs use the CDN base when contentGateway is null or empty."""
+    data = {
+        "releaseNotes": {
+            "content": {
+                "artifacts": [
+                    {
+                        "component": "iso",
+                        "architecture": "x86_64",
+                        "os": "linux",
+                        "purl": "placeholder",
+                    },
+                ],
+            },
+        },
+    }
+    component = {
+        "name": "iso",
+        "contentGateway": None,
+        "staged": {"version": "1.5"},
+    }
+    updated = rnp_module._updated_disk_image_entries(
+        data,
+        component,
+        staged_files=[{"filename": "product-1.5-x86_64.iso.gz"}],
+        checksum_map=[
+            {"component": "iso", "files": {"product-1.5-x86_64.iso.gz": "sha256:iso"}},
+        ],
+        cgw_base_url="https://developers.redhat.com/products",
+        cdn_base_url="https://access.redhat.com/downloads",
+    )
+    assert "download_url=https%3A%2F%2Faccess.redhat.com%2Fdownloads" in updated[0]["purl"]
+
+    component["contentGateway"] = {}
+    updated_empty = rnp_module._updated_disk_image_entries(
+        data,
+        component,
+        staged_files=[{"filename": "product-1.5-x86_64.iso.gz"}],
+        checksum_map=[
+            {"component": "iso", "files": {"product-1.5-x86_64.iso.gz": "sha256:iso"}},
+        ],
+        cgw_base_url="https://developers.redhat.com/products",
+        cdn_base_url="https://access.redhat.com/downloads",
+    )
+    assert (
+        "download_url=https%3A%2F%2Faccess.redhat.com%2Fdownloads" in updated_empty[0]["purl"]
+    )
+
+
+def test_update_artifact_purls_skips_marketplace_release(tmp_path: Path) -> None:
+    """Skip PURL updates when cloudMarketplacesSecret is set."""
+    data = {
+        "mapping": {"cloudMarketplacesSecret": "secret", "components": []},
+        "releaseNotes": {"content": {"artifacts": []}},
+    }
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    rnp_module.update_artifact_purls(
+        data_file,
+        checksum_map_param="oci:checksum",
+    )
+    assert json.loads(data_file.read_text(encoding="utf-8")) == data
+
+
+def test_update_artifact_purls_skips_github_release(tmp_path: Path) -> None:
+    """Skip PURL updates for GitHub-only releases."""
+    data = {"github": {}, "releaseNotes": {"content": {"artifacts": []}}}
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    rnp_module.update_artifact_purls(
+        data_file,
+        checksum_map_param="oci:checksum",
+    )
+    assert "github" in json.loads(data_file.read_text(encoding="utf-8"))
+
+
+def test_update_artifact_purls_skips_unsupported_content_type(tmp_path: Path) -> None:
+    """Skip PURL updates for content types outside binary/generic/disk-image."""
+    data = {
+        "mapping": {"components": [{"name": "img", "contentType": "image"}]},
+        "releaseNotes": {"content": {"artifacts": []}},
+    }
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    rnp_module.update_artifact_purls(
+        data_file,
+        checksum_map_param="oci:checksum",
+    )
+    assert json.loads(data_file.read_text(encoding="utf-8")) == data
+
+
+def test_update_artifact_purls_skips_when_no_content_type_and_not_github(
+    tmp_path: Path,
+) -> None:
+    """Skip when mapping has no artifact content type and this is not a github release."""
+    data = {
+        "mapping": {"components": []},
+        "releaseNotes": {"content": {"artifacts": []}},
+    }
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    rnp_module.update_artifact_purls(
+        data_file,
+        checksum_map_param="oci:checksum",
+    )
+    assert json.loads(data_file.read_text(encoding="utf-8")) == data
+
+
+def test_update_artifact_purls_skips_when_all_purls_populated(tmp_path: Path) -> None:
+    """Skip when every artifact row already has a non-placeholder PURL."""
+    data = {
+        "mapping": {"components": [{"name": "app", "contentType": "generic"}]},
+        "releaseNotes": {
+            "content": {
+                "artifacts": [
+                    {
+                        "component": "app",
+                        "architecture": "x86_64",
+                        "os": "linux",
+                        "purl": "pkg:generic/app@1.0?filename=app.tgz",
+                    },
+                ],
+            },
+        },
+    }
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    with _patch_oci_update([{"component": "app", "files": {}}]):
+        rnp_module.update_artifact_purls(
+            data_file,
+            checksum_map_param="oci:checksum",
+        )
+    assert json.loads(data_file.read_text(encoding="utf-8")) == data
+
+
+def test_update_artifact_purls_requires_checksum_map(tmp_path: Path) -> None:
+    """Fail when checksum_map is missing for binary/generic/disk-image content."""
+    data = _generic_mapping_data()
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    with pytest.raises(ValueError, match="checksum map is required"):
+        rnp_module.update_artifact_purls(
+            data_file,
+            checksum_map_param="",
+        )
+
+
+def test_update_artifact_purls_updates_binary_artifact_purl(tmp_path: Path) -> None:
+    """Populate PURLs for generic/binary artifacts from checksum_map."""
+    data = _generic_mapping_data()
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    checksum_map = [{"component": "app", "files": {"app.tgz": "sha256:abc"}}]
+    with _patch_oci_update(checksum_map):
+        rnp_module.update_artifact_purls(
+            data_file,
+            checksum_map_param="oci:checksum",
+        )
+
+    purl = json.loads(data_file.read_text(encoding="utf-8"))["releaseNotes"]["content"][
+        "artifacts"
+    ][0]["purl"]
+    assert "pkg:generic/app@1.0" in purl
+    assert "filename=app.tgz" in purl
+    assert "download_url=https%3A%2F%2Faccess.redhat.com%2Fdownloads" in purl
+
+
+def test_update_artifact_purls_updates_disk_image_artifact_purl(tmp_path: Path) -> None:
+    """Populate PURLs for disk-image rows from snapshot staged.files[]."""
+    data = _generic_mapping_data(
+        component_name="iso-image",
+        content_type="disk-image",
+        component_extra={"staged": {"version": "1.5"}},
+        artifact_extra={"component": "iso-image"},
+    )
+    del data["mapping"]["components"][0]["files"]
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    snapshot_file = tmp_path / "snapshot.json"
+    _write_data(
+        snapshot_file,
+        {
+            "components": [
+                {
+                    "name": "iso-image",
+                    "staged": {
+                        "files": [{"filename": "product-1.5-x86_64.iso.gz"}],
+                    },
+                },
+            ],
+        },
+    )
+    checksum_map = [
+        {"component": "iso-image", "files": {"product-1.5-x86_64.iso.gz": "sha256:iso"}},
+    ]
+    with _patch_oci_update(checksum_map):
+        rnp_module.update_artifact_purls(
+            data_file,
+            checksum_map_param="oci:checksum",
+            snapshot_path=snapshot_file,
+        )
+
+    artifact = json.loads(data_file.read_text(encoding="utf-8"))["releaseNotes"]["content"][
+        "artifacts"
+    ][0]
+    assert "pkg:generic/iso-image@1.5" in artifact["purl"]
+    assert "filename=product-1.5-x86_64.iso.gz" in artifact["purl"]
+    assert artifact["architecture"] == "x86_64"
+    assert artifact["os"] == "linux"
+
+
+def test_update_artifact_purls_expands_disk_image_per_staged_file(tmp_path: Path) -> None:
+    """Expand one artifact row per staged file when multiple share the same arch."""
+    data = _generic_mapping_data(
+        component_name="bootc",
+        content_type="disk-image",
+        component_extra={"staged": {"version": "1.5"}},
+        artifact_extra={"component": "bootc"},
+    )
+    del data["mapping"]["components"][0]["files"]
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    snapshot_file = tmp_path / "snapshot.json"
+    _write_data(
+        snapshot_file,
+        {
+            "components": [
+                {
+                    "name": "bootc",
+                    "staged": {
+                        "files": [
+                            {"filename": "product-1.5-x86_64.iso.gz"},
+                            {"filename": "product-1.5-x86_64.qcow2"},
+                        ],
+                    },
+                },
+            ],
+        },
+    )
+    checksum_map = [
+        {
+            "component": "bootc",
+            "files": {
+                "product-1.5-x86_64.iso.gz": "sha256:iso",
+                "product-1.5-x86_64.qcow2": "sha256:qcow",
+            },
+        },
+    ]
+    with _patch_oci_update(checksum_map):
+        rnp_module.update_artifact_purls(
+            data_file,
+            checksum_map_param="oci:checksum",
+            snapshot_path=snapshot_file,
+        )
+
+    artifacts = json.loads(data_file.read_text(encoding="utf-8"))["releaseNotes"]["content"][
+        "artifacts"
+    ]
+    assert len(artifacts) == 2
+    filenames = {row["purl"].split("filename=")[1].split("&")[0] for row in artifacts}
+    assert filenames == {"product-1.5-x86_64.iso.gz", "product-1.5-x86_64.qcow2"}
+    assert all(row["architecture"] == "x86_64" for row in artifacts)
+
+
+def test_update_artifact_purls_mixed_content_types(tmp_path: Path) -> None:
+    """Update later PURL components even when the first mapping component is image."""
+    data = {
+        "cdn": {"env": "production"},
+        "mapping": {
+            "components": [
+                {
+                    "name": "container",
+                    "contentType": "image",
+                },
+                {
+                    "name": "cli",
+                    "contentType": "binary",
+                    "staged": {"version": "1.0"},
+                    "files": [{"arch": "x86_64", "os": "linux", "source": "cli.tgz"}],
+                },
+                {
+                    "name": "iso-image",
+                    "contentType": "disk-image",
+                    "staged": {"version": "1.5"},
+                },
+            ],
+        },
+        "releaseNotes": {
+            "content": {
+                "artifacts": [
+                    {
+                        "component": "cli",
+                        "architecture": "x86_64",
+                        "os": "linux",
+                        "purl": "placeholder",
+                    },
+                    {
+                        "component": "iso-image",
+                        "architecture": "x86_64",
+                        "os": "linux",
+                        "purl": "placeholder",
+                    },
+                ],
+            },
+        },
+    }
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    snapshot_file = tmp_path / "snapshot.json"
+    _write_data(
+        snapshot_file,
+        {
+            "components": [
+                {
+                    "name": "iso-image",
+                    "staged": {
+                        "files": [{"filename": "product-1.5-x86_64.iso.gz"}],
+                    },
+                },
+            ],
+        },
+    )
+    checksum_map = [
+        {"component": "cli", "files": {"cli.tgz": "sha256:cli"}},
+        {"component": "iso-image", "files": {"product-1.5-x86_64.iso.gz": "sha256:iso"}},
+    ]
+    with _patch_oci_update(checksum_map):
+        rnp_module.update_artifact_purls(
+            data_file,
+            checksum_map_param="oci:checksum",
+            snapshot_path=snapshot_file,
+        )
+
+    artifacts = json.loads(data_file.read_text(encoding="utf-8"))["releaseNotes"]["content"][
+        "artifacts"
+    ]
+    by_component = {row["component"]: row for row in artifacts}
+    assert "filename=cli.tgz" in by_component["cli"]["purl"]
+    assert "filename=product-1.5-x86_64.iso.gz" in by_component["iso-image"]["purl"]
+
+
+def test_update_artifact_purls_uses_windows_zip_for_checksum_lookup(tmp_path: Path) -> None:
+    """Windows rows look up checksums using the .zip name after compress-artifacts."""
+    data = _generic_mapping_data(
+        component_extra={
+            "files": [
+                {"arch": "x86_64", "os": "windows", "source": "app-windows-amd64.tar.gz"},
+            ],
+        },
+        artifact_extra={"os": "windows"},
+    )
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    checksum_map = [
+        {"component": "app", "files": {"app-windows-amd64.zip": "sha256:win"}},
+    ]
+    with _patch_oci_update(checksum_map):
+        rnp_module.update_artifact_purls(
+            data_file,
+            checksum_map_param="oci:checksum",
+        )
+
+    purl = json.loads(data_file.read_text(encoding="utf-8"))["releaseNotes"]["content"][
+        "artifacts"
+    ][0]["purl"]
+    assert "filename=app-windows-amd64.zip" in purl
+    assert "checksum=sha256%3Awin" in purl
+
+
+def test_update_artifact_purls_leaves_file_unchanged_when_nothing_updated(
+    tmp_path: Path,
+) -> None:
+    """Return without writing data.json when no component produces updated rows."""
+    data = {
+        "mapping": {
+            "components": [
+                {
+                    "name": "app",
+                    "contentType": "generic",
+                    "staged": {"version": "1.0"},
+                    "files": [],
+                },
+            ],
+        },
+        "releaseNotes": {"content": {"artifacts": []}},
+    }
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    original_text = data_file.read_text(encoding="utf-8")
+    with _patch_oci_update([{"component": "unused", "files": {}}]):
+        rnp_module.update_artifact_purls(
+            data_file,
+            checksum_map_param="oci:checksum",
+        )
+    assert data_file.read_text(encoding="utf-8") == original_text
+
+
+def test_update_artifact_purls_skips_malformed_mapping_components(tmp_path: Path) -> None:
+    """Ignore non-list components and non-dict component entries during iteration."""
+    data = _generic_mapping_data()
+    data["mapping"]["components"] = [
+        "skip",
+        {
+            "name": "app",
+            "contentType": "generic",
+            "staged": {"version": "1.0"},
+            "files": [{"arch": "x86_64", "os": "linux", "source": "app.tgz"}],
+        },
+    ]
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    checksum_map = [{"component": "app", "files": {"app.tgz": "sha256:abc"}}]
+    with _patch_oci_update(checksum_map):
+        rnp_module.update_artifact_purls(
+            data_file,
+            checksum_map_param="oci:checksum",
+        )
+
+    purl = json.loads(data_file.read_text(encoding="utf-8"))["releaseNotes"]["content"][
+        "artifacts"
+    ][0]["purl"]
+    assert "pkg:generic/app@1.0" in purl
+
+
+def test_update_artifact_purls_treats_non_list_components_as_empty(tmp_path: Path) -> None:
+    """When mapping.components is not a list, no PURL content type is detected."""
+    data = _generic_mapping_data()
+    data["mapping"]["components"] = "not-a-list"
+    data["releaseNotes"]["content"]["artifacts"] = []
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    original_text = data_file.read_text(encoding="utf-8")
+    rnp_module.update_artifact_purls(
+        data_file,
+        checksum_map_param="oci:checksum",
+    )
+    assert data_file.read_text(encoding="utf-8") == original_text
+
+
+def test_component_content_type_prefers_content_gateway() -> None:
+    """Prefer contentGateway.contentType over the top-level contentType field."""
+    component = {
+        "contentType": "image",
+        "contentGateway": {"contentType": "disk-image"},
+    }
+    assert rnp_module._component_content_type(component) == "disk-image"
+
+
+def test_staged_files_by_component_edge_cases() -> None:
+    """Skip invalid snapshot rows and treat missing staged.files as an empty list."""
+    assert rnp_module._staged_files_by_component({"components": "not-a-list"}) == {}
+    assert rnp_module._staged_files_by_component(
+        {
+            "components": [
+                "skip-me",
+                {"name": ""},
+                {"name": None},
+                {"name": "no-staged"},
+                {"name": "bad-files", "staged": {"files": "not-a-list"}},
+                {
+                    "name": "ok",
+                    "staged": {
+                        "files": [
+                            {"filename": "a.iso"},
+                            "skip-row",
+                        ],
+                    },
+                },
+            ],
+        },
+    ) == {
+        "no-staged": [],
+        "bad-files": [],
+        "ok": [{"filename": "a.iso"}],
+    }
+
+
+def test_updated_disk_image_entries_returns_empty_when_version_missing() -> None:
+    """Skip disk-image components that have neither CGW nor staged version metadata."""
+    data = {
+        "releaseNotes": {
+            "content": {
+                "artifacts": [{"component": "iso", "purl": "placeholder"}],
+            },
+        },
+    }
+    updated = rnp_module._updated_disk_image_entries(
+        data,
+        {"name": "iso"},
+        staged_files=[{"filename": "product-x86_64.iso.gz"}],
+        checksum_map=[],
+        cgw_base_url="https://developers.redhat.com/products",
+        cdn_base_url="https://access.redhat.com/downloads",
+    )
+    assert updated == []
+
+
+def test_updated_disk_image_entries_returns_empty_when_no_matching_artifacts() -> None:
+    """Skip disk-image components with no matching releaseNotes artifact rows."""
+    data = {"releaseNotes": {"content": {"artifacts": []}}}
+    updated = rnp_module._updated_disk_image_entries(
+        data,
+        {"name": "iso", "staged": {"version": "1.0"}},
+        staged_files=[{"filename": "product-x86_64.iso.gz"}],
+        checksum_map=[],
+        cgw_base_url="https://developers.redhat.com/products",
+        cdn_base_url="https://access.redhat.com/downloads",
+    )
+    assert updated == []
+
+
+def test_update_artifact_purls_non_list_components_after_purl_gate(
+    tmp_path: Path,
+) -> None:
+    """Treat mapping.components as empty when it is not a list after the PURL gate."""
+    data = _generic_mapping_data()
+    data["mapping"]["components"] = "not-a-list"
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    original_text = data_file.read_text(encoding="utf-8")
+    with (
+        mock.patch.object(rnp_module, "_first_purl_content_type", return_value="generic"),
+        _patch_oci_update([{"component": "unused", "files": {}}]),
+    ):
+        rnp_module.update_artifact_purls(
+            data_file,
+            checksum_map_param="oci:checksum",
+        )
+    assert data_file.read_text(encoding="utf-8") == original_text
+
+
+def test_update_artifact_purls_uses_content_gateway_content_type(tmp_path: Path) -> None:
+    """Detect PURL content types nested under contentGateway.contentType."""
+    data = _generic_mapping_data(
+        component_name="iso-image",
+        content_type="image",
+        component_extra={
+            "contentGateway": {"contentType": "disk-image", "productVersionName": "1.5"},
+            "staged": {"version": "ignored"},
+        },
+        artifact_extra={"component": "iso-image"},
+    )
+    del data["mapping"]["components"][0]["files"]
+    data_file = tmp_path / "data.json"
+    _write_data(data_file, data)
+    snapshot_file = tmp_path / "snapshot.json"
+    _write_data(
+        snapshot_file,
+        {
+            "components": [
+                {
+                    "name": "iso-image",
+                    "staged": {
+                        "files": [{"filename": "product-1.5-x86_64.iso.gz"}],
+                    },
+                },
+            ],
+        },
+    )
+    checksum_map = [
+        {"component": "iso-image", "files": {"product-1.5-x86_64.iso.gz": "sha256:iso"}},
+    ]
+    with _patch_oci_update(checksum_map):
+        rnp_module.update_artifact_purls(
+            data_file,
+            checksum_map_param="oci:checksum",
+            snapshot_path=snapshot_file,
+        )
+
+    artifact = json.loads(data_file.read_text(encoding="utf-8"))["releaseNotes"]["content"][
+        "artifacts"
+    ][0]
+    assert "pkg:generic/iso-image@1.5" in artifact["purl"]
+    assert "filename=product-1.5-x86_64.iso.gz" in artifact["purl"]

--- a/scripts/python/helpers/test_advisory_data.py
+++ b/scripts/python/helpers/test_advisory_data.py
@@ -378,3 +378,38 @@ def test_list_existing_advisory_subdirs_skips_files(tmp_path: Path) -> None:
     (base / "2024" / "notadir.txt").write_text("x", encoding="utf-8")
     (base / "file.txt").write_text("y", encoding="utf-8")
     assert advisory_data.list_existing_advisory_subdirs(base) == []
+
+
+def test_encode_advisory_param_round_trips_decode() -> None:
+    """Gzip/base64 encoding round-trips through decode_advisory_param."""
+    payload = {"type": "RHBA", "content": {"artifacts": []}}
+    encoded = advisory_data.encode_advisory_param(payload)
+    assert advisory_data.decode_advisory_param(encoded) == payload
+
+
+def test_first_mapping_content_type_reads_component_rows() -> None:
+    """Return the first mapping.components content type."""
+    data = {
+        "mapping": {
+            "components": [
+                {"contentType": "generic"},
+                {"contentType": "image"},
+            ],
+        },
+    }
+    assert advisory_data.first_mapping_content_type(data) == "generic"
+
+
+def test_first_mapping_content_type_reads_content_gateway_rows() -> None:
+    """Prefer contentGateway.contentType over top-level contentType."""
+    data = {
+        "mapping": {
+            "components": [
+                {
+                    "contentGateway": {"contentType": "binary"},
+                    "contentType": "image",
+                },
+            ],
+        },
+    }
+    assert advisory_data.first_mapping_content_type(data) == "binary"

--- a/scripts/python/helpers/test_compress_artifacts.py
+++ b/scripts/python/helpers/test_compress_artifacts.py
@@ -54,31 +54,6 @@ def _make_arch_dir(base: Path, os_name: str, arch: str, binary_name: str = "mybi
 
 
 # ---------------------------------------------------------------------------
-# _windows_filename
-# ---------------------------------------------------------------------------
-
-
-def test_windows_filename_tar_gz() -> None:
-    """A .tar.gz filename is converted to the equivalent .zip name."""
-    assert compress_artifacts._windows_filename("binary-amd64.tar.gz") == "binary-amd64.zip"
-
-
-def test_windows_filename_tar() -> None:
-    """A .tar filename is converted to the equivalent .zip name."""
-    assert compress_artifacts._windows_filename("binary-amd64.tar") == "binary-amd64.zip"
-
-
-def test_windows_filename_already_zip() -> None:
-    """A filename already ending in .zip is returned unchanged."""
-    assert compress_artifacts._windows_filename("binary-amd64.zip") == "binary-amd64.zip"
-
-
-def test_windows_filename_exe() -> None:
-    """A .exe filename that is not a tar archive is returned unchanged."""
-    assert compress_artifacts._windows_filename("binary.exe") == "binary.exe"
-
-
-# ---------------------------------------------------------------------------
 # _compress_file_entry
 # ---------------------------------------------------------------------------
 

--- a/scripts/python/helpers/test_disk_image_utils.py
+++ b/scripts/python/helpers/test_disk_image_utils.py
@@ -114,3 +114,36 @@ def test_is_disk_image_component_non_disk_image_content_types(content_type: str)
     """Non-disk-image contentType values return False."""
     component = {"contentType": content_type}
     assert disk_image_utils.is_disk_image_component(component) is False
+
+
+# ---------------------------------------------------------------------------
+# architecture_from_filename
+# ---------------------------------------------------------------------------
+
+
+def test_architecture_from_filename_x86_64() -> None:
+    """Return x86_64 when that token appears in the basename."""
+    assert disk_image_utils.architecture_from_filename("product-1.0-x86_64.iso.gz") == "x86_64"
+
+
+def test_architecture_from_filename_aarch64() -> None:
+    """Return aarch64 when that token appears in the basename."""
+    assert (
+        disk_image_utils.architecture_from_filename("product-1.0-aarch64.qcow2") == "aarch64"
+    )
+
+
+def test_architecture_from_filename_prefers_aarch64() -> None:
+    """Prefer aarch64 when both arch tokens appear in the name."""
+    assert disk_image_utils.architecture_from_filename("weird-aarch64-x86_64.iso") == "aarch64"
+
+
+def test_architecture_from_filename_unknown() -> None:
+    """Return unknown when no recognised arch token is present."""
+    assert disk_image_utils.architecture_from_filename("product.iso") == "unknown"
+
+
+def test_architecture_from_filename_uses_basename() -> None:
+    """Ignore directory path segments when sniffing architecture."""
+    path = "/build/x86_64/product-aarch64.iso.gz"
+    assert disk_image_utils.architecture_from_filename(path) == "aarch64"

--- a/scripts/python/tasks/managed/request_advisory_creation.py
+++ b/scripts/python/tasks/managed/request_advisory_creation.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Update artifact PURLs and request advisory creation via InternalRequest.
+
+This script is used for the create-advisory managed task. It uses a different name
+so it does not conflict with the create-advisory internal task script.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import advisory_data
+import file
+import internal_request
+import release_notes_purl
+import tekton
+from logger import logger
+
+# params.environment accepts either spelling for non-production image/rpm releases.
+_STAGE_ENV_RE = re.compile(r"^(stage|staging)$")
+# InternalRequest wait and PipelineRun timeouts.
+_IR_PIPELINE_TIMEOUT = "01h05m00s"
+_IR_TASK_TIMEOUT = "01h00m00s"
+_IR_FINALLY_TIMEOUT = "0h5m0s"
+_IR_WAIT_TIMEOUT_SECONDS = (
+    internal_request.duration_to_seconds(_IR_PIPELINE_TIMEOUT)
+    + internal_request.SPAWN_OVERHEAD_SECONDS
+)
+
+
+@dataclass(frozen=True)
+class TaskParams:
+    """Paths and Tekton parameters for the request-advisory-creation step."""
+
+    data_dir: Path
+    data_path: Path
+    snapshot_path: Path
+    release_plan_admission_path: Path
+    results_dir_path: Path
+    environment: str
+    request_pipeline: str
+    synchronously: str
+    pipeline_run_uid: str
+    task_git_url: str
+    task_git_revision: str
+    task_name: str
+    checksum_map: str
+    dockerconfig_path: Path
+    advisory_url_result: Path
+    advisory_internal_url_result: Path
+
+
+def _resolve_content_type(data: dict[str, Any]) -> str:
+    """Derive advisory content type from mapping, GitHub, or image defaults."""
+    content_type = advisory_data.first_mapping_content_type(data)
+    if content_type:
+        return content_type
+    # GitHub-only releases have no mapping.components contentType; treat as generic.
+    if "github" in data:
+        return "generic"
+    # Container image releases are the default when no artifact content type is present.
+    return "image"
+
+
+def _content_path_for_type(content_type: str) -> str:
+    """Return the advisory JSON path used for CVE counting."""
+    # File-based releases store CVEs under content.artifacts; images use content.images.
+    if content_type in advisory_data.ARTIFACT_CONTENT_TYPES:
+        return ".content.artifacts"
+    return ".content.images"
+
+
+def _count_fixed_cves(advisory: dict[str, Any], content_path: str) -> int:
+    """Count fixed CVE ids across all content rows."""
+    total = 0
+    for item in advisory_data.content_array_from_decoded(advisory, content_path):
+        if not isinstance(item, dict):
+            continue
+        cves = item.get("cves")
+        if not isinstance(cves, dict):
+            continue
+        fixed = cves.get("fixed")
+        # populate-release-notes stores fixed CVEs as a map (CVE id -> metadata).
+        if isinstance(fixed, dict):
+            total += len(fixed)
+        elif isinstance(fixed, list):
+            total += len(fixed)
+    return total
+
+
+def _prepare_advisory_data(
+    release_notes: dict[str, Any],
+    content_path: str,
+) -> dict[str, Any]:
+    """Validate advisory fields and apply RHBA default type when missing."""
+    live_id = release_notes.get("live_id")
+    allow_custom_live_id = release_notes.get("allow_custom_live_id", False) is True
+    if not allow_custom_live_id and live_id is not None:
+        msg = "advisory live id is only allowed if allow_custom_live_id is set to true"
+        raise ValueError(msg)
+
+    advisory_type = release_notes.get("type")
+    if advisory_type is None:
+        logger.info("Defaulting to type = %s", advisory_data.DEFAULT_ADVISORY_TYPE)
+        release_notes = {**release_notes, "type": advisory_data.DEFAULT_ADVISORY_TYPE}
+        advisory_type = advisory_data.DEFAULT_ADVISORY_TYPE
+
+    if advisory_type not in advisory_data.VALID_ADVISORY_TYPES:
+        msg = "advisory type must be one of RHSA, RHBA or RHEA"
+        raise ValueError(msg)
+
+    # RHSA requires at least one fixed CVE in the content array for this release type.
+    if advisory_type == "RHSA" and _count_fixed_cves(release_notes, content_path) == 0:
+        msg = (
+            "Provided advisory type is RHSA, but no fixed CVEs were listed. "
+            "RHSA should only be used if CVEs are fixed in the advisory. Failing..."
+        )
+        raise ValueError(msg)
+
+    return release_notes
+
+
+def _resolve_secret_names(
+    content_type: str,
+    *,
+    environment: str,
+    data: dict[str, Any],
+) -> tuple[str, str]:
+    """Select advisory and Errata secret names for the release content type.
+
+    All content types use the same prod/staging GitLab repos and secret names.
+    Which pair to use depends on how the release environment is determined:
+
+    - image/rpm: ``environment`` (stage/staging vs everything else)
+    - binary/generic/disk-image: ``data['intention']`` (production vs staging)
+    """
+    if content_type in {"image", "rpm"}:
+        is_staging = bool(_STAGE_ENV_RE.match(environment.strip()))
+    else:
+        intention = str(data.get("intention", ""))
+        if intention == "production":
+            is_staging = False
+        elif intention == "staging":
+            is_staging = True
+        else:
+            msg = f"unsupported intention for advisory secrets: {intention!r}"
+            raise ValueError(msg)
+
+    if is_staging:
+        return (
+            advisory_data.ADVISORY_SECRET_STAGE,
+            advisory_data.ERRATA_SECRET_STAGE,
+        )
+    return advisory_data.ADVISORY_SECRET_PROD, advisory_data.ERRATA_SECRET_PROD
+
+
+def _sync_from_param(value: str) -> bool:
+    """Parse Tekton synchronously param (``true`` / ``false``) to a bool."""
+    return value.strip().lower() == "true"
+
+
+def _create_internal_request(
+    params: TaskParams,
+    *,
+    component_group: str,
+    origin: str,
+    advisory_json: str,
+    config_map_name: str,
+    content_type: str,
+    advisory_secret_name: str,
+    errata_secret_name: str,
+) -> str:
+    """Create an InternalRequest and optionally wait for it to complete."""
+    logger.info("Creating InternalRequest to create advisory...")
+    sync = _sync_from_param(params.synchronously)
+    try:
+        internal_request_name = internal_request.create(
+            params.request_pipeline,
+            params={
+                "componentGroup": component_group,
+                "origin": origin,
+                "advisory_json": advisory_json,
+                "config_map_name": config_map_name,
+                "contentType": content_type,
+                "advisory_secret_name": advisory_secret_name,
+                "errata_secret_name": errata_secret_name,
+                "taskGitUrl": params.task_git_url,
+                "taskGitRevision": params.task_git_revision,
+            },
+            labels={
+                internal_request.PIPELINERUN_UID_LABEL: params.pipeline_run_uid,
+            },
+            sync=sync,
+            timeout=_IR_WAIT_TIMEOUT_SECONDS,
+            pipeline_timeout=_IR_PIPELINE_TIMEOUT,
+            task_timeout=_IR_TASK_TIMEOUT,
+            finally_timeout=_IR_FINALLY_TIMEOUT,
+        )
+    except internal_request.InternalRequestWaitError as err:
+        raise RuntimeError(str(err)) from err
+    logger.info("done (%s)", internal_request_name)
+    return internal_request_name
+
+
+def _write_task_results(
+    params: TaskParams,
+    results: dict[str, Any],
+) -> None:
+    """Write Tekton results and the create-advisory results JSON file."""
+    # Clear Tekton results before checking IR status (matches result initialization).
+    params.advisory_url_result.write_text("", encoding="utf-8")
+    params.advisory_internal_url_result.write_text("", encoding="utf-8")
+
+    pipeline_run_name = str(results.get("internalRequestPipelineRunName") or "")
+    task_run_name = str(results.get("internalRequestTaskRunName") or "")
+    logger.info("** internalRequestPipelineRunName: %s", pipeline_run_name)
+    logger.info("** internalRequestTaskRunName: %s", task_run_name)
+
+    if results.get("result") != "Success":
+        logger.info("Advisory creation failed")
+        print(json.dumps(results))
+        msg = "advisory creation failed"
+        raise RuntimeError(msg)
+
+    logger.info("Advisory created")
+    advisory_url = str(results.get("advisory_url") or "")
+    advisory_internal_url = str(results.get("advisory_internal_url") or "")
+    params.advisory_url_result.write_text(advisory_url, encoding="utf-8")
+    params.advisory_internal_url_result.write_text(
+        advisory_internal_url,
+        encoding="utf-8",
+    )
+
+    results_file = params.data_dir / params.results_dir_path / "create-advisory-results.json"
+    results_file.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "advisory": {
+            "url": advisory_url,
+            "internal_url": advisory_internal_url,
+        },
+    }
+    # Downstream tasks read advisory URLs from this results file under resultsDirPath.
+    results_file.write_text(
+        json.dumps(payload, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+
+
+def run_request_advisory_creation(params: TaskParams) -> None:
+    """Update PURLs, submit the InternalRequest, and write Tekton results."""
+    data_file = params.data_dir / params.data_path
+    # Populate releaseNotes PURLs from the checksum_map OCI artifact when applicable.
+    # Pass the snapshot so disk-image staged.files use substituted filenames (not
+    # unresolved {{ release_timestamp }} templates left in data.json).
+    release_notes_purl.update_artifact_purls(
+        data_file,
+        checksum_map_param=params.checksum_map,
+        dockerconfig_path=params.dockerconfig_path,
+        snapshot_path=params.data_dir / params.snapshot_path,
+    )
+
+    snapshot_file = params.data_dir / params.snapshot_path
+    rpa_file = params.data_dir / params.release_plan_admission_path
+
+    data = file.load_json_dict(data_file)
+    snapshot = file.load_json_dict(snapshot_file)
+    release_plan_admission = file.load_json_dict(rpa_file)
+
+    component_group = snapshot["componentGroup"]
+    origin = release_plan_admission["spec"]["origin"]
+    advisory_data_dict = data["releaseNotes"]
+    if not isinstance(advisory_data_dict, dict):
+        msg = "releaseNotes must be a JSON object"
+        raise TypeError(msg)
+    config_map_name = data["sign"]["configMapName"]
+
+    content_type = _resolve_content_type(data)
+    content_path = _content_path_for_type(content_type)
+    advisory_data_dict = _prepare_advisory_data(dict(advisory_data_dict), content_path)
+
+    advisory_secret_name, errata_secret_name = _resolve_secret_names(
+        content_type,
+        environment=params.environment,
+        data=data,
+    )
+    # InternalRequest param is gzip+base64 advisory JSON for the create-advisory pipeline.
+    advisory_json = advisory_data.encode_advisory_param(advisory_data_dict)
+
+    internal_request_name = _create_internal_request(
+        params,
+        component_group=component_group,
+        origin=origin,
+        advisory_json=advisory_json,
+        config_map_name=config_map_name,
+        content_type=content_type,
+        advisory_secret_name=advisory_secret_name,
+        errata_secret_name=errata_secret_name,
+    )
+    results = internal_request.fetch_results(internal_request_name)
+    _write_task_results(params, results)
+
+
+def _params_from_env() -> TaskParams:
+    """Build task parameters from Tekton PARAM_* and RESULT_* environment variables."""
+    data_dir = Path(tekton.require_env("PARAM_DATA_DIR"))
+    advisory_url_result, advisory_internal_url_result = tekton.result_paths_from_env(
+        "RESULT_ADVISORY_URL",
+        "RESULT_ADVISORY_INTERNAL_URL",
+    )
+    dockerconfig_raw = os.environ.get("PARAM_TA_DOCKERCONFIG_PATH", "").strip()
+    dockerconfig_path = (
+        Path(dockerconfig_raw)
+        if dockerconfig_raw
+        else release_notes_purl.TA_DOCKERCONFIG_DEFAULT
+    )
+    return TaskParams(
+        data_dir=data_dir,
+        data_path=Path(tekton.require_env("PARAM_DATA_PATH")),
+        snapshot_path=Path(tekton.require_env("PARAM_SNAPSHOT_PATH")),
+        release_plan_admission_path=Path(
+            tekton.require_env("PARAM_RELEASE_PLAN_ADMISSION_PATH"),
+        ),
+        results_dir_path=Path(tekton.require_env("PARAM_RESULTS_DIR_PATH")),
+        environment=os.environ.get("PARAM_ENVIRONMENT", "").strip(),
+        request_pipeline=os.environ.get("PARAM_REQUEST", "create-advisory").strip()
+        or "create-advisory",
+        synchronously=os.environ.get("PARAM_SYNCHRONOUSLY", "true").strip() or "true",
+        pipeline_run_uid=tekton.require_env("PARAM_PIPELINE_RUN_UID"),
+        task_git_url=tekton.require_env("PARAM_TASK_GIT_URL"),
+        task_git_revision=tekton.require_env("PARAM_TASK_GIT_REVISION"),
+        task_name=tekton.require_env("PARAM_TASK_NAME"),
+        checksum_map=os.environ.get("PARAM_CHECKSUM_MAP", "").strip(),
+        dockerconfig_path=dockerconfig_path,
+        advisory_url_result=advisory_url_result,
+        advisory_internal_url_result=advisory_internal_url_result,
+    )
+
+
+def main() -> int:
+    """Entry point: load params from the environment and run the workflow."""
+    run_request_advisory_creation(_params_from_env())
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_request_advisory_creation.py
+++ b/scripts/python/tasks/managed/test_request_advisory_creation.py
@@ -1,0 +1,474 @@
+"""Tests for the managed request_advisory_creation task script."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import advisory_data
+import pytest
+
+_MODULE_PATH = Path(__file__).with_name("request_advisory_creation.py")
+_SPEC = importlib.util.spec_from_file_location("request_advisory_creation", _MODULE_PATH)
+assert _SPEC and _SPEC.loader
+request_advisory_creation = importlib.util.module_from_spec(_SPEC)
+sys.modules["request_advisory_creation"] = request_advisory_creation
+_SPEC.loader.exec_module(request_advisory_creation)
+
+
+def _task_params(tmp_path: Path) -> request_advisory_creation.TaskParams:
+    """Build minimal task params for orchestration tests."""
+    return request_advisory_creation.TaskParams(
+        data_dir=tmp_path,
+        data_path=Path("data.json"),
+        snapshot_path=Path("snapshot.json"),
+        release_plan_admission_path=Path("rpa.json"),
+        results_dir_path=Path("results"),
+        environment="stage",
+        request_pipeline="create-advisory",
+        synchronously="true",
+        pipeline_run_uid="uid-1",
+        task_git_url="https://example.test/catalog.git",
+        task_git_revision="main",
+        task_name="create-advisory",
+        checksum_map="oci:checksum",
+        dockerconfig_path=tmp_path / "missing-dockerconfig",
+        advisory_url_result=tmp_path / "advisory_url",
+        advisory_internal_url_result=tmp_path / "advisory_internal_url",
+    )
+
+
+def _write_release_files(tmp_path: Path, *, advisory_type: str | None = "RHBA") -> None:
+    """Write snapshot, RPA, and data files for a happy-path run."""
+    (tmp_path / "snapshot.json").write_text(
+        json.dumps({"componentGroup": "my-group"}) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "rpa.json").write_text(
+        json.dumps({"spec": {"origin": "my-origin"}}) + "\n",
+        encoding="utf-8",
+    )
+    release_notes: dict[str, Any] = {
+        "type": advisory_type,
+        "content": {"images": [{"cves": {"fixed": ["CVE-2024-1"]}}]},
+    }
+    if advisory_type is None:
+        release_notes.pop("type")
+    (tmp_path / "data.json").write_text(
+        json.dumps(
+            {
+                "sign": {"configMapName": "signing-config"},
+                "mapping": {"components": [{"contentType": "image"}]},
+                "releaseNotes": release_notes,
+            },
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_prepare_advisory_data_defaults_missing_type_to_rhba() -> None:
+    """Default advisory type to RHBA when releaseNotes.type is null."""
+    advisory = {"content": {"images": []}}
+    out = request_advisory_creation._prepare_advisory_data(
+        advisory,
+        ".content.images",
+    )
+    assert out["type"] == "RHBA"
+
+
+def test_prepare_advisory_data_rejects_rhsa_without_cves() -> None:
+    """Reject RHSA advisories that do not list fixed CVEs."""
+    with pytest.raises(ValueError, match="no fixed CVEs were listed"):
+        request_advisory_creation._prepare_advisory_data(
+            {"type": "RHSA", "content": {"images": []}},
+            ".content.images",
+        )
+
+
+def test_prepare_advisory_data_accepts_rhsa_with_fixed_cve_map() -> None:
+    """Accept RHSA when fixed CVEs are stored as a map (populate-release-notes format)."""
+    advisory = {
+        "type": "RHSA",
+        "content": {
+            "images": [
+                {
+                    "cves": {
+                        "fixed": {
+                            "CVE-2024-1234": {"packages": ["pkg:example/foo@1.0"]},
+                        },
+                    },
+                },
+            ],
+        },
+    }
+    out = request_advisory_creation._prepare_advisory_data(advisory, ".content.images")
+    assert out["type"] == "RHSA"
+
+
+def test_resolve_content_type_uses_github_generic_default() -> None:
+    """Treat GitHub-only data as generic content."""
+    assert request_advisory_creation._resolve_content_type({"github": {}}) == "generic"
+
+
+def test_run_request_advisory_creation_calls_update_purl_before_internal_request(
+    tmp_path: Path,
+) -> None:
+    """Run PURL updates before creating the InternalRequest."""
+    _write_release_files(tmp_path, advisory_type=None)
+    params = _task_params(tmp_path)
+    calls: list[str] = []
+
+    with (
+        mock.patch.object(
+            request_advisory_creation.release_notes_purl,
+            "update_artifact_purls",
+            side_effect=lambda *_a, **_k: calls.append("purl"),
+        ),
+        mock.patch.object(
+            request_advisory_creation,
+            "_create_internal_request",
+            return_value="create-advisory-abc",
+        ) as run_ir,
+        mock.patch.object(
+            request_advisory_creation.internal_request,
+            "fetch_results",
+            return_value={
+                "result": "Success",
+                "advisory_url": "url",
+                "advisory_internal_url": "internal",
+            },
+        ),
+    ):
+        request_advisory_creation.run_request_advisory_creation(params)
+
+    assert calls == ["purl"]
+    run_ir.assert_called_once()
+
+
+def test_run_request_advisory_creation_happy_path(tmp_path: Path) -> None:
+    """Submit an InternalRequest and write advisory URLs on success."""
+    _write_release_files(tmp_path, advisory_type=None)
+    params = _task_params(tmp_path)
+    ir_results = {
+        "result": "Success",
+        "advisory_url": "https://access.redhat.com/errata/RHBA-2025:1111",
+        "advisory_internal_url": "https://gitlab.example/advisory",
+    }
+
+    with (
+        mock.patch.object(
+            request_advisory_creation.release_notes_purl, "update_artifact_purls"
+        ),
+        mock.patch.object(
+            request_advisory_creation,
+            "_create_internal_request",
+            return_value="create-advisory-abc",
+        ),
+        mock.patch.object(
+            request_advisory_creation.internal_request,
+            "fetch_results",
+            return_value=ir_results,
+        ),
+    ):
+        request_advisory_creation.run_request_advisory_creation(params)
+
+    url_text = params.advisory_url_result.read_text(encoding="utf-8")
+    assert url_text == ir_results["advisory_url"]
+
+
+def test_encode_advisory_json_matches_decoder() -> None:
+    """Round-trip advisory JSON through gzip/base64 encoding."""
+    payload = {"type": "RHBA", "content": {"artifacts": []}}
+    encoded = advisory_data.encode_advisory_param(payload)
+    assert advisory_data.decode_advisory_param(encoded) == payload
+
+
+def test_create_internal_request_calls_python_helper() -> None:
+    """Submit the InternalRequest through the Python internal_request helper."""
+    params = request_advisory_creation.TaskParams(
+        data_dir=Path("/tmp"),
+        data_path=Path("data.json"),
+        snapshot_path=Path("snap.json"),
+        release_plan_admission_path=Path("rpa.json"),
+        results_dir_path=Path("results"),
+        environment="stage",
+        request_pipeline="create-advisory",
+        synchronously="true",
+        pipeline_run_uid="uid-42",
+        task_git_url="https://example.test/catalog.git",
+        task_git_revision="main",
+        task_name="create-advisory",
+        checksum_map="",
+        dockerconfig_path=Path("/tmp/dockerconfig"),
+        advisory_url_result=Path("/tmp/advisory_url"),
+        advisory_internal_url_result=Path("/tmp/advisory_internal_url"),
+    )
+
+    with mock.patch.object(
+        request_advisory_creation.internal_request, "create", return_value="ir-abc"
+    ) as ir:
+        name = request_advisory_creation._create_internal_request(
+            params,
+            component_group="grp",
+            origin="origin-ws",
+            advisory_json="encoded",
+            config_map_name="cm",
+            content_type="image",
+            advisory_secret_name="adv-secret",
+            errata_secret_name="errata-secret",
+        )
+
+    assert name == "ir-abc"
+    ir.assert_called_once_with(
+        "create-advisory",
+        params={
+            "componentGroup": "grp",
+            "origin": "origin-ws",
+            "advisory_json": "encoded",
+            "config_map_name": "cm",
+            "contentType": "image",
+            "advisory_secret_name": "adv-secret",
+            "errata_secret_name": "errata-secret",
+            "taskGitUrl": "https://example.test/catalog.git",
+            "taskGitRevision": "main",
+        },
+        labels={
+            "internal-services.appstudio.openshift.io/pipelinerun-uid": "uid-42",
+        },
+        sync=True,
+        timeout=request_advisory_creation._IR_WAIT_TIMEOUT_SECONDS,
+        pipeline_timeout=request_advisory_creation._IR_PIPELINE_TIMEOUT,
+        task_timeout=request_advisory_creation._IR_TASK_TIMEOUT,
+        finally_timeout=request_advisory_creation._IR_FINALLY_TIMEOUT,
+    )
+
+
+def test_main_success(tmp_path: Path) -> None:
+    """Exit 0 when orchestration completes."""
+    with (
+        mock.patch.object(
+            request_advisory_creation,
+            "_params_from_env",
+            return_value=_task_params(tmp_path),
+        ),
+        mock.patch.object(request_advisory_creation, "run_request_advisory_creation"),
+    ):
+        assert request_advisory_creation.main() == 0
+
+
+def test_resolve_content_type_defaults_to_image() -> None:
+    """Default to image when no mapping or GitHub content is present."""
+    assert request_advisory_creation._resolve_content_type({}) == "image"
+
+
+def test_content_path_for_type_uses_artifacts_for_binary() -> None:
+    """Binary releases store CVEs under content.artifacts."""
+    assert request_advisory_creation._content_path_for_type("binary") == ".content.artifacts"
+
+
+def test_count_fixed_cves_counts_list_fixed_cves() -> None:
+    """Count fixed CVEs stored as a list."""
+    advisory = {
+        "content": {
+            "images": [{"cves": {"fixed": ["CVE-1", "CVE-2"]}}],
+        },
+    }
+    assert request_advisory_creation._count_fixed_cves(advisory, ".content.images") == 2
+
+
+def test_count_fixed_cves_skips_invalid_rows() -> None:
+    """Ignore non-dict content rows and non-dict cves blocks."""
+    advisory = {
+        "content": {
+            "images": ["invalid", {"cves": "invalid"}],
+        },
+    }
+    assert request_advisory_creation._count_fixed_cves(advisory, ".content.images") == 0
+
+
+def test_prepare_advisory_data_rejects_live_id_without_flag() -> None:
+    """Reject live_id unless allow_custom_live_id is true."""
+    with pytest.raises(ValueError, match="live id is only allowed"):
+        request_advisory_creation._prepare_advisory_data(
+            {
+                "live_id": "RHBA-1",
+                "type": "RHBA",
+                "content": {"images": []},
+            },
+            ".content.images",
+        )
+
+
+def test_prepare_advisory_data_rejects_invalid_type() -> None:
+    """Reject advisory types outside RHSA, RHBA, and RHEA."""
+    with pytest.raises(ValueError, match="advisory type must be one of"):
+        request_advisory_creation._prepare_advisory_data(
+            {"type": "INVALID", "content": {"images": []}},
+            ".content.images",
+        )
+
+
+def test_resolve_secret_names_image_uses_staging_secrets() -> None:
+    """Image releases use staging secrets when environment is stage."""
+    assert request_advisory_creation._resolve_secret_names(
+        "image",
+        environment="staging",
+        data={},
+    ) == (
+        advisory_data.ADVISORY_SECRET_STAGE,
+        advisory_data.ERRATA_SECRET_STAGE,
+    )
+
+
+def test_resolve_secret_names_image_uses_prod_secrets() -> None:
+    """Image releases use production secrets for non-stage environments."""
+    assert request_advisory_creation._resolve_secret_names(
+        "image",
+        environment="production",
+        data={},
+    ) == (
+        advisory_data.ADVISORY_SECRET_PROD,
+        advisory_data.ERRATA_SECRET_PROD,
+    )
+
+
+def test_resolve_secret_names_binary_uses_intention() -> None:
+    """Binary releases select secrets from data.intention."""
+    prod = request_advisory_creation._resolve_secret_names(
+        "binary",
+        environment="",
+        data={"intention": "production"},
+    )
+    staging = request_advisory_creation._resolve_secret_names(
+        "binary",
+        environment="",
+        data={"intention": "staging"},
+    )
+    assert prod == (
+        advisory_data.ADVISORY_SECRET_PROD,
+        advisory_data.ERRATA_SECRET_PROD,
+    )
+    assert staging == (
+        advisory_data.ADVISORY_SECRET_STAGE,
+        advisory_data.ERRATA_SECRET_STAGE,
+    )
+
+
+def test_resolve_secret_names_rejects_unsupported_intention() -> None:
+    """Reject binary/generic releases with unknown intention values."""
+    with pytest.raises(ValueError, match="unsupported intention"):
+        request_advisory_creation._resolve_secret_names(
+            "binary",
+            environment="",
+            data={"intention": "dev"},
+        )
+
+
+def test_sync_from_param_parses_false() -> None:
+    """Parse synchronously=false as a boolean false."""
+    assert request_advisory_creation._sync_from_param("false") is False
+
+
+def test_create_internal_request_wraps_wait_error(tmp_path: Path) -> None:
+    """Surface InternalRequest wait failures as RuntimeError."""
+    params = _task_params(tmp_path)
+    with (
+        mock.patch.object(
+            request_advisory_creation.internal_request,
+            "create",
+            side_effect=request_advisory_creation.internal_request.InternalRequestWaitError(
+                "timed out",
+                1,
+            ),
+        ),
+        pytest.raises(RuntimeError, match="timed out"),
+    ):
+        request_advisory_creation._create_internal_request(
+            params,
+            component_group="grp",
+            origin="origin-ws",
+            advisory_json="encoded",
+            config_map_name="cm",
+            content_type="image",
+            advisory_secret_name="adv-secret",
+            errata_secret_name="errata-secret",
+        )
+
+
+def test_write_task_results_raises_on_failure(tmp_path: Path) -> None:
+    """Fail the step when InternalRequest results are not Success."""
+    params = _task_params(tmp_path)
+    params.advisory_internal_url_result.write_text("stale-internal", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="advisory creation failed"):
+        request_advisory_creation._write_task_results(
+            params,
+            {"result": "Failed", "message": "boom"},
+        )
+    assert params.advisory_url_result.read_text(encoding="utf-8") == ""
+    assert params.advisory_internal_url_result.read_text(encoding="utf-8") == ""
+
+
+def test_ir_wait_timeout_covers_pipeline_budget() -> None:
+    """Script wait timeout must cover pipeline budget plus spawn overhead."""
+    import internal_request
+
+    pipeline_seconds = internal_request.duration_to_seconds(
+        request_advisory_creation._IR_PIPELINE_TIMEOUT,
+    )
+    assert request_advisory_creation._IR_WAIT_TIMEOUT_SECONDS == (
+        pipeline_seconds + internal_request.SPAWN_OVERHEAD_SECONDS
+    )
+
+
+def test_run_request_advisory_creation_rejects_release_notes_not_dict(
+    tmp_path: Path,
+) -> None:
+    """Require releaseNotes to be a JSON object."""
+    _write_release_files(tmp_path)
+    data = json.loads((tmp_path / "data.json").read_text(encoding="utf-8"))
+    data["releaseNotes"] = "invalid"
+    (tmp_path / "data.json").write_text(json.dumps(data) + "\n", encoding="utf-8")
+    params = _task_params(tmp_path)
+    with (
+        mock.patch.object(
+            request_advisory_creation.release_notes_purl, "update_artifact_purls"
+        ),
+        pytest.raises(TypeError, match="releaseNotes must be a JSON object"),
+    ):
+        request_advisory_creation.run_request_advisory_creation(params)
+
+
+def test_params_from_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Build TaskParams from Tekton-style environment variables."""
+    monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("PARAM_DATA_PATH", "data.json")
+    monkeypatch.setenv("PARAM_SNAPSHOT_PATH", "snapshot.json")
+    monkeypatch.setenv("PARAM_RELEASE_PLAN_ADMISSION_PATH", "rpa.json")
+    monkeypatch.setenv("PARAM_RESULTS_DIR_PATH", "results")
+    monkeypatch.setenv("PARAM_ENVIRONMENT", "stage")
+    monkeypatch.setenv("PARAM_REQUEST", "create-advisory")
+    monkeypatch.setenv("PARAM_SYNCHRONOUSLY", "false")
+    monkeypatch.setenv("PARAM_PIPELINE_RUN_UID", "uid-99")
+    monkeypatch.setenv("PARAM_TASK_GIT_URL", "https://example.test/catalog.git")
+    monkeypatch.setenv("PARAM_TASK_GIT_REVISION", "main")
+    monkeypatch.setenv("PARAM_TASK_NAME", "create-advisory")
+    monkeypatch.setenv("PARAM_CHECKSUM_MAP", "oci:checksum")
+    monkeypatch.setenv("PARAM_TA_DOCKERCONFIG_PATH", str(tmp_path / "dockerconfig"))
+    monkeypatch.setenv("RESULT_ADVISORY_URL", str(tmp_path / "advisory_url"))
+    monkeypatch.setenv(
+        "RESULT_ADVISORY_INTERNAL_URL",
+        str(tmp_path / "advisory_internal_url"),
+    )
+
+    params = request_advisory_creation._params_from_env()
+
+    assert params.data_dir == tmp_path / "data"
+    assert params.environment == "stage"
+    assert params.synchronously == "false"
+    assert params.dockerconfig_path == tmp_path / "dockerconfig"
+    assert params.advisory_url_result == tmp_path / "advisory_url"


### PR DESCRIPTION
This commit adds a python script to replicate the functionality of the
inline bash script in the create-advisory managed task in the catalog
repo. The task will be updated to use this python module instead.
    
Assisted-By: Cursor