### PR TITLE
fix(ISV-7116): retry POST for Pyxis GraphQL and log batch duration

### DIFF
--- a/pyxis/pyxis.py
+++ b/pyxis/pyxis.py
@@ -1,29 +1,36 @@
+"""Pyxis API client for container image metadata and signature operations."""
+
+from __future__ import annotations
+
 import logging
 import os
 import sys
 from typing import Any, Dict, Optional, Tuple
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 LOGGER = logging.getLogger("pyxis")
 
 session = None
 
 
-def _get_session(auth_required: bool = True) -> requests.Session:
+def _get_session(
+    auth_required: bool = True, retry_allowed_methods: Any = Retry.DEFAULT_ALLOWED_METHODS
+) -> requests.Session:
     """Create a Pyxis http session with auth based on env variables.
 
     Auth is optional and can be set to use either API key or certificate + key.
 
     Args:
         auth_required (bool): Whether authentication should be required for the session
+        retry_allowed_methods: HTTP methods to retry on. Defaults to
+            Retry.DEFAULT_ALLOWED_METHODS (excludes POST). Pass None to retry all.
 
     Raises:
         Exception: Exception is raised when auth ENV variables are missing.
 
-    :return: Pyxis session
     """
     cert_string = "PYXIS_CERT_PATH"
     key_string = "PYXIS_KEY_PATH"
@@ -31,7 +38,7 @@ def _get_session(auth_required: bool = True) -> requests.Session:
     key = os.environ.get(key_string)
 
     session = requests.Session()
-    add_session_retries(session)
+    add_session_retries(session, allowed_methods=retry_allowed_methods)
 
     if not auth_required:
         LOGGER.debug("Pyxis session without authentication is created")
@@ -55,13 +62,14 @@ def _get_session(auth_required: bool = True) -> requests.Session:
 
 
 def post(url: str, body: Dict[str, Any]) -> requests.Response:
-    """POST pyxis API request to given URL with given payload
+    """POST pyxis API request to given URL with given payload.
 
     Args:
         url (str): Pyxis API URL
         body (Dict[str, Any]): Request payload
 
     :return: Pyxis response
+
     """
     global session
     if session is None:
@@ -83,13 +91,14 @@ def post(url: str, body: Dict[str, Any]) -> requests.Response:
 
 
 def patch(url: str, body: Dict[str, Any]) -> requests.Response:
-    """PATCH pyxis API request to given URL with given payload
+    """PATCH pyxis API request to given URL with given payload.
 
     Args:
         url (str): Pyxis API URL
         body (Dict[str, Any]): Request payload
 
     :return: Pyxis response
+
     """
     global session
     if session is None:
@@ -113,7 +122,7 @@ def patch(url: str, body: Dict[str, Any]) -> requests.Response:
 def graphql_query(
     graphql_api: str, body: Dict[str, Any], allow_not_found: bool = False
 ) -> Dict[str, Any]:
-    """Make a request to Pyxis GraphQL API
+    """Make a request to Pyxis GraphQL API.
 
     This will make a POST request and then check the result
     for errors and return the data json if no errors found.
