### PR TITLE
chore: add checks for schema file updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Container image (UBI9) with Python scripts, wrappers, and templates used by Tekt
 - `templates/` — Jinja2 templates (advisory.yaml.jinja, GraphQL)
 - `utils/` — General utilities (apply_template, get_resource, find_matching_purl)
 - `integration-tests/` — Orchestration harness that detects which catalog E2E suites are affected by utils changes, patches a temporary catalog fork with the new image, and runs the matching tests
+- `schemas/` - Schema files to describe structs such as the `data` one used in various python scripts
 
 ## Python
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,12 @@ This project follows specific Python coding standards:
 - **Utilities**: General utilities go in `utils/`
 - **Templates**: Jinja2 templates go in `templates/`
 
+### Data Keys Schema
+
+This repository maintains a json schema for the data struct used in various scripts in this repo. It is stored [here](schemas/dataKeys.json).
+
+If your change adds or removes a key to the data struct, the schema must be updated accordingly as part of your pull request.
+
 ## Testing
 
 ### Running Tests Locally

--- a/integration-tests/lib/find_catalog_suite_from_utils_diff.py
+++ b/integration-tests/lib/find_catalog_suite_from_utils_diff.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""
-Map a release-service-utils diff to catalog ``PIPELINE_TEST_SUITE`` /
-``PIPELINE_USED`` strings.
+"""Map a release-service-utils diff to catalog pipeline test suite strings.
+
+Maps changed utils paths to catalog ``PIPELINE_TEST_SUITE`` / ``PIPELINE_USED``
+strings.
 
 1. Build search tokens from changed paths using the utils ``Dockerfile``
    (``COPY`` into ``/home``, ``PATH``) via :mod:`find_search_tokens_from_dockerfile`
@@ -13,8 +14,9 @@ Map a release-service-utils diff to catalog ``PIPELINE_TEST_SUITE`` /
    ``_catalog_stdin_task_paths_to_testcase_tokens`` (same mapping as catalog PR
    tooling).
 4. Changes under **utils** ``integration-tests/`` (except ``run-test.sh`` and
-   any ``*.md`` file), or changes to the repo-root ``Dockerfile``, force all catalog
-   RPA suites—plumbing and image layout are not reliably reflected in Task YAML
+   any ``*.md`` file), changes to the repo-root ``Dockerfile``, or changes to
+   ``schemas/dataKeys.json``, force all catalog RPA suites—plumbing, image
+   layout, and the shared data schema are not reliably reflected in Task YAML
    substring search alone.
 5. Changes under ``scripts/python/helpers/*.py`` also add repo paths for task
    scripts that import those modules (see `helper_task_import_graph`) so
@@ -134,11 +136,12 @@ def _all_managed_pipeline_tokens_from_rpa(catalog: Path) -> set[str]:
 
 
 def _changed_paths_trigger_global_catalog_run(changed: list[str]) -> bool:
-    """True if changed paths should force union of all catalog RPA pipeline tokens.
+    """Return whether changed paths force union of all catalog RPA pipeline tokens.
 
-    Triggers when the repo-root ``Dockerfile`` changes, or when any path under
-    ``integration-tests/`` changes except ``integration-tests/run-test.sh`` and
-    except Markdown files (``*.md``, case-insensitive).
+    Triggers when the repo-root ``Dockerfile`` or ``schemas/dataKeys.json``
+    changes, or when any path under ``integration-tests/`` changes except
+    ``integration-tests/run-test.sh`` and except Markdown files (``*.md``,
+    case-insensitive).
     """
     for raw in changed:
         s = raw.strip()
@@ -148,6 +151,8 @@ def _changed_paths_trigger_global_catalog_run(changed: list[str]) -> bool:
         if not p:
             continue
         if p == "Dockerfile":
+            return True
+        if p == "schemas/dataKeys.json":
             return True
         if Path(p).suffix.lower() == ".md":
             continue

--- a/integration-tests/lib/tests/test_find_catalog_suite_from_utils_diff.py
+++ b/integration-tests/lib/tests/test_find_catalog_suite_from_utils_diff.py
@@ -128,7 +128,7 @@ def test_all_managed_pipeline_tokens_from_rpa(tmp_path: Path) -> None:
 
 
 def test_changed_paths_trigger_global_catalog_run() -> None:
-    """Integration-tests plumbing (with exclusions) and repo-root Dockerfile."""
+    """Integration-tests plumbing (with exclusions), Dockerfile, dataKeys schema."""
     g = fc._changed_paths_trigger_global_catalog_run
     assert g(["integration-tests/lib/x.py"]) is True
     assert g(["integration-tests/run-test.sh"]) is False
@@ -142,6 +142,10 @@ def test_changed_paths_trigger_global_catalog_run() -> None:
     assert g(["  Dockerfile  "]) is True
     assert g(["subdir/Dockerfile"]) is False
     assert g(["Dockerfile/"]) is False
+    assert g(["schemas/dataKeys.json"]) is True
+    assert g(["./schemas/dataKeys.json"]) is True
+    assert g(["  schemas/dataKeys.json  "]) is True
+    assert g(["schemas/other.json"]) is False
 
 
 def test_is_under_task_tests_dir(tmp_path: Path) -> None:
@@ -483,6 +487,19 @@ def test_resolve_dockerfile_only_unions_all_rpa_tokens(tmp_path: Path) -> None:
     _write_rpa(tmp_path, "suite-b", "p: pipelines/managed/zebra-pipe/")
     with patch.object(fc, "_suites_from_catalog_script", return_value=set()):
         out = fc.resolve(tmp_path, ["Dockerfile"])
+    assert out == {
+        "pipelineTestSuite": "suite-a suite-b",
+        "pipelineUsed": "alpha-pipe zebra-pipe",
+    }
+
+
+@pytest.mark.usefixtures("utils_repo_root")
+def test_resolve_datakeys_schema_unions_all_rpa_tokens(tmp_path: Path) -> None:
+    """Changes to ``schemas/dataKeys.json`` union every managed pipeline token from RPA."""
+    _write_rpa(tmp_path, "suite-a", "p: pipelines/managed/alpha-pipe/")
+    _write_rpa(tmp_path, "suite-b", "p: pipelines/managed/zebra-pipe/")
+    with patch.object(fc, "_suites_from_catalog_script", return_value=set()):
+        out = fc.resolve(tmp_path, ["schemas/dataKeys.json"])
     assert out == {
         "pipelineTestSuite": "suite-a suite-b",
         "pipelineUsed": "alpha-pipe zebra-pipe",


### PR DESCRIPTION
When the check-data-keys task was migrated to use python, the dataKeys.json schema file was moved from the catalog repo to this one. However, some checks and docs were missed, so this commit adds those in.

Assisted-By: Cursor