### PR TITLE
feat(RELEASE-2503): convert publish-to-mrrc steps to python

### DIFF
--- a/scripts/python/helpers/charon_env.py
+++ b/scripts/python/helpers/charon_env.py
@@ -80,3 +80,11 @@ NRRC_WORK_DIR_DEFAULT = Path("/var/workdir/nrrc")
 def nrrc_work_dir() -> Path:
     """Return the NRRC staging directory from ``WORK_DIR`` or ``/var/workdir/nrrc``."""
     return file.path_from_env_variable("WORK_DIR", NRRC_WORK_DIR_DEFAULT)
+
+
+MRRC_WORK_DIR_DEFAULT = Path("/var/workdir/mrrc")
+
+
+def mrrc_work_dir() -> Path:
+    """Return the MRRC staging directory from ``WORK_DIR`` or ``/var/workdir/mrrc``."""
+    return file.path_from_env_variable("WORK_DIR", MRRC_WORK_DIR_DEFAULT)

--- a/scripts/python/helpers/test_charon_env.py
+++ b/scripts/python/helpers/test_charon_env.py
@@ -141,6 +141,18 @@ def test_nrrc_work_dir_from_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     assert charon_env.nrrc_work_dir() == custom
 
 
+def test_mrrc_work_dir_default() -> None:
+    """Default MRRC work directory uses the volume mount root."""
+    assert charon_env.mrrc_work_dir() == Path("/var/workdir/mrrc")
+
+
+def test_mrrc_work_dir_from_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``WORK_DIR`` overrides the default MRRC staging directory."""
+    custom = tmp_path / "staging"
+    monkeypatch.setenv("WORK_DIR", str(custom))
+    assert charon_env.mrrc_work_dir() == custom
+
+
 def test_charon_config_path_uses_explicit_home(tmp_path: Path) -> None:
     """An explicit *home* overrides ``Path.home()``."""
     assert charon_env.charon_config_path(home=tmp_path) == tmp_path / ".charon" / "charon.yaml"

--- a/scripts/python/tasks/managed/publish_to_mrrc_prepare_repo.py
+++ b/scripts/python/tasks/managed/publish_to_mrrc_prepare_repo.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Download maven repo zips from OCI registries for publish-to-mrrc.
+
+Tekton injects ``DATA_DIR``, ``CHARON_PARAM_FILE_PATH`` and optionally
+``WORK_DIR`` which defaults to ``/var/workdir/mrrc`` via env.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import charon_env
+import file
+import oras_utils
+import tekton
+from logger import logger
+
+
+def prepare_repo(
+    *,
+    charon_param_file: Path,
+    work_dir: Path,
+) -> None:
+    """Pull maven repo zips from each OCI registry into a short-hash subdir."""
+    env = charon_env.load_charon_env(charon_param_file)
+    registries = charon_env.require_oci_registries(env)
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    for registry in registries:
+        logger.info("Downloading the maven repo zip %s", registry)
+        short_hash = charon_env.short_sha256_prefix(registry)
+        subdir = work_dir / short_hash
+        subdir.mkdir(parents=True, exist_ok=True)
+        oras_utils.oras_pull(registry, subdir)
+
+
+def main() -> int:
+    """Parse env vars and pull maven repo zips."""
+    data_dir = Path(tekton.require_env("DATA_DIR"))
+    work_dir = charon_env.mrrc_work_dir()
+    charon_param_file = file.resolve_path_under_base(
+        data_dir,
+        tekton.require_env("CHARON_PARAM_FILE_PATH"),
+    )
+    prepare_repo(
+        charon_param_file=charon_param_file,
+        work_dir=work_dir,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/publish_to_mrrc_push_merged.py
+++ b/scripts/python/tasks/managed/publish_to_mrrc_push_merged.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Push merged maven zip to OCI registry for publish-to-mrrc.
+
+Tekton injects ``IMAGE``, ``IMAGE_EXPIRES_AFTER`` which is optional and
+``WORK_DIR`` which defaults to ``/var/workdir/mrrc`` via env.  Result paths
+come from ``RESULT_IMAGE_DIGEST`` and ``RESULT_IMAGE_TAG``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import charon_env
+import file
+import oras_utils
+import tekton
+from logger import logger
+
+
+def generate_tag() -> str:
+    """Build a tag from the current UTC time and a uuid4."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return f"{timestamp}-{uuid.uuid4()}"
+
+
+def push_merged_maven_repo(
+    *,
+    work_dir: Path,
+    image: str,
+    image_expires_after: str,
+    result_image_digest: Path,
+    result_image_tag: Path,
+) -> None:
+    """Push merged.zip to the registry and write digest and tag to results."""
+    merge_dir = work_dir / "merged"
+    merged_zip = merge_dir / "merged.zip"
+
+    if not merged_zip.is_file():
+        logger.info("No merged maven zip found, skipping push")
+        return
+
+    tag = generate_tag()
+    tagged_ref = f"{image}:{tag}"
+
+    auth_out = subprocess.check_output(
+        ["select-oci-auth", image],
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    auth_file = file.make_tempfile_path("oras-auth-", auth_out.encode("utf-8"))
+
+    cmd: list[str] = [
+        "oras",
+        "push",
+        "--registry-config",
+        str(auth_file),
+        "--artifact-type",
+        "application/vnd.maven+zip",
+    ]
+    if image_expires_after:
+        logger.info("Setting image expiration to %s", image_expires_after)
+        cmd.extend(["--annotation", f"quay.expires-after={image_expires_after}"])
+    cmd.extend([tagged_ref, "merged.zip"])
+
+    logger.info("Pushing image %s to registry", tagged_ref)
+    subprocess.check_output(cmd, cwd=str(merge_dir), stderr=subprocess.STDOUT, text=True)
+
+    digest = oras_utils.oras_resolve(tagged_ref)
+    result_image_digest.write_text(digest, encoding="utf-8")
+    result_image_tag.write_text(tag, encoding="utf-8")
+    logger.info("Push merged zip %s@%s successfully", tagged_ref, digest)
+
+
+def main() -> int:
+    """Parse env vars and push the merged maven zip."""
+    image = tekton.require_env("IMAGE")
+    image_expires_after = os.environ.get("IMAGE_EXPIRES_AFTER", "").strip()
+    work_dir = charon_env.mrrc_work_dir()
+    result_digest, result_tag = tekton.result_paths_from_env(
+        "RESULT_IMAGE_DIGEST",
+        "RESULT_IMAGE_TAG",
+    )
+    push_merged_maven_repo(
+        work_dir=work_dir,
+        image=image,
+        image_expires_after=image_expires_after,
+        result_image_digest=result_digest,
+        result_image_tag=result_tag,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_publish_to_mrrc_prepare_repo.py
+++ b/scripts/python/tasks/managed/test_publish_to_mrrc_prepare_repo.py
@@ -1,0 +1,163 @@
+"""Tests for publish_to_mrrc_prepare_repo."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import publish_to_mrrc_prepare_repo
+import pytest
+
+
+def _write_charon_env(path: Path, registry: str) -> None:
+    path.write_text(
+        f"CHARON_OCI_REGISTRY={registry}\n",
+        encoding="utf-8",
+    )
+
+
+def _set_prepare_repo_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    charon_param_file_path: str = "charon.env",
+    work_dir: str | None = None,
+) -> None:
+    """Set env vars for main()."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CHARON_PARAM_FILE_PATH", charon_param_file_path)
+    if work_dir is not None:
+        monkeypatch.setenv("WORK_DIR", work_dir)
+
+
+def test_prepare_repo_downloads_into_short_hash_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Registry is pulled into a subdir named by its sha256 prefix."""
+    env_file = tmp_path / "charon.env"
+    _write_charon_env(env_file, "quay.io/test/app@sha256:0b15aad24f1b847")
+    work_dir = tmp_path / "mrrc"
+
+    def fake_oras_pull(pull_spec: str, download_dir: Path, **kwargs: object) -> None:
+        del kwargs
+        assert pull_spec == "quay.io/test/app@sha256:0b15aad24f1b847"
+        download_dir.mkdir(parents=True, exist_ok=True)
+        (download_dir / "maven-repo.zip").write_bytes(b"fake-zip")
+
+    monkeypatch.setattr(publish_to_mrrc_prepare_repo.oras_utils, "oras_pull", fake_oras_pull)
+    publish_to_mrrc_prepare_repo.prepare_repo(
+        charon_param_file=env_file,
+        work_dir=work_dir,
+    )
+    subdir = work_dir / "0b15aa"
+    assert subdir.is_dir()
+    assert (subdir / "maven-repo.zip").is_file()
+
+
+def test_prepare_repo_multiple_registries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Multiple %-separated registries each get their own subdir."""
+    env_file = tmp_path / "charon.env"
+    env_file.write_text(
+        "CHARON_OCI_REGISTRY="
+        "quay.io/a@sha256:0b15aad24f1b847%"
+        "quay.io/b@sha256:e400bc4b4398295\n",
+        encoding="utf-8",
+    )
+    work_dir = tmp_path / "mrrc"
+    pulls: list[str] = []
+
+    def fake_oras_pull(pull_spec: str, download_dir: Path, **kwargs: object) -> None:
+        del kwargs
+        pulls.append(pull_spec)
+        download_dir.mkdir(parents=True, exist_ok=True)
+        (download_dir / "maven-repo.zip").write_bytes(b"fake-zip")
+
+    monkeypatch.setattr(publish_to_mrrc_prepare_repo.oras_utils, "oras_pull", fake_oras_pull)
+    publish_to_mrrc_prepare_repo.prepare_repo(
+        charon_param_file=env_file,
+        work_dir=work_dir,
+    )
+    assert pulls == [
+        "quay.io/a@sha256:0b15aad24f1b847",
+        "quay.io/b@sha256:e400bc4b4398295",
+    ]
+    assert (work_dir / "0b15aa").is_dir()
+    assert (work_dir / "e400bc").is_dir()
+
+
+def test_prepare_repo_requires_charon_oci_registry(tmp_path: Path) -> None:
+    """Missing CHARON_OCI_REGISTRY raises ValueError."""
+    env_file = tmp_path / "charon.env"
+    env_file.write_text("CHARON_TARGET=dev\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="CHARON_OCI_REGISTRY"):
+        publish_to_mrrc_prepare_repo.prepare_repo(
+            charon_param_file=env_file,
+            work_dir=tmp_path / "mrrc",
+        )
+
+
+def test_prepare_repo_empty_oci_registry(tmp_path: Path) -> None:
+    """Empty CHARON_OCI_REGISTRY raises ValueError."""
+    env_file = tmp_path / "charon.env"
+    env_file.write_text("CHARON_OCI_REGISTRY=\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="at least one registry"):
+        publish_to_mrrc_prepare_repo.prepare_repo(
+            charon_param_file=env_file,
+            work_dir=tmp_path / "mrrc",
+        )
+
+
+def test_prepare_repo_oras_pull_failure_propagates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pull failure from oras propagates."""
+    env_file = tmp_path / "charon.env"
+    _write_charon_env(env_file, "quay.io/test/app@sha256:0b15aad24f1b847")
+
+    def fail_oras_pull(pull_spec: str, download_dir: Path, **kwargs: object) -> None:
+        del pull_spec, download_dir, kwargs
+        raise subprocess.CalledProcessError(1, ["oras", "pull"])
+
+    monkeypatch.setattr(publish_to_mrrc_prepare_repo.oras_utils, "oras_pull", fail_oras_pull)
+    with pytest.raises(subprocess.CalledProcessError):
+        publish_to_mrrc_prepare_repo.prepare_repo(
+            charon_param_file=env_file,
+            work_dir=tmp_path / "mrrc",
+        )
+
+
+def test_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() returns 0 on success."""
+    _set_prepare_repo_env(
+        monkeypatch,
+        tmp_path,
+        work_dir=str(tmp_path / "mrrc"),
+    )
+    monkeypatch.setattr(
+        publish_to_mrrc_prepare_repo,
+        "prepare_repo",
+        lambda **_: None,
+    )
+    assert publish_to_mrrc_prepare_repo.main() == 0
+
+
+def test_main_missing_data_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing DATA_DIR exits with code 1."""
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    with pytest.raises(SystemExit) as exc_info:
+        publish_to_mrrc_prepare_repo.main()
+    assert exc_info.value.code == 1
+
+
+def test_main_missing_charon_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing charon env file raises FileNotFoundError."""
+    _set_prepare_repo_env(
+        monkeypatch,
+        tmp_path,
+        charon_param_file_path="missing.env",
+        work_dir=str(tmp_path / "mrrc"),
+    )
+    with pytest.raises(FileNotFoundError, match="charon env file not found"):
+        publish_to_mrrc_prepare_repo.main()

--- a/scripts/python/tasks/managed/test_publish_to_mrrc_push_merged.py
+++ b/scripts/python/tasks/managed/test_publish_to_mrrc_push_merged.py
@@ -1,0 +1,332 @@
+"""Tests for publish_to_mrrc_push_merged."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import publish_to_mrrc_push_merged
+import pytest
+
+
+def _make_result_paths(tmp_path: Path) -> tuple[Path, Path]:
+    results = tmp_path / "results"
+    results.mkdir()
+    return results / "IMAGE_DIGEST", results / "IMAGE_TAG"
+
+
+def _set_push_env(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    image: str = "quay.io/konflux-mrrc/mrrc-merge",
+    image_expires_after: str | None = "1d",
+    work_dir: str = "/workdir/mrrc",
+    result_digest: Path,
+    result_tag: Path,
+) -> None:
+    """Set env vars for main()."""
+    monkeypatch.setenv("IMAGE", image)
+    if image_expires_after is not None:
+        monkeypatch.setenv("IMAGE_EXPIRES_AFTER", image_expires_after)
+    else:
+        monkeypatch.delenv("IMAGE_EXPIRES_AFTER", raising=False)
+    monkeypatch.setenv("WORK_DIR", work_dir)
+    monkeypatch.setenv("RESULT_IMAGE_DIGEST", str(result_digest))
+    monkeypatch.setenv("RESULT_IMAGE_TAG", str(result_tag))
+
+
+def test_push_merged_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Merged zip is pushed and result files are written."""
+    work_dir = tmp_path / "mrrc"
+    merge_dir = work_dir / "merged"
+    merge_dir.mkdir(parents=True)
+    (merge_dir / "merged.zip").write_bytes(b"fake-zip")
+
+    result_digest, result_tag = _make_result_paths(tmp_path)
+
+    calls: list[list[str]] = []
+
+    def fake_check_output(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append([str(x) for x in cmd])
+        if cmd[0] == "select-oci-auth":
+            return '{"auths":{}}'
+        return ""
+
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged.subprocess,
+        "check_output",
+        fake_check_output,
+    )
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged.oras_utils,
+        "oras_resolve",
+        lambda ref: "sha256:abcdef1234567890",
+    )
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged,
+        "generate_tag",
+        lambda: "20260716-120000-test-uuid",
+    )
+
+    publish_to_mrrc_push_merged.push_merged_maven_repo(
+        work_dir=work_dir,
+        image="quay.io/konflux-mrrc/mrrc-merge",
+        image_expires_after="1d",
+        result_image_digest=result_digest,
+        result_image_tag=result_tag,
+    )
+
+    assert result_digest.read_text(encoding="utf-8") == "sha256:abcdef1234567890"
+    assert result_tag.read_text(encoding="utf-8") == "20260716-120000-test-uuid"
+
+    assert calls[0] == ["select-oci-auth", "quay.io/konflux-mrrc/mrrc-merge"]
+    push_cmd = calls[1]
+    assert push_cmd[0] == "oras"
+    assert push_cmd[1] == "push"
+    assert "--artifact-type" in push_cmd
+    assert "application/vnd.maven+zip" in push_cmd
+    assert "quay.expires-after=1d" in " ".join(push_cmd)
+    assert push_cmd[-1] == "merged.zip"
+
+
+def test_push_merged_no_merged_zip(tmp_path: Path) -> None:
+    """No-op when merged.zip does not exist."""
+    work_dir = tmp_path / "mrrc"
+    merge_dir = work_dir / "merged"
+    merge_dir.mkdir(parents=True)
+
+    result_digest, result_tag = _make_result_paths(tmp_path)
+
+    publish_to_mrrc_push_merged.push_merged_maven_repo(
+        work_dir=work_dir,
+        image="quay.io/konflux-mrrc/mrrc-merge",
+        image_expires_after="1d",
+        result_image_digest=result_digest,
+        result_image_tag=result_tag,
+    )
+
+    assert not result_digest.exists()
+    assert not result_tag.exists()
+
+
+def test_push_merged_no_expire_annotation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty image_expires_after skips the annotation."""
+    work_dir = tmp_path / "mrrc"
+    merge_dir = work_dir / "merged"
+    merge_dir.mkdir(parents=True)
+    (merge_dir / "merged.zip").write_bytes(b"fake-zip")
+
+    result_digest, result_tag = _make_result_paths(tmp_path)
+
+    calls: list[list[str]] = []
+
+    def fake_check_output(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append([str(x) for x in cmd])
+        if cmd[0] == "select-oci-auth":
+            return '{"auths":{}}'
+        return ""
+
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged.subprocess,
+        "check_output",
+        fake_check_output,
+    )
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged.oras_utils,
+        "oras_resolve",
+        lambda ref: "sha256:abcdef",
+    )
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged,
+        "generate_tag",
+        lambda: "20260716-120000-test-uuid",
+    )
+
+    publish_to_mrrc_push_merged.push_merged_maven_repo(
+        work_dir=work_dir,
+        image="quay.io/konflux-mrrc/mrrc-merge",
+        image_expires_after="",
+        result_image_digest=result_digest,
+        result_image_tag=result_tag,
+    )
+
+    push_cmd = calls[1]
+    assert "--annotation" not in push_cmd
+
+
+def test_push_merged_oras_push_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Push failure from oras propagates."""
+    work_dir = tmp_path / "mrrc"
+    merge_dir = work_dir / "merged"
+    merge_dir.mkdir(parents=True)
+    (merge_dir / "merged.zip").write_bytes(b"fake-zip")
+
+    result_digest, result_tag = _make_result_paths(tmp_path)
+
+    def fake_check_output(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[0] == "select-oci-auth":
+            return '{"auths":{}}'
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged.subprocess,
+        "check_output",
+        fake_check_output,
+    )
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged,
+        "generate_tag",
+        lambda: "20260716-120000-test-uuid",
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        publish_to_mrrc_push_merged.push_merged_maven_repo(
+            work_dir=work_dir,
+            image="quay.io/konflux-mrrc/mrrc-merge",
+            image_expires_after="1d",
+            result_image_digest=result_digest,
+            result_image_tag=result_tag,
+        )
+
+
+def test_push_merged_oras_resolve_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resolve failure from oras propagates."""
+    work_dir = tmp_path / "mrrc"
+    merge_dir = work_dir / "merged"
+    merge_dir.mkdir(parents=True)
+    (merge_dir / "merged.zip").write_bytes(b"fake-zip")
+
+    result_digest, result_tag = _make_result_paths(tmp_path)
+
+    def fake_check_output(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[0] == "select-oci-auth":
+            return '{"auths":{}}'
+        return ""
+
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged.subprocess,
+        "check_output",
+        fake_check_output,
+    )
+
+    def fail_resolve(ref: str) -> str:
+        raise RuntimeError("oras resolve failed")
+
+    monkeypatch.setattr(publish_to_mrrc_push_merged.oras_utils, "oras_resolve", fail_resolve)
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged,
+        "generate_tag",
+        lambda: "20260716-120000-test-uuid",
+    )
+
+    with pytest.raises(RuntimeError, match="oras resolve failed"):
+        publish_to_mrrc_push_merged.push_merged_maven_repo(
+            work_dir=work_dir,
+            image="quay.io/konflux-mrrc/mrrc-merge",
+            image_expires_after="1d",
+            result_image_digest=result_digest,
+            result_image_tag=result_tag,
+        )
+
+
+def test_generate_tag_format() -> None:
+    """Tag looks like YYYYMMDD-HHMMSS-uuid4."""
+    tag = publish_to_mrrc_push_merged.generate_tag()
+    pattern = r"^\d{8}-\d{6}-" r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    assert re.match(pattern, tag), f"Tag {tag!r} does not match expected format"
+
+
+def test_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() returns 0 on success."""
+    result_digest, result_tag = _make_result_paths(tmp_path)
+    _set_push_env(
+        monkeypatch,
+        work_dir=str(tmp_path / "mrrc"),
+        result_digest=result_digest,
+        result_tag=result_tag,
+    )
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged,
+        "push_merged_maven_repo",
+        lambda **_: None,
+    )
+    assert publish_to_mrrc_push_merged.main() == 0
+
+
+def test_main_missing_image_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing IMAGE exits with code 1."""
+    monkeypatch.delenv("IMAGE", raising=False)
+    with pytest.raises(SystemExit) as exc_info:
+        publish_to_mrrc_push_merged.main()
+    assert exc_info.value.code == 1
+
+
+def test_main_missing_result_env_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing result env vars exits with code 1."""
+    monkeypatch.setenv("IMAGE", "quay.io/konflux-mrrc/mrrc-merge")
+    monkeypatch.delenv("RESULT_IMAGE_DIGEST", raising=False)
+    monkeypatch.delenv("RESULT_IMAGE_TAG", raising=False)
+    with pytest.raises(SystemExit) as exc_info:
+        publish_to_mrrc_push_merged.main()
+    assert exc_info.value.code == 1
+
+
+def test_main_image_expires_after_defaults_to_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unset IMAGE_EXPIRES_AFTER defaults to empty string."""
+    result_digest, result_tag = _make_result_paths(tmp_path)
+    _set_push_env(
+        monkeypatch,
+        image_expires_after=None,
+        work_dir=str(tmp_path / "mrrc"),
+        result_digest=result_digest,
+        result_tag=result_tag,
+    )
+    captured_kwargs: dict[str, object] = {}
+
+    def capture(**kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged,
+        "push_merged_maven_repo",
+        capture,
+    )
+    publish_to_mrrc_push_merged.main()
+    assert captured_kwargs["image_expires_after"] == ""
+
+
+def test_main_image_expires_after_strips_whitespace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Whitespace-only IMAGE_EXPIRES_AFTER is stripped to empty."""
+    result_digest, result_tag = _make_result_paths(tmp_path)
+    _set_push_env(
+        monkeypatch,
+        image_expires_after="   ",
+        work_dir=str(tmp_path / "mrrc"),
+        result_digest=result_digest,
+        result_tag=result_tag,
+    )
+    captured_kwargs: dict[str, object] = {}
+
+    def capture(**kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(
+        publish_to_mrrc_push_merged,
+        "push_merged_maven_repo",
+        capture,
+    )
+    publish_to_mrrc_push_merged.main()
+    assert captured_kwargs["image_expires_after"] == ""


### PR DESCRIPTION
Convert the prepare-repo and push-merged-maven-repo-to-registry steps to python scripts.
Adds mrrc_work_dir() to charon_env.

Assisted-by: Claude

prepare-repo
https://github.com/konflux-ci/release-service-catalog/blob/3dbcc8556da2a827617a8fd7558180d20a63f7b0/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml#L144

push-merged-maven-repo-to-registry
https://github.com/konflux-ci/release-service-catalog/blob/3dbcc8556da2a827617a8fd7558180d20a63f7b0/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml#L313