### PR TITLE
fix: deduplicate architectures in get-image-architectures

### DIFF
--- a/utils/get-image-architectures
+++ b/utils/get-image-architectures
@@ -86,5 +86,23 @@ elif [ $(jq -r '.mediaType' <<< $RAW_OUTPUT) == "application/vnd.docker.distribu
 else
     # Multi arch
     manifests=$(jq '.manifests[] += {multiarch: true}' <<< "$RAW_OUTPUT")
-    jq -cr '.manifests[]' <<< "$manifests"
+    # Deduplicate: when an image index contains both gzip and zstd:chunked
+    # manifests per architecture (dual-compression), keep only the non-zstd
+    # entry per (architecture, os). If all entries for a platform are zstd,
+    # keep the first one so the error surfaces downstream rather than
+    # silently returning nothing.
+    # Ref: ADR 0070 (konflux-ci/architecture)
+    jq -cr '.manifests[]' <<< "$manifests" | jq -cs '
+        group_by(.platform.architecture + "/" + .platform.os)
+        | map(
+            if (.[0].platform.architecture == null or .[0].platform.os == null or
+                .[0].platform.architecture == "unknown" or .[0].platform.os == "unknown")
+            then .[]
+            else
+                (map(select(.annotations["io.github.containers.compression.zstd"] == null)) | .[0])
+                // .[0]
+            end
+        )
+        | .[]
+    '
 fi


### PR DESCRIPTION
When an image index contains both gzip and zstd:chunked manifests per architecture (dual-compression), return only the non-zstd entry per platform. If all entries for a platform are zstd, keep the first one.

Ref: https://github.com/konflux-ci/architecture/blob/main/ADR/0070-dual-compression-for-container-builds.md