### PR TITLE
feat(KONFLUX-12379): convert index image tasks to python

### DIFF
--- a/scripts/python/tasks/internal/inspect_target_index.py
+++ b/scripts/python/tasks/internal/inspect_target_index.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Inspect a built FBC target index image using skopeo."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from logger import logger
+from subprocess_cmd import run_cmd
+
+import tekton
+
+
+def read_credential(path: Path) -> str:
+    """Read a registry credential from a mounted secret file.
+
+    Args:
+        path: Path to the credential file (user:password format).
+
+    Returns:
+        The credential string.
+
+    """
+    return path.read_text(encoding="utf-8").strip()
+
+
+def inspect_image(source_index: str, credential: str) -> dict[str, Any]:
+    """Inspect a container image with skopeo and return its sha and per-arch digests.
+
+    Args:
+        source_index: Image pullspec to inspect (e.g. quay.io/redhat/index:v4.13).
+        credential: Registry credential in user:password format.
+
+    Returns:
+        Dict with "sha" (overall image digest) and "digests" (list of per-arch digests).
+
+    """
+    result = run_cmd(
+        [
+            "skopeo",
+            "inspect",
+            "--retry-times",
+            "3",
+            "--creds",
+            credential,
+            f"docker://{source_index}",
+        ]
+    )
+    image_info = json.loads(result.stdout)
+    sha = image_info["Digest"]
+
+    raw_result = run_cmd(
+        [
+            "skopeo",
+            "inspect",
+            "--retry-times",
+            "3",
+            "--raw",
+            "--creds",
+            credential,
+            f"docker://{source_index}",
+        ]
+    )
+    manifest = json.loads(raw_result.stdout)
+    digests = [m["digest"] for m in manifest["manifests"]]
+
+    logger.info("Inspected %s: sha=%s, %d arch digests", source_index, sha, len(digests))
+    return {"sha": sha, "digests": digests}
+
+
+def main() -> int:
+    """Entry point for inspect-target-index task."""
+    source_index = tekton.require_env("PARAM_SOURCE_INDEX")
+    credentials_path = Path(tekton.require_env("PARAM_INSPECT_CREDENTIALS_PATH"))
+    (result_path,) = tekton.result_paths_from_env("RESULT_REQUEST_MESSAGE_PATH")
+
+    try:
+        credential = read_credential(credentials_path)
+        result = inspect_image(source_index, credential)
+        result_path.write_text(json.dumps(result, separators=(",", ":")), encoding="utf-8")
+    except Exception as exc:  # Tekton task: always exit 0, report via result
+        logger.error("Failed to inspect target index: %s", exc)
+        result_path.write_text("Error: Failed to inspect target index", encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/python/tasks/internal/inspect_target_index.py
+++ b/scripts/python/tasks/internal/inspect_target_index.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -13,25 +15,12 @@ from subprocess_cmd import run_cmd
 import tekton
 
 
-def read_credential(path: Path) -> str:
-    """Read a registry credential from a mounted secret file.
-
-    Args:
-        path: Path to the credential file (user:password format).
-
-    Returns:
-        The credential string.
-
-    """
-    return path.read_text(encoding="utf-8").strip()
-
-
-def inspect_image(source_index: str, credential: str) -> dict[str, Any]:
+def inspect_image(source_index: str, auth_file: Path) -> dict[str, Any]:
     """Inspect a container image with skopeo and return its sha and per-arch digests.
 
     Args:
         source_index: Image pullspec to inspect (e.g. quay.io/redhat/index:v4.13).
-        credential: Registry credential in user:password format.
+        auth_file: Path to a Docker-style auth JSON file for registry authentication.
 
     Returns:
         Dict with "sha" (overall image digest) and "digests" (list of per-arch digests).
@@ -43,8 +32,8 @@ def inspect_image(source_index: str, credential: str) -> dict[str, Any]:
             "inspect",
             "--retry-times",
             "3",
-            "--creds",
-            credential,
+            "--authfile",
+            str(auth_file),
             f"docker://{source_index}",
         ]
     )
@@ -58,8 +47,8 @@ def inspect_image(source_index: str, credential: str) -> dict[str, Any]:
             "--retry-times",
             "3",
             "--raw",
-            "--creds",
-            credential,
+            "--authfile",
+            str(auth_file),
             f"docker://{source_index}",
         ]
     )
@@ -73,16 +62,25 @@ def inspect_image(source_index: str, credential: str) -> dict[str, Any]:
 def main() -> int:
     """Entry point for inspect-target-index task."""
     source_index = tekton.require_env("PARAM_SOURCE_INDEX")
-    credentials_path = Path(tekton.require_env("PARAM_INSPECT_CREDENTIALS_PATH"))
     (result_path,) = tekton.result_paths_from_env("RESULT_REQUEST_MESSAGE_PATH")
 
+    auth_file: Path | None = None
     try:
-        credential = read_credential(credentials_path)
-        result = inspect_image(source_index, credential)
+        with tempfile.NamedTemporaryFile(mode="wb", delete=False) as auth_fp:
+            auth_file = Path(auth_fp.name)
+            auth_data = subprocess.check_output(
+                ["select-oci-auth", source_index], stderr=subprocess.PIPE
+            )
+            auth_fp.write(auth_data)
+
+        result = inspect_image(source_index, auth_file)
         result_path.write_text(json.dumps(result, separators=(",", ":")), encoding="utf-8")
     except Exception as exc:  # Tekton task: always exit 0, report via result
         logger.error("Failed to inspect target index: %s", exc)
         result_path.write_text("Error: Failed to inspect target index", encoding="utf-8")
+    finally:
+        if auth_file is not None:
+            auth_file.unlink(missing_ok=True)
 
     return 0
 

--- a/scripts/python/tasks/internal/test_inspect_target_index.py
+++ b/scripts/python/tasks/internal/test_inspect_target_index.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from inspect_target_index import inspect_image, main, read_credential
+from inspect_target_index import inspect_image, main
 
 SKOPEO_INSPECT_OUTPUT = json.dumps(
     {
@@ -25,34 +27,20 @@ SKOPEO_RAW_OUTPUT = json.dumps(
 )
 
 
-# --- read_credential ---
-
-
-def test_read_credential(tmp_path) -> None:
-    """Reads and strips the credential file."""
-    cred_file = tmp_path / "cred"
-    cred_file.write_text("user:pass\n")
-    assert read_credential(cred_file) == "user:pass"
-
-
-def test_read_credential_missing_file(tmp_path) -> None:
-    """Raises when credential file does not exist."""
-    with pytest.raises(FileNotFoundError):
-        read_credential(tmp_path / "nonexistent")
-
-
 # --- inspect_image ---
 
 
 @patch("inspect_target_index.run_cmd")
-def test_inspect_image_happy_path(mock_run) -> None:
-    """Returns sha and digests from skopeo output."""
+def test_inspect_image_happy_path(mock_run, tmp_path) -> None:
+    """Return sha and digests from skopeo output."""
     mock_run.side_effect = [
         MagicMock(stdout=SKOPEO_INSPECT_OUTPUT),
         MagicMock(stdout=SKOPEO_RAW_OUTPUT),
     ]
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text("{}")
 
-    result = inspect_image("quay.io/redhat/index:v4.13", "user:pass")
+    result = inspect_image("quay.io/redhat/index:v4.13", auth_file)
 
     assert result["sha"] == (
         "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
@@ -63,14 +51,16 @@ def test_inspect_image_happy_path(mock_run) -> None:
 
 
 @patch("inspect_target_index.run_cmd")
-def test_inspect_image_calls_skopeo_with_correct_args(mock_run) -> None:
-    """Verifies the exact skopeo commands issued."""
+def test_inspect_image_calls_skopeo_with_authfile(mock_run, tmp_path) -> None:
+    """Verify skopeo is called with --authfile instead of --creds."""
     mock_run.side_effect = [
         MagicMock(stdout=SKOPEO_INSPECT_OUTPUT),
         MagicMock(stdout=SKOPEO_RAW_OUTPUT),
     ]
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text("{}")
 
-    inspect_image("quay.io/redhat/index:v4.13", "user:pass")
+    inspect_image("quay.io/redhat/index:v4.13", auth_file)
 
     calls = mock_run.call_args_list
     assert calls[0].args[0] == [
@@ -78,8 +68,8 @@ def test_inspect_image_calls_skopeo_with_correct_args(mock_run) -> None:
         "inspect",
         "--retry-times",
         "3",
-        "--creds",
-        "user:pass",
+        "--authfile",
+        str(auth_file),
         "docker://quay.io/redhat/index:v4.13",
     ]
     assert calls[1].args[0] == [
@@ -88,38 +78,38 @@ def test_inspect_image_calls_skopeo_with_correct_args(mock_run) -> None:
         "--retry-times",
         "3",
         "--raw",
-        "--creds",
-        "user:pass",
+        "--authfile",
+        str(auth_file),
         "docker://quay.io/redhat/index:v4.13",
     ]
 
 
 @patch("inspect_target_index.run_cmd")
-def test_inspect_image_skopeo_failure_raises(mock_run) -> None:
-    """Propagates exceptions from skopeo."""
+def test_inspect_image_skopeo_failure_raises(mock_run, tmp_path) -> None:
+    """Propagate exceptions from skopeo."""
     mock_run.side_effect = RuntimeError("skopeo failed")
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text("{}")
 
     with pytest.raises(RuntimeError, match="skopeo failed"):
-        inspect_image("quay.io/redhat/index:v4.13", "user:pass")
+        inspect_image("quay.io/redhat/index:v4.13", auth_file)
 
 
 # --- main ---
 
 
+@patch("inspect_target_index.subprocess.check_output", return_value=b'{"auths":{}}')
 @patch("inspect_target_index.run_cmd")
-def test_main_happy_path(mock_run, tmp_path, monkeypatch) -> None:
-    """Writes JSON result on success."""
+def test_main_happy_path(mock_run, mock_check_output, tmp_path, monkeypatch) -> None:
+    """Write JSON result on success."""
     mock_run.side_effect = [
         MagicMock(stdout=SKOPEO_INSPECT_OUTPUT),
         MagicMock(stdout=SKOPEO_RAW_OUTPUT),
     ]
 
-    cred_file = tmp_path / "cred"
-    cred_file.write_text("user:pass")
     result_file = tmp_path / "result"
 
     monkeypatch.setenv("PARAM_SOURCE_INDEX", "quay.io/redhat/index:v4.13")
-    monkeypatch.setenv("PARAM_INSPECT_CREDENTIALS_PATH", str(cred_file))
     monkeypatch.setenv("RESULT_REQUEST_MESSAGE_PATH", str(result_file))
 
     exit_code = main()
@@ -128,19 +118,40 @@ def test_main_happy_path(mock_run, tmp_path, monkeypatch) -> None:
     result = json.loads(result_file.read_text())
     assert result["sha"].startswith("sha256:")
     assert len(result["digests"]) == 2
+    mock_check_output.assert_called_once_with(
+        ["select-oci-auth", "quay.io/redhat/index:v4.13"],
+        stderr=mock_check_output.call_args.kwargs["stderr"],
+    )
 
 
+@patch(
+    "inspect_target_index.subprocess.check_output",
+    side_effect=RuntimeError("select-oci-auth failed"),
+)
+def test_main_auth_error_writes_error_string(mock_check_output, tmp_path, monkeypatch) -> None:
+    """Write error message and exit 0 when select-oci-auth fails."""
+    result_file = tmp_path / "result"
+
+    monkeypatch.setenv("PARAM_SOURCE_INDEX", "quay.io/redhat/index:v4.13")
+    monkeypatch.setenv("RESULT_REQUEST_MESSAGE_PATH", str(result_file))
+
+    exit_code = main()
+
+    assert exit_code == 0
+    assert result_file.read_text() == "Error: Failed to inspect target index"
+
+
+@patch("inspect_target_index.subprocess.check_output", return_value=b'{"auths":{}}')
 @patch("inspect_target_index.run_cmd")
-def test_main_error_writes_error_string(mock_run, tmp_path, monkeypatch) -> None:
-    """Writes error message and exits 0 on failure."""
+def test_main_skopeo_error_writes_error_string(
+    mock_run, mock_check_output, tmp_path, monkeypatch
+) -> None:
+    """Write error message and exit 0 on skopeo failure."""
     mock_run.side_effect = RuntimeError("connection refused")
 
-    cred_file = tmp_path / "cred"
-    cred_file.write_text("user:pass")
     result_file = tmp_path / "result"
 
     monkeypatch.setenv("PARAM_SOURCE_INDEX", "quay.io/redhat/index:v4.13")
-    monkeypatch.setenv("PARAM_INSPECT_CREDENTIALS_PATH", str(cred_file))
     monkeypatch.setenv("RESULT_REQUEST_MESSAGE_PATH", str(result_file))
 
     exit_code = main()
@@ -149,15 +160,34 @@ def test_main_error_writes_error_string(mock_run, tmp_path, monkeypatch) -> None
     assert result_file.read_text() == "Error: Failed to inspect target index"
 
 
-def test_main_missing_credential_writes_error(tmp_path, monkeypatch) -> None:
-    """Writes error when credential file is missing."""
+@patch("inspect_target_index.subprocess.check_output", return_value=b'{"auths":{}}')
+@patch("inspect_target_index.run_cmd")
+def test_main_cleans_up_auth_file(mock_run, mock_check_output, tmp_path, monkeypatch) -> None:
+    """Verify the temporary auth file is removed after main completes."""
+    mock_run.side_effect = [
+        MagicMock(stdout=SKOPEO_INSPECT_OUTPUT),
+        MagicMock(stdout=SKOPEO_RAW_OUTPUT),
+    ]
+
     result_file = tmp_path / "result"
 
     monkeypatch.setenv("PARAM_SOURCE_INDEX", "quay.io/redhat/index:v4.13")
-    monkeypatch.setenv("PARAM_INSPECT_CREDENTIALS_PATH", str(tmp_path / "nonexistent"))
     monkeypatch.setenv("RESULT_REQUEST_MESSAGE_PATH", str(result_file))
 
-    exit_code = main()
+    created_paths: list[Path] = []
+    original_named = tempfile.NamedTemporaryFile
 
-    assert exit_code == 0
-    assert result_file.read_text() == "Error: Failed to inspect target index"
+    def tracking_named(*args, **kwargs):
+        kwargs["delete"] = False
+        f = original_named(*args, **kwargs)
+        created_paths.append(Path(f.name))
+        return f
+
+    with patch(
+        "inspect_target_index.tempfile.NamedTemporaryFile",
+        side_effect=tracking_named,
+    ):
+        main()
+
+    for p in created_paths:
+        assert not p.exists(), f"Auth file was not cleaned up: {p}"

--- a/scripts/python/tasks/internal/test_inspect_target_index.py
+++ b/scripts/python/tasks/internal/test_inspect_target_index.py
@@ -1,0 +1,163 @@
+"""Unit tests for inspect_target_index."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from inspect_target_index import inspect_image, main, read_credential
+
+SKOPEO_INSPECT_OUTPUT = json.dumps(
+    {
+        "Digest": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    }
+)
+
+SKOPEO_RAW_OUTPUT = json.dumps(
+    {
+        "manifests": [
+            {"digest": "sha256:amd64digest1234567890abcdef1234567890abcdef1234567890abcdef"},
+            {"digest": "sha256:arm64digest1234567890abcdef1234567890abcdef1234567890abcdef"},
+        ],
+    }
+)
+
+
+# --- read_credential ---
+
+
+def test_read_credential(tmp_path) -> None:
+    """Reads and strips the credential file."""
+    cred_file = tmp_path / "cred"
+    cred_file.write_text("user:pass\n")
+    assert read_credential(cred_file) == "user:pass"
+
+
+def test_read_credential_missing_file(tmp_path) -> None:
+    """Raises when credential file does not exist."""
+    with pytest.raises(FileNotFoundError):
+        read_credential(tmp_path / "nonexistent")
+
+
+# --- inspect_image ---
+
+
+@patch("inspect_target_index.run_cmd")
+def test_inspect_image_happy_path(mock_run) -> None:
+    """Returns sha and digests from skopeo output."""
+    mock_run.side_effect = [
+        MagicMock(stdout=SKOPEO_INSPECT_OUTPUT),
+        MagicMock(stdout=SKOPEO_RAW_OUTPUT),
+    ]
+
+    result = inspect_image("quay.io/redhat/index:v4.13", "user:pass")
+
+    assert result["sha"] == (
+        "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    )
+    assert len(result["digests"]) == 2
+    assert result["digests"][0].startswith("sha256:")
+    assert mock_run.call_count == 2
+
+
+@patch("inspect_target_index.run_cmd")
+def test_inspect_image_calls_skopeo_with_correct_args(mock_run) -> None:
+    """Verifies the exact skopeo commands issued."""
+    mock_run.side_effect = [
+        MagicMock(stdout=SKOPEO_INSPECT_OUTPUT),
+        MagicMock(stdout=SKOPEO_RAW_OUTPUT),
+    ]
+
+    inspect_image("quay.io/redhat/index:v4.13", "user:pass")
+
+    calls = mock_run.call_args_list
+    assert calls[0].args[0] == [
+        "skopeo",
+        "inspect",
+        "--retry-times",
+        "3",
+        "--creds",
+        "user:pass",
+        "docker://quay.io/redhat/index:v4.13",
+    ]
+    assert calls[1].args[0] == [
+        "skopeo",
+        "inspect",
+        "--retry-times",
+        "3",
+        "--raw",
+        "--creds",
+        "user:pass",
+        "docker://quay.io/redhat/index:v4.13",
+    ]
+
+
+@patch("inspect_target_index.run_cmd")
+def test_inspect_image_skopeo_failure_raises(mock_run) -> None:
+    """Propagates exceptions from skopeo."""
+    mock_run.side_effect = RuntimeError("skopeo failed")
+
+    with pytest.raises(RuntimeError, match="skopeo failed"):
+        inspect_image("quay.io/redhat/index:v4.13", "user:pass")
+
+
+# --- main ---
+
+
+@patch("inspect_target_index.run_cmd")
+def test_main_happy_path(mock_run, tmp_path, monkeypatch) -> None:
+    """Writes JSON result on success."""
+    mock_run.side_effect = [
+        MagicMock(stdout=SKOPEO_INSPECT_OUTPUT),
+        MagicMock(stdout=SKOPEO_RAW_OUTPUT),
+    ]
+
+    cred_file = tmp_path / "cred"
+    cred_file.write_text("user:pass")
+    result_file = tmp_path / "result"
+
+    monkeypatch.setenv("PARAM_SOURCE_INDEX", "quay.io/redhat/index:v4.13")
+    monkeypatch.setenv("PARAM_INSPECT_CREDENTIALS_PATH", str(cred_file))
+    monkeypatch.setenv("RESULT_REQUEST_MESSAGE_PATH", str(result_file))
+
+    exit_code = main()
+
+    assert exit_code == 0
+    result = json.loads(result_file.read_text())
+    assert result["sha"].startswith("sha256:")
+    assert len(result["digests"]) == 2
+
+
+@patch("inspect_target_index.run_cmd")
+def test_main_error_writes_error_string(mock_run, tmp_path, monkeypatch) -> None:
+    """Writes error message and exits 0 on failure."""
+    mock_run.side_effect = RuntimeError("connection refused")
+
+    cred_file = tmp_path / "cred"
+    cred_file.write_text("user:pass")
+    result_file = tmp_path / "result"
+
+    monkeypatch.setenv("PARAM_SOURCE_INDEX", "quay.io/redhat/index:v4.13")
+    monkeypatch.setenv("PARAM_INSPECT_CREDENTIALS_PATH", str(cred_file))
+    monkeypatch.setenv("RESULT_REQUEST_MESSAGE_PATH", str(result_file))
+
+    exit_code = main()
+
+    assert exit_code == 0
+    assert result_file.read_text() == "Error: Failed to inspect target index"
+
+
+def test_main_missing_credential_writes_error(tmp_path, monkeypatch) -> None:
+    """Writes error when credential file is missing."""
+    result_file = tmp_path / "result"
+
+    monkeypatch.setenv("PARAM_SOURCE_INDEX", "quay.io/redhat/index:v4.13")
+    monkeypatch.setenv("PARAM_INSPECT_CREDENTIALS_PATH", str(tmp_path / "nonexistent"))
+    monkeypatch.setenv("RESULT_REQUEST_MESSAGE_PATH", str(result_file))
+
+    exit_code = main()
+
+    assert exit_code == 0
+    assert result_file.read_text() == "Error: Failed to inspect target index"

--- a/scripts/python/tasks/managed/test_update_index_image.py
+++ b/scripts/python/tasks/managed/test_update_index_image.py
@@ -1,0 +1,481 @@
+"""Unit tests for update_index_image."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from update_index_image import (
+    UPDATED_SNAPSHOT_FILENAME,
+    is_floating_tag,
+    main,
+    run_inspect_internal_request,
+    run_update_index_image,
+    update_index_images,
+    validate_inspect_result,
+)
+
+MOCK_SHA = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+MOCK_DIGESTS = [
+    "sha256:amd64digest1234567890abcdef1234567890abcdef1234567890abcdef",
+    "sha256:arm64digest1234567890abcdef1234567890abcdef1234567890abcdef",
+]
+
+FLOATING_SNAPSHOT = {
+    "application": "test-app",
+    "components": [
+        {
+            "name": "floating-component",
+            "containerImage": "quay.io/redhat/index@sha256:olddigest",
+            "repositories": [
+                {"url": "quay.io/redhat/preview-operator-index", "tags": ["v4.13"]}
+            ],
+            "imageDigests": ["sha256:olddigest"],
+        }
+    ],
+}
+
+TIMESTAMPED_SNAPSHOT = {
+    "application": "test-app",
+    "components": [
+        {
+            "name": "timestamped-component",
+            "containerImage": "quay.io/redhat/index@sha256:olddigest",
+            "repositories": [
+                {
+                    "url": "quay.io/redhat/preview-operator-index",
+                    "tags": ["v4.13-1783440062"],
+                }
+            ],
+            "imageDigests": ["sha256:olddigest"],
+        }
+    ],
+}
+
+MIXED_SNAPSHOT = {
+    "application": "test-app",
+    "components": [
+        {
+            "name": "floating",
+            "containerImage": "quay.io/redhat/index@sha256:olddigest1",
+            "repositories": [
+                {"url": "quay.io/redhat/preview-operator-index", "tags": ["v4.13"]}
+            ],
+            "imageDigests": ["sha256:olddigest1"],
+        },
+        {
+            "name": "timestamped",
+            "containerImage": "quay.io/redhat/index@sha256:olddigest2",
+            "repositories": [
+                {
+                    "url": "quay.io/redhat/preview-operator-index",
+                    "tags": ["v4.13-1783440062"],
+                }
+            ],
+            "imageDigests": ["sha256:olddigest2"],
+        },
+    ],
+}
+
+DATA = {"fbc": {"publishingCredentials": "fbc-publishing-credentials"}}
+
+
+# --- is_floating_tag ---
+
+
+def test_is_floating_tag_bare_ocp_version() -> None:
+    """Bare OCP version tags are floating."""
+    assert is_floating_tag("v4.13") is True
+    assert is_floating_tag("v4.9") is True
+
+
+def test_is_floating_tag_timestamped() -> None:
+    """Timestamped tags are not floating."""
+    assert is_floating_tag("v4.13-1783440062") is False
+
+
+def test_is_floating_tag_patch_version() -> None:
+    """Patch version tags are not floating."""
+    assert is_floating_tag("v4.13.1") is False
+
+
+def test_is_floating_tag_pre_ga() -> None:
+    """Pre-GA tags are not floating."""
+    assert is_floating_tag("v4.13-pre-ga") is False
+
+
+def test_is_floating_tag_empty() -> None:
+    """Empty string is not a floating tag."""
+    assert is_floating_tag("") is False
+
+
+# --- validate_inspect_result ---
+
+
+def test_validate_inspect_result_valid() -> None:
+    """Returns sha and digests for valid input."""
+    result = {"sha": MOCK_SHA, "digests": MOCK_DIGESTS}
+    sha, digests = validate_inspect_result(result, "ir-test")
+    assert sha == MOCK_SHA
+    assert digests == MOCK_DIGESTS
+
+
+def test_validate_inspect_result_missing_sha() -> None:
+    """Raises on missing sha."""
+    with pytest.raises(ValueError, match="missing or null 'sha'"):
+        validate_inspect_result({"digests": MOCK_DIGESTS}, "ir-test")
+
+
+def test_validate_inspect_result_null_sha() -> None:
+    """Raises on null sha."""
+    with pytest.raises(ValueError, match="missing or null 'sha'"):
+        validate_inspect_result({"sha": None, "digests": MOCK_DIGESTS}, "ir-test")
+
+
+def test_validate_inspect_result_invalid_sha_prefix() -> None:
+    """Raises when sha doesn't start with sha256:."""
+    with pytest.raises(ValueError, match="invalid sha"):
+        validate_inspect_result(
+            {"sha": "md5:abcdef", "digests": MOCK_DIGESTS},
+            "ir-test",
+        )
+
+
+def test_validate_inspect_result_non_array_digests() -> None:
+    """Raises when digests is not a list."""
+    with pytest.raises(ValueError, match="non-array 'digests'"):
+        validate_inspect_result(
+            {"sha": MOCK_SHA, "digests": "not-a-list"},
+            "ir-test",
+        )
+
+
+def test_validate_inspect_result_empty_digests() -> None:
+    """Raises on empty digests array."""
+    with pytest.raises(ValueError, match="empty 'digests' array"):
+        validate_inspect_result({"sha": MOCK_SHA, "digests": []}, "ir-test")
+
+
+def test_validate_inspect_result_invalid_digest_prefix() -> None:
+    """Raises when a digest doesn't start with sha256:."""
+    with pytest.raises(ValueError, match="invalid digests"):
+        validate_inspect_result(
+            {"sha": MOCK_SHA, "digests": ["sha256:valid", "md5:invalid"]},
+            "ir-test",
+        )
+
+
+# --- run_inspect_internal_request ---
+
+
+@patch("update_index_image.run_cmd")
+def test_run_inspect_internal_request_happy_path(mock_run) -> None:
+    """Returns parsed requestMessage from InternalRequest."""
+    ir_output = "InternalRequest 'ir-abc-123' created\n"
+    kubectl_output = json.dumps(
+        {"requestMessage": json.dumps({"sha": MOCK_SHA, "digests": MOCK_DIGESTS})}
+    )
+    mock_run.side_effect = [
+        MagicMock(stdout=ir_output),
+        MagicMock(stdout=kubectl_output),
+    ]
+
+    result = run_inspect_internal_request(
+        "quay.io/redhat/index:v4.13",
+        "creds-secret",
+        "http://localhost",
+        "main",
+        "task-1",
+        "pr-1",
+    )
+
+    assert result["sha"] == MOCK_SHA
+    assert result["digests"] == MOCK_DIGESTS
+    assert mock_run.call_count == 2
+
+
+@patch("update_index_image.run_cmd")
+def test_run_inspect_internal_request_no_ir_name(mock_run) -> None:
+    """Raises when IR name cannot be extracted from output."""
+    mock_run.return_value = MagicMock(stdout="some unexpected output\n")
+
+    with pytest.raises(RuntimeError, match="Failed to extract InternalRequest name"):
+        run_inspect_internal_request(
+            "quay.io/redhat/index:v4.13",
+            "creds-secret",
+            "http://localhost",
+            "main",
+            "task-1",
+            "pr-1",
+        )
+
+
+@patch("update_index_image.run_cmd")
+def test_run_inspect_internal_request_empty_request_message(mock_run) -> None:
+    """Raises when requestMessage is empty."""
+    ir_output = "InternalRequest 'ir-abc-123' created\n"
+    kubectl_output = json.dumps({"requestMessage": ""})
+    mock_run.side_effect = [
+        MagicMock(stdout=ir_output),
+        MagicMock(stdout=kubectl_output),
+    ]
+
+    with pytest.raises(RuntimeError, match="empty requestMessage"):
+        run_inspect_internal_request(
+            "quay.io/redhat/index:v4.13",
+            "creds-secret",
+            "http://localhost",
+            "main",
+            "task-1",
+            "pr-1",
+        )
+
+
+# --- update_index_images ---
+
+
+@patch("update_index_image.run_inspect_internal_request")
+def test_update_index_images_floating_tag(mock_inspect) -> None:
+    """Floating tag component is inspected and updated."""
+    mock_inspect.return_value = {"sha": MOCK_SHA, "digests": MOCK_DIGESTS}
+
+    result = update_index_images(
+        FLOATING_SNAPSHOT,
+        "creds",
+        "git-url",
+        "main",
+        "task-1",
+        "pr-1",
+    )
+
+    assert result["components"][0]["containerImage"] == (
+        f"quay.io/redhat/preview-operator-index@{MOCK_SHA}"
+    )
+    assert result["components"][0]["imageDigests"] == MOCK_DIGESTS
+    mock_inspect.assert_called_once()
+
+
+@patch("update_index_image.run_inspect_internal_request")
+def test_update_index_images_timestamped_tag(mock_inspect) -> None:
+    """Timestamped tag component is not inspected."""
+    result = update_index_images(
+        TIMESTAMPED_SNAPSHOT,
+        "creds",
+        "git-url",
+        "main",
+        "task-1",
+        "pr-1",
+    )
+
+    assert result["components"][0]["containerImage"] == (
+        "quay.io/redhat/index@sha256:olddigest"
+    )
+    assert result["components"][0]["imageDigests"] == ["sha256:olddigest"]
+    mock_inspect.assert_not_called()
+
+
+@patch("update_index_image.run_inspect_internal_request")
+def test_update_index_images_mixed_tags(mock_inspect) -> None:
+    """Only floating tag components are updated in a mixed snapshot."""
+    mock_inspect.return_value = {"sha": MOCK_SHA, "digests": MOCK_DIGESTS}
+
+    result = update_index_images(
+        MIXED_SNAPSHOT,
+        "creds",
+        "git-url",
+        "main",
+        "task-1",
+        "pr-1",
+    )
+
+    assert result["components"][0]["containerImage"] == (
+        f"quay.io/redhat/preview-operator-index@{MOCK_SHA}"
+    )
+    assert result["components"][0]["imageDigests"] == MOCK_DIGESTS
+
+    assert result["components"][1]["containerImage"] == (
+        "quay.io/redhat/index@sha256:olddigest2"
+    )
+    assert result["components"][1]["imageDigests"] == ["sha256:olddigest2"]
+    mock_inspect.assert_called_once()
+
+
+@patch("update_index_image.run_inspect_internal_request")
+def test_update_index_images_no_repositories(mock_inspect) -> None:
+    """Component without repositories is skipped."""
+    snapshot = {
+        "components": [
+            {
+                "name": "no-repos",
+                "containerImage": "quay.io/redhat/index@sha256:old",
+            }
+        ]
+    }
+    result = update_index_images(snapshot, "creds", "git-url", "main", "task-1", "pr-1")
+
+    assert result["components"][0]["containerImage"] == ("quay.io/redhat/index@sha256:old")
+    mock_inspect.assert_not_called()
+
+
+@patch("update_index_image.run_inspect_internal_request")
+def test_update_index_images_empty_components(mock_inspect) -> None:
+    """Empty components list produces no changes."""
+    snapshot = {"components": []}
+    result = update_index_images(
+        snapshot,
+        "creds",
+        "git-url",
+        "main",
+        "task-1",
+        "pr-1",
+    )
+
+    assert result["components"] == []
+    mock_inspect.assert_not_called()
+
+
+@patch("update_index_image.run_inspect_internal_request")
+def test_update_index_images_does_not_mutate_input(mock_inspect) -> None:
+    """Input snapshot is not mutated."""
+    mock_inspect.return_value = {"sha": MOCK_SHA, "digests": MOCK_DIGESTS}
+    original_image = FLOATING_SNAPSHOT["components"][0]["containerImage"]
+
+    update_index_images(
+        FLOATING_SNAPSHOT,
+        "creds",
+        "git-url",
+        "main",
+        "task-1",
+        "pr-1",
+    )
+
+    assert FLOATING_SNAPSHOT["components"][0]["containerImage"] == original_image
+
+
+# --- run_update_index_image ---
+
+
+def _write_fixtures(
+    tmp_path: Path,
+    snapshot: dict | None = None,
+    data: dict | None = None,
+) -> tuple[Path, str, str, Path]:
+    """Write snapshot and data fixtures.
+
+    Returns (data_dir, snapshot_path, data_path, result_path).
+    """
+    uid_dir = tmp_path / "uid123"
+    uid_dir.mkdir()
+
+    snap = uid_dir / "index_image_snapshot.json"
+    snap.write_text(json.dumps(snapshot or FLOATING_SNAPSHOT))
+
+    data_file = uid_dir / "data.json"
+    data_file.write_text(json.dumps(data or DATA))
+
+    result_path = tmp_path / "result"
+    return tmp_path, "uid123/index_image_snapshot.json", "uid123/data.json", result_path
+
+
+@patch("update_index_image.run_inspect_internal_request")
+def test_run_update_index_image_writes_output(mock_inspect, tmp_path) -> None:
+    """Writes updated snapshot and result file."""
+    mock_inspect.return_value = {"sha": MOCK_SHA, "digests": MOCK_DIGESTS}
+    data_dir, snap_path, data_path, result_path = _write_fixtures(tmp_path)
+
+    run_update_index_image(
+        data_dir=data_dir,
+        snapshot_path=snap_path,
+        data_path=data_path,
+        task_git_url="http://localhost",
+        task_git_revision="main",
+        task_id="task-1",
+        pipelinerun_uid="pr-1",
+        index_image_snapshot_result_path=result_path,
+    )
+
+    output_file = data_dir / "uid123" / UPDATED_SNAPSHOT_FILENAME
+    assert output_file.is_file()
+    updated = json.loads(output_file.read_text())
+    assert updated["components"][0]["containerImage"].endswith(f"@{MOCK_SHA}")
+    assert result_path.read_text() == UPDATED_SNAPSHOT_FILENAME
+
+
+def test_run_update_index_image_missing_snapshot(tmp_path) -> None:
+    """Raises when snapshot file does not exist."""
+    result_path = tmp_path / "result"
+    with pytest.raises(FileNotFoundError, match="snapshot"):
+        run_update_index_image(
+            data_dir=tmp_path,
+            snapshot_path="nonexistent.json",
+            data_path="data.json",
+            task_git_url="http://localhost",
+            task_git_revision="main",
+            task_id="task-1",
+            pipelinerun_uid="pr-1",
+            index_image_snapshot_result_path=result_path,
+        )
+
+
+def test_run_update_index_image_missing_data(tmp_path) -> None:
+    """Raises when data file does not exist."""
+    snap = tmp_path / "snap.json"
+    snap.write_text(json.dumps(FLOATING_SNAPSHOT))
+    result_path = tmp_path / "result"
+
+    with pytest.raises(FileNotFoundError, match="data JSON"):
+        run_update_index_image(
+            data_dir=tmp_path,
+            snapshot_path="snap.json",
+            data_path="nonexistent.json",
+            task_git_url="http://localhost",
+            task_git_revision="main",
+            task_id="task-1",
+            pipelinerun_uid="pr-1",
+            index_image_snapshot_result_path=result_path,
+        )
+
+
+def test_run_update_index_image_missing_credentials(tmp_path) -> None:
+    """Raises when publishingCredentials is missing from data."""
+    data_dir, snap_path, data_path, result_path = _write_fixtures(
+        tmp_path,
+        data={"fbc": {}},
+    )
+
+    with pytest.raises(ValueError, match="publishingCredentials"):
+        run_update_index_image(
+            data_dir=data_dir,
+            snapshot_path=snap_path,
+            data_path=data_path,
+            task_git_url="http://localhost",
+            task_git_revision="main",
+            task_id="task-1",
+            pipelinerun_uid="pr-1",
+            index_image_snapshot_result_path=result_path,
+        )
+
+
+# --- main ---
+
+
+@patch("update_index_image.run_inspect_internal_request")
+def test_main_success(mock_inspect, tmp_path, monkeypatch) -> None:
+    """Main returns 0 on success."""
+    mock_inspect.return_value = {"sha": MOCK_SHA, "digests": MOCK_DIGESTS}
+    data_dir, snap_path, data_path, result_path = _write_fixtures(tmp_path)
+
+    monkeypatch.setenv("PARAM_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("PARAM_SNAPSHOT_PATH", snap_path)
+    monkeypatch.setenv("PARAM_DATA_PATH", data_path)
+    monkeypatch.setenv("PARAM_TASK_GIT_URL", "http://localhost")
+    monkeypatch.setenv("PARAM_TASK_GIT_REVISION", "main")
+    monkeypatch.setenv("PARAM_TASK_ID", "task-1")
+    monkeypatch.setenv("PARAM_PIPELINERUN_UID", "pr-1")
+    monkeypatch.setenv("RESULT_INDEX_IMAGE_SNAPSHOT_PATH", str(result_path))
+
+    assert main() == 0
+    assert result_path.read_text() == UPDATED_SNAPSHOT_FILENAME

--- a/scripts/python/tasks/managed/test_update_index_image.py
+++ b/scripts/python/tasks/managed/test_update_index_image.py
@@ -321,6 +321,24 @@ def test_update_index_images_no_repositories(mock_inspect) -> None:
 
 
 @patch("update_index_image.run_inspect_internal_request")
+def test_update_index_images_empty_tags_list(mock_inspect) -> None:
+    """Component with empty tags list is skipped without IndexError."""
+    snapshot = {
+        "components": [
+            {
+                "name": "empty-tags",
+                "containerImage": "quay.io/redhat/index@sha256:old",
+                "repositories": [{"url": "quay.io/redhat/preview-operator-index", "tags": []}],
+            }
+        ]
+    }
+    result = update_index_images(snapshot, "creds", "git-url", "main", "task-1", "pr-1")
+
+    assert result["components"][0]["containerImage"] == ("quay.io/redhat/index@sha256:old")
+    mock_inspect.assert_not_called()
+
+
+@patch("update_index_image.run_inspect_internal_request")
 def test_update_index_images_empty_components(mock_inspect) -> None:
     """Empty components list produces no changes."""
     snapshot = {"components": []}

--- a/scripts/python/tasks/managed/update_index_image.py
+++ b/scripts/python/tasks/managed/update_index_image.py
@@ -174,7 +174,8 @@ def update_index_images(
         if not repos:
             continue
 
-        tag = repos[0].get("tags", [""])[0]
+        tags = repos[0].get("tags") or []
+        tag = tags[0] if tags else ""
         repository = repos[0].get("url", "")
 
         if not is_floating_tag(tag):

--- a/scripts/python/tasks/managed/update_index_image.py
+++ b/scripts/python/tasks/managed/update_index_image.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Update index image snapshot with current digests from the target registry.
+
+Re-inspects floating tags in the TARGET registry to capture the current digest
+after publish-index-image, as a parallel IIB build + publish might have changed it.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import file as file_utils
+import tekton
+from logger import logger
+from subprocess_cmd import run_cmd
+
+UPDATED_SNAPSHOT_FILENAME = "index_image_snapshot_updated.json"
+_FLOATING_TAG = re.compile(r"^v[0-9]+\.[0-9]+$")
+
+TASK_LABEL = "internal-services.appstudio.openshift.io/group-id"
+PIPELINERUN_LABEL = "internal-services.appstudio.openshift.io/pipelinerun-uid"
+
+
+def is_floating_tag(tag: str) -> bool:
+    """Return True if *tag* is a bare OCP floating version (e.g. v4.13)."""
+    return bool(_FLOATING_TAG.fullmatch(tag))
+
+
+def validate_inspect_result(
+    request_message: dict[str, Any], ir_name: str
+) -> tuple[str, list[str]]:
+    """Validate and extract sha and digests from an inspect InternalRequest result.
+
+    Args:
+        request_message: Parsed requestMessage from the InternalRequest status.
+        ir_name: Name of the InternalRequest (for error messages).
+
+    Returns:
+        Tuple of (sha, digests).
+
+    Raises:
+        ValueError: If validation fails.
+
+    """
+    sha = request_message.get("sha")
+    if not sha:
+        raise ValueError(
+            f"InternalRequest {ir_name} requestMessage missing or null 'sha' field"
+        )
+    if not str(sha).startswith("sha256:"):
+        raise ValueError(f"InternalRequest {ir_name} returned invalid sha: {sha}")
+
+    digests = request_message.get("digests")
+    if not isinstance(digests, list):
+        raise ValueError(f"InternalRequest {ir_name} returned non-array 'digests' field")
+    if not digests:
+        raise ValueError(f"InternalRequest {ir_name} returned empty 'digests' array")
+
+    invalid = [d for d in digests if not str(d).startswith("sha256:")]
+    if invalid:
+        raise ValueError(f"InternalRequest {ir_name} returned invalid digests: {invalid}")
+
+    return str(sha), [str(d) for d in digests]
+
+
+def run_inspect_internal_request(
+    floating_target: str,
+    credentials: str,
+    task_git_url: str,
+    task_git_revision: str,
+    task_id: str,
+    pipelinerun_uid: str,
+) -> dict[str, Any]:
+    """Run an internal-request for inspect-target-index-pipeline and return the result.
+
+    Args:
+        floating_target: Image pullspec to inspect (e.g. quay.io/redhat/index:v4.13).
+        credentials: Name of the Kubernetes secret with registry credentials.
+        task_git_url: Git URL for task references.
+        task_git_revision: Git revision for task references.
+        task_id: Task run UID for labeling.
+        pipelinerun_uid: Pipeline run UID for labeling.
+
+    Returns:
+        Parsed requestMessage dict from the InternalRequest status.
+
+    Raises:
+        RuntimeError: If the internal-request fails or returns invalid results.
+
+    """
+    result = run_cmd(
+        [
+            "internal-request",
+            "--pipeline",
+            "inspect-target-index-pipeline",
+            "-p",
+            f"sourceIndex={floating_target}",
+            "-p",
+            f"inspectCredentials={credentials}",
+            "-p",
+            f"taskGitUrl={task_git_url}",
+            "-p",
+            f"taskGitRevision={task_git_revision}",
+            "-l",
+            f"{TASK_LABEL}={task_id}",
+            "-l",
+            f"{PIPELINERUN_LABEL}={pipelinerun_uid}",
+            "-t",
+            "120",
+        ]
+    )
+
+    # internal-request CLI outputs: "InternalRequest '<name>' created"
+    ir_name = ""
+    for line in result.stdout.splitlines():
+        if "created" in line and "'" in line:
+            ir_name = line.split("'")[1]
+            break
+
+    if not ir_name:
+        raise RuntimeError(
+            "Failed to extract InternalRequest name from internal-request output"
+        )
+
+    kubectl_result = run_cmd(
+        [
+            "kubectl",
+            "get",
+            "internalrequest",
+            ir_name,
+            "-o=jsonpath={.status.results}",
+        ]
+    )
+
+    results = json.loads(kubectl_result.stdout)
+    request_message_str = results.get("requestMessage", "")
+    if not request_message_str:
+        raise RuntimeError(f"InternalRequest {ir_name} returned empty requestMessage")
+
+    return json.loads(request_message_str)
+
+
+def update_index_images(
+    snapshot: dict[str, Any],
+    credentials: str,
+    task_git_url: str,
+    task_git_revision: str,
+    task_id: str,
+    pipelinerun_uid: str,
+) -> dict[str, Any]:
+    """Update snapshot components that have floating tags with current digests.
+
+    Args:
+        snapshot: Parsed snapshot JSON with components array.
+        credentials: Name of the Kubernetes secret with registry credentials.
+        task_git_url: Git URL for task references.
+        task_git_revision: Git revision for task references.
+        task_id: Task run UID for labeling.
+        pipelinerun_uid: Pipeline run UID for labeling.
+
+    Returns:
+        Updated snapshot dict (deep copy of input with modified components).
+
+    """
+    updated = copy.deepcopy(snapshot)
+    components = updated.get("components", [])
+
+    for i, component in enumerate(components):
+        repos = component.get("repositories", [])
+        if not repos:
+            continue
+
+        tag = repos[0].get("tags", [""])[0]
+        repository = repos[0].get("url", "")
+
+        if not is_floating_tag(tag):
+            logger.info(
+                "Skipping component %d: tag '%s' is not a floating tag",
+                i,
+                tag,
+            )
+            continue
+
+        floating_target = f"{repository}:{tag}"
+        logger.info("Inspecting floating target index: %s", floating_target)
+
+        request_message = run_inspect_internal_request(
+            floating_target,
+            credentials,
+            task_git_url,
+            task_git_revision,
+            task_id,
+            pipelinerun_uid,
+        )
+
+        component_label = f"component-{i}"
+        sha, digests = validate_inspect_result(request_message, component_label)
+
+        component["containerImage"] = f"{repository}@{sha}"
+        component["imageDigests"] = digests
+        logger.info(
+            "Updated component %d: containerImage=%s, %d digests",
+            i,
+            component["containerImage"],
+            len(digests),
+        )
+
+    return updated
+
+
+def run_update_index_image(
+    *,
+    data_dir: Path,
+    snapshot_path: str,
+    data_path: str,
+    task_git_url: str,
+    task_git_revision: str,
+    task_id: str,
+    pipelinerun_uid: str,
+    index_image_snapshot_result_path: Path,
+) -> None:
+    """Load files, run the update logic, and write outputs."""
+    snapshot_file = data_dir / snapshot_path
+    if not snapshot_file.is_file():
+        raise FileNotFoundError(f"No valid snapshot file was provided: {snapshot_file}")
+
+    data_file = data_dir / data_path
+    if not data_file.is_file():
+        raise FileNotFoundError(f"No data JSON was provided: {data_file}")
+
+    snapshot = file_utils.load_json_dict(snapshot_file)
+    data = file_utils.load_json_dict(data_file)
+
+    credentials = data.get("fbc", {}).get("publishingCredentials", "")
+    if not credentials:
+        raise ValueError("data.fbc.publishingCredentials is missing or empty")
+
+    updated_snapshot = update_index_images(
+        snapshot,
+        credentials,
+        task_git_url,
+        task_git_revision,
+        task_id,
+        pipelinerun_uid,
+    )
+
+    output_dir = snapshot_file.parent
+    output_file = output_dir / UPDATED_SNAPSHOT_FILENAME
+    output_file.write_text(json.dumps(updated_snapshot) + "\n", encoding="utf-8")
+    index_image_snapshot_result_path.write_text(
+        UPDATED_SNAPSHOT_FILENAME,
+        encoding="utf-8",
+    )
+    logger.info("Wrote updated snapshot to %s", output_file)
+
+
+def main() -> int:
+    """Entry point for update-index-image task."""
+    data_dir = Path(tekton.require_env("PARAM_DATA_DIR"))
+    run_update_index_image(
+        data_dir=data_dir,
+        snapshot_path=tekton.require_env("PARAM_SNAPSHOT_PATH"),
+        data_path=tekton.require_env("PARAM_DATA_PATH"),
+        task_git_url=tekton.require_env("PARAM_TASK_GIT_URL"),
+        task_git_revision=tekton.require_env("PARAM_TASK_GIT_REVISION"),
+        task_id=tekton.require_env("PARAM_TASK_ID"),
+        pipelinerun_uid=tekton.require_env("PARAM_PIPELINERUN_UID"),
+        index_image_snapshot_result_path=tekton.result_paths_from_env(
+            "RESULT_INDEX_IMAGE_SNAPSHOT_PATH",
+        )[0],
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
Convert update-index-image and inspect-target-index
from inline bash to standalone Python scripts with
unit tests in release-service-utils.

Assisted-by: Claude
Signed-Off-By: Leandro Mendes