### PR TITLE
feat(RELEASE-2703): add AI skills for task creation and helper usage

### DIFF
--- a/.claude/skills/using-helpers
+++ b/.claude/skills/using-helpers
@@ -1,0 +1,1 @@
+../../skills/using-helpers

--- a/.claude/skills/writing-new-task-scripts
+++ b/.claude/skills/writing-new-task-scripts
@@ -1,0 +1,1 @@
+../../skills/writing-new-task-scripts

--- a/.cursor/skills/using-helpers
+++ b/.cursor/skills/using-helpers
@@ -1,0 +1,1 @@
+../../skills/using-helpers

--- a/.cursor/skills/writing-new-task-scripts
+++ b/.cursor/skills/writing-new-task-scripts
@@ -1,0 +1,1 @@
+../../skills/writing-new-task-scripts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,9 @@ Container image (UBI9) with Python scripts, wrappers, and templates used by Tekt
 - Type hints on all function signatures.
 - Docstrings on every module and public function (triple-double-quote, imperative mood).
 - Black formatter, line length 95. Flake8 linter, line length 95, E203 ignored.
-- Named loggers: `LOGGER = logging.getLogger("module_name")`.
+- Named loggers: `from logger import logger` (shared helper) in task scripts;
+  `logging.getLogger("module_name")` only in standalone helper submodules
+  (e.g. the artifact-signing pipeline).
 - argparse for CLI arguments; env vars for Tekton-injected config.
 - Entry point: `if __name__ == "__main__": raise SystemExit(main())`.
 - Exception chaining: always use `raise ... from e`.
@@ -62,3 +64,13 @@ Container image (UBI9) with Python scripts, wrappers, and templates used by Tekt
 - Wrapper scripts call external tools (pubtools-pulp, pubtools-marketplacesvm, etc.) via subprocess or library APIs.
 - Internal task scripts (`scripts/python/tasks/internal/`) must catch all exceptions in `main()` and save errors to Tekton result files (the script itself must succeed).
 - Managed task scripts (`scripts/python/tasks/managed/`) must not catch exceptions in `main()` — let the script fail with traceback.
