### PR TITLE
refactor: remove redundant is_file pre-checks before file reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,6 @@ Container image (UBI9) with Python scripts, wrappers, and templates used by Tekt
 - Unit tests are co-located with source files (e.g., `pyxis/test_pyxis.py` next to `pyxis/pyxis.py`).
 - Exception: `utils/` has tests in `utils/tests/`.
 - Mocking with `unittest.mock`: use `patch`, `MagicMock`, `monkeypatch` for env vars.
-- Inject dependencies as callable kwargs with real defaults, replaced only in tests.
 - Integration tests live in `integration-tests/` and are not run by pytest.
 - Test function names: `test_<what_is_being_tested>`. Type-hint test functions with `-> None`.
 

--- a/scripts/python/helpers/test_charon_env.py
+++ b/scripts/python/helpers/test_charon_env.py
@@ -171,5 +171,5 @@ def test_install_charon_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
 
 def test_install_charon_config_missing_source(tmp_path: Path) -> None:
     """Missing config sources raise FileNotFoundError."""
-    with pytest.raises(FileNotFoundError, match="charon config file not found"):
+    with pytest.raises(FileNotFoundError):
         charon_env.install_charon_config(tmp_path / "missing.yaml")

--- a/scripts/python/tasks/managed/check_data_keys.py
+++ b/scripts/python/tasks/managed/check_data_keys.py
@@ -22,14 +22,6 @@ from logger import logger
 DEFAULT_SCHEMA_PATH = Path("/home/schemas/dataKeys.json")
 
 
-def resolve_schema_path(schema_path: Path) -> Path:
-    """Return *schema_path* when the file exists."""
-    if not schema_path.is_file():
-        msg = f"schema file not found: {schema_path}"
-        raise FileNotFoundError(msg)
-    return schema_path
-
-
 def parse_systems_param(systems_json: str) -> list[dict[str, Any]]:
     """Parse the Tekton `systems` param as a JSON array of system objects."""
     text = systems_json.strip()
@@ -84,10 +76,6 @@ def run_check_data_keys(
 ) -> None:
     """Load data, merge systems, and validate against the schema."""
     data_file = data_dir / data_path
-    if not data_file.is_file():
-        msg = "No data JSON was provided."
-        raise FileNotFoundError(msg)
-
     logger.info("Loading data from %s", data_file)
     data = file.load_json_dict(data_file)
     systems = parse_systems_param(systems_json)
