### PR TITLE
fix: implement optional timeout constraints in core subprocess engine

### DIFF
--- a/scripts/python/helpers/subprocess_cmd.py
+++ b/scripts/python/helpers/subprocess_cmd.py
@@ -22,6 +22,7 @@ def run_cmd(
     stdin: str | bytes | None = None,
     stderr_path: Path | None = None,
     check: bool = True,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run *cmd*; capture stdout as text; optionally append stderr to *stderr_path*."""
     # Child must inherit pod env (PATH, KUBECONFIG, etc.); only overlay *env*.
@@ -48,7 +49,18 @@ def run_cmd(
                 stderr=err_f,
                 text=True,
                 check=check,
+                timeout=timeout,
             )
+        except subprocess.TimeoutExpired:
+            if stderr_path is not None:
+                with open(
+                    stderr_path,
+                    "a",
+                    encoding="utf-8",
+                    errors="replace",
+                ) as errf:
+                    errf.write(f"\ncommand timed out after {timeout}s: {' '.join(argv)}\n")
+            raise
         except subprocess.CalledProcessError:
             if stderr_path is not None:
                 with open(
@@ -68,19 +80,30 @@ def run_cmd_text(
     cmd: Sequence[str | Path],
     *,
     cwd: Path | None = None,
+    timeout: float | None = None,
 ) -> str:
     """Run *cmd*, return captured stdout as text, and raise on non-zero exit.
 
     Uses a Tekton-friendly command preview in ``CalledProcessError.cmd``.
     """
     argv = [str(x) for x in cmd]
-    proc = subprocess.run(
-        argv,
-        cwd=str(cwd) if cwd else None,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            argv,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as e:
+        preview = tekton.subprocess_cmd_preview_for_tekton_result(argv)
+        raise subprocess.CalledProcessError(
+            returncode=124,
+            cmd=preview,
+            output=f"Command timed out after {timeout} seconds",
+        ) from e
+
     if proc.returncode != 0:
         preview = tekton.subprocess_cmd_preview_for_tekton_result(argv)
         err = (proc.stderr or proc.stdout or "").strip()

--- a/scripts/python/helpers/test_subprocess_cmd.py
+++ b/scripts/python/helpers/test_subprocess_cmd.py
@@ -118,3 +118,28 @@ metadata:
     ]
     assert subprocess_cmd.run_yq_json(path, ".spec.type") == "RHBA"
     assert subprocess_cmd.run_yq_json(path, ".metadata.name") == "2025:1"
+
+
+def test_run_cmd_timeout_handling(tmp_path: Path) -> None:
+    """``run_cmd`` handles TimeoutExpired, logs to stderr_path, and raises."""
+    log = tmp_path / "timeout_log.txt"
+    with mock.patch("subprocess_cmd.subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd=["sleep", "10"], timeout=1.0)
+
+        with pytest.raises(subprocess.TimeoutExpired):
+            subprocess_cmd.run_cmd(["sleep", "10"], stderr_path=log, timeout=1.0)
+    log_text = log.read_text(encoding="utf-8")
+    assert "command timed out after 1.0s" in log_text
+    assert "sleep 10" in log_text
+
+
+def test_run_cmd_text_timeout_handling() -> None:
+    """``run_cmd_text`` transforms TimeoutExpired into a CalledProcessError."""
+    with mock.patch("subprocess_cmd.subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd=["sleep", "10"], timeout=1.0)
+
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            subprocess_cmd.run_cmd_text(["sleep", "10"], timeout=1.0)
+
+    assert exc_info.value.returncode == 124
+    assert "Command timed out after 1.0 seconds" in exc_info.value.output


### PR DESCRIPTION
Expose a configurable timeout cascade down to the fundamental subprocess wrapper execution modules. This shields integration pipelines from hitting global infrastructure limits when network sockets drop or lock up silently.

Assisted-By: Gemini