### PR TITLE
fix(RELEASE-1988): restore component group scoping in MR search

### DIFF
--- a/scripts/python/tasks/internal/process_file_updates.py
+++ b/scripts/python/tasks/internal/process_file_updates.py
@@ -30,6 +30,7 @@ import re
 import subprocess
 import sys
 import uuid
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -146,21 +147,37 @@ def gitlab_create_mr(
     )
 
 
-def list_konflux_open_mrs(upstream_repo: str, gitlab_client: gitlab.Gitlab) -> list[Any]:
-    """List open MRs in *upstream_repo* matching ``Konflux release`` (paginated)."""
+def iter_konflux_open_mrs(
+    upstream_repo: str,
+    gitlab_client: gitlab.Gitlab,
+    component_group: str,
+) -> Iterator[Any]:
+    """Yield open MRs in *upstream_repo* matching the component group.
+
+    Searches for ``[Konflux release] <component_group>:`` and yields only MRs whose
+    title starts with that prefix. The trailing ``:`` matches titles created by
+    ``commit_and_create_mr`` and avoids prefix collisions (e.g. group ``foo`` must
+    not match ``[Konflux release] foobar: ...``). This two-level filter (API search
+    + title check) also skips unrelated MRs that only mention the search term in
+    other fields, avoiding expensive git fetch operations.
+
+    Yields lazily so callers can stop early when a match is found.
+    """
     project_path = vcs_gitlab.gitlab_project_path(upstream_repo)
     try:
         project = gitlab_client.projects.get(project_path)
     except GitlabError as e:
         raise tekton.CheckStepError("getting GitLab project", e) from e
 
+    # Include the colon delimiter used in created MR titles so a shorter group
+    # name cannot match a longer one that shares the same prefix.
+    title_prefix = f"[Konflux release] {component_group}:"
     page = 1
-    found: list[Any] = []
     while True:
         try:
             batch = project.mergerequests.list(
                 state="opened",
-                search="Konflux release",
+                search=title_prefix,
                 per_page=100,
                 page=page,
             )
@@ -168,9 +185,11 @@ def list_konflux_open_mrs(upstream_repo: str, gitlab_client: gitlab.Gitlab) -> l
             raise tekton.CheckStepError("listing GitLab merge requests", e) from e
         if not batch:
             break
-        found.extend(batch)
+        for mr in batch:
+            mr_title = getattr(mr, "title", "") or ""
+            if mr_title.startswith(title_prefix):
+                yield mr
         page += 1
-    return found
 
 
 def blank_lines_before_yaml(target_file: Path) -> int:
@@ -549,9 +568,14 @@ def find_existing_mr_with_same_diff(
     repo_cwd: Path,
     temp_dir: Path,
     gitlab_client: gitlab.Gitlab,
+    component_group: str,
 ) -> str | None:
-    """Return result info when an open MR already has the same staged diff."""
-    for mr in list_konflux_open_mrs(upstream_repo, gitlab_client):
+    """Return result info when an open MR already has the same staged diff.
+
+    Uses lazy iteration to stop as soon as a matching MR is found, avoiding
+    unnecessary git fetch operations for remaining MRs.
+    """
+    for mr in iter_konflux_open_mrs(upstream_repo, gitlab_client, component_group):
         mr_num = mr.iid
         local_ref = _fetch_merge_request_head(repo_cwd, mr_num)
         final_diff = vcs_git.working_tree_diff(repo_cwd, cached=True, other_ref=local_ref)
