### PR TITLE
fix(RELEASE-2367): log elapsed seconds in wait_for_task TimeoutError

### DIFF
--- a/pubtools-pulp-wrapper/pulp_push_wrapper.py
+++ b/pubtools-pulp-wrapper/pulp_push_wrapper.py
@@ -217,7 +217,8 @@ def pulp_request(url, context, payload=None):
 def wait_for_task(task_href, context):
     """Poll *task_href* until the Pulp task finishes, raising on error or timeout."""
     task_url = task_href
-    deadline = time.time() + POLL_TIMEOUT_SECONDS
+    start = time.time()
+    deadline = start + POLL_TIMEOUT_SECONDS
     while time.time() < deadline:
         task = pulp_request(task_url, context=context)
         if task is None:
@@ -232,7 +233,10 @@ def wait_for_task(task_href, context):
         if state in ("error", "canceled"):
             raise RuntimeError(f"Pulp task {state}: {task_url}: {task}")
         time.sleep(POLL_INTERVAL_SECONDS)
-    raise TimeoutError(f"Timed out waiting for Pulp task: {task_url}")
+    elapsed = int(time.time() - start)
+    raise TimeoutError(
+        f"Timed out waiting for Pulp task after {elapsed}s: {task_url}"
+    )
 
 
 def prune_matching_content_before_push(parsed):

--- a/pubtools-pulp-wrapper/test_pulp_push_wrapper.py
+++ b/pubtools-pulp-wrapper/test_pulp_push_wrapper.py
@@ -199,10 +199,11 @@ def test_wait_for_task_success(mock_pulp_request, mock_time, _mock_sleep):
 @patch("pulp_push_wrapper.time.time")
 @patch("pulp_push_wrapper.pulp_request")
 def test_wait_for_task_timeout(mock_pulp_request, mock_time, _mock_sleep):
-    mock_time.side_effect = [0, 200]
+    # start time, deadline check (exceeds timeout), elapsed calculation
+    mock_time.side_effect = [0, 200, 200]
     mock_pulp_request.return_value = {"state": "running"}
 
-    with pytest.raises(TimeoutError):
+    with pytest.raises(TimeoutError, match="after 200s"):
         pulp_push_wrapper.wait_for_task("https://example.com/task", context="ctx")
 
 


### PR DESCRIPTION
## Summary
- Include elapsed seconds in the `TimeoutError` raised by `wait_for_task()`, so operators can distinguish a tight timeout from a stuck Pulp server.

## Test plan
- [x] Updated `test_wait_for_task_timeout` to assert "after 200s" appears in the error message
- [x] All 20 existing tests pass

Fixes #910