@@ -125,6 +134,7 @@ def graphql_query(
             data is returned as-is (with None values). Defaults to False.
 
     :return: Pyxis response
+
     """
     resp = post(graphql_api, body)
     resp_json = resp.json()
@@ -152,13 +162,14 @@ def graphql_query(
 
 
 def put(url: str, body: Dict[str, Any]) -> Dict[str, Any]:
-    """PUT pyxis API request to given URL with given payload
+    """PUT pyxis API request to given URL with given payload.
 
     Args:
         url (str): Pyxis API URL
         body (Dict[str, Any]): Request payload
 
     :return: Pyxis response
+
     """
     global session
     if session is None:
@@ -178,7 +189,7 @@ def put(url: str, body: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def get(url: str, params: Optional[Dict[str, str]] = None, auth_required: bool = True) -> Any:
-    """Pyxis GET request
+    """Pyxis GET request.
 
     Args:
         url (str): Pyxis URL
@@ -186,6 +197,7 @@ def get(url: str, params: Optional[Dict[str, str]] = None, auth_required: bool =
         auth_required (bool): Whether authentication should be required for the session
 
     :return: Pyxis GET request response
+
     """
     global session
     if session is None:
@@ -205,10 +217,11 @@ def add_session_retries(
     total: int = 10,
     backoff_factor: float = 1.0,
     status_forcelist: Optional[Tuple[int, ...]] = (408, 500, 502, 503, 504),
+    allowed_methods: Any = Retry.DEFAULT_ALLOWED_METHODS,
 ) -> None:
-    """Adds retries to a requests HTTP/HTTPS session.
-    The default values provide exponential backoff for a max wait of ~8.5 mins
+    """Add retries to a requests HTTP/HTTPS session.
 
+    The default values provide exponential backoff for a max wait of ~8.5 mins.
     Reference the urllib3 documentation for more details about the kwargs.
 
     Args:
@@ -216,11 +229,15 @@ def add_session_retries(
         total (int): See urllib3 docs
         backoff_factor (int): See urllib3 docs
         status_forcelist (tuple[int]|None): See urllib3 docs
+        allowed_methods: See urllib3 docs. Defaults to Retry.DEFAULT_ALLOWED_METHODS
+            (excludes POST). Pass None to retry all HTTP methods.
+
     """
     retries = Retry(
         total=total,
         backoff_factor=backoff_factor,
         status_forcelist=status_forcelist,
+        allowed_methods=allowed_methods,
         # Don't raise a MaxRetryError for codes in status_forcelist.
         # This allows for more graceful exception handling using
         # Response.raise_for_status.
@@ -233,10 +250,13 @@ def add_session_retries(
 
 def setup_logger(level: int = logging.INFO, log_format: Any = None):
     """Set up and configure 'pyxis' logger.
+
     Args:
         level (str, optional): Logging level. Defaults to logging.INFO.
         log_format (Any, optional): Logging message format. Defaults to None.
+
     :return: Logger object
+
     """
     if log_format is None:
         log_format = "%(asctime)s [%(name)s] %(levelname)s %(message)s"

--- a/pyxis/test_pyxis.py
+++ b/pyxis/test_pyxis.py
@@ -1,3 +1,7 @@
+"""Unit tests for pyxis API client."""
+
+from __future__ import annotations
+
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -15,6 +19,7 @@ QUERY = "myquery"
 
 @patch("os.path.exists")
 def test_get_session_cert(mock_path_exists: MagicMock, monkeypatch: Any) -> None:
+    """Return a session with cert and key when valid paths are provided."""
     mock_path_exists.return_value = True
     monkeypatch.setenv("PYXIS_CERT_PATH", "/path/to/cert.pem")
     monkeypatch.setenv("PYXIS_KEY_PATH", "/path/to/key.key")
@@ -26,6 +31,7 @@ def test_get_session_cert(mock_path_exists: MagicMock, monkeypatch: Any) -> None
 
 @patch("os.path.exists")
 def test_get_session_cert_not_exist(mock_path_exists: MagicMock, monkeypatch: Any) -> None:
+    """Raise an exception when the cert or key path does not exist."""
     mock_path_exists.return_value = False
     monkeypatch.setenv("PYXIS_CERT_PATH", "/path/to/cert.pem")
     monkeypatch.setenv("PYXIS_KEY_PATH", "/path/to/key.key")
@@ -35,14 +41,26 @@ def test_get_session_cert_not_exist(mock_path_exists: MagicMock, monkeypatch: An
 
 
 def test_get_session_no_auth(monkeypatch: Any) -> None:
+    """Return a session without auth when auth_required is False."""
     session = pyxis._get_session(auth_required=False)
 
     assert session.cert is None
 
 
+@patch("pyxis.add_session_retries")
+def test_get_session_retry_allowed_methods(mock_add_retries: MagicMock) -> None:
+    """Forward retry_allowed_methods to add_session_retries as allowed_methods."""
+    pyxis._get_session(auth_required=False, retry_allowed_methods=None)
+
+    mock_add_retries.assert_called_once()
+    _, kwargs = mock_add_retries.call_args
+    assert kwargs["allowed_methods"] is None
+
+
 @patch("pyxis.session", None)
 @patch("pyxis._get_session")
 def test_post(mock_get_session: MagicMock) -> None:
+    """Return the response from the session POST call."""
     resp = pyxis.post(API_URL, {})
 
     assert resp == mock_get_session.return_value.post.return_value
@@ -52,6 +70,7 @@ def test_post(mock_get_session: MagicMock) -> None:
 @patch("pyxis.session")
 @patch("pyxis._get_session")
 def test_post_existing_session(mock_get_session, mock_session: MagicMock) -> None:
+    """Use the existing session without creating a new one."""
     resp = pyxis.post(API_URL, {})
 
     assert resp == mock_session.post.return_value
@@ -61,6 +80,7 @@ def test_post_existing_session(mock_get_session, mock_session: MagicMock) -> Non
 @patch("pyxis.session", None)
 @patch("pyxis._get_session")
 def test_post_error(mock_get_session: MagicMock) -> None:
+    """Raise HTTPError when the POST response has an error status."""
     response = Response()
     response.status_code = 400
     mock_get_session.return_value.post.return_value.raise_for_status.side_effect = HTTPError(
@@ -74,6 +94,7 @@ def test_post_error(mock_get_session: MagicMock) -> None:
 @patch("pyxis.session", None)
 @patch("pyxis._get_session")
 def test_patch(mock_get_session: MagicMock) -> None:
+    """Return the response from the session PATCH call."""
     resp = pyxis.patch(API_URL, {})
 
     assert resp == mock_get_session.return_value.patch.return_value
@@ -83,6 +104,7 @@ def test_patch(mock_get_session: MagicMock) -> None:
 @patch("pyxis.session")
 @patch("pyxis._get_session")
 def test_patch_existing_session(mock_get_session, mock_session: MagicMock) -> None:
+    """Use the existing session without creating a new one."""
     resp = pyxis.patch(API_URL, {})
 
     assert resp == mock_session.patch.return_value
@@ -92,6 +114,7 @@ def test_patch_existing_session(mock_get_session, mock_session: MagicMock) -> No
 @patch("pyxis.session", None)
 @patch("pyxis._get_session")
 def test_patch_error(mock_get_session: MagicMock) -> None:
+    """Raise HTTPError when the PATCH response has an error status."""
     response = Response()
     response.status_code = 400
     mock_get_session.return_value.patch.return_value.raise_for_status.side_effect = HTTPError(
@@ -104,6 +127,7 @@ def test_patch_error(mock_get_session: MagicMock) -> None:
 
 @patch("pyxis.post")
 def test_graphql_query__success(mock_post: MagicMock):
+    """Return query data when the GraphQL response contains no errors."""
     mock_data = {
         "output": "something",
     }
@@ -124,8 +148,11 @@ def test_graphql_query__success(mock_post: MagicMock):
 
 @patch("pyxis.post")
 def test_graphql_query__general_graphql_error(mock_post: MagicMock):
-    """For example, if there is a syntax error in the query,
-    the response won't even include the query property"""
+    """Raise RuntimeError when the response has a top-level errors field.
+
+    For example, if there is a syntax error in the query,
+    the response won't even include the query property.
+    """
     mock_post.return_value.json.return_value = {
         "data": None,
         "errors": [{"message": "Major failure"}],
@@ -139,8 +166,11 @@ def test_graphql_query__general_graphql_error(mock_post: MagicMock):
 
 @patch("pyxis.post")
 def test_graphql_query__pyxis_error(mock_post: MagicMock):
-    """For example, if the image id does not exist in Pyxis
-    there will be an error property under the query property"""
+    """Raise RuntimeError when the response contains a Pyxis-level error.
+
+    For example, if the image id does not exist in Pyxis
+    there will be an error property under the query property.
+    """
     mock_post.return_value.json.return_value = {
         "data": {
             QUERY: {
@@ -158,8 +188,11 @@ def test_graphql_query__pyxis_error(mock_post: MagicMock):
 
 @patch("pyxis.post")
 def test_graphql_query__allow_not_found_with_404(mock_post: MagicMock):
-    """When allow_not_found=True and the error is a 404,
-    the function should return the data without raising"""
+    """Return data without raising when allow_not_found=True and error is 404.
+
+    When allow_not_found=True and the error is a 404,
+    the function should return the data without raising.
+    """
     mock_post.return_value.json.return_value = {
         "data": {
             QUERY: {
@@ -178,8 +211,11 @@ def test_graphql_query__allow_not_found_with_404(mock_post: MagicMock):
 
 @patch("pyxis.post")
 def test_graphql_query__allow_not_found_with_other_error(mock_post: MagicMock):
-    """When allow_not_found=True but the error is not a 404,
-    the function should still raise"""
+    """Raise RuntimeError when allow_not_found=True but the error is not a 404.
+
+    When allow_not_found=True but the error is not a 404,
+    the function should still raise.
+    """
     mock_post.return_value.json.return_value = {
         "data": {
             QUERY: {
@@ -198,6 +234,7 @@ def test_graphql_query__allow_not_found_with_other_error(mock_post: MagicMock):
 @patch("pyxis.session", None)
 @patch("pyxis._get_session")
 def test_put(mock_get_session: MagicMock) -> None:
+    """Return the JSON body from the session PUT call."""
     mock_get_session.return_value.put.return_value.json.return_value = {"key": "val"}
 
     resp = pyxis.put(API_URL, {})
@@ -209,6 +246,7 @@ def test_put(mock_get_session: MagicMock) -> None:
 @patch("pyxis.session")
 @patch("pyxis._get_session")
 def test_put_existing_session(mock_get_session, mock_session: MagicMock) -> None:
+    """Use the existing session without creating a new one."""
     mock_session.put.return_value.json.return_value = {"key": "val"}
 
     resp = pyxis.put(API_URL, {})
@@ -220,6 +258,7 @@ def test_put_existing_session(mock_get_session, mock_session: MagicMock) -> None
 @patch("pyxis.session", None)
 @patch("pyxis._get_session")
 def test_put_error(mock_get_session: MagicMock) -> None:
+    """Raise HTTPError when the PUT response has an error status."""
     response = Response()
     response.status_code = 400
     mock_get_session.return_value.put.return_value.raise_for_status.side_effect = HTTPError(
@@ -233,6 +272,7 @@ def test_put_error(mock_get_session: MagicMock) -> None:
 @patch("pyxis.session", None)
 @patch("pyxis._get_session")
 def test_get(mock_get_session: MagicMock) -> None:
+    """Return the response from the session GET call."""
     mock_get_session.return_value.get.return_value = {"key": "val"}
 
     resp = pyxis.get(API_URL)
@@ -244,6 +284,7 @@ def test_get(mock_get_session: MagicMock) -> None:
 @patch("pyxis.session")
 @patch("pyxis._get_session")
 def test_get_existing_session(mock_get_session, mock_session: MagicMock) -> None:
+    """Use the existing session without creating a new one."""
     mock_session.get.return_value = {"key": "val"}
 
     resp = pyxis.get(API_URL)
@@ -253,6 +294,7 @@ def test_get_existing_session(mock_get_session, mock_session: MagicMock) -> None
 
 
 def test_add_session_retries() -> None:
+    """Configure retry settings on both http:// and https:// adapters."""
     status_forcelist = (404, 503)
     total = 3
     backoff_factor = 0.5
@@ -271,3 +313,13 @@ def test_add_session_retries() -> None:
     assert session.adapters["https://"].max_retries.total == total
     assert session.adapters["https://"].max_retries.backoff_factor == backoff_factor
     assert session.adapters["https://"].max_retries.status_forcelist == status_forcelist
+
+
+def test_add_session_retries_custom_allowed_methods() -> None:
+    """Set allowed_methods to None on adapters when None is passed."""
+    session = Session()
+
+    pyxis.add_session_retries(session, allowed_methods=None)
+
+    assert session.adapters["http://"].max_retries.allowed_methods is None
+    assert session.adapters["https://"].max_retries.allowed_methods is None

--- a/scripts/python/tasks/managed/rh_direct_sign_image.py
+++ b/scripts/python/tasks/managed/rh_direct_sign_image.py
@@ -9,16 +9,18 @@ import json
 import logging
 import re
 import tempfile
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import pyxis
 from kubectl import get_configmap
 from logger import logger as LOGGER
 from oras_utils import oras_resolve
 from subprocess_cmd import run_cmd
+
+import pyxis
 
 PYXIS_INSTANCE_MAP = {
     "production": "https://graphql-pyxis.api.redhat.com/graphql/",
@@ -714,14 +716,16 @@ def submit_batch(batch_file: Path, config: SubmitConfig) -> None:
     ]
 
     LOGGER.debug("Submitting batch with command: %s", " ".join(cmd))
+    start = time.monotonic()
     result = run_cmd(
         cmd,
         check=False,
     )
+    duration = time.monotonic() - start
     if result.returncode != 0:
         LOGGER.error("Failed to submit batch '%s': %s", batch_file, result.stderr.strip())
         raise RuntimeError(f"Failed to submit batch '{batch_file}': {result.stderr.strip()}")
-    LOGGER.info("Submitted batch '%s' successfully", batch_file)
+    LOGGER.info("Batch '%s' completed successfully in %.1fs", batch_file, duration)
 
 
 def submit_batches(batch_dir: Path, config: SubmitConfig) -> None:
@@ -769,6 +773,9 @@ def main() -> int:
         LOGGER.setLevel(logging.DEBUG if args.verbose else logging.INFO)
         pyxis_url = PYXIS_INSTANCE_MAP[args.pyxis_server]
         LOGGER.info("Using Pyxis instance URL: %s", pyxis_url)
+        # Retry all HTTP methods including POST — needed for GraphQL queries.
+        # Default retry excludes POST, which misses 503s from the GraphQL endpoint.
+        pyxis.session = pyxis._get_session(retry_allowed_methods=None)
         sign_registry_access_repos = set(
             args.sign_registry_access_file.read_text().splitlines()
         )

--- a/scripts/python/tasks/managed/test_rh_direct_sign_image.py
+++ b/scripts/python/tasks/managed/test_rh_direct_sign_image.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -698,6 +700,7 @@ def test_main_collects_candidates_and_writes_batches(tmp_path) -> None:
         "registry.redhat.io/myproduct/myrepo:v1.0", "sha256:abc", "myproduct/myrepo", "key-a"
     )
     with (
+        patch("rh_direct_sign_image.pyxis._get_session"),
         patch(
             "rh_direct_sign_image.get_configmap",
             return_value={"data": {"SIG_KEY_NAME": "key-a"}},
@@ -759,6 +762,7 @@ def test_main_returns_zero_on_success(tmp_path) -> None:
     data_path.write_text(json.dumps(data_file))
 
     with (
+        patch("rh_direct_sign_image.pyxis._get_session"),
         patch(
             "rh_direct_sign_image.get_configmap",
             return_value={"data": {"SIG_KEY_NAME": "key-a"}},
@@ -798,6 +802,7 @@ def test_main_returns_one_on_unexpected_error(tmp_path) -> None:
     data_path.write_text(json.dumps({}))
 
     with (
+        patch("rh_direct_sign_image.pyxis._get_session"),
         patch(
             "rh_direct_sign_image.get_configmap",
             side_effect=RuntimeError("something went wrong"),
@@ -954,6 +959,34 @@ def test_submit_batch_includes_intention_label(tmp_path) -> None:
     assert any("internal-services.appstudio.openshift.io/intention=release" in a for a in cmd)
 
 
+def test_submit_batch_logs_completed_with_duration(tmp_path, caplog) -> None:
+    """submit_batch logs completion with elapsed time after the request finishes."""
+    cfg = get_submit_config(_FULL_CONFIGMAP, _make_submit_args(), {})
+    batch_file = tmp_path / "batch_0000.txt"
+    batch_file.write_text("base64content==")
+
+    with patch("rh_direct_sign_image.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        with caplog.at_level(logging.INFO, logger="release"):
+            submit_batch(batch_file, cfg)
+
+    assert any(
+        re.search(r"completed successfully in \d+\.\d+s", r.message) for r in caplog.records
+    )
+
+
+def test_submit_batch_raises_on_nonzero_returncode(tmp_path) -> None:
+    """submit_batch raises RuntimeError when internal-request exits non-zero."""
+    cfg = get_submit_config(_FULL_CONFIGMAP, _make_submit_args(), {})
+    batch_file = tmp_path / "batch_0000.txt"
+    batch_file.write_text("base64content==")
+
+    with patch("rh_direct_sign_image.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stderr="something broke")
+        with pytest.raises(RuntimeError, match="Failed to submit batch"):
+            submit_batch(batch_file, cfg)
+
+
 # --- submit_batches ---
 
 
@@ -1099,6 +1132,7 @@ def test_main_submits_batches_when_flag_set(tmp_path) -> None:
     output_dir = tmp_path / "batches"
 
     with (
+        patch("rh_direct_sign_image.pyxis._get_session"),
         patch(
             "rh_direct_sign_image.get_configmap",
             return_value=_FULL_CONFIGMAP,
@@ -1158,6 +1192,7 @@ def test_main_uses_temp_dir_when_output_not_specified(tmp_path) -> None:
     data_path.write_text(json.dumps(data_file))
 
     with (
+        patch("rh_direct_sign_image.pyxis._get_session"),
         patch(
             "rh_direct_sign_image.get_configmap",
             return_value=_FULL_CONFIGMAP,
@@ -1215,6 +1250,7 @@ def test_main_always_writes_batches(tmp_path) -> None:
     data_path.write_text(json.dumps(data_file))
 
     with (
+        patch("rh_direct_sign_image.pyxis._get_session"),
         patch(
             "rh_direct_sign_image.get_configmap",
             return_value={"data": {"SIG_KEY_NAME": "key-a"}},


### PR DESCRIPTION
- Add allowed_methods param to add_session_retries() and _get_session() so callers can opt in to retrying POST requests (default keeps existing GET-only behaviour via Retry.DEFAULT_ALLOWED_METHODS)
- Override the global pyxis session in rh_direct_sign_image main() with allowed_methods=None so 503s from the GraphQL endpoint are retried
- Change "Submitted batch" log to "Batch completed" with elapsed seconds to reflect that internal-request runs in sync mode and the request is done when run_cmd returns
- Add tests for the completed log message and the failure branch of submit_batch

Assisted-by: Claude Sonnet 4.6