### PR TITLE
Add contentType at component level in dataKeys schema

### DIFF
--- a/schemas/dataKeys.json
+++ b/schemas/dataKeys.json
@@ -737,6 +737,16 @@
               "public": {
                 "type": "boolean",
                 "description": "Indicates if the target repository should be made public"
+              },
+              "contentType": {
+                "type": "string",
+                "enum": [
+                  "disk-image",
+                  "binary",
+                  "generic",
+                  "rpm"
+                ],
+                "description": "Specifies the type of content being published"
               }
             }
           }


### PR DESCRIPTION
## Summary

- Add `contentType` as a top-level field on `mapping.components[]` in the dataKeys schema
- Currently `contentType` only exists under `contentGateway`, but tasks like `populate-release-notes` and `create-advisory` check for a component-level fallback
- Enum values: `["disk-image", "binary", "generic", "rpm"]` based on actual usage across tasks

## Context

Related to https://github.com/konflux-ci/release-service-catalog/pull/2342 and https://redhat.atlassian.net/browse/KONFLUX-14912

Signed-off-by: Jose Angel Morena <jmorenas@redhat.com>