### PR TITLE
feat(RELEASE-2666): sign target_index_with_timestamp

### DIFF
--- a/scripts/python/tasks/managed/direct_sign_index_image.py
+++ b/scripts/python/tasks/managed/direct_sign_index_image.py
@@ -55,8 +55,9 @@ def collect_fbc_signing_items(
 ) -> list[SigningItem]:
     """Build signing items from FBC results.
 
-    For each component, translates the target_index to a public reference
-    and creates a SigningItem for every (digest, key) combination.
+    For each component, translates the target_index (and target_index_with_timestamp
+    when present and different) to public references and creates a SigningItem for
+    every (reference, digest, key) combination.
 
     Args:
         fbc_results: Parsed FBC results JSON containing components.
@@ -70,17 +71,23 @@ def collect_fbc_signing_items(
 
     for component in fbc_results.get("components", []):
         target_index = component["target_index"]
-        reference = translate_reference(target_index)
-        LOGGER.info("Translated %s -> %s", target_index, reference)
 
         rh_registry_repo = component.get("rh-registry-repo", "")
         repository = (
             rh_registry_repo.split("/", 1)[1] if "/" in rh_registry_repo else rh_registry_repo
         )
 
-        for digest in component.get("image_digests", []):
-            for key in signing_keys:
-                items.append(SigningItem(reference, digest, repository, key))
+        target_indexes = [target_index]
+        ts_index = component.get("target_index_with_timestamp", "")
+        if ts_index and ts_index != target_index:
+            target_indexes.append(ts_index)
+
+        for idx in target_indexes:
+            reference = translate_reference(idx)
+            LOGGER.info("Translated %s -> %s", idx, reference)
+            for digest in component.get("image_digests", []):
+                for key in signing_keys:
+                    items.append(SigningItem(reference, digest, repository, key))
 
     return items
 

--- a/scripts/python/tasks/managed/test_direct_sign_index_image.py
+++ b/scripts/python/tasks/managed/test_direct_sign_index_image.py
@@ -227,6 +227,77 @@ def test_collect_fbc_signing_items_missing_rh_registry_repo(mock_translate) -> N
     assert items[0].repository == ""
 
 
+@patch("direct_sign_index_image.translate_reference")
+def test_collect_fbc_signing_items_with_timestamp(mock_translate) -> None:
+    """Items are created for both target_index and target_index_with_timestamp."""
+    mock_translate.side_effect = [
+        "registry.redhat.io/redhat/fbc-target-index:v4.23",
+        "registry.redhat.io/redhat/fbc-target-index:v4.23-1783502029",
+    ]
+    fbc = {
+        "components": [
+            {
+                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.23",
+                "target_index_with_timestamp": (
+                    "quay.io/redhat/redhat----fbc-target-index:v4.23-1783502029"
+                ),
+                "rh-registry-repo": "registry.redhat.io/redhat/fbc-target-index",
+                "image_digests": ["sha256:aaa"],
+            }
+        ]
+    }
+    items = collect_fbc_signing_items(fbc, ["key-a"])
+
+    assert len(items) == 2
+    assert items[0].reference == "registry.redhat.io/redhat/fbc-target-index:v4.23"
+    assert items[1].reference == "registry.redhat.io/redhat/fbc-target-index:v4.23-1783502029"
+    assert mock_translate.call_count == 2
+
+
+@patch("direct_sign_index_image.translate_reference")
+def test_collect_fbc_signing_items_timestamp_empty(mock_translate) -> None:
+    """Empty target_index_with_timestamp is skipped."""
+    mock_translate.return_value = "registry.redhat.io/redhat/fbc-target-index:v4.23"
+    fbc = {
+        "components": [
+            {
+                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.23",
+                "target_index_with_timestamp": "",
+                "rh-registry-repo": "registry.redhat.io/redhat/fbc-target-index",
+                "image_digests": ["sha256:aaa"],
+            }
+        ]
+    }
+    items = collect_fbc_signing_items(fbc, ["key-a"])
+
+    assert len(items) == 1
+    assert items[0].reference == "registry.redhat.io/redhat/fbc-target-index:v4.23"
+    mock_translate.assert_called_once()
+
+
+@patch("direct_sign_index_image.translate_reference")
+def test_collect_fbc_signing_items_timestamp_equals_target(mock_translate) -> None:
+    """target_index_with_timestamp equal to target_index does not create duplicates."""
+    mock_translate.return_value = "registry.redhat.io/redhat/fbc-target-index:v4.23"
+    fbc = {
+        "components": [
+            {
+                "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.23",
+                "target_index_with_timestamp": (
+                    "quay.io/redhat/redhat----fbc-target-index:v4.23"
+                ),
+                "rh-registry-repo": "registry.redhat.io/redhat/fbc-target-index",
+                "image_digests": ["sha256:aaa"],
+            }
+        ]
+    }
+    items = collect_fbc_signing_items(fbc, ["key-a"])
+
+    assert len(items) == 1
+    assert items[0].reference == "registry.redhat.io/redhat/fbc-target-index:v4.23"
+    mock_translate.assert_called_once()
+
+
 # --- setup_argparser ---
 
 


### PR DESCRIPTION
Sign both target_index and target_index_with_timestamp in collect_fbc_signing_items when the timestamped tag is non-empty and differs from target_index. This aligns signing with what publish-index-image already publishes.

Assisted-by: Claude