@@ -634,7 +658,7 @@ def run_file_updates(
         return "nothing needs change\n", "Success", 0
 
     existing_mr = find_existing_mr_with_same_diff(
-        upstream_repo, repo_cwd, temp_dir, gitlab_client
+        upstream_repo, repo_cwd, temp_dir, gitlab_client, component_group
     )
     if existing_mr is not None:
         return existing_mr, "Success", 0

--- a/scripts/python/tasks/internal/test_process_file_updates.py
+++ b/scripts/python/tasks/internal/test_process_file_updates.py
@@ -459,20 +459,28 @@ def test_gitlab_create_mr_raises_on_gitlab_error() -> None:
     assert "creating GitLab merge request" in str(exc.value)
 
 
-def test_list_konflux_open_mrs_raises_on_project_lookup_error() -> None:
+def test_iter_konflux_open_mrs_raises_on_project_lookup_error() -> None:
     """Project lookup failures raise ``CheckStepError``."""
     with pytest.raises(tekton.CheckStepError) as exc:
-        process_file_updates.list_konflux_open_mrs(
-            "org/up", _mock_gitlab_client(get_error=GitlabError("project not found"))
+        list(
+            process_file_updates.iter_konflux_open_mrs(
+                "org/up",
+                _mock_gitlab_client(get_error=GitlabError("project not found")),
+                "test-group",
+            )
         )
     assert "getting GitLab project" in str(exc.value)
 
 
-def test_list_konflux_open_mrs_raises_on_list_error() -> None:
+def test_iter_konflux_open_mrs_raises_on_list_error() -> None:
     """MR list failures raise ``CheckStepError``."""
     with pytest.raises(tekton.CheckStepError) as exc:
-        process_file_updates.list_konflux_open_mrs(
-            "org/up", _mock_gitlab_client(list_error=GitlabError("list failed"))
+        list(
+            process_file_updates.iter_konflux_open_mrs(
+                "org/up",
+                _mock_gitlab_client(list_error=GitlabError("list failed")),
+                "test-group",
+            )
         )
     assert "listing GitLab merge requests" in str(exc.value)
 
@@ -796,6 +804,23 @@ def test_resolve_target_file_rejects_unsafe_paths(tmp_path: Path, entry_path: st
         process_file_updates.resolve_target_file(repo, entry_path)
 
 
+def test_resolve_target_file_rejects_symlink_escape(tmp_path: Path) -> None:
+    """Symlink pointing outside repo is rejected after resolution."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.yaml"
+    secret.write_text("sensitive: data\n", encoding="utf-8")
+    symlink = repo / "link"
+    try:
+        symlink.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not supported")
+    with pytest.raises(ValueError, match="escapes repository root"):
+        process_file_updates.resolve_target_file(repo, "link/secret.yaml")
+
+
 def test_process_all_paths_rejects_unsafe_path_entry(tmp_path: Path) -> None:
     """Unsafe path entries fail before seed or replacement side effects."""
     repo = tmp_path / "repo"
@@ -1078,16 +1103,63 @@ def test_get_cached_diff(tmp_path: Path) -> None:
     assert (tmp_path / "tempMRFile-cached.diff").read_text(encoding="utf-8") == "diff\n"
 
 
-def test_list_konflux_open_mrs_paginates() -> None:
-    """Open MR listing paginates until an empty page."""
-    page1_mr = mock.Mock()
-    page1_mr.iid = 1
-    items = process_file_updates.list_konflux_open_mrs(
-        "org/up",
-        _mock_gitlab_client(list_pages=[[page1_mr], []]),
+def test_fetch_merge_request_head(tmp_path: Path) -> None:
+    """MR head is fetched into a local ref named ``mr_<iid>``."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with mock.patch.object(process_file_updates.vcs_git, "fetch") as fetch:
+        ref = process_file_updates._fetch_merge_request_head(repo, 42)
+    assert ref == "mr_42"
+    fetch.assert_called_once_with(repo, "origin", "merge-requests/42/head:mr_42")
+
+
+def test_iter_konflux_open_mrs_paginates_and_filters_by_title() -> None:
+    """Open MR listing paginates and filters by delimiter-aware title prefix."""
+    matching_mr = mock.Mock()
+    matching_mr.iid = 1
+    matching_mr.title = "[Konflux release] test-group: fileUpdates changes abc123"
+
+    unrelated_mr = mock.Mock()
+    unrelated_mr.iid = 2
+    unrelated_mr.title = "Some other MR mentioning test-group"
+
+    client = _mock_gitlab_client(list_pages=[[matching_mr, unrelated_mr], []])
+    items = list(
+        process_file_updates.iter_konflux_open_mrs(
+            "org/up",
+            client,
+            "test-group",
+        )
     )
     assert len(items) == 1
     assert items[0].iid == 1
+    client.projects.get.return_value.mergerequests.list.assert_any_call(
+        state="opened",
+        search="[Konflux release] test-group:",
+        per_page=100,
+        page=1,
+    )
+
+
+def test_iter_konflux_open_mrs_rejects_component_group_prefix_collision() -> None:
+    """Shorter component groups must not match longer groups sharing a prefix."""
+    collision_mr = mock.Mock()
+    collision_mr.iid = 3
+    collision_mr.title = "[Konflux release] foobar: fileUpdates changes abc123"
+
+    exact_mr = mock.Mock()
+    exact_mr.iid = 4
+    exact_mr.title = "[Konflux release] foo: fileUpdates changes def456"
+
+    items = list(
+        process_file_updates.iter_konflux_open_mrs(
+            "org/up",
+            _mock_gitlab_client(list_pages=[[collision_mr, exact_mr], []]),
+            "foo",
+        )
+    )
+    assert len(items) == 1
+    assert items[0].iid == 4
 
 
 def test_find_existing_mr_with_same_diff(tmp_path: Path) -> None:
@@ -1100,8 +1172,8 @@ def test_find_existing_mr_with_same_diff(tmp_path: Path) -> None:
     with (
         mock.patch.object(
             process_file_updates,
-            "list_konflux_open_mrs",
-            return_value=[existing_mr],
+            "iter_konflux_open_mrs",
+            return_value=iter([existing_mr]),
         ),
         mock.patch.object(
             process_file_updates,
@@ -1111,7 +1183,7 @@ def test_find_existing_mr_with_same_diff(tmp_path: Path) -> None:
         mock.patch.object(process_file_updates.vcs_git, "working_tree_diff", return_value=""),
     ):
         info = process_file_updates.find_existing_mr_with_same_diff(
-            "org/up", repo, tmp_path, _mock_gitlab_client()
+            "org/up", repo, tmp_path, _mock_gitlab_client(), "test-group"
         )
     assert info is not None
     assert "merge_requests/99" in info
@@ -1429,8 +1501,8 @@ def test_find_existing_mr_returns_none_when_diff_differs(tmp_path: Path) -> None
     with (
         mock.patch.object(
             process_file_updates,
-            "list_konflux_open_mrs",
-            return_value=[existing_mr],
+            "iter_konflux_open_mrs",
+            return_value=iter([existing_mr]),
         ),
         mock.patch.object(
             process_file_updates,
@@ -1445,7 +1517,7 @@ def test_find_existing_mr_returns_none_when_diff_differs(tmp_path: Path) -> None
     ):
         assert (
             process_file_updates.find_existing_mr_with_same_diff(
-                "org/up", repo, tmp_path, mock.Mock()
+                "org/up", repo, tmp_path, mock.Mock(), "test-group"
             )
             is None
         )


### PR DESCRIPTION
The original bash script searched for "[Konflux release] {componentGroup}" but the Python conversion only searched for "Konflux release", causing hundreds of unrelated MRs to be fetched in shared repos. 
This led to timeouts in process-file-updates.

## Relevant Jira
[RELEASE-1988](https://redhat.atlassian.net/browse/RELEASE-1988)

Assisted-by: Cursor

[RELEASE-1988]: https://redhat.atlassian.net/browse/RELEASE-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