### PR TITLE
feat(RELEASE-2500): convert marketplacesvm-push-disk-images to python

### DIFF
--- a/scripts/python/helpers/memory_throttle.py
+++ b/scripts/python/helpers/memory_throttle.py
@@ -1,0 +1,150 @@
+"""Memory-aware job throttling, ported from ``utils/memory-throttle.sh``.
+
+Reads container memory usage from cgroups (v2, falling back to v1) so
+parallel task runners can pause spawning new work while memory is under
+pressure, reducing the frequency of OOMKills. Callers that cannot read
+cgroup memory info (e.g. outside a container) get a no-op: throttling
+relies solely on the caller's own concurrency limit in that case.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from logger import logger
+
+DEFAULT_THRESHOLD = 80
+DEFAULT_INTERVAL = 5.0
+
+_CGROUP_V2_CURRENT = Path("/sys/fs/cgroup/memory.current")
+_CGROUP_V2_MAX = Path("/sys/fs/cgroup/memory.max")
+_CGROUP_V1_CURRENT = Path("/sys/fs/cgroup/memory/memory.usage_in_bytes")
+_CGROUP_V1_MAX = Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+
+ReadMemory = Callable[[], tuple[int, int] | None]
+
+
+def _read_int(path: Path) -> int | None:
+    """Read an integer value from *path*, or None if missing/unreadable."""
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not text or text == "max":
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def read_cgroup_memory(
+    *,
+    v2_current: Path = _CGROUP_V2_CURRENT,
+    v2_max: Path = _CGROUP_V2_MAX,
+    v1_current: Path = _CGROUP_V1_CURRENT,
+    v1_max: Path = _CGROUP_V1_MAX,
+) -> tuple[int, int] | None:
+    """Return ``(current, max)`` memory bytes from cgroups v2 or v1.
+
+    Returns None when neither cgroup interface is readable, matching the
+    original bash helper's "memory monitoring unavailable" case.
+    """
+    current = _read_int(v2_current)
+    maximum = _read_int(v2_max)
+    if current is not None and maximum is not None and maximum > 0:
+        return current, maximum
+
+    current = _read_int(v1_current)
+    maximum = _read_int(v1_max)
+    if current is not None and maximum is not None and maximum > 0:
+        return current, maximum
+
+    return None
+
+
+def get_memory_usage_percent(*, read_memory: ReadMemory = read_cgroup_memory) -> int | None:
+    """Return current memory usage as an integer percentage, or None if unavailable."""
+    values = read_memory()
+    if values is None:
+        return None
+    current, maximum = values
+    return current * 100 // maximum
+
+
+def format_bytes(num_bytes: int) -> str:
+    """Format *num_bytes* as a human-readable Gi/Mi/Ki/B string."""
+    if num_bytes >= 1024**3:
+        return f"{num_bytes // 1024**3}Gi"
+    if num_bytes >= 1024**2:
+        return f"{num_bytes // 1024**2}Mi"
+    if num_bytes >= 1024:
+        return f"{num_bytes // 1024}Ki"
+    return f"{num_bytes}B"
+
+
+def get_memory_stats(*, read_memory: ReadMemory = read_cgroup_memory) -> str:
+    """Return ``"used/limit (XX%)"``, or ``"unavailable"`` when unreadable."""
+    values = read_memory()
+    if values is None:
+        return "unavailable"
+    current, maximum = values
+    usage = current * 100 // maximum
+    return f"{format_bytes(current)}/{format_bytes(maximum)} ({usage}%)"
+
+
+def log_memory_throttle_status(
+    threshold: int = DEFAULT_THRESHOLD,
+    *,
+    read_memory: ReadMemory = read_cgroup_memory,
+) -> None:
+    """Log whether memory-based throttling is available. Call once at task start."""
+    stats = get_memory_stats(read_memory=read_memory)
+    if stats == "unavailable":
+        logger.info(
+            "Memory throttle: cgroup memory info not available, using concurrent-limit only"
+        )
+    else:
+        logger.info(
+            "Memory throttle: enabled with %s%% threshold, current usage: %s", threshold, stats
+        )
+
+
+def wait_for_memory(
+    threshold: int = DEFAULT_THRESHOLD,
+    interval: float = DEFAULT_INTERVAL,
+    *,
+    read_memory: ReadMemory = read_cgroup_memory,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """Block the calling thread until memory usage is below *threshold* percent.
+
+    Returns immediately without blocking when cgroup memory info cannot be
+    read, so callers fall back to relying on their own concurrency limit.
+    """
+    usage = get_memory_usage_percent(read_memory=read_memory)
+    if usage is None:
+        return
+
+    waited = False
+    while usage is not None and usage >= threshold:
+        if not waited:
+            logger.info(
+                "Memory throttle: usage above %s%% threshold, pausing new job spawns...",
+                threshold,
+            )
+            waited = True
+        logger.info(
+            "  Memory: %s - waiting for running jobs to free memory...",
+            get_memory_stats(read_memory=read_memory),
+        )
+        sleep(interval)
+        usage = get_memory_usage_percent(read_memory=read_memory)
+
+    if waited:
+        logger.info(
+            "Memory throttle: usage now at %s, resuming...",
+            get_memory_stats(read_memory=read_memory),
+        )

--- a/scripts/python/helpers/test_memory_throttle.py
+++ b/scripts/python/helpers/test_memory_throttle.py
@@ -1,0 +1,172 @@
+"""Tests for memory_throttle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import memory_throttle as mt
+import pytest
+
+
+def _write(path: Path, value: str) -> None:
+    path.write_text(value, encoding="utf-8")
+
+
+# --- read_cgroup_memory ---
+
+
+def test_read_cgroup_memory_v2(tmp_path: Path) -> None:
+    """Cgroups v2 files are preferred and parsed as (current, max)."""
+    v2_current = tmp_path / "memory.current"
+    v2_max = tmp_path / "memory.max"
+    _write(v2_current, "1000\n")
+    _write(v2_max, "4000\n")
+
+    result = mt.read_cgroup_memory(
+        v2_current=v2_current,
+        v2_max=v2_max,
+        v1_current=tmp_path / "missing-v1-current",
+        v1_max=tmp_path / "missing-v1-max",
+    )
+    assert result == (1000, 4000)
+
+
+def test_read_cgroup_memory_v2_unlimited_falls_back_to_v1(tmp_path: Path) -> None:
+    """A v2 max of 'max' (unlimited) is ignored in favor of v1 values."""
+    v2_current = tmp_path / "memory.current"
+    v2_max = tmp_path / "memory.max"
+    v1_current = tmp_path / "usage_in_bytes"
+    v1_max = tmp_path / "limit_in_bytes"
+    _write(v2_current, "1000")
+    _write(v2_max, "max")
+    _write(v1_current, "2000")
+    _write(v1_max, "8000")
+
+    result = mt.read_cgroup_memory(
+        v2_current=v2_current, v2_max=v2_max, v1_current=v1_current, v1_max=v1_max
+    )
+    assert result == (2000, 8000)
+
+
+def test_read_cgroup_memory_unavailable(tmp_path: Path) -> None:
+    """None is returned when no cgroup interface is readable."""
+    missing = tmp_path / "missing"
+    result = mt.read_cgroup_memory(
+        v2_current=missing, v2_max=missing, v1_current=missing, v1_max=missing
+    )
+    assert result is None
+
+
+def test_read_cgroup_memory_non_numeric_content(tmp_path: Path) -> None:
+    """Non-numeric file content (corrupt/unexpected) is treated as unreadable."""
+    v2_current = tmp_path / "memory.current"
+    v2_max = tmp_path / "memory.max"
+    missing = tmp_path / "missing"
+    _write(v2_current, "not-a-number")
+    _write(v2_max, "4000")
+
+    result = mt.read_cgroup_memory(
+        v2_current=v2_current, v2_max=v2_max, v1_current=missing, v1_max=missing
+    )
+    assert result is None
+
+
+# --- get_memory_usage_percent / format_bytes / get_memory_stats ---
+
+
+def test_get_memory_usage_percent() -> None:
+    """Usage percent is computed as an integer floor division."""
+    assert mt.get_memory_usage_percent(read_memory=lambda: (500, 1000)) == 50
+    assert mt.get_memory_usage_percent(read_memory=lambda: (333, 1000)) == 33
+
+
+def test_get_memory_usage_percent_unavailable() -> None:
+    """None is returned when the reader has no data."""
+    assert mt.get_memory_usage_percent(read_memory=lambda: None) is None
+
+
+@pytest.mark.parametrize(
+    ("num_bytes", "expected"),
+    [
+        (512, "512B"),
+        (2545, "2Ki"),
+        (5 * 1024 * 1024 + 777, "5Mi"),
+        (3 * 1024 * 1024 * 1024 + 123456, "3Gi"),
+    ],
+)
+def test_format_bytes(num_bytes: int, expected: str) -> None:
+    """Byte counts are formatted with the largest whole unit, truncated."""
+    assert mt.format_bytes(num_bytes) == expected
+
+
+def test_get_memory_stats() -> None:
+    """Stats string reports used/limit and the usage percentage."""
+    assert mt.get_memory_stats(
+        read_memory=lambda: (512 * 1024 * 1024, 1024 * 1024 * 1024)
+    ) == ("512Mi/1Gi (50%)")
+
+
+def test_get_memory_stats_unavailable() -> None:
+    """'unavailable' is reported when the reader has no data."""
+    assert mt.get_memory_stats(read_memory=lambda: None) == "unavailable"
+
+
+# --- log_memory_throttle_status ---
+
+
+def test_log_memory_throttle_status_available() -> None:
+    """No exception is raised when logging available memory stats."""
+    mt.log_memory_throttle_status(80, read_memory=lambda: (500, 1000))
+
+
+def test_log_memory_throttle_status_unavailable() -> None:
+    """No exception is raised when memory info is unavailable."""
+    mt.log_memory_throttle_status(80, read_memory=lambda: None)
+
+
+# --- wait_for_memory ---
+
+
+def test_wait_for_memory_returns_immediately_when_unavailable() -> None:
+    """No sleep occurs when cgroup memory info cannot be read."""
+    sleeps: list[float] = []
+    mt.wait_for_memory(read_memory=lambda: None, sleep=sleeps.append)
+    assert sleeps == []
+
+
+def test_wait_for_memory_returns_immediately_when_below_threshold() -> None:
+    """No sleep occurs when usage is already below the threshold."""
+    sleeps: list[float] = []
+    mt.wait_for_memory(80, read_memory=lambda: (100, 1000), sleep=sleeps.append)
+    assert sleeps == []
+
+
+def test_wait_for_memory_polls_until_below_threshold() -> None:
+    """Sleeps until a subsequent read reports usage below the threshold.
+
+    Each loop iteration reads memory twice (once for the logged stats, once
+    for the loop condition), so two full high-usage iterations require four
+    high readings before the usage drops on the fifth read.
+    """
+    calls = {"n": 0}
+
+    def reader() -> tuple[int, int]:
+        calls["n"] += 1
+        return (900, 1000) if calls["n"] <= 4 else (500, 1000)
+
+    sleeps: list[float] = []
+    mt.wait_for_memory(80, interval=1.5, read_memory=reader, sleep=sleeps.append)
+    assert sleeps == [1.5, 1.5]
+
+
+def test_wait_for_memory_stops_if_reader_loses_access_mid_wait() -> None:
+    """Polling stops if the reader starts returning None mid-wait."""
+    calls = {"n": 0}
+
+    def flaky_reader() -> tuple[int, int] | None:
+        calls["n"] += 1
+        return (900, 1000) if calls["n"] == 1 else None
+
+    sleeps: list[float] = []
+    mt.wait_for_memory(80, read_memory=flaky_reader, sleep=sleeps.append)
+    assert sleeps == [5.0]