@@ -96,9 +84,8 @@ def run_check_data_keys(
     data = merge_systems_into_data(data, systems)
     data_file.write_text(json.dumps(data) + "\n", encoding="utf-8")
 
-    schema = resolve_schema_path(schema_path)
-    logger.info("Validating %s against schema %s", data_file, schema)
-    validate_data_against_schema(schema, data_file)
+    logger.info("Validating %s against schema %s", data_file, schema_path)
+    validate_data_against_schema(schema_path, data_file)
     logger.info("Schema validation succeeded")
 
 

--- a/scripts/python/tasks/managed/check_labels.py
+++ b/scripts/python/tasks/managed/check_labels.py
@@ -149,12 +149,6 @@ def check_labels(snapshot_path: Path, data_path: Path, enforce: bool) -> None:
     Raise ``LabelValidationError`` on validation failure (enforce mode) or
     on hard data errors.
     """
-    if not snapshot_path.is_file():
-        raise LabelValidationError(f"No valid snapshot file was provided: {snapshot_path}")
-
-    if not data_path.is_file():
-        raise LabelValidationError(f"No valid data file was provided: {data_path}")
-
     snapshot = load_json_dict(snapshot_path)
     data = load_json_dict(data_path)
 

--- a/scripts/python/tasks/managed/close_advisory_issues.py
+++ b/scripts/python/tasks/managed/close_advisory_issues.py
@@ -194,10 +194,6 @@ def close_advisory_issues(
 ) -> None:
     """Close fixed Jira issues referenced in the release data file."""
     data_file = data_dir / data_path
-    if not data_file.is_file():
-        msg = "No data JSON was provided."
-        raise FileNotFoundError(msg)
-
     logger.info("Loading release data from %s", data_file)
     data = file.load_json_dict(data_file)
     fixed_issues = load_fixed_issues(data)

--- a/scripts/python/tasks/managed/collect_gh_params.py
+++ b/scripts/python/tasks/managed/collect_gh_params.py
@@ -14,16 +14,6 @@ import tekton
 from file import load_json_dict
 
 
-def validate_input_files(
-    data_file: Path,
-    snapshot_file: Path,
-) -> None:
-    """Raise RuntimeError when any required input file is missing."""
-    for label, path in [("data", data_file), ("snapshot", snapshot_file)]:
-        if not path.is_file():
-            raise RuntimeError(f"No valid {label} file was provided.")
-
-
 def collect_params(
     *,
     data_file: Path,
@@ -34,8 +24,6 @@ def collect_params(
     result_github_secret: Path,
 ) -> int:
     """Collect github parameters and write to results."""
-    validate_input_files(data_file, snapshot_file)
-
     data = load_json_dict(data_file)
     snapshot = load_json_dict(snapshot_file)
 

--- a/scripts/python/tasks/managed/collect_index_images.py
+++ b/scripts/python/tasks/managed/collect_index_images.py
@@ -176,10 +176,6 @@ def run_collect_index_images(
 ) -> None:
     """Load results, build the snapshot JSON, and write Tekton outputs."""
     results_path = data_dir / internal_request_results_file
-    if not results_path.is_file():
-        msg = f"internal request results file not found: {results_path}"
-        raise FileNotFoundError(msg)
-
     logger.info("Loading internal request results from %s", results_path)
     results = file.load_json_dict(results_path)
     snapshot = collect_index_image_components(results)

--- a/scripts/python/tasks/managed/collect_slack_notification_params.py
+++ b/scripts/python/tasks/managed/collect_slack_notification_params.py
@@ -21,21 +21,6 @@ class ReleaseMetadata(NamedTuple):
     release_pipeline_name: str
 
 
-def validate_input_files(
-    data_file: Path,
-    snapshot_file: Path,
-    release_file: Path,
-) -> None:
-    """Raise RuntimeError when any required input file is missing."""
-    for label, path in [
-        ("data", data_file),
-        ("snapshot", snapshot_file),
-        ("release", release_file),
-    ]:
-        if not path.is_file():
-            raise RuntimeError(f"No valid {label} file was provided.")
-
-
 def _get_slack_field(data: dict[str, Any], key: str) -> str | None:
     """Return a string value from data['slack'][key], or None if absent."""
     slack = data.get("slack")
@@ -193,8 +178,6 @@ def collect_params(
     result_keyname: Path,
 ) -> int:
     """Collect Slack notification parameters and write result files."""
-    validate_input_files(data_file, snapshot_file, release_file)
-
     data = load_json_dict(data_file)
 
     secret = extract_slack_secret(data)

--- a/scripts/python/tasks/managed/extract_checksums_from_image.py
+++ b/scripts/python/tasks/managed/extract_checksums_from_image.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+import file
 import skopeo
 import tekton
 from logger import logger
@@ -27,9 +28,7 @@ BINARIES_DIR = "binaries"
 
 def load_snapshot(snapshot_path: Path) -> dict[str, Any]:
     """Load and return the snapshot JSON from *snapshot_path*."""
-    if not snapshot_path.is_file():
-        raise ValueError(f"No valid snapshot file was provided: {snapshot_path}")
-    return json.loads(snapshot_path.read_text(encoding="utf-8"))
+    return file.load_json_dict(snapshot_path)
 
 
 def load_components(data_path: Path) -> list[str]:

--- a/scripts/python/tasks/managed/extract_index_image.py
+++ b/scripts/python/tasks/managed/extract_index_image.py
@@ -49,10 +49,6 @@ def extract_index_image(
 ) -> Path:
     """Load InternalRequest results and write extract-index-image output."""
     input_path = data_dir / internal_request_results_file
-    if not input_path.is_file():
-        msg = f"InternalRequest results file not found: {input_path}"
-        raise FileNotFoundError(msg)
-
     logger.info("Loading InternalRequest results from %s", input_path)
     internal_request_results = file.load_json_dict(input_path)
     payload = extract_index_image_results(internal_request_results)

--- a/scripts/python/tasks/managed/make_repo_public.py
+++ b/scripts/python/tasks/managed/make_repo_public.py
@@ -125,24 +125,17 @@ def run(
     Quay registry is supported per invocation; encountering repos on two
     different Quay registries raises ``RuntimeError``.
     """
-    if not data_file.is_file():
-        raise RuntimeError("No valid data file was provided.")
-    if not snapshot_file.is_file():
-        raise RuntimeError("No valid snapshot file was provided.")
-
     setup_ca_bundle(ca_cert_path)
 
     token_path = secret_path / "token"
-    if not token_path.is_file():
-        raise RuntimeError(f"Registry secret token file not found at {token_path}")
     token = token_path.read_text(encoding="utf-8").strip()
 
     try:
-        data: dict[str, Any] = json.loads(data_file.read_text(encoding="utf-8"))
+        data: dict[str, Any] = file.load_json_dict(data_file)
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"Invalid JSON in data file {data_file}: {exc}") from exc
     try:
