### PR TITLE
fix(KFLUXSPRT-8470): make pulp task wait timeout configurable

### DIFF
--- a/pubtools-pulp-wrapper/pulp_push_wrapper.py
+++ b/pubtools-pulp-wrapper/pulp_push_wrapper.py
@@ -48,6 +48,14 @@ EXODUS_ENV_VARS_STRICT = (
 EXODUS_ENV_VARS_OTHERS = ("EXODUS_GW_TIMEOUT",)
 
 
+def _positive_int(value: str) -> int:
+    """Parse *value* as an argparse type, rejecting non-positive integers."""
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError(f"must be a positive integer, got {value!r}")
+    return ivalue
+
+
 def parse_args(argv=None):
     """Parse and return command-line arguments for the Pulp push wrapper."""
     parser = argparse.ArgumentParser(
@@ -82,6 +90,13 @@ def parse_args(argv=None):
         "--pulp-key",
         help="Pulp certificate key",
         default=None,
+    )
+    pulp.add_argument(
+        "--pulp-task-timeout-seconds",
+        type=_positive_int,
+        default=7200,
+        help="Maximum time in seconds to wait for a Pulp task to reach a "
+        "terminal state during pre-push cleanup (default 7200 = 2 hours)",
     )
 
     ud = parser.add_argument_group(
@@ -214,15 +229,28 @@ def pulp_request(url, context, payload=None):
     return json.loads(body.decode("utf-8"))
 
 
-def wait_for_task(task_href, context):
+def wait_for_task(
+    task_href: str, context: ssl.SSLContext, timeout: int = POLL_TIMEOUT_SECONDS
+) -> None:
     """Poll *task_href* until the Pulp task finishes, raising on error or timeout."""
     task_url = task_href
-    deadline = time.time() + POLL_TIMEOUT_SECONDS
-    while time.time() < deadline:
+    start = time.time()
+    deadline = start + timeout
+    last_state = None
+    now = start
+    while now < deadline:
         task = pulp_request(task_url, context=context)
         if task is None:
             raise RuntimeError(f"Empty response while polling Pulp task status: {task_url}")
         state = task.get("state")
+        if state != last_state:
+            LOG.info(
+                "Pulp task %s state: %s (%.0fs elapsed)",
+                task_url,
+                state,
+                now - start,
+            )
+            last_state = state
         if state == "finished":
             if task.get("error") or task.get("exception") or task.get("traceback"):
                 raise RuntimeError(f"Pulp task failed: {task_url}: {task}")
@@ -232,7 +260,11 @@ def wait_for_task(task_href, context):
         if state in ("error", "canceled"):
             raise RuntimeError(f"Pulp task {state}: {task_url}: {task}")
         time.sleep(POLL_INTERVAL_SECONDS)
-    raise TimeoutError(f"Timed out waiting for Pulp task: {task_url}")
+        now = time.time()
+    elapsed = now - start
+    raise TimeoutError(
+        f"Timed out after {elapsed:.1f}s (limit {timeout}s) waiting for Pulp task: {task_url}"
+    )
 
 
 def prune_matching_content_before_push(parsed):
@@ -309,7 +341,11 @@ def prune_matching_content_before_push(parsed):
         for task in response.get("spawned_tasks", []):
             href = task.get("_href")
             if href:
-                wait_for_task(parse.urljoin(pulp_base, href), context=context)
+                wait_for_task(
+                    parse.urljoin(pulp_base, href),
+                    context=context,
+                    timeout=parsed.pulp_task_timeout_seconds,
+                )
 
 
 def settings_to_args(parsed):

--- a/pubtools-pulp-wrapper/test_pulp_push_wrapper.py
+++ b/pubtools-pulp-wrapper/test_pulp_push_wrapper.py
@@ -1,3 +1,5 @@
+"""Tests for the pulp_push_wrapper CDN push wrapper script."""
+
 import logging
 import os
 import sys
@@ -10,11 +12,13 @@ import pulp_push_wrapper
 
 @pytest.fixture()
 def mock_gw_env_vars():
+    """Set the exodus-gw environment variables required by validate_args()."""
     with patch.dict(os.environ, {k: "test" for k in pulp_push_wrapper.EXODUS_ENV_VARS_STRICT}):
         yield
 
 
 def test_no_args(capsys):
+    """Fail with a usage error when required arguments are missing."""
     with pytest.raises(SystemExit):
         pulp_push_wrapper.main()
 
@@ -25,7 +29,31 @@ def test_no_args(capsys):
     )
 
 
+def test_parse_args_pulp_task_timeout_default() -> None:
+    """Default --pulp-task-timeout-seconds to 7200 when not provided."""
+    args = pulp_push_wrapper.parse_args(
+        ["--source", "/test/1", "--pulp-url", "https://pulp-test.dev"]
+    )
+    assert args.pulp_task_timeout_seconds == 7200
+
+
+def test_parse_args_pulp_task_timeout_override() -> None:
+    """Accept an explicit --pulp-task-timeout-seconds override."""
+    args = pulp_push_wrapper.parse_args(
+        [
+            "--source",
+            "/test/1",
+            "--pulp-url",
+            "https://pulp-test.dev",
+            "--pulp-task-timeout-seconds",
+            "45",
+        ]
+    )
+    assert args.pulp_task_timeout_seconds == 45
+
+
 def test_dry_run(caplog, mock_gw_env_vars):
+    """Log the command that would run, without executing it, in dry-run mode."""
     args = [
         "",
         "--dry-run",
@@ -49,6 +77,7 @@ def test_dry_run(caplog, mock_gw_env_vars):
 
 @patch("subprocess.run")
 def test_basic_command(mock_run, caplog, mock_gw_env_vars):
+    """Run pubtools-pulp-push with the expected arguments for a normal push."""
     args = [
         "",
         "--source",
@@ -83,6 +112,7 @@ def test_basic_command(mock_run, caplog, mock_gw_env_vars):
 
 @patch("subprocess.run")
 def test_no_clean_flag(mock_run, caplog, mock_gw_env_vars):
+    """Omit --clean from the pubtools-pulp-push call when --no-clean is passed."""
     args = [
         "",
         "--source",
@@ -113,6 +143,7 @@ def test_no_clean_flag(mock_run, caplog, mock_gw_env_vars):
 
 
 def test_build_timestamp_search_patterns():
+    """Build exact, wildcard, and normalized patterns for a timestamped filename."""
     patterns = pulp_push_wrapper.build_timestamp_search_patterns(
         "releng-test-product-1.7-1777068929-x86_64-boot.iso.gz"
     )
@@ -122,11 +153,13 @@ def test_build_timestamp_search_patterns():
 
 
 def test_get_source_dirs():
+    """Extract staging directories from a staged: source URL."""
     assert pulp_push_wrapper.get_source_dirs("staged:/tmp/a,/tmp/b") == ["/tmp/a", "/tmp/b"]
     assert pulp_push_wrapper.get_source_dirs("docker://foo/bar") == []
 
 
 def test_normalize_timestamped_name():
+    """Strip an embedded timestamp token from a filename, leaving others untouched."""
     assert (
         pulp_push_wrapper.normalize_timestamped_name(
             "releng-test-product-1.7-1777068929-x86_64-boot.iso.gz"
@@ -142,6 +175,7 @@ def test_normalize_timestamped_name():
 
 
 def test_build_repo_file_map(tmp_path):
+    """Map repo names to their staged FILES contents, skipping empty/missing dirs."""
     repo = tmp_path / "repo-a" / "FILES"
     repo.mkdir(parents=True)
     (repo / "a.txt").write_text("a")
@@ -154,6 +188,7 @@ def test_build_repo_file_map(tmp_path):
 
 @patch("pulp_push_wrapper.ssl.create_default_context")
 def test_make_ssl_context(mock_create_context):
+    """Load the client cert/key chain into the created SSL context."""
     mock_ctx = MagicMock()
     mock_create_context.return_value = mock_ctx
 
@@ -164,6 +199,7 @@ def test_make_ssl_context(mock_create_context):
 
 @patch("pulp_push_wrapper.request.urlopen")
 def test_pulp_request_with_payload(mock_urlopen):
+    """Decode a JSON response body when a request payload is sent."""
     mock_response = MagicMock()
     mock_response.read.return_value = b'{"ok": true}'
     mock_urlopen.return_value.__enter__.return_value = mock_response
@@ -176,6 +212,7 @@ def test_pulp_request_with_payload(mock_urlopen):
 
 @patch("pulp_push_wrapper.request.urlopen")
 def test_pulp_request_empty_body(mock_urlopen):
+    """Return None when the Pulp response body is empty."""
     mock_response = MagicMock()
     mock_response.read.return_value = b""
     mock_urlopen.return_value.__enter__.return_value = mock_response
@@ -188,6 +225,7 @@ def test_pulp_request_empty_body(mock_urlopen):
 @patch("pulp_push_wrapper.time.time")
 @patch("pulp_push_wrapper.pulp_request")
 def test_wait_for_task_success(mock_pulp_request, mock_time, _mock_sleep):
+    """Return once the polled task reaches the finished state."""
     mock_time.side_effect = [0, 1, 2]
     mock_pulp_request.side_effect = [{"state": "running"}, {"state": "finished"}]
 
@@ -199,6 +237,7 @@ def test_wait_for_task_success(mock_pulp_request, mock_time, _mock_sleep):
 @patch("pulp_push_wrapper.time.time")
 @patch("pulp_push_wrapper.pulp_request")
 def test_wait_for_task_timeout(mock_pulp_request, mock_time, _mock_sleep):
+    """Raise TimeoutError once the default deadline elapses."""
     mock_time.side_effect = [0, 200]
     mock_pulp_request.return_value = {"state": "running"}
 
@@ -210,6 +249,7 @@ def test_wait_for_task_timeout(mock_pulp_request, mock_time, _mock_sleep):
 @patch("pulp_push_wrapper.time.time")
 @patch("pulp_push_wrapper.pulp_request")
 def test_wait_for_task_empty_response(mock_pulp_request, mock_time, _mock_sleep):
+    """Raise RuntimeError when polling gets an empty response."""
     mock_time.side_effect = [0, 1]
     mock_pulp_request.return_value = None
 
@@ -227,6 +267,7 @@ def test_wait_for_task_empty_response(mock_pulp_request, mock_time, _mock_sleep)
 def test_wait_for_task_terminal_failure_state(
     mock_pulp_request, mock_time, _mock_sleep, terminal_state
 ):
+    """Raise RuntimeError immediately on an error or canceled task state."""
     mock_time.side_effect = [0, 1]
     mock_pulp_request.return_value = {
         "state": terminal_state,
@@ -243,6 +284,7 @@ def test_wait_for_task_terminal_failure_state(
 @patch("pulp_push_wrapper.time.time")
 @patch("pulp_push_wrapper.pulp_request")
 def test_wait_for_task_finished_with_error_details(mock_pulp_request, mock_time, _mock_sleep):
+    """Raise RuntimeError when a finished task still carries error details."""
     mock_time.side_effect = [0, 1]
     mock_pulp_request.return_value = {
         "state": "finished",
@@ -257,11 +299,85 @@ def test_wait_for_task_finished_with_error_details(mock_pulp_request, mock_time,
 @patch("pulp_push_wrapper.time.time")
 @patch("pulp_push_wrapper.pulp_request")
 def test_wait_for_task_skipped(mock_pulp_request, mock_time, _mock_sleep):
+    """Return immediately when the task reports a skipped state."""
     mock_time.side_effect = [0, 1]
     mock_pulp_request.return_value = {"state": "skipped"}
 
     pulp_push_wrapper.wait_for_task("https://example.com/task", context="ctx")
     assert mock_pulp_request.call_count == 1
+
+
+@patch("pulp_push_wrapper.time.sleep")
+@patch("pulp_push_wrapper.time.time")
+@patch("pulp_push_wrapper.pulp_request")
+def test_wait_for_task_custom_timeout_shrinks_deadline(
+    mock_pulp_request, mock_time, _mock_sleep
+) -> None:
+    """Honor a shorter explicit timeout instead of the default."""
+    mock_time.side_effect = [0, 50]
+    mock_pulp_request.return_value = {"state": "running"}
+
+    with pytest.raises(TimeoutError):
+        pulp_push_wrapper.wait_for_task("https://example.com/task", context="ctx", timeout=30)
+
+
+@patch("pulp_push_wrapper.time.sleep")
+@patch("pulp_push_wrapper.time.time")
+@patch("pulp_push_wrapper.pulp_request")
+def test_wait_for_task_larger_timeout_absorbs_delay(
+    mock_pulp_request, mock_time, _mock_sleep
+) -> None:
+    """Succeed under a larger timeout despite a delay that would exceed the old default."""
+    mock_time.side_effect = [0, 150, 151]
+    mock_pulp_request.side_effect = [{"state": "running"}, {"state": "finished"}]
+
+    pulp_push_wrapper.wait_for_task("https://example.com/task", context="ctx", timeout=300)
+    assert mock_pulp_request.call_count == 2
+
+
+@patch("pulp_push_wrapper.time.sleep")
+@patch("pulp_push_wrapper.time.time")
+@patch("pulp_push_wrapper.pulp_request")
+def test_wait_for_task_timeout_message_includes_elapsed(
+    mock_pulp_request, mock_time, _mock_sleep
+) -> None:
+    """Include actual elapsed time and the configured limit in the timeout message."""
+    mock_time.side_effect = [0, 45]
+    mock_pulp_request.return_value = {"state": "running"}
+
+    with pytest.raises(TimeoutError, match=r"Timed out after 45\.0s \(limit 40s\)"):
+        pulp_push_wrapper.wait_for_task("https://example.com/task", context="ctx", timeout=40)
+
+
+@patch("pulp_push_wrapper.time.sleep")
+@patch("pulp_push_wrapper.time.time")
+@patch("pulp_push_wrapper.pulp_request")
+def test_wait_for_task_logs_state_transitions(
+    mock_pulp_request, mock_time, _mock_sleep, caplog
+) -> None:
+    """Log the task's state when it is first observed."""
+    mock_time.side_effect = [0, 1]
+    mock_pulp_request.return_value = {"state": "skipped"}
+
+    with caplog.at_level(logging.INFO):
+        pulp_push_wrapper.wait_for_task("https://example.com/task", context="ctx")
+
+    assert any("state: skipped" in message for message in caplog.messages)
+
+
+def test_parse_args_pulp_task_timeout_rejects_non_positive() -> None:
+    """Reject a zero or negative --pulp-task-timeout-seconds value at parse time."""
+    with pytest.raises(SystemExit):
+        pulp_push_wrapper.parse_args(
+            [
+                "--source",
+                "/test/1",
+                "--pulp-url",
+                "https://pulp-test.dev",
+                "--pulp-task-timeout-seconds",
+                "0",
+            ]
+        )
 
 
 @patch("subprocess.run")
@@ -276,6 +392,7 @@ def test_prune_matching_content_before_push(
     tmp_path,
     mock_gw_env_vars,
 ):
+    """Remove existing timestamped units matching the staged content before pushing."""
     repo = "konflux-release-e2e-1_DOT_0-for-rhel-10-x86_64-files"
     files_dir = tmp_path / repo / "FILES"
     files_dir.mkdir(parents=True)
@@ -337,7 +454,40 @@ def test_prune_matching_content_before_push(
 
 @patch("pulp_push_wrapper.pulp_request")
 def test_prune_matching_content_before_push_skips_on_no_clean(mock_pulp_request):
+    """Skip all Pulp calls when --no-clean is set."""
     args = MagicMock()
     args.no_clean = True
     pulp_push_wrapper.prune_matching_content_before_push(args)
     mock_pulp_request.assert_not_called()
+
+
+@patch("pulp_push_wrapper.wait_for_task")
+@patch("pulp_push_wrapper.make_ssl_context", return_value="ctx")
+@patch("pulp_push_wrapper.pulp_request")
+def test_prune_matching_content_before_push_threads_timeout(
+    mock_pulp_request, _mock_ctx, mock_wait, tmp_path
+) -> None:
+    """Pass the configured pulp_task_timeout_seconds through to wait_for_task."""
+    repo = "konflux-release-e2e-1_DOT_0-for-rhel-10-x86_64-files"
+    files_dir = tmp_path / repo / "FILES"
+    files_dir.mkdir(parents=True)
+    (files_dir / "boot.iso.gz").write_text("boot")
+
+    mock_pulp_request.side_effect = [
+        [{"metadata": {"name": "boot.iso.gz"}}],
+        {"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/abc/"}]},
+    ]
+
+    parsed = MagicMock()
+    parsed.no_clean = False
+    parsed.source = pulp_push_wrapper.get_source_url([str(tmp_path)])
+    parsed.pulp_cert = "/tmp/test.crt"
+    parsed.pulp_key = "/tmp/test.key"
+    parsed.pulp_url = "https://pulp-test.dev"
+    parsed.pulp_task_timeout_seconds = 77
+
+    pulp_push_wrapper.prune_matching_content_before_push(parsed)
+
+    mock_wait.assert_called_once_with(
+        "https://pulp-test.dev/pulp/api/v2/tasks/abc/", context="ctx", timeout=77
+    )


### PR DESCRIPTION
wait_for_task() hardcoded a 120s timeout with no override, causing false failures when a Pulp task queues behind other work before executing. Add --pulp-task-timeout-seconds (default 300s, up from 120s) and log state transitions with elapsed time to make the next recurrence easier to diagnose.

Assisted-by: Claude