--- a/scripts/python/tasks/managed/marketplacesvm_push_disk_images.py
+++ b/scripts/python/tasks/managed/marketplacesvm_push_disk_images.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Push VM disk images to cloud marketplaces via pubtools-marketplacesvm.
+
+Validates marketplace credentials, pulls OCI disk-image artifacts with oras,
+stages them for pushsource, then invokes ``marketplacesvm_push_wrapper``.
+
+CLI arguments map to Tekton task parameters. ``CLOUD_CREDENTIALS`` is set from
+validated secret files under ``--secrets-dir`` (default ``/etc/secrets``).
+``UPLOAD_CONTAINER_NAME`` remains an environment variable consumed by the
+underlying pubtools-marketplacesvm tooling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import memory_throttle
+import oras_utils
+import subprocess_cmd
+import yaml
+from file import load_json_dict
+from logger import logger
+
+PROG = "marketplacesvm_push_disk_images.py"
+
+DEFAULT_SECRETS_DIR = Path("/etc/secrets")
+DEFAULT_WORKDIR = Path("/var/workdir")
+MEMORY_THRESHOLD = 80
+
+_EXTENSION_STRIP_RE = re.compile(r"\.[.a-zA-Z0-9]*$")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse and return CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__, prog=PROG)
+    parser.add_argument(
+        "--data-dir",
+        required=True,
+        help="Base directory where release data and artifacts are stored",
+    )
+    parser.add_argument(
+        "--snapshot-path",
+        required=True,
+        help="Path to the mapped snapshot JSON relative to --data-dir",
+    )
+    parser.add_argument(
+        "--pre-push",
+        default="false",
+        choices=["true", "false"],
+        help="When true, pass --nochannel to marketplacesvm_push_wrapper",
+    )
+    parser.add_argument(
+        "--concurrent-limit",
+        type=int,
+        default=3,
+        help="Maximum number of components to prepare in parallel",
+    )
+    parser.add_argument(
+        "--secrets-dir",
+        default=str(DEFAULT_SECRETS_DIR),
+        help="Directory containing marketplace credential JSON files",
+    )
+    parser.add_argument(
+        "--workdir",
+        default=str(DEFAULT_WORKDIR),
+        help="Parent directory for temporary staging directories",
+    )
+    return parser.parse_args(argv)
+
+
+def log_command_failure(exc: BaseException) -> None:
+    """Log captured subprocess stdout/stderr from *exc*, if any.
+
+    ``subprocess.CalledProcessError.__str__`` only reports the exit status, so
+    without this the operator gets no diagnostic output when a shelled-out
+    command (oras, pushsource-ls, marketplacesvm_push_wrapper) fails.
+    """
+    if not isinstance(exc, subprocess.CalledProcessError):
+        return
+    if exc.stdout:
+        logger.error("command stdout:\n%s", exc.stdout)
+    if exc.stderr:
+        logger.error("command stderr:\n%s", exc.stderr)
+
+
+def require_field(data: Mapping[str, Any], *keys: str) -> Any:
+    """Return ``data[keys...]`` or raise ``ValueError`` when missing/empty."""
+    cur: Any = data
+    path = ""
+    for key in keys:
+        path = f"{path}.{key}" if path else key
+        if not isinstance(cur, Mapping) or key not in cur:
+            raise ValueError(f"Missing {path} value for component")
+        cur = cur[key]
+    if cur in (None, ""):
+        raise ValueError(f"Missing {path} value for component")
+    return cur
+
+
+def validate_credentials(secrets_dir: Path) -> list[Path]:
+    """Validate marketplace credential JSON files and return their paths.
+
+    Each ``*.json`` file under *secrets_dir* must contain ``marketplace_account``
+    and ``auth`` keys. Raises ``RuntimeError`` when no files exist or validation
+    fails.
+    """
+    logger.info("Sanity validation of credentials")
+    json_files = sorted(secrets_dir.glob("*.json"))
+    if not json_files:
+        raise RuntimeError(f"No credential files found in {secrets_dir}/")
+
+    for path in json_files:
+        try:
+            payload = load_json_dict(path)
+        except (json.JSONDecodeError, TypeError, OSError) as exc:
+            raise RuntimeError(f"Validation failed for credential file: '{path}'") from exc
+        if not ("marketplace_account" in payload and "auth" in payload):
+            raise RuntimeError(
+                f"Validation failed for credential file: '{path}'\n"
+                "The file is missing required keys "
+                "('marketplace_account' or 'auth')."
+            )
+    return json_files
+
+
+def set_cloud_credentials(credential_files: Sequence[Path]) -> str:
+    """Set ``CLOUD_CREDENTIALS`` from *credential_files* and return the value."""
+    value = ",".join(str(path) for path in credential_files)
+    os.environ["CLOUD_CREDENTIALS"] = value
+    return value
+
+
+def write_starmap_file(snapshot: Mapping[str, Any], snapshot_file: Path) -> Path:
+    """Flatten component starmap entries and write ``starmap.yaml`` beside snapshot."""
+    components = snapshot.get("components") or []
+    mapping: list[Any] = []
+    for component in components:
+        if not isinstance(component, Mapping):
+            continue
+        starmap = component.get("starmap") or []
+        if isinstance(starmap, list):
+            mapping.extend(starmap)
+
+    starmap_file = snapshot_file.parent / "starmap.yaml"
+    starmap_file.write_text(
+        yaml.safe_dump(mapping, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+    return starmap_file
+
+
+def strip_extensions(filename: str) -> str:
+    """Remove a trailing compound extension (bash sed equivalent)."""
+    return _EXTENSION_STRIP_RE.sub("", filename)
+
+
+def parse_build_respin(filename: str) -> str:
+    """Extract the unix-timestamp respin from a staged filename."""
+    without_ext = strip_extensions(filename)
+    without_arch = without_ext.rsplit("-", 1)[0]
+    return without_arch.rsplit("-", 1)[-1]
+
+
+def parse_build_name(file_prefix: str) -> str:
+    """Return build name by stripping the version suffix from *file_prefix*."""
+    return file_prefix.rsplit("-", 1)[0]
+
+
+def parse_architecture(filename: str) -> str:
+    """Return architecture token from a staged filename (before extension)."""
+    without_ext = filename.rsplit(".", 1)[0]
+    return without_ext.rsplit("-", 1)[-1]
+
+
+def image_type_for_filename(filename: str) -> str | None:
+    """Return marketplace image type for *filename*, or None if unsupported."""
+    lower = filename.lower()
+    if lower.endswith(".vhd"):
+        return "VHD"
+    if lower.endswith(".raw"):
+        return "AMI"
+    return None
+
+
+def build_date_from_respin(respin: str) -> str:
+    """Convert a unix-timestamp respin to ``YYYYMMDD`` UTC."""
+    return datetime.fromtimestamp(int(respin), tz=timezone.utc).strftime("%Y%m%d")
+
+
+def decompress_gzip_source(source_path: Path) -> Path:
+    """Decompress *source_path* when it ends with ``.gz``; return final path."""
+    if not source_path.name.endswith(".gz"):
+        return source_path
+
+    destination = Path(str(source_path)[: -len(".gz")])
+    with gzip.open(source_path, "rb") as src, destination.open("wb") as dst:
+        shutil.copyfileobj(src, dst)
+    source_path.unlink()
+    return destination
+
+
+def write_resources_yaml(destination: Path, resources: Mapping[str, Any]) -> None:
+    """Write *resources* as YAML to ``destination/resources.yaml``."""
+    (destination / "resources.yaml").write_text(
+        yaml.safe_dump(dict(resources), default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def prepare_component(
+    component: Mapping[str, Any],
+    disk_imgs_dir: Path,
+    workdir: Path,
+) -> None:
+    """Pull one component's OCI artifact and stage cloud-image files.
+
+    Blocks on ``memory_throttle.wait_for_memory`` before pulling/decompressing,
+    so a bounded number of large disk images are held in memory at once even
+    when several worker threads are active concurrently.
+    """
+    product_info = require_field(component, "productInfo")
+    pullspec = str(require_field(component, "containerImage"))
+    img_name = str(require_field(component, "name"))
+
+    try:
+        memory_throttle.wait_for_memory(MEMORY_THRESHOLD)
+        file_prefix = str(require_field(product_info, "filePrefix"))
+        build_name = parse_build_name(file_prefix)
+        build_version = str(require_field(product_info, "productVersionName"))
+        staged_files = require_field(component, "staged", "files")
+        if not isinstance(staged_files, list) or not staged_files:
+            raise ValueError("staged.files must be a non-empty list")
+        first_filename = str(require_field(staged_files[0], "filename"))
+        build_respin = parse_build_respin(first_filename)
+
+        resources: dict[str, Any] = {
+            "api": "v1",
+            "resource": "CloudImage",
+            "description": "",
+            "build": {
+                "name": build_name,
+                "respin": build_respin,
+                "version": build_version,
+            },
+            "release": {"date": build_date_from_respin(build_respin)},
+            "images": [],
+        }
+
+        destination = disk_imgs_dir / img_name
+        destination.mkdir(parents=True, exist_ok=True)
+
+        with tempfile.TemporaryDirectory(dir=workdir) as download_dir_name:
+            download_dir = Path(download_dir_name)
+            oras_utils.oras_pull(pullspec, download_dir)
+
+            for entry in staged_files:
+                if not isinstance(entry, Mapping):
+                    raise ValueError("staged.files entries must be objects")
+                source = str(require_field(entry, "source"))
+                filename = str(require_field(entry, "filename"))
+                source_path = download_dir / source
+
+                if not source_path.is_file():
+                    raise RuntimeError(
+                        f"Source file '{source}' for component '{filename}' "
+                        "was not found after oras pull."
+                    )
+
+                if source.endswith(".gz"):
+                    source_path = decompress_gzip_source(source_path)
+                    if filename.endswith(".gz"):
+                        filename = filename[: -len(".gz")]
+
+                dest_file = destination / filename
+                if dest_file.exists():
+                    raise RuntimeError(
+                        "Multiple files use the same destination value: "
+                        f"{destination} and filename value: {filename}. "
+                        "Failing..."
+                    )
+
+                image_type = image_type_for_filename(filename)
+                if image_type is None:
+                    logger.info("Skipping unsupported file: %s", filename)
+                    continue
+
+                build_arch = parse_architecture(filename)
+                shutil.move(str(source_path), str(dest_file))
+                resources["images"].append({"path": filename, "architecture": build_arch})
+                resources["type"] = image_type
+
+        write_resources_yaml(destination, resources)
+    except Exception as exc:
+        logger.error("ERROR: prepare_component failed for component: %s", img_name)
+        log_command_failure(exc)
+        raise
+
+
+def prepare_components(
+    components: Sequence[Mapping[str, Any]],
+    disk_imgs_dir: Path,
+    workdir: Path,
+    concurrent_limit: int,
+) -> None:
+    """Prepare all *components* in parallel, bounded by *concurrent_limit*.
+
+    Each worker also throttles on memory usage via
+    ``memory_throttle.wait_for_memory`` before doing its pull/decompress work,
+    since disk images can be large enough to risk OOMKills even within a
+    small concurrency limit.
+    """
+    memory_throttle.log_memory_throttle_status(MEMORY_THRESHOLD)
+    workers = max(1, concurrent_limit)
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [
+            pool.submit(
+                prepare_component,
+                component,
+                disk_imgs_dir,
+                workdir,
+            )
+            for component in components
+        ]
+        errors: list[Exception] = []
+        for future in as_completed(futures):
+            try:
+                future.result()
+            except Exception as exc:  # collect worker failures, then re-raise once
+                errors.append(exc)
+        if errors:
+            raise RuntimeError(
+                "prepare_component failed for at least one component"
+            ) from errors[0]
+
+
+def validate_staged_structure(base_dir: Path) -> None:
+    """Validate the staged directory layout with ``pushsource-ls``."""
+    try:
+        subprocess_cmd.run_cmd(["pushsource-ls", f"staged:{base_dir}"], check=True)
+    except subprocess.CalledProcessError as exc:
+        log_command_failure(exc)
+        raise
+
+
+def run_marketplacesvm_push(
+    base_dir: Path,
+    starmap_file: Path,
+    *,
+    pre_push: bool,
+    env: Mapping[str, str] | None = None,
+) -> None:
+    """Invoke ``marketplacesvm_push_wrapper`` against the staged content."""
+    cmd = [
+        "marketplacesvm_push_wrapper",
+        "--debug",
+    ]
+    if pre_push:
+        cmd.append("--nochannel")
+    cmd.extend(["--source", str(base_dir), "--starmap-file", str(starmap_file)])
+    try:
+        subprocess_cmd.run_cmd(cmd, cwd=base_dir, env=env, check=True)
+    except subprocess.CalledProcessError as exc:
+        log_command_failure(exc)
+        raise
+
+
+def copy_artifacts(base_dir: Path, data_dir: Path) -> None:
+    """Copy wrapper-generated artifacts into *data_dir* when present."""
+    artifacts = base_dir / "artifacts"
+    if artifacts.is_dir():
+        shutil.copytree(artifacts, data_dir / "artifacts", dirs_exist_ok=True)
+
+
+def run(
+    *,
+    data_dir: Path,
+    snapshot_path: str,
+    pre_push: bool,
+    concurrent_limit: int,
+    secrets_dir: Path,
+    workdir: Path,
+) -> int:
+    """Execute the full marketplacesvm disk-image push workflow."""
+    credential_files = validate_credentials(secrets_dir)
+    set_cloud_credentials(credential_files)
+
+    snapshot_file = data_dir / snapshot_path
+    snapshot = load_json_dict(snapshot_file)
+
+    components = snapshot.get("components")
+    if not isinstance(components, list) or not components:
+        raise ValueError("snapshot must contain a non-empty components list")
+    if not all(isinstance(component, Mapping) for component in components):
+        raise ValueError("snapshot components must all be JSON objects")
+
+    starmap_file = write_starmap_file(snapshot, snapshot_file)
+
+    workdir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=workdir) as base_dir_name:
+        base_dir = Path(base_dir_name)
+        disk_imgs_dir = base_dir / "starmap" / "CLOUD_IMAGES"
+        disk_imgs_dir.mkdir(parents=True, exist_ok=True)
+
+        prepare_components(
+            components,
+            disk_imgs_dir,
+            workdir,
+            concurrent_limit,
+        )
+
+        validate_staged_structure(base_dir)
+        run_marketplacesvm_push(
+            base_dir,
+            starmap_file,
+            pre_push=pre_push,
+        )
+        copy_artifacts(base_dir, data_dir)
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse CLI flags and run the marketplacesvm push workflow."""
+    args = parse_args(argv)
+    return run(
+        data_dir=Path(args.data_dir),
+        snapshot_path=args.snapshot_path,
+        pre_push=args.pre_push == "true",
+        concurrent_limit=args.concurrent_limit,
+        secrets_dir=Path(args.secrets_dir),
+        workdir=Path(args.workdir),
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_marketplacesvm_push_disk_images.py
+++ b/scripts/python/tasks/managed/test_marketplacesvm_push_disk_images.py
@@ -1,0 +1,847 @@
+"""Tests for marketplacesvm_push_disk_images."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import marketplacesvm_push_disk_images as m
+import pytest
+import yaml
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _no_wait(*_args: Any, **_kwargs: Any) -> None:
+    """No-op stand-in for memory_throttle.wait_for_memory in tests."""
+    return None
+
+
+def _patch_wait_for_memory(monkeypatch: pytest.MonkeyPatch, fake: Any = _no_wait) -> None:
+    """Replace ``memory_throttle.wait_for_memory`` so tests never block on real cgroups."""
+    monkeypatch.setattr(m.memory_throttle, "wait_for_memory", fake)
+
+
+def _patch_oras_pull(monkeypatch: pytest.MonkeyPatch, fake: Any) -> None:
+    """Replace ``oras_utils.oras_pull`` so tests never hit a real registry."""
+    monkeypatch.setattr(m.oras_utils, "oras_pull", fake)
+
+
+def _patch_run_cmd(monkeypatch: pytest.MonkeyPatch, fake: Any) -> None:
+    """Replace ``subprocess_cmd.run_cmd`` so tests never shell out for real."""
+    monkeypatch.setattr(m.subprocess_cmd, "run_cmd", fake)
+
+
+def _valid_credential() -> dict[str, Any]:
+    return {"marketplace_account": "aws-na", "auth": {"token": "secret"}}
+
+
+def _valid_component(
+    *,
+    name: str = "amd-bootc-1-3-raw-disk-image",
+    filename: str = "test-product-amd-1.3-1732045201-x86_64.raw.gz",
+    source: str = "disk.raw.gz",
+    file_prefix: str = "test-product-amd-1.3",
+) -> dict[str, Any]:
+    return {
+        "containerImage": "quay.io/org/image@sha256:abc",
+        "name": name,
+        "productInfo": {
+            "filePrefix": file_prefix,
+            "productCode": "TEST",
+            "productName": "Test Product",
+            "productVersionName": "1.3",
+        },
+        "staged": {
+            "destination": "dest",
+            "files": [{"filename": filename, "source": source}],
+            "version": "1.3",
+        },
+        "starmap": [{"cloud": "aws", "name": "test-product-amd"}],
+    }
+
+
+def _valid_snapshot(components: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    return {
+        "application": "app",
+        "components": components if components is not None else [_valid_component()],
+    }
+
+
+# --- parse_args ---
+
+
+def test_parse_args_defaults() -> None:
+    """Required flags parse; optional flags use defaults."""
+    args = m.parse_args(["--data-dir", "/data", "--snapshot-path", "snap.json"])
+    assert args.data_dir == "/data"
+    assert args.snapshot_path == "snap.json"
+    assert args.pre_push == "false"
+    assert args.concurrent_limit == 3
+    assert args.secrets_dir == str(m.DEFAULT_SECRETS_DIR)
+    assert args.workdir == str(m.DEFAULT_WORKDIR)
+
+
+def test_parse_args_custom_values() -> None:
+    """Custom optional flags are accepted."""
+    args = m.parse_args(
+        [
+            "--data-dir",
+            "/data",
+            "--snapshot-path",
+            "snap.json",
+            "--pre-push",
+            "true",
+            "--concurrent-limit",
+            "5",
+            "--secrets-dir",
+            "/secrets",
+            "--workdir",
+            "/work",
+        ]
+    )
+    assert args.pre_push == "true"
+    assert args.concurrent_limit == 5
+    assert args.secrets_dir == "/secrets"
+    assert args.workdir == "/work"
+
+
+# --- require_field ---
+
+
+def test_require_field_nested_ok() -> None:
+    """Nested keys resolve to the leaf value."""
+    assert m.require_field({"a": {"b": "x"}}, "a", "b") == "x"
+
+
+def test_require_field_missing() -> None:
+    """Missing nested keys raise ValueError with a path."""
+    with pytest.raises(ValueError, match="Missing productInfo.filePrefix"):
+        m.require_field({"productInfo": {}}, "productInfo", "filePrefix")
+
+
+def test_require_field_empty() -> None:
+    """Empty string values raise ValueError."""
+    with pytest.raises(ValueError, match="Missing name"):
+        m.require_field({"name": ""}, "name")
+
+
+# --- log_command_failure ---
+
+
+def test_log_command_failure_logs_stdout_and_stderr(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Captured stdout and stderr are both logged for a CalledProcessError."""
+    exc = subprocess.CalledProcessError(
+        1, ["cmd"], output="captured stdout", stderr="captured stderr"
+    )
+    with caplog.at_level(logging.ERROR, logger="release"):
+        m.log_command_failure(exc)
+    assert "captured stdout" in caplog.text
+    assert "captured stderr" in caplog.text
+
+
+def test_log_command_failure_non_called_process_error_is_noop(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-CalledProcessError exceptions produce no log output."""
+    with caplog.at_level(logging.ERROR, logger="release"):
+        m.log_command_failure(ValueError("boom"))
+    assert caplog.text == ""
+
+
+# --- validate_credentials / set_cloud_credentials ---
+
+
+def test_validate_credentials_happy_path(tmp_path: Path) -> None:
+    """Valid credential JSON files are returned sorted."""
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    _write_json(secrets / "b.json", _valid_credential())
+    _write_json(secrets / "a.json", _valid_credential())
+
+    files = m.validate_credentials(secrets)
+    assert [p.name for p in files] == ["a.json", "b.json"]
+
+
+def test_validate_credentials_none_found(tmp_path: Path) -> None:
+    """RuntimeError when the secrets directory has no JSON files."""
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    with pytest.raises(RuntimeError, match="No credential files found"):
+        m.validate_credentials(secrets)
+
+
+def test_validate_credentials_missing_keys(tmp_path: Path) -> None:
+    """RuntimeError when marketplace_account or auth is missing."""
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    _write_json(secrets / "bad.json", {"marketplace_account": "x"})
+    with pytest.raises(RuntimeError, match="Validation failed"):
+        m.validate_credentials(secrets)
+
+
+def test_validate_credentials_invalid_json(tmp_path: Path) -> None:
+    """RuntimeError when a credential file is not valid JSON."""
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    (secrets / "bad.json").write_text("{not-json", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="Validation failed"):
+        m.validate_credentials(secrets)
+
+
+def test_validate_credentials_non_object_json(tmp_path: Path) -> None:
+    """RuntimeError when credential JSON root is not an object."""
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    (secrets / "bad.json").write_text('["not", "an", "object"]', encoding="utf-8")
+    with pytest.raises(RuntimeError, match="Validation failed"):
+        m.validate_credentials(secrets)
+
+
+def test_set_cloud_credentials(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLOUD_CREDENTIALS is set to a comma-separated path list."""
+    monkeypatch.delenv("CLOUD_CREDENTIALS", raising=False)
+    paths = [tmp_path / "a.json", tmp_path / "b.json"]
+    value = m.set_cloud_credentials(paths)
+    assert value == f"{paths[0]},{paths[1]}"
+    assert os.environ["CLOUD_CREDENTIALS"] == value
+
+
+# --- write_starmap_file ---
+
+
+def test_write_starmap_file_flattens_components(tmp_path: Path) -> None:
+    """Starmap entries from all components are flattened into one YAML list."""
+    snapshot_file = tmp_path / "mapped" / "snapshot.json"
+    snapshot = _valid_snapshot(
+        [
+            _valid_component(name="c1"),
+            {
+                **_valid_component(name="c2"),
+                "starmap": [{"cloud": "azure", "name": "other"}],
+            },
+        ]
+    )
+    _write_json(snapshot_file, snapshot)
+
+    out = m.write_starmap_file(snapshot, snapshot_file)
+    assert out == snapshot_file.parent / "starmap.yaml"
+    loaded = yaml.safe_load(out.read_text(encoding="utf-8"))
+    assert loaded == [
+        {"cloud": "aws", "name": "test-product-amd"},
+        {"cloud": "azure", "name": "other"},
+    ]
+
+
+def test_write_starmap_file_skips_non_mapping_components(tmp_path: Path) -> None:
+    """Non-object entries in components are skipped rather than erroring."""
+    snapshot_file = tmp_path / "mapped" / "snapshot.json"
+    snapshot = _valid_snapshot([_valid_component(name="c1"), "not-a-mapping"])
+    _write_json(snapshot_file, snapshot)
+
+    out = m.write_starmap_file(snapshot, snapshot_file)
+    loaded = yaml.safe_load(out.read_text(encoding="utf-8"))
+    assert loaded == [{"cloud": "aws", "name": "test-product-amd"}]
+
+
+# --- filename / metadata parsers ---
+
+
+def test_strip_extensions() -> None:
+    """Compound extensions are stripped in one pass."""
+    assert (
+        m.strip_extensions("test-product-amd-1.3-1732045201-x86_64.raw.gz")
+        == "test-product-amd-1.3-1732045201-x86_64"
+    )
+
+
+def test_parse_build_respin() -> None:
+    """Respin is the timestamp between version and architecture."""
+    assert (
+        m.parse_build_respin("test-product-amd-1.3-1732045201-x86_64.raw.gz") == "1732045201"
+    )
+
+
+def test_parse_build_name() -> None:
+    """Build name drops the trailing version segment from filePrefix."""
+    assert m.parse_build_name("test-product-amd-1.3") == "test-product-amd"
+
+
+def test_parse_architecture() -> None:
+    """Architecture is the final hyphen segment before the extension."""
+    assert m.parse_architecture("test-product-amd-1.3-1732045201-x86_64.raw") == "x86_64"
+
+
+def test_image_type_for_filename() -> None:
+    """VHD and AMI types are detected; others return None."""
+    assert m.image_type_for_filename("disk.vhd") == "VHD"
+    assert m.image_type_for_filename("disk.raw") == "AMI"
+    assert m.image_type_for_filename("disk.qcow2") is None
+
+
+def test_build_date_from_respin() -> None:
+    """Unix timestamp respin converts to YYYYMMDD UTC."""
+    assert m.build_date_from_respin("1732045201") == "20241119"
+
+
+# --- decompress_gzip_source ---
+
+
+def test_decompress_gzip_source_decompresses(tmp_path: Path) -> None:
+    """Gzipped sources are decompressed and the .gz file is removed."""
+    gz_path = tmp_path / "disk.raw.gz"
+    with gzip.open(gz_path, "wb") as handle:
+        handle.write(b"disk-bytes")
+
+    out = m.decompress_gzip_source(gz_path)
+    assert out == tmp_path / "disk.raw"
+    assert out.read_bytes() == b"disk-bytes"
+    assert not gz_path.exists()
+
+
+def test_decompress_gzip_source_noop(tmp_path: Path) -> None:
+    """Non-gzip paths are returned unchanged."""
+    path = tmp_path / "disk.raw"
+    path.write_bytes(b"x")
+    assert m.decompress_gzip_source(path) == path
+
+
+# --- write_resources_yaml ---
+
+
+def test_write_resources_yaml(tmp_path: Path) -> None:
+    """resources.yaml is written under the destination directory."""
+    resources = {"api": "v1", "type": "AMI", "images": []}
+    m.write_resources_yaml(tmp_path, resources)
+    loaded = yaml.safe_load((tmp_path / "resources.yaml").read_text(encoding="utf-8"))
+    assert loaded["type"] == "AMI"
+
+
+# --- prepare_component ---
+
+
+def test_prepare_component_raw_image(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Raw gzipped disk images are staged with AMI resources metadata."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    disk_imgs = tmp_path / "starmap" / "CLOUD_IMAGES"
+    component = _valid_component()
+
+    def fake_oras_pull(pullspec: str, download_dir: Path, **_kwargs: Any) -> None:
+        assert pullspec == component["containerImage"]
+        gz_path = download_dir / "disk.raw.gz"
+        with gzip.open(gz_path, "wb") as handle:
+            handle.write(b"raw-content")
+
+    _patch_oras_pull(monkeypatch, fake_oras_pull)
+    _patch_wait_for_memory(monkeypatch)
+    m.prepare_component(component, disk_imgs, workdir)
+
+    dest = disk_imgs / component["name"]
+    staged = dest / "test-product-amd-1.3-1732045201-x86_64.raw"
+    assert staged.read_bytes() == b"raw-content"
+    resources = yaml.safe_load((dest / "resources.yaml").read_text(encoding="utf-8"))
+    assert resources["type"] == "AMI"
+    assert resources["build"]["name"] == "test-product-amd"
+    assert resources["build"]["respin"] == "1732045201"
+    assert resources["build"]["version"] == "1.3"
+    assert resources["release"]["date"] == "20241119"
+    assert resources["images"] == [
+        {
+            "path": "test-product-amd-1.3-1732045201-x86_64.raw",
+            "architecture": "x86_64",
+        }
+    ]
+
+
+def test_prepare_component_vhd_image(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """VHD gzipped disk images are staged with VHD resources metadata."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    disk_imgs = tmp_path / "starmap" / "CLOUD_IMAGES"
+    component = _valid_component(
+        name="azure-disk",
+        filename="test-product-amd-1.3-1732045201-x86_64.vhd.gz",
+        source="disk.vhd.gz",
+    )
+
+    def fake_oras_pull(_pullspec: str, download_dir: Path, **_kwargs: Any) -> None:
+        gz_path = download_dir / "disk.vhd.gz"
+        with gzip.open(gz_path, "wb") as handle:
+            handle.write(b"vhd-content")
+
+    _patch_oras_pull(monkeypatch, fake_oras_pull)
+    _patch_wait_for_memory(monkeypatch)
+    m.prepare_component(component, disk_imgs, workdir)
+
+    dest = disk_imgs / "azure-disk"
+    assert (dest / "test-product-amd-1.3-1732045201-x86_64.vhd").is_file()
+    resources = yaml.safe_load((dest / "resources.yaml").read_text(encoding="utf-8"))
+    assert resources["type"] == "VHD"
+
+
+def test_prepare_component_missing_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RuntimeError when the mapped source file is absent after oras pull."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    disk_imgs = tmp_path / "starmap" / "CLOUD_IMAGES"
+
+    def fake_oras_pull(_pullspec: str, _download_dir: Path, **_kwargs: Any) -> None:
+        return None
+
+    _patch_oras_pull(monkeypatch, fake_oras_pull)
+    _patch_wait_for_memory(monkeypatch)
+    with pytest.raises(RuntimeError, match="was not found after oras pull"):
+        m.prepare_component(_valid_component(), disk_imgs, workdir)
+
+
+def test_prepare_component_duplicate_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RuntimeError when two staged files share the same destination name."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    disk_imgs = tmp_path / "starmap" / "CLOUD_IMAGES"
+    component = _valid_component()
+    component["staged"]["files"] = [
+        {
+            "filename": "test-product-amd-1.3-1732045201-x86_64.raw.gz",
+            "source": "disk1.raw.gz",
+        },
+        {
+            "filename": "test-product-amd-1.3-1732045201-x86_64.raw.gz",
+            "source": "disk2.raw.gz",
+        },
+    ]
+
+    def fake_oras_pull(_pullspec: str, download_dir: Path, **_kwargs: Any) -> None:
+        for name in ("disk1.raw.gz", "disk2.raw.gz"):
+            with gzip.open(download_dir / name, "wb") as handle:
+                handle.write(b"x")
+
+    _patch_oras_pull(monkeypatch, fake_oras_pull)
+    _patch_wait_for_memory(monkeypatch)
+    with pytest.raises(RuntimeError, match="Multiple files use the same destination"):
+        m.prepare_component(component, disk_imgs, workdir)
+
+
+def test_prepare_component_empty_staged_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ValueError when staged.files is an empty list."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    disk_imgs = tmp_path / "starmap" / "CLOUD_IMAGES"
+    component = _valid_component()
+    component["staged"]["files"] = []
+
+    _patch_wait_for_memory(monkeypatch)
+    with pytest.raises(ValueError, match="staged.files must be a non-empty list"):
+        m.prepare_component(component, disk_imgs, workdir)
+
+
+def test_prepare_component_non_mapping_staged_file_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ValueError when a staged.files entry is not an object."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    disk_imgs = tmp_path / "starmap" / "CLOUD_IMAGES"
+    component = _valid_component()
+    component["staged"]["files"] = [
+        {"filename": "test-product-amd-1.3-1732045201-x86_64.raw.gz", "source": "disk.raw.gz"},
+        "not-a-mapping",
+    ]
+
+    def fake_oras_pull(_pullspec: str, download_dir: Path, **_kwargs: Any) -> None:
+        with gzip.open(download_dir / "disk.raw.gz", "wb") as handle:
+            handle.write(b"raw-content")
+
+    _patch_oras_pull(monkeypatch, fake_oras_pull)
+    _patch_wait_for_memory(monkeypatch)
+    with pytest.raises(ValueError, match="staged.files entries must be objects"):
+        m.prepare_component(component, disk_imgs, workdir)
+
+
+def test_prepare_component_skips_unsupported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unsupported extensions are skipped and omitted from resources.yaml."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    disk_imgs = tmp_path / "starmap" / "CLOUD_IMAGES"
+    component = _valid_component(
+        filename="test-product-amd-1.3-1732045201-x86_64.qcow2",
+        source="disk.qcow2",
+    )
+
+    def fake_oras_pull(_pullspec: str, download_dir: Path, **_kwargs: Any) -> None:
+        (download_dir / "disk.qcow2").write_bytes(b"qcow")
+
+    _patch_oras_pull(monkeypatch, fake_oras_pull)
+    _patch_wait_for_memory(monkeypatch)
+    m.prepare_component(component, disk_imgs, workdir)
+    resources = yaml.safe_load(
+        (disk_imgs / component["name"] / "resources.yaml").read_text(encoding="utf-8")
+    )
+    assert resources["images"] == []
+    assert "type" not in resources
+
+
+# --- prepare_components ---
+
+
+def test_prepare_components_aggregates_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One failing component fails the whole prepare_components call."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    disk_imgs = tmp_path / "imgs"
+
+    def boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("pull failed")
+
+    _patch_oras_pull(monkeypatch, boom)
+    _patch_wait_for_memory(monkeypatch)
+    with pytest.raises(RuntimeError, match="prepare_component failed for at least"):
+        m.prepare_components(
+            [_valid_component()],
+            disk_imgs,
+            workdir,
+            concurrent_limit=1,
+        )
+
+
+def test_prepare_components_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """All components succeed when oras_pull stages expected files."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    disk_imgs = tmp_path / "imgs"
+
+    def fake_oras_pull(_pullspec: str, download_dir: Path, **_kwargs: Any) -> None:
+        with gzip.open(download_dir / "disk.raw.gz", "wb") as handle:
+            handle.write(b"ok")
+
+    _patch_oras_pull(monkeypatch, fake_oras_pull)
+    _patch_wait_for_memory(monkeypatch)
+    m.prepare_components(
+        [_valid_component(name="one"), _valid_component(name="two")],
+        disk_imgs,
+        workdir,
+        concurrent_limit=2,
+    )
+    assert (disk_imgs / "one" / "resources.yaml").is_file()
+    assert (disk_imgs / "two" / "resources.yaml").is_file()
+
+
+def test_prepare_components_throttles_memory_per_component(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """wait_for_memory is called once per component before its heavy work."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    disk_imgs = tmp_path / "imgs"
+    calls: list[int] = []
+
+    def fake_oras_pull(_pullspec: str, download_dir: Path, **_kwargs: Any) -> None:
+        with gzip.open(download_dir / "disk.raw.gz", "wb") as handle:
+            handle.write(b"ok")
+
+    def counting_wait(threshold: int) -> None:
+        calls.append(threshold)
+
+    _patch_oras_pull(monkeypatch, fake_oras_pull)
+    _patch_wait_for_memory(monkeypatch, counting_wait)
+    m.prepare_components(
+        [_valid_component(name="one"), _valid_component(name="two")],
+        disk_imgs,
+        workdir,
+        concurrent_limit=2,
+    )
+    assert calls == [m.MEMORY_THRESHOLD, m.MEMORY_THRESHOLD]
+
+
+# --- validate_staged_structure / run_marketplacesvm_push / copy_artifacts ---
+
+
+def test_validate_staged_structure_calls_pushsource_ls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """pushsource-ls is invoked with the staged: URL."""
+    calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append([str(x) for x in cmd])
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    _patch_run_cmd(monkeypatch, fake_run_cmd)
+    m.validate_staged_structure(tmp_path)
+    assert calls == [["pushsource-ls", f"staged:{tmp_path}"]]
+
+
+def test_validate_staged_structure_logs_and_reraises_on_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pushsource-ls failure is logged (with stdout/stderr) and re-raised."""
+
+    def failing_run_cmd(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            1, cmd, output="pushsource-ls stdout", stderr="pushsource-ls stderr"
+        )
+
+    _patch_run_cmd(monkeypatch, failing_run_cmd)
+    with caplog.at_level(logging.ERROR, logger="release"):
+        with pytest.raises(subprocess.CalledProcessError):
+            m.validate_staged_structure(tmp_path)
+    assert "pushsource-ls stdout" in caplog.text
+    assert "pushsource-ls stderr" in caplog.text
+
+
+def test_run_marketplacesvm_push_with_pre_push(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """pre_push adds --nochannel to the wrapper invocation."""
+    starmap = tmp_path / "starmap.yaml"
+    starmap.write_text("[]\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append([str(x) for x in cmd])
+        assert kwargs["cwd"] == tmp_path
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    _patch_run_cmd(monkeypatch, fake_run_cmd)
+    m.run_marketplacesvm_push(tmp_path, starmap, pre_push=True)
+    assert calls[0][:3] == ["marketplacesvm_push_wrapper", "--debug", "--nochannel"]
+    assert "--source" in calls[0]
+    assert "--starmap-file" in calls[0]
+
+
+def test_run_marketplacesvm_push_without_pre_push(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without pre_push, --nochannel is omitted."""
+    starmap = tmp_path / "starmap.yaml"
+    starmap.write_text("[]\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append([str(x) for x in cmd])
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    _patch_run_cmd(monkeypatch, fake_run_cmd)
+    m.run_marketplacesvm_push(tmp_path, starmap, pre_push=False)
+    assert "--nochannel" not in calls[0]
+
+
+def test_run_marketplacesvm_push_logs_and_reraises_on_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A wrapper failure is logged (with stdout/stderr) and re-raised."""
+    starmap = tmp_path / "starmap.yaml"
+    starmap.write_text("[]\n", encoding="utf-8")
+
+    def failing_run_cmd(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            1, cmd, output="wrapper stdout", stderr="wrapper stderr"
+        )
+
+    _patch_run_cmd(monkeypatch, failing_run_cmd)
+    with caplog.at_level(logging.ERROR, logger="release"):
+        with pytest.raises(subprocess.CalledProcessError):
+            m.run_marketplacesvm_push(tmp_path, starmap, pre_push=False)
+    assert "wrapper stdout" in caplog.text
+    assert "wrapper stderr" in caplog.text
+
+
+def test_copy_artifacts(tmp_path: Path) -> None:
+    """Artifacts directory is copied into data_dir when present."""
+    base = tmp_path / "base"
+    data = tmp_path / "data"
+    data.mkdir()
+    artifacts = base / "artifacts" / "run1"
+    artifacts.mkdir(parents=True)
+    (artifacts / "clouds.json").write_text("{}", encoding="utf-8")
+
+    m.copy_artifacts(base, data)
+    assert (data / "artifacts" / "run1" / "clouds.json").read_text(encoding="utf-8") == "{}"
+
+
+def test_copy_artifacts_noop_when_missing(tmp_path: Path) -> None:
+    """Missing artifacts directory is a no-op."""
+    data = tmp_path / "data"
+    data.mkdir()
+    m.copy_artifacts(tmp_path / "base", data)
+    assert not (data / "artifacts").exists()
+
+
+# --- run / main ---
+
+
+def test_run_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end run stages content, validates, pushes, and copies artifacts."""
+    data_dir = tmp_path / "data"
+    secrets = tmp_path / "secrets"
+    workdir = tmp_path / "work"
+    secrets.mkdir()
+    workdir.mkdir()
+    _write_json(secrets / "creds.json", _valid_credential())
+    _write_json(data_dir / "snapshot.json", _valid_snapshot())
+
+    def fake_oras_pull(_pullspec: str, download_dir: Path, **_kwargs: Any) -> None:
+        with gzip.open(download_dir / "disk.raw.gz", "wb") as handle:
+            handle.write(b"raw")
+
+    def fake_run_cmd(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if cmd[0] == "marketplacesvm_push_wrapper":
+            cwd = Path(kwargs["cwd"])
+            artifact_dir = cwd / "artifacts" / "20260430181240"
+            artifact_dir.mkdir(parents=True)
+            (artifact_dir / "clouds.json").write_text("{}", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.delenv("CLOUD_CREDENTIALS", raising=False)
+    _patch_oras_pull(monkeypatch, fake_oras_pull)
+    _patch_run_cmd(monkeypatch, fake_run_cmd)
+    _patch_wait_for_memory(monkeypatch)
+    rc = m.run(
+        data_dir=data_dir,
+        snapshot_path="snapshot.json",
+        pre_push=False,
+        concurrent_limit=1,
+        secrets_dir=secrets,
+        workdir=workdir,
+    )
+    assert rc == 0
+    assert (data_dir / "starmap.yaml").is_file()
+    assert (data_dir / "artifacts" / "20260430181240" / "clouds.json").is_file()
+    assert "creds.json" in os.environ["CLOUD_CREDENTIALS"]
+
+
+def test_run_pre_push_true(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """pre_push=True forwards --nochannel to the wrapper."""
+    data_dir = tmp_path / "data"
+    secrets = tmp_path / "secrets"
+    workdir = tmp_path / "work"
+    secrets.mkdir()
+    workdir.mkdir()
+    _write_json(secrets / "creds.json", _valid_credential())
+    _write_json(data_dir / "snapshot.json", _valid_snapshot())
+    seen: list[list[str]] = []
+
+    def fake_oras_pull(_pullspec: str, download_dir: Path, **_kwargs: Any) -> None:
+        with gzip.open(download_dir / "disk.raw.gz", "wb") as handle:
+            handle.write(b"raw")
+
+    def fake_run_cmd(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        seen.append([str(x) for x in cmd])
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.delenv("CLOUD_CREDENTIALS", raising=False)
+    _patch_oras_pull(monkeypatch, fake_oras_pull)
+    _patch_run_cmd(monkeypatch, fake_run_cmd)
+    _patch_wait_for_memory(monkeypatch)
+    m.run(
+        data_dir=data_dir,
+        snapshot_path="snapshot.json",
+        pre_push=True,
+        concurrent_limit=1,
+        secrets_dir=secrets,
+        workdir=workdir,
+    )
+    wrapper_calls = [c for c in seen if c and c[0] == "marketplacesvm_push_wrapper"]
+    assert any("--nochannel" in c for c in wrapper_calls)
+
+
+def test_run_empty_components(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """ValueError when snapshot has no components."""
+    data_dir = tmp_path / "data"
+    secrets = tmp_path / "secrets"
+    workdir = tmp_path / "work"
+    secrets.mkdir()
+    workdir.mkdir()
+    _write_json(secrets / "creds.json", _valid_credential())
+    _write_json(data_dir / "snapshot.json", {"components": []})
+    monkeypatch.delenv("CLOUD_CREDENTIALS", raising=False)
+
+    with pytest.raises(ValueError, match="non-empty components"):
+        m.run(
+            data_dir=data_dir,
+            snapshot_path="snapshot.json",
+            pre_push=False,
+            concurrent_limit=1,
+            secrets_dir=secrets,
+            workdir=workdir,
+        )
+
+
+def test_run_non_object_component(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """ValueError when a components entry is not a JSON object."""
+    data_dir = tmp_path / "data"
+    secrets = tmp_path / "secrets"
+    workdir = tmp_path / "work"
+    secrets.mkdir()
+    workdir.mkdir()
+    _write_json(secrets / "creds.json", _valid_credential())
+    _write_json(
+        data_dir / "snapshot.json", {"components": [_valid_component(), "not-an-object"]}
+    )
+    monkeypatch.delenv("CLOUD_CREDENTIALS", raising=False)
+
+    with pytest.raises(ValueError, match="must all be JSON objects"):
+        m.run(
+            data_dir=data_dir,
+            snapshot_path="snapshot.json",
+            pre_push=False,
+            concurrent_limit=1,
+            secrets_dir=secrets,
+            workdir=workdir,
+        )
+
+
+def test_main_wires_args(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() parses argv and delegates to run()."""
+    monkeypatch.setattr(
+        m,
+        "run",
+        mock.Mock(return_value=0),
+    )
+    rc = m.main(
+        [
+            "--data-dir",
+            str(tmp_path),
+            "--snapshot-path",
+            "snap.json",
+            "--pre-push",
+            "true",
+            "--concurrent-limit",
+            "2",
+            "--secrets-dir",
+            "/secrets",
+            "--workdir",
+            "/work",
+        ]
+    )
+    assert rc == 0
+    m.run.assert_called_once_with(
+        data_dir=tmp_path,
+        snapshot_path="snap.json",
+        pre_push=True,
+        concurrent_limit=2,
+        secrets_dir=Path("/secrets"),
+        workdir=Path("/work"),
+    )


### PR DESCRIPTION
Move the managed task bash into a standalone script with pytest
coverage so the catalog can call it from the utils image. Also port
memory-throttle.sh's cgroup usage check to a reusable Python helper
and call it before each component's oras pull, so the converted
task still pauses new work under memory pressure like the other
bash tasks that use memory-throttle.sh.

Assisted-by: Cursor AI