+
+## Skills
+
+AI skills are in `skills/`. Each skill has a `SKILL.md` following the [agentskills.io](https://agentskills.io) spec.
+Symlinked to `.claude/skills/` and `.cursor/skills/` for agent discovery.
+
+Available skills:
+
+- `writing-new-task-scripts` — how to create a new Python task script following repo conventions
+- `using-helpers` — catalog of shared helpers to avoid reinventing existing code

--- a/skills/test_skills.py
+++ b/skills/test_skills.py
@@ -1,0 +1,78 @@
+"""Validate AI skill layout, frontmatter, and agent discovery symlinks."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+AGENTS_MD = REPO_ROOT / "AGENTS.md"
+
+FRONTMATTER_RE = re.compile(
+    r"^---\s*\nname:\s*(?P<name>\S+)\s*\ndescription:\s*>-\s*\n(?P<desc>(?:\s+.+\n)+)---",
+    re.MULTILINE,
+)
+
+SYMLINK_ROOTS = (
+    REPO_ROOT / ".claude" / "skills",
+    REPO_ROOT / ".cursor" / "skills",
+)
+
+
+@pytest.fixture(scope="session")
+def skill_names() -> tuple[str, ...]:
+    """Return skill directory names that contain a SKILL.md file."""
+    names: list[str] = []
+    for child in sorted(SKILLS_DIR.iterdir()):
+        if child.is_dir() and (child / "SKILL.md").is_file():
+            names.append(child.name)
+    return tuple(names)
+
+
+def test_skills_directory_exists() -> None:
+    """skills/ must exist at the repository root."""
+    assert SKILLS_DIR.is_dir()
+
+
+def test_at_least_one_skill_exists(skill_names: tuple[str, ...]) -> None:
+    """At least one repo-specific skill must be present."""
+    assert len(skill_names) >= 1
+
+
+@pytest.mark.parametrize("skill_name", ("writing-new-task-scripts", "using-helpers"))
+def test_release_2703_skills_present(skill_name: str, skill_names: tuple[str, ...]) -> None:
+    """RELEASE-2703 deliverables must remain present."""
+    assert skill_name in skill_names
+
+
+def test_skill_frontmatter(skill_names: tuple[str, ...]) -> None:
+    """Each SKILL.md must follow agentskills.io frontmatter (name + description)."""
+    for skill_name in skill_names:
+        content = (SKILLS_DIR / skill_name / "SKILL.md").read_text(encoding="utf-8")
+        match = FRONTMATTER_RE.match(content)
+        assert match is not None, f"{skill_name}: missing or invalid frontmatter"
+        assert match.group("name") == skill_name
+        assert match.group("desc").strip()
+
+
+def test_skill_symlinks(skill_names: tuple[str, ...]) -> None:
+    """Every skill must be symlinked for Claude and Cursor agent discovery."""
+    for root in SYMLINK_ROOTS:
+        for skill_name in skill_names:
+            link = root / skill_name
+            assert link.is_symlink(), f"missing symlink: {link}"
+            assert link.resolve() == (SKILLS_DIR / skill_name).resolve()
+
+
+def test_agents_md_references_skills(skill_names: tuple[str, ...]) -> None:
+    """AGENTS.md must document the skills directory and list available skills."""
+    text = AGENTS_MD.read_text(encoding="utf-8")
+    assert "## Skills" in text
+    assert "`skills/`" in text
+    assert ".claude/skills/" in text
+    assert ".cursor/skills/" in text
+    for name in skill_names:
+        assert f"`{name}`" in text

--- a/skills/using-helpers/SKILL.md
+++ b/skills/using-helpers/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: using-helpers
+description: >-
+  Use when implementing task logic in release-service-utils and tempted to write
+  a new utility function — check scripts/python/helpers/ first. Also use when
+  working with Tekton results, HTTP, auth, file I/O, Pyxis, OSIDB, git, or
+  subprocess wrappers.
+---
+
+# Using Shared Helpers
+
+**Before writing any new utility function, check if a helper already exists in
+`scripts/python/helpers/`.** Task scripts should orchestrate; helpers should
+implement reusable, task-agnostic behavior.
+
+Helpers are on `PYTHONPATH` in the container and in pytest — import by module name:
+
+```python
+import file
+import tekton
+import http_client
+```
+
+Subpackage `vcs` provides host-specific git operations:
+
+```python
+from vcs import git, github, gitlab
+```
+
+---
+
+## Don't duplicate what a helper already does
+
+Before guarding a call with your own check, confirm the helper doesn't already
+do it. This is one of the most frequent review comments across conversion PRs
+in this repo — reviewers have called it out on unrelated tasks written by
+different authors, months apart:
+
+```python
+# Don't — file.load_json_dict already raises if the file doesn't exist
+if not data_file.is_file():
+    raise FileNotFoundError("No valid data file was provided.")
+data = file.load_json_dict(data_file)
+```
+
+```python
+# Do — trust the helper, let it raise
+data = file.load_json_dict(data_file)
+```
+
+This applies broadly: `tekton.require_env` already exits on a missing var,
+`file.load_json_dict` already raises `TypeError` if the root isn't a dict, etc.
+Read the helper's docstring before adding a check it already performs — the
+duplicate check is dead code plus an extra test to maintain.
+
+## If you write it more than once, it belongs in a helper
+
+The single most repeated piece of review feedback in this repo's history is
+some version of: *"we already do this in several other tasks — please move it
+to a helper instead of adding another copy."* It's been said about file
+existence/validation, per-component snapshot logic, secret and mount names,
+auth/cert setup, and checksum extraction — all things one author wrote inline
+in a task file before a reviewer pointed out other tasks needed the same
+logic. Concretely: a shared credential-redaction helper (`redact.py`) exists
+today *because* three separate modules each had their own private copy of the
+same substring-replacement logic, until a reviewer pushed to consolidate them
+into one.
+
+Before writing task-specific logic, ask "would a second task plausibly need
+this too?" If yes, write it in the closest matching helper module (or a new
+one) from the start, with its own test — don't wait for a reviewer to ask you
+to move it later.
+
+---
+
+## How to find the right helper
+
+This skill lists **what module to reach for**, not every function it exposes —
+that detail lives in the module itself and would go stale here the moment
+someone adds a function. Before writing new logic:
+
+1. Scan the index below for a module that matches the domain (file I/O, HTTP,
+   Tekton, auth, git, ...).
+2. Confirm the exact function/signature by reading the module's source or
+   docstring, e.g. `rg "^def " scripts/python/helpers/file.py`.
+3. Check the module's co-located `test_<module>.py` for real usage examples.
+4. If nothing fits, `rg` the helpers directory for related keywords — a
+   helper may exist under a name you didn't expect.
+5. New helpers get added over time; if you don't see something here that
+   plausibly exists, check `scripts/python/helpers/` directly rather than
+   assuming this list is exhaustive.
+
+---
+
+## Helper index
+
+Import by module name — helpers are on `PYTHONPATH` in the container and in
+pytest.
+
+### Core infrastructure
+
+| Module | Purpose | Import |
+|--------|---------|--------|
+| `logger` | Configured stderr logger for task scripts | `from logger import logger` |
+| `file` | JSON/path/temp-file/gzip helpers (`load_json_dict` raises if missing/not-a-dict) | `import file` |
+| `tekton` | Tekton result files, step errors, CLI parsing (`require_env`, `result_paths_from_env`) | `import tekton` |
+| `retry` | Exponential backoff for transient failures | `import retry` |
+| `redact` | Strip credentials from text before logging/results | `from redact import redact_secrets` |
+| `subprocess_cmd` | Run subprocess commands with optional stderr log capture | `import subprocess_cmd` |
+| `kubectl` | Kubernetes ConfigMap fetch via kubectl CLI | `import kubectl` |
+| `internal_request` | Write internal-request Tekton result paths | `import internal_request` |
+
+```python
+import file
+import tekton
+
+data = file.load_json_dict(data_dir / data_path)
+data_path = tekton.require_env("PARAM_DATA_DIR")
+```
+
+### HTTP and authentication
+
+| Module | Purpose | Import |
+|--------|---------|--------|
+| `http_client` | GET with retries (429/404 backoff), session builder | `import http_client` |
+| `authentication` | Kerberos, keytabs, mounted service-account layouts | `import authentication` |
+
+```python
+import authentication
+
+princ, keytab, text = authentication.load_service_account(
+    mount, ("osidb_url",), principal_file="name", keytab_b64_file="base64_keytab"
+)
+```
+
+### Domain APIs
+
+| Module | Purpose |
+|--------|---------|
+| `osidb` | OSIDB flaw API — token fetch and flaw queries |
+| `pyxis_api` | Pyxis URL mapping, repository GET/PATCH, catalog prefixes |
+| `image_ref` | Image ref parsing; Quay digest → git SHA; Pyxis URL builder |
+| `snapshot` | Read Konflux snapshot JSON (component fields) |
+| `iib` | IIB REST client; gzip/base64 for Tekton's 4KB result limit |
+| `skopeo` | Skopeo CLI wrapper (`inspect`, `copy`) |
+| `oras_utils` | OCI artifact operations via `oras` CLI |
+
+```python
+import pyxis_api
+
+repo_json = pyxis_api.get_repository_json(pyxis_url, repo_id, auth=auth)
+```
+
+### Advisory and artifact pipeline
+
+Full orchestration scripts for the push-artifacts / signing workflow — prefer
+calling their `run()` over reimplementing routing, cert checks, or component
+loops: `advisory_data`, `extract_artifacts`, `push_unsigned`, `sign_mac`,
+`sign_windows`, `compress_artifacts`, `generate_checksums`,
+`build_checksum_map`, `push_artifacts`. Read each module's docstring for
+specifics — this pipeline changes often enough that a static table here would
+drift quickly.
+
+### Version control (`helpers/vcs/`)
+
+| Module | Purpose |
+|--------|---------|
+| `vcs.git` | Host-agnostic git CLI (clone, commit, push, retry) |
+| `vcs.github` | GitHub App auth, REST API, PR workflow |
+| `vcs.gitlab` | GitLab OAuth git auth, sparse clone, raw file URLs |
+
+```python
+from vcs import git
+
+repo_dir = git.clone(parent_dir, clone_url, revision="main")
+```
+
+### Other repo packages (not under `helpers/`)
+
+Task scripts also call into top-level packages copied into the image:
+`pyxis/` (Pyxis container image API), `utils/` (`apply_template`,
+`get_resource`, `find_matching_purl`), `pubtools-pulp-wrapper/`,
+`publish-to-cgw-wrapper/`, `developer-portal-wrapper/`. Use existing wrappers
+via `subprocess_cmd.run_cmd` or their Python APIs — do not shell out with raw
+paths unless matching an existing task pattern.
+
+---
+
+## Decision checklist
+
+1. Need file/JSON/env-path handling? → `file`
+2. Need Tekton results or CLI parsing? → `tekton`
+3. Need HTTP GET/PATCH with retries? → `http_client`
+4. Need Kerberos / mounted secrets? → `authentication`
+5. Need subprocess with stderr capture? → `subprocess_cmd`
+6. Need git/GitHub/GitLab? → `vcs.*`
+7. Logic reads/interprets fields from a shared domain object (e.g. a snapshot
+   component's `public` flag)? → put it in that object's helper (e.g.
+   `snapshot`), not your task file — other tasks likely need it too.
+8. None of the above, or unsure? → grep `scripts/python/helpers/` for the
+   domain first; only add a **new function to the closest existing module**
+   (with a co-located test) if nothing fits — new module only if the domain
+   is genuinely distinct.

--- a/skills/writing-new-task-scripts/SKILL.md
+++ b/skills/writing-new-task-scripts/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: writing-new-task-scripts
+description: >-
+  Use when creating a new Python task script in release-service-utils, converting
+  a Tekton task from release-service-catalog, adding scripts/python/tasks/ code,
+  wiring Tekton params/results, or writing co-located pytest tests for a task.
+---
+
+# Writing New Task Scripts
+
+Create Python task scripts under `scripts/python/tasks/` that Tekton tasks in
+**release-service-catalog** invoke via `command` + `args` + `env` from the utils
+container image (`quay.io/konflux-ci/release-service-utils`).
+
+**Before writing anything:** read `using-helpers` — reuse helpers instead of
+duplicating auth, HTTP, file I/O, or Tekton plumbing.
+
+---
+
+## File placement
+
+| Task type | Catalog path | Utils script path |
+|-----------|--------------|-------------------|
+| **Managed** (runs on managed cluster, secrets available) | `tasks/managed/<name>/` | `scripts/python/tasks/managed/<snake_name>.py` |
+| **Internal** (runs via internal-request on another cluster) | `tasks/internal/<name>/` | `scripts/python/tasks/internal/<snake_name>.py` |
+
+Naming: catalog uses kebab-case (`check-data-keys`); utils uses snake_case
+(`check_data_keys.py`). Co-located test: `test_<snake_name>.py` in the same directory.
+
+Helpers live in `scripts/python/helpers/` — never put reusable logic in a task file.
+
+---
+
+## Module boilerplate
+
+Every task script follows this skeleton:
+
+```python
+#!/usr/bin/env python3
+"""One-line summary of what the task does."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import file
+import tekton
+from logger import logger
+
+PROG = "my_task.py"
+
+
+def run(...) -> ...:
+    """Core logic — pure enough to unit-test without Tekton."""
+    ...
+
+
+def main() -> int:
+    """Read Tekton env, call run(), write results."""
+    ...
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+**Required conventions** (also in `AGENTS.md`):
+
+- `from __future__ import annotations` at top
+- Type hints on all function signatures; docstrings on module + public functions
+- `PROG = "<filename>"` for error messages and Tekton result text
+- Entry point: `if __name__ == "__main__": raise SystemExit(main())`
+- Named loggers via `from logger import logger` (or `logging.getLogger` for submodules)
+- Exception chaining: `raise ... from e`
+- Black, line length 95
+
+**Imports:** helpers and sibling task modules are on `PYTHONPATH` (see `Dockerfile`
+and `pyproject.toml` `[tool.pytest.ini_options]`). Import directly:
+
+```python
+import file
+import tekton
+import authentication
+```
+
+Do not use relative imports from task scripts.
+
+---
+
+## Managed vs internal: error handling
+
+This is the most important behavioral split:
+
+### Managed tasks (`scripts/python/tasks/managed/`)
+
+- **`main()` must NOT catch exceptions** — let the script fail with traceback.
+- Tekton marks the step failed; no result-file dance needed.
+- Example: `check_data_keys.py` — `main()` calls `run_check_data_keys()` and returns 0.
+
+```python
+def main() -> int:
+    run_check_data_keys(
+        data_dir=Path(tekton.require_env("PARAM_DATA_DIR")),
+        data_path=Path(tekton.require_env("PARAM_DATA_PATH")),
+        ...
+    )
+    return 0
+```
+
+### Internal tasks (`scripts/python/tasks/internal/`)
+
+- **Catch all exceptions in `main()`** and write failure text to Tekton result files.
+- The script process must **exit 0** so Tekton publishes results (catalog documents this).
+- Use `tekton.CheckStepError(action, cause)` to attach a human step name to failures.
+- Use `tekton.write_failure_result()` for the one-line `result` body.
+
+Example pattern from `check_embargoed_cves.py`:
+
+```python
+def main(argv: list[str] | None = None) -> int:
+    rpath, epath = tekton.result_paths_from_env("RESULT_RESULT", "RESULT_EMBARGOED_CVES")
+    try:
+        problem, out_rc = run_check(cve_list, mount=mount)
+    except tekton.CheckStepError as e:
+        out_rc, step_err = 1, e
+    ...
+    if not out_rc:
+        rpath.write_text("Success", encoding="utf-8")
+    elif step_err is not None:
+        tekton.write_failure_result(rpath, name, step_err)
+    return 0  # always 0 for internal tasks after writing results
+```
+
+`check_fbc_opt_in.py` is a simpler internal variant: catch `ValueError` / `CheckStepError`
+in `main()`, raise `SystemExit` with a message (still exits non-zero — acceptable when
+the catalog task only has one result and no "always exit 0" requirement; match siblings).
+
+**Rule of thumb:** read the catalog task YAML and sibling internal scripts; match their
+result/exit contract exactly.
+
+---
+
+## Tekton wiring: params, env, results
+
+Catalog tasks pass configuration via **environment variables**, not only CLI flags.
+
+| Catalog YAML | Utils env var | Helper |
+|--------------|---------------|--------|
+| `$(params.dataDir)` | `PARAM_DATA_DIR` | `tekton.require_env("PARAM_DATA_DIR")` |
+| `$(params.dataPath)` | `PARAM_DATA_PATH` | `tekton.require_env("PARAM_DATA_PATH")` |
+| `$(results.foo.path)` | `RESULT_FOO` | `tekton.result_paths_from_env("RESULT_FOO")` |
+
+CLI flags (`--cves`, `--concurrent-limit`) are used when the catalog task passes
+`args:` — parse with `tekton.tekton_argument_parser(PROG)` for consistent `--help`
+and missing-flag behavior (stderr + exit 1).
+
+Mount paths for secrets: use `file.path_from_env_variable("MOUNT_VAR", "/default/path")`
+so tests can override via env.
+
+Credentials: read from **mounted secret files** (`authentication.load_service_account`,
+`authentication.read_mounted_text`), not bare env vars for secret values.
+
+---
+
+## Structure: separate `run()` from `main()`
+
+Extract testable logic into `run()` or named functions so `main()` stays a thin
+Tekton-env-to-function wrapper.
+
+**Do not add callable kwargs to a function's signature just to make it
+mockable** (e.g. `kinit: Any = authentication.kinit_with_retry`). This was an
+old convention — still visible in `check_embargoed_cves.py` — but reviewers
+now consistently ask authors to hardcode the real call and drop the injected
+parameter instead. If `AGENTS.md` still shows the old convention on this
+point, treat it as stale and follow this skill.
+
+The same principle applies more broadly: don't shape production code around
+testing needs at all (env-var switches like `USE_SHELL=1`, fake/mock classes
+built into a task module, etc.). Real test tooling covers this — `mock.patch`/
+`monkeypatch` for unit tests, and the catalog's `tests/mocks/<name>` directory
+(auto-prepended to `PATH`) for integration-test mocking of external CLIs like
+`git` or `skopeo`.
+
+Hardcode the real call and patch it at the **call site's module** in tests
+instead:
+
+```python
+# production code — call the real function directly
+def run_check(cve_ids: Sequence[str], mount: Path) -> tuple[list[str], int]:
+    authentication.kinit_with_retry(princ, keytab_path, kenv, max_attempts=5)
+    token = osidb.get_access_token(osidb_url)
+    ...
+```
+
+```python
+# test — patch where the name is looked up (the task module), not where it's defined
+from unittest.mock import patch
+
+@patch("check_embargoed_cves.osidb.get_access_token", return_value="tok")
+@patch("check_embargoed_cves.authentication.kinit_with_retry")
+def test_run_check_success(mock_kinit, mock_token, tmp_path):
+    ...
+```
+
+`check_embargoed_cves.py` and `check_fbc_opt_in.py` still use the old
+callable-kwarg pattern — that's legacy, don't copy it into new task scripts.
+
+Reference implementations:
+
+| Task | Path | Notes |
+|------|------|-------|
+| Managed, schema validation | `scripts/python/tasks/managed/check_data_keys.py` | `run_check_data_keys()`, no catch in `main()` |
+| Managed, JSON + single result | `scripts/python/tasks/managed/make_repo_public.py` | Thin `main()`, writes one result |
+| Internal, OSIDB + results | `scripts/python/tasks/internal/check_embargoed_cves.py` | `CheckStepError`, always exit 0; **predates** the no-callable-kwargs convention |
+| Internal, Pyxis queries | `scripts/python/tasks/internal/check_fbc_opt_in.py` | JSON result array, mount overrides; **predates** the no-callable-kwargs convention |
+
+---
+
+## Testing
+
+- Co-locate: `test_<task>.py` next to `<task>.py`
+- Run: `uv sync --dev && uv run pytest scripts/python/tasks/<managed|internal>/test_<task>.py -v`
+- Function names: `test_<behavior>` with `-> None` return type
+- Use `pytest`, `unittest.mock.patch`, `monkeypatch` for env vars
+- Test `run()` and parsers directly; test `main()` only for wiring smoke tests
+- Fixture data: minimal JSON under `tmp_path`; copy patterns from `test_check_data_keys.py`
+- Mock HTTP/subprocess/auth calls with `@patch("<task_module>.<helper_module>.<function>")`
+  at the task module's namespace — do **not** add callable kwargs to production
+  code to make mocking easier (see "Structure" above)
+- Cover every type/branch a validation function accepts, not just one (e.g. if a
+  flag can be JSON `true` or the string `"true"`, test both — a real review
+  comment caught a bool-only test suite for a function that also handled strings)
+
+Prefer co-located tests whenever you add non-trivial logic — most merged
+conversion PRs ship with full test coverage, so treat that as the default.
+Skip tests only for a genuinely mechanical port with no new behavior, or when
+the Jira ticket explicitly defers testing to a separate follow-up story
+(matching the two-phase bash-extraction-then-python-rewrite pattern some
+epics use). When in doubt, write the tests.
+
+---
+
+## Common review feedback — read before opening a PR
+
+These are patterns that keep coming up across conversion PRs from multiple
+authors and reviewers, not a one-off comment on a single PR. Check your diff
+against these before requesting review:
+
+1. **Don't re-validate what a helper already checks.** If `file.load_json_dict()`
+   already raises `FileNotFoundError` when the file is missing, don't add your
+   own `if not path.is_file(): raise ...` first — see `using-helpers`.
+2. **Don't add callable kwargs to a function just so tests can mock it.**
+   Hardcode the call, `patch`/`monkeypatch` it in tests. See "Structure" above.
+3. **Let Python raise naturally when that's clear enough.** `mapping["key"]`
+   raising `KeyError`, or `rpa["spec"]["origin"]` raising on a missing field,
+   is often fine — don't wrap it in your own exception unless the default
+   error message would be genuinely confusing in a Tekton result.
+4. **Don't write comments/docstrings that describe the bash task being
+   replaced** (e.g. "mirrors the bash task's X logic"). The bash is deleted once
+   the catalog PR merges — the comment goes stale immediately. Describe what the
+   Python code does, not what it used to look like in bash.
+5. **If the same logic, constant, or validation shows up in more than one task**
+   (component `public` flags, secret/mount names, file-existence checks, auth
+   setup, checksum extraction, ...), it belongs in a shared helper, not a
+   private function copy-pasted into each task file. This is the single most
+   frequent piece of review feedback across this repo's conversion PRs — see
+   `using-helpers`.
+6. **Use `logger` (from the `logger` helper), never bare `print()`** — even if
+   the bash task being replaced printed raw text and matching that output
+   exactly seems convenient. Consistency across tasks' logs wins over
+   replicating old bash formatting.
+7. **Module-level constants go at the top of the file**, not inline near
+   where they're first used.
+
+---
+
+## Dual-PR workflow (catalog + utils)
+
+1. **Utils PR first** — add script; wait for Konflux `on-pr-<commit>` image build.
+2. **Catalog PR** — thin YAML calling `/home/scripts/python/tasks/<managed|internal>/<script>.py`,
+   bump `image:` to the PR digest, update `tests/pre-apply-task-hook.sh` / mocks if needed.
+3. **Merge utils first**, then bump catalog image to `quay.io/konflux-ci/release-service-utils@sha256:<main>`.
+
+Run catalog local tests: `./scripts/run-local-tests.sh tasks/<managed|internal>/<task-dir>`.
+
+---
+
+## Commits
+
+```
+feat(RELEASE-xxxx): add <task_name> python script
+
+Assisted-by: cursor-agent
+```
+
+- Conventional commits: `(feat|fix|refactor|test)(RELEASE-xxxx): <lowercase summary>`
+- Max 72 characters per line (gitlint)
+- Cryptographically signed (`git commit -S`)
+- Add `Assisted-by: <agent>` trailer when AI-assisted


### PR DESCRIPTION
## Summary
Adds repo-specific AI skills for release-service-utils per [RELEASE-2703](https://redhat.atlassian.net/browse/RELEASE-2703).
- `writing-new-task-scripts` — how to create Python task scripts (managed vs internal, Tekton wiring, testing, dual-PR workflow)
- `using-helpers` — catalog of shared helpers in `scripts/python/helpers/`
Skills follow the agentskills.io spec, are symlinked to `.claude/skills/` and `.cursor/skills/`, and `AGENTS.md` documents them.

[RELEASE-2703]: https://redhat.atlassian.net/browse/RELEASE-2703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