-        snapshot: dict[str, Any] = json.loads(snapshot_file.read_text(encoding="utf-8"))
+        snapshot: dict[str, Any] = file.load_json_dict(snapshot_file)
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"Invalid JSON in snapshot file {snapshot_file}: {exc}") from exc
 

--- a/scripts/python/tasks/managed/publish_pyxis_repository.py
+++ b/scripts/python/tasks/managed/publish_pyxis_repository.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 from typing import Any
 
+import file
 import pyxis_api
 import tekton
 from logger import logger
@@ -212,15 +213,8 @@ def run_publish_pyxis_repository(
     task_name: str,
 ) -> None:
     """Load inputs, publish repositories in Pyxis, and write workspace outputs."""
-    if not snapshot_path.is_file():
-        msg = "No valid snapshot file was provided."
-        raise FileNotFoundError(msg)
-    if not data_path.is_file():
-        msg = "No data JSON was provided."
-        raise FileNotFoundError(msg)
-
-    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
-    data = json.loads(data_path.read_text(encoding="utf-8"))
+    snapshot = file.load_json_dict(snapshot_path)
+    data = file.load_json_dict(data_path)
 
     sign_registry_relative = (data_path.parent / SIGN_REGISTRY_ACCESS_FILENAME).relative_to(
         data_dir

--- a/scripts/python/tasks/managed/test_check_data_keys.py
+++ b/scripts/python/tasks/managed/test_check_data_keys.py
@@ -76,20 +76,6 @@ def test_default_schema_path_is_image_location() -> None:
     assert check_data_keys.DEFAULT_SCHEMA_PATH == Path("/home/schemas/dataKeys.json")
 
 
-def test_resolve_schema_path_returns_existing_file(tmp_path: Path) -> None:
-    """Return the path when the schema file exists."""
-    schema = tmp_path / "schema.json"
-    schema.write_text("{}", encoding="utf-8")
-    assert check_data_keys.resolve_schema_path(schema) == schema
-
-
-def test_resolve_schema_path_missing_file(tmp_path: Path) -> None:
-    """Fail when the schema file does not exist."""
-    missing = tmp_path / "missing-schema.json"
-    with pytest.raises(FileNotFoundError, match="schema file not found"):
-        check_data_keys.resolve_schema_path(missing)
-
-
 def test_parse_systems_param_empty_string() -> None:
     """Treat a blank systems param as an empty array."""
     assert check_data_keys.parse_systems_param("") == []
@@ -148,7 +134,7 @@ def test_module_main_guard(monkeypatch: pytest.MonkeyPatch, schema_path: Path) -
     monkeypatch.setenv("PARAM_DATA_DIR", "/tmp")
     monkeypatch.setenv("PARAM_DATA_PATH", "missing.json")
     monkeypatch.setenv("SCHEMA_FILE", str(schema_path))
-    with pytest.raises(FileNotFoundError, match="No data JSON was provided"):
+    with pytest.raises(FileNotFoundError):
         runpy.run_module("check_data_keys", run_name="__main__")
 
 
@@ -186,7 +172,7 @@ def test_run_check_data_keys_missing_data_file(
     schema_path: Path,
 ) -> None:
     """Fail when the data JSON path does not exist."""
-    with pytest.raises(FileNotFoundError, match="No data JSON was provided"):
+    with pytest.raises(FileNotFoundError):
         check_data_keys.run_check_data_keys(
             data_dir=tmp_path,
             data_path=Path("missing.json"),
@@ -318,7 +304,7 @@ def test_main_failure_propagates_exception(
     monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("PARAM_DATA_PATH", "missing.json")
     monkeypatch.setenv("SCHEMA_FILE", str(schema_path))
-    with pytest.raises(FileNotFoundError, match="No data JSON was provided"):
+    with pytest.raises(FileNotFoundError):
         check_data_keys.main()
 
 

--- a/scripts/python/tasks/managed/test_check_labels.py
+++ b/scripts/python/tasks/managed/test_check_labels.py
@@ -513,7 +513,7 @@ def test_missing_snapshot_file(tmp_path: Path) -> None:
     """Raise when the snapshot file does not exist."""
     data = tmp_path / "data.json"
     _write_data(data)
-    with pytest.raises(check_labels.LabelValidationError, match="missing.json"):
+    with pytest.raises(FileNotFoundError):
         check_labels.check_labels(tmp_path / "missing.json", data, enforce=True)
 
 
@@ -521,7 +521,7 @@ def test_missing_data_file(tmp_path: Path) -> None:
     """Raise when the data file does not exist."""
     snap = tmp_path / "snapshot.json"
     _write_snapshot(snap, [])
-    with pytest.raises(check_labels.LabelValidationError, match="missing.json"):
+    with pytest.raises(FileNotFoundError):
         check_labels.check_labels(snap, tmp_path / "missing.json", enforce=True)
 
 

--- a/scripts/python/tasks/managed/test_close_advisory_issues.py
+++ b/scripts/python/tasks/managed/test_close_advisory_issues.py
@@ -587,7 +587,7 @@ def test_close_advisory_issues_no_issues(tmp_path: Path) -> None:
 def test_close_advisory_issues_missing_data_file(tmp_path: Path) -> None:
     """Fail when the release data file is missing."""
     _write_jira_secret(tmp_path / "secrets")
-    with pytest.raises(FileNotFoundError, match="No data JSON was provided"):
+    with pytest.raises(FileNotFoundError):
         close_advisory_issues.close_advisory_issues(
             data_dir=tmp_path,
             data_path=Path("missing.json"),
@@ -692,5 +692,5 @@ def test_module_main_guard_propagates_failure(
         "https://access.redhat.com/errata/RHBA-2025:1111",
     )
     monkeypatch.setenv("JIRA_SECRET_PATH", str(tmp_path / "secrets"))
-    with pytest.raises(FileNotFoundError, match="No data JSON was provided"):
+    with pytest.raises(FileNotFoundError):
         runpy.run_module("close_advisory_issues", run_name="__main__")

--- a/scripts/python/tasks/managed/test_collect_gh_params.py
+++ b/scripts/python/tasks/managed/test_collect_gh_params.py
@@ -59,37 +59,6 @@ def _setup_happy_path(
     }
 
 
-# --- validate_input_files ---
-
-
-def test_validate_input_files_both_exist(tmp_path: Path) -> None:
-    """No error when both files exist."""
-    data_file = tmp_path / "data.json"
-    snapshot_file = tmp_path / "snapshot.json"
-    data_file.touch()
-    snapshot_file.touch()
-
-    collect_gh_params.validate_input_files(data_file, snapshot_file)
-
-
-def test_validate_input_files_missing_data(tmp_path: Path) -> None:
-    """RuntimeError when data file is missing."""
-    snapshot_file = tmp_path / "snapshot.json"
-    snapshot_file.touch()
-
-    with pytest.raises(RuntimeError, match="No valid data file"):
-        collect_gh_params.validate_input_files(tmp_path / "missing.json", snapshot_file)
-
-
-def test_validate_input_files_missing_snapshot(tmp_path: Path) -> None:
-    """RuntimeError when snapshot file is missing."""
-    data_file = tmp_path / "data.json"
-    data_file.touch()
-
-    with pytest.raises(RuntimeError, match="No valid snapshot file"):
-        collect_gh_params.validate_input_files(data_file, tmp_path / "missing.json")
-
-
 # --- collect_params happy path ---
 
 

--- a/scripts/python/tasks/managed/test_collect_index_images.py
+++ b/scripts/python/tasks/managed/test_collect_index_images.py
@@ -442,7 +442,7 @@ def test_run_collect_index_images_writes_snapshot_and_result(
 
 def test_run_collect_index_images_missing_results_file(tmp_path: Path) -> None:
     """Fail when the internal request results file is missing."""
-    with pytest.raises(FileNotFoundError, match="internal request results file not found"):
+    with pytest.raises(FileNotFoundError):
         collect_index_images.run_collect_index_images(
             data_dir=tmp_path,
             internal_request_results_file=Path("missing.json"),
@@ -461,7 +461,7 @@ def test_module_main_guard_propagates_failure(
     monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("PARAM_INTERNAL_REQUEST_RESULTS_FILE", "missing.json")
     monkeypatch.setenv("RESULT_INDEX_IMAGE_SNAPSHOT_PATH", str(tmp_path / "result.txt"))
-    with pytest.raises(FileNotFoundError, match="internal request results file not found"):
+    with pytest.raises(FileNotFoundError):
         runpy.run_module("collect_index_images", run_name="__main__")
 
 

--- a/scripts/python/tasks/managed/test_collect_slack_notification_params.py
+++ b/scripts/python/tasks/managed/test_collect_slack_notification_params.py
@@ -17,7 +17,6 @@ from collect_slack_notification_params import (
     extract_slack_keyname,
     extract_slack_secret,
     main,
-    validate_input_files,
 )
 
 
@@ -56,53 +55,6 @@ def _sample_release() -> dict:
 def _sample_snapshot() -> dict:
     """Return a snapshot dict with componentGroup."""
     return {"componentGroup": "my-app"}
-
-
-# -- validate_input_files --
-
-
-def test_validate_input_files_all_exist(tmp_path: Path) -> None:
-    """No exception when all three files exist."""
-    data = tmp_path / "data.json"
-    snapshot = tmp_path / "snapshot.json"
-    release = tmp_path / "release.json"
-    for f in (data, snapshot, release):
-        f.write_text("{}")
-
-    validate_input_files(data, snapshot, release)
-
-
-def test_validate_input_files_data_missing(tmp_path: Path) -> None:
-    """Raise RuntimeError when data file is missing."""
-    snapshot = tmp_path / "snapshot.json"
-    release = tmp_path / "release.json"
-    for f in (snapshot, release):
-        f.write_text("{}")
-
-    with pytest.raises(RuntimeError, match="No valid data file"):
-        validate_input_files(tmp_path / "missing.json", snapshot, release)
-
-
-def test_validate_input_files_snapshot_missing(tmp_path: Path) -> None:
-    """Raise RuntimeError when snapshot file is missing."""
-    data = tmp_path / "data.json"
-    release = tmp_path / "release.json"
-    for f in (data, release):
-        f.write_text("{}")
-
-    with pytest.raises(RuntimeError, match="No valid snapshot file"):
-        validate_input_files(data, tmp_path / "missing.json", release)
-
-
-def test_validate_input_files_release_missing(tmp_path: Path) -> None:
-    """Raise RuntimeError when release file is missing."""
-    data = tmp_path / "data.json"
-    snapshot = tmp_path / "snapshot.json"
-    for f in (data, snapshot):
-        f.write_text("{}")
-
-    with pytest.raises(RuntimeError, match="No valid release file"):
-        validate_input_files(data, snapshot, tmp_path / "missing.json")
 
 
 # -- extract_slack_secret --
@@ -341,12 +293,12 @@ def test_collect_params_no_slack_keyname(tmp_path: Path) -> None:
 
 
 def test_collect_params_missing_input_file(tmp_path: Path) -> None:
-    """Raise RuntimeError when an input file is missing."""
+    """Raise FileNotFoundError when an input file is missing."""
     r_msg = tmp_path / "r_msg"
     r_secret = tmp_path / "r_secret"
     r_keyname = tmp_path / "r_keyname"
 
-    with pytest.raises(RuntimeError, match="No valid data file"):
+    with pytest.raises(FileNotFoundError):
         collect_params(
             data_file=tmp_path / "missing.json",
             snapshot_file=tmp_path / "snapshot.json",

--- a/scripts/python/tasks/managed/test_extract_checksums_from_image.py
+++ b/scripts/python/tasks/managed/test_extract_checksums_from_image.py
@@ -114,8 +114,8 @@ def test_load_snapshot_valid(tmp_path: Path) -> None:
 
 
 def test_load_snapshot_missing_file(tmp_path: Path) -> None:
-    """Missing file raises ValueError."""
-    with pytest.raises(ValueError, match="No valid snapshot file"):
+    """Missing file raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
         ecfi.load_snapshot(tmp_path / "nope.json")
 
 
@@ -418,11 +418,11 @@ def test_extract_checksums_null_components(tmp_path: Path) -> None:
 
 
 def test_extract_checksums_missing_snapshot_raises(tmp_path: Path) -> None:
-    """Missing snapshot file raises ValueError."""
+    """Missing snapshot file raises FileNotFoundError."""
     data_dir = tmp_path / "workdir"
     data_dir.mkdir()
 
-    with pytest.raises(ValueError, match="No valid snapshot file"):
+    with pytest.raises(FileNotFoundError):
         ecfi.extract_checksums(
             data_dir / "nope.json",
             data_dir / "data.json",

--- a/scripts/python/tasks/managed/test_extract_index_image.py
+++ b/scripts/python/tasks/managed/test_extract_index_image.py
@@ -205,7 +205,7 @@ def test_extract_index_image_writes_expected_file(
 
 def test_extract_index_image_missing_input_raises(tmp_path: Path) -> None:
     """Raise when the InternalRequest results file is missing (catalog fail test)."""
-    with pytest.raises(FileNotFoundError, match="InternalRequest results file not found"):
+    with pytest.raises(FileNotFoundError):
         extract_index_image.extract_index_image(
             data_dir=tmp_path,
             results_dir_path=Path("results"),

--- a/scripts/python/tasks/managed/test_make_repo_public.py
+++ b/scripts/python/tasks/managed/test_make_repo_public.py
@@ -284,7 +284,7 @@ class TestRun:
 
     def test_missing_data_file(self, tmp_path: Path) -> None:
         """Error when data file does not exist."""
-        with pytest.raises(RuntimeError, match="No valid data file"):
+        with pytest.raises(FileNotFoundError):
             make_repo_public.run(
                 tmp_path / "missing.json",
                 tmp_path / "snapshot.json",
@@ -297,7 +297,7 @@ class TestRun:
         data_file = tmp_path / "data.json"
         _write_data(data_file, _default_data())
 
-        with pytest.raises(RuntimeError, match="No valid snapshot file"):
+        with pytest.raises(FileNotFoundError):
             make_repo_public.run(
                 data_file,
                 tmp_path / "missing.json",
@@ -315,7 +315,7 @@ class TestRun:
         _write_data(data_file, _default_data())
         _write_data(snapshot_file, _snapshot_with_components([]))
 
-        with pytest.raises(RuntimeError, match="token file not found"):
+        with pytest.raises(FileNotFoundError):
             make_repo_public.run(
                 data_file,
                 snapshot_file,
@@ -481,12 +481,12 @@ class TestMain:
     def test_runtime_error_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """`main` raises RuntimeError when run() fails."""
+        """`main` raises FileNotFoundError when run() fails."""
         monkeypatch.setenv("DATA_FILE", str(tmp_path / "missing.json"))
         monkeypatch.setenv("SNAPSHOT_FILE", str(tmp_path / "snap.json"))
         monkeypatch.setenv("REGISTRY_SECRET_PATH", str(tmp_path))
         monkeypatch.setenv("CA_CERT_PATH", str(tmp_path / "no-ca.crt"))
-        with pytest.raises(RuntimeError):
+        with pytest.raises(FileNotFoundError):
             make_repo_public.main()
 
 

--- a/scripts/python/tasks/managed/test_publish_pyxis_repository.py
+++ b/scripts/python/tasks/managed/test_publish_pyxis_repository.py
@@ -580,7 +580,7 @@ def test_run_publish_pyxis_repository_writes_outputs(tmp_path: Path) -> None:
 
 def test_run_publish_missing_snapshot_raises(tmp_path: Path) -> None:
     """Fail fast when the snapshot file is missing."""
-    with pytest.raises(FileNotFoundError, match="No valid snapshot file"):
+    with pytest.raises(FileNotFoundError):
         publish_pyxis_repository.run_publish_pyxis_repository(
             data_dir=tmp_path,
             snapshot_path=tmp_path / "missing.json",
@@ -597,7 +597,7 @@ def test_run_publish_missing_data_raises(tmp_path: Path) -> None:
     """Fail fast when the data JSON file is missing."""
     snapshot = tmp_path / "snap.json"
     snapshot.write_text("{}", encoding="utf-8")
-    with pytest.raises(FileNotFoundError, match="No data JSON"):
+    with pytest.raises(FileNotFoundError):
         publish_pyxis_repository.run_publish_pyxis_repository(
             data_dir=tmp_path,
             snapshot_path=snapshot,


### PR DESCRIPTION
Remove inline is_file() guards and local validate_input_files functions, letting open()/read_text()/load_json_dict() raise FileNotFoundError.

Also remove outdated callable-kwargs testing guideline from AGENTS.md.

Assisted-by: Claude Code