### PR TITLE
feat(RELEASE-2487): convert create-pyxis-image task logic to Python

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -44,6 +44,7 @@ so these images are available from both registries
 """
 
 import argparse
+from dataclasses import dataclass
 from urllib.parse import quote
 from datetime import datetime
 import json
@@ -60,6 +61,31 @@ MANIFEST_LIST_TYPES = [
     "application/vnd.oci.image.index.v1+json",
     "application/vnd.docker.distribution.manifest.list.v2+json",
 ]
+
+
+@dataclass(frozen=True)
+class ContainerImageArgs:
+    """Typed argument bundle for create_or_update and its helpers.
+
+    All fields mirror the CLI flags accepted by ``setup_argparser``.
+    The class is frozen so it can be safely shared across threads.
+    """
+
+    pyxis_url: str
+    certified: str
+    tags: str
+    is_latest: str
+    oras_manifest_fetch: str
+    name: str
+    media_type: str
+    digest: str
+    architecture_digest: str
+    architecture: str
+    rh_push: str = "false"
+    append_tags: str = "false"
+    dockerfile: str = ""
+    metadata: str = ""
+    verbose: bool = False
 
 
 def setup_argparser() -> Any:  # pragma: no cover
@@ -323,8 +349,11 @@ def repository_digest_values(args):
     return result
 
 
-def create_container_image(args, parsed_data: Dict[str, Any], tags: List[str]):
-    """Create a new containerImage entry in a pyxis instance."""
+def create_container_image(args, parsed_data: Dict[str, Any], tags: List[str]) -> str:
+    """Create a new containerImage entry in a pyxis instance.
+
+    :return: The ``_id`` of the newly created ContainerImage.
+    """
     LOGGER.info("Creating new container image")
 
     constructed_tags = construct_tags(tags)
@@ -361,6 +390,7 @@ def create_container_image(args, parsed_data: Dict[str, Any], tags: List[str]):
     # Make sure container metadata was successfully added to Pyxis
     if "_id" in rsp:
         emit_id(rsp["_id"])
+        return rsp["_id"]
     else:
         raise Exception("Image metadata was not successfully added to Pyxis.")
 
@@ -440,13 +470,11 @@ def construct_repository(args, tag_dicts):
     return repo
 
 
-def main():  # pragma: no cover
-    """Execute main function."""
-    parser = setup_argparser()
-    args = parser.parse_args()
-    log_level = logging.DEBUG if args.verbose else logging.INFO
-    pyxis.setup_logger(level=log_level)
+def create_or_update(args) -> str:
+    """Find, create, or update a container image in Pyxis.
 
+    :return: The ``_id`` of the container image.
+    """
     parsed_data = prepare_parsed_data(args)
 
     if args.rh_push == "true":
@@ -458,16 +486,13 @@ def main():  # pragma: no cover
     if args.is_latest == "true":
         tags.append("latest")
 
-    # First check if it exists at all. If not, create it
     LOGGER.info(f"Checking to see if digest {args.architecture_digest} exists in pyxis")
     image = find_image(args.pyxis_url, args.architecture_digest)
     if image is None:
         LOGGER.info("Image with given docker_image_digest doesn't exist yet.")
-        create_container_image(args, parsed_data, tags)
-        return
+        return str(create_container_image(args, parsed_data, tags))
 
-    identifier = image["_id"]
-    # Then, check if it already references the given repository. If not, add the repo
+    identifier = str(image["_id"])
     repo_index = find_repo_in_image(image_repo, image)
     repositories = image["repositories"]
     if repo_index is None:
@@ -478,9 +503,8 @@ def main():  # pragma: no cover
         constructed_tags = construct_tags(tags)
         repositories.append(construct_repository(args, constructed_tags))
         update_container_image_repositories(args.pyxis_url, identifier, repositories)
-        return
+        return identifier
 
-    # Then, check if the tags are different. If they are, update them
     existing_tags = [tag["name"] for tag in repositories[repo_index].get("tags", [])]
     if existing_tags != tags:
         LOGGER.info(
@@ -495,14 +519,24 @@ def main():  # pragma: no cover
             constructed_tags = construct_tags(tags)
         repositories[repo_index] = construct_repository(args, constructed_tags)
         update_container_image_repositories(args.pyxis_url, identifier, repositories)
-        return
+        return identifier
 
     LOGGER.info(
         f"Image with given docker_image_digest already exists as {identifier} "
         f"and is associated with repository {args.name} and tags {args.tags}. "
         "Skipping the image creation."
     )
+    return identifier
+
+
+def main():  # pragma: no cover
+    """Execute main function."""
+    parser = setup_argparser()
+    args = parser.parse_args()
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    pyxis.setup_logger(level=log_level)
+    create_or_update(args)
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main()
+    raise SystemExit(main())

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -16,6 +16,7 @@ from create_container_image import (
     create_container_image,
     update_container_image_repositories,
     construct_repository,
+    create_or_update,
     _rh_push_registry,
     main,
 )
@@ -836,6 +837,143 @@ def test_construct_tags__append_mode_empty_existing(mock_datetime):
     ]
 
 
+@patch("create_container_image.create_container_image")
+@patch("create_container_image.find_image")
+@patch("create_container_image.prepare_parsed_data")
+def test_create_or_update__new_image(mock_prepare, mock_find, mock_create) -> None:
+    """Test create_or_update creates a new image when none exists."""
+    mock_prepare.return_value = {"architecture": "amd64"}
+    mock_find.return_value = None
+    mock_create.return_value = "new123"
+
+    args = MagicMock()
+    args.rh_push = "false"
+    args.name = "quay.io/org/img"
+    args.tags = "v1.0"
+    args.is_latest = "false"
+    args.architecture_digest = "sha256:abc"
+    args.pyxis_url = PYXIS_URL
+    args.append_tags = "false"
+
+    result = create_or_update(args)
+
+    assert result == "new123"
+    mock_create.assert_called_once()
+
+
+@patch("create_container_image.create_container_image")
+@patch("create_container_image.find_image")
+@patch("create_container_image.prepare_parsed_data")
+def test_create_or_update__is_latest_appends_tag(mock_prepare, mock_find, mock_create) -> None:
+    """Test create_or_update appends 'latest' tag when is_latest is true."""
+    mock_prepare.return_value = {"architecture": "amd64"}
+    mock_find.return_value = None
+    mock_create.return_value = "lat123"
+
+    args = MagicMock()
+    args.rh_push = "false"
+    args.name = "quay.io/org/img"
+    args.tags = "v1.0"
+    args.is_latest = "true"
+    args.architecture_digest = "sha256:abc"
+    args.pyxis_url = PYXIS_URL
+    args.append_tags = "false"
+
+    result = create_or_update(args)
+
+    assert result == "lat123"
+    tags_arg = mock_create.call_args.args[2]
+    assert "latest" in tags_arg
+
+
+@patch("create_container_image.update_container_image_repositories")
+@patch("create_container_image.construct_repository")
+@patch("create_container_image.construct_tags")
+@patch("create_container_image.find_repo_in_image")
+@patch("create_container_image.find_image")
+@patch("create_container_image.prepare_parsed_data")
+def test_create_or_update__adds_repo(
+    mock_prepare, mock_find, mock_find_repo, mock_ctags, mock_crepo, mock_update
+) -> None:
+    """Test create_or_update adds repo to existing image."""
+    mock_prepare.return_value = {"architecture": "amd64"}
+    mock_find.return_value = {"_id": "exist123", "repositories": []}
+    mock_find_repo.return_value = None
+    mock_ctags.return_value = [{"name": "v1.0"}]
+    mock_crepo.return_value = {"repository": "org/img"}
+
+    args = MagicMock()
+    args.rh_push = "false"
+    args.name = "quay.io/org/img"
+    args.tags = "v1.0"
+    args.is_latest = "false"
+    args.architecture_digest = "sha256:abc"
+    args.pyxis_url = PYXIS_URL
+    args.append_tags = "false"
+
+    result = create_or_update(args)
+
+    assert result == "exist123"
+    mock_update.assert_called_once()
+
+
+@patch("create_container_image.find_repo_in_image")
+@patch("create_container_image.find_image")
+@patch("create_container_image.prepare_parsed_data")
+def test_create_or_update__skips_matching(mock_prepare, mock_find, mock_find_repo) -> None:
+    """Test create_or_update skips when image and tags match."""
+    mock_prepare.return_value = {"architecture": "amd64"}
+    mock_find.return_value = {
+        "_id": "exist123",
+        "repositories": [{"repository": "org/img", "tags": [{"name": "v1.0"}]}],
+    }
+    mock_find_repo.return_value = 0
+
+    args = MagicMock()
+    args.rh_push = "false"
+    args.name = "quay.io/org/img"
+    args.tags = "v1.0"
+    args.is_latest = "false"
+    args.architecture_digest = "sha256:abc"
+    args.pyxis_url = PYXIS_URL
+    args.append_tags = "false"
+
+    result = create_or_update(args)
+
+    assert result == "exist123"
+
+
+@patch("create_container_image.find_repo_in_image")
+@patch("create_container_image.find_image")
+@patch("create_container_image.prepare_parsed_data")
+def test_create_or_update__rh_push_uses_proxymap(
+    mock_prepare, mock_find, mock_find_repo
+) -> None:
+    """Test create_or_update uses proxymap for rh_push repo derivation."""
+    mock_prepare.return_value = {"architecture": "amd64"}
+    mock_find.return_value = {
+        "_id": "exist123",
+        "repositories": [
+            {"repository": "product/image", "tags": [{"name": "v1.0"}]},
+        ],
+    }
+    mock_find_repo.return_value = 0
+
+    args = MagicMock()
+    args.rh_push = "true"
+    args.name = "quay.io/redhat-prod/product----image"
+    args.tags = "v1.0"
+    args.is_latest = "false"
+    args.architecture_digest = "sha256:abc"
+    args.pyxis_url = PYXIS_URL
+    args.append_tags = "false"
+
+    result = create_or_update(args)
+
+    assert result == "exist123"
+    mock_find_repo.assert_called_once_with("product/image", mock_find.return_value)
+
+
 @patch("create_container_image.update_container_image_repositories")
 @patch("create_container_image.find_image")
 @patch("create_container_image.prepare_parsed_data")
@@ -847,7 +985,7 @@ def test_main__append_tags_false_replaces_tags(
     mock_prepare_parsed_data,
     mock_find_image,
     mock_update,
-):
+) -> None:
     """Test that without --append-tags, tags are replaced (existing behavior)."""
     mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
     mock_prepare_parsed_data.return_value = {"architecture": "amd64"}
@@ -919,7 +1057,7 @@ def test_main__append_tags_true_preserves_tags(
     mock_prepare_parsed_data,
     mock_find_image,
     mock_update,
-):
+) -> None:
     """Test that with --append-tags true, existing tags are preserved."""
     mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
     mock_prepare_parsed_data.return_value = {"architecture": "amd64"}
@@ -1002,7 +1140,7 @@ def test_main__append_tags_true_updates_reapplied_tag_date(
     mock_prepare_parsed_data,
     mock_find_image,
     mock_update,
-):
+) -> None:
     """Test that with --append-tags true, re-applied tags get updated dates."""
     mock_datetime.now = MagicMock(return_value=datetime(2026, 5, 21, 12, 0, 0))
     mock_prepare_parsed_data.return_value = {"architecture": "amd64"}

--- a/scripts/python/helpers/image_ref.py
+++ b/scripts/python/helpers/image_ref.py
@@ -13,6 +13,21 @@ _QUAY_SHA_TAG = re.compile(r"^[0-9a-f]{40}$")
 _MAX_QUAY_TAG_PAGES = 50
 
 
+def split_image_ref(image: str) -> tuple[str, str]:
+    """Split a container image reference into ``(repository, digest)``.
+
+    Expects the format ``repository@algo:hex`` (e.g.
+    ``quay.io/org/img@sha256:abc123``).  Returns ``(repository, digest)``
+    where *digest* includes the algorithm prefix (``sha256:abc123``).
+
+    Raises ``ValueError`` when the reference contains no ``@`` separator.
+    """
+    if "@" not in image:
+        raise ValueError(f"image reference missing digest separator '@': {image!r}")
+    repo, digest = image.split("@", 1)
+    return repo, digest
+
+
 def translate_delivery_repo(repo: str) -> list[dict[str, str]]:
     """Translate a Quay delivery-repo reference to public registry URLs.
 

--- a/scripts/python/helpers/memory_throttle.py
+++ b/scripts/python/helpers/memory_throttle.py
@@ -1,0 +1,150 @@
+"""Memory-aware job throttling, ported from ``utils/memory-throttle.sh``.
+
+Reads container memory usage from cgroups (v2, falling back to v1) so
+parallel task runners can pause spawning new work while memory is under
+pressure, reducing the frequency of OOMKills. Callers that cannot read
+cgroup memory info (e.g. outside a container) get a no-op: throttling
+relies solely on the caller's own concurrency limit in that case.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from logger import logger
+
+DEFAULT_THRESHOLD = 80
+DEFAULT_INTERVAL = 5.0
+
+_CGROUP_V2_CURRENT = Path("/sys/fs/cgroup/memory.current")
+_CGROUP_V2_MAX = Path("/sys/fs/cgroup/memory.max")
+_CGROUP_V1_CURRENT = Path("/sys/fs/cgroup/memory/memory.usage_in_bytes")
+_CGROUP_V1_MAX = Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+
+ReadMemory = Callable[[], tuple[int, int] | None]
+
+
+def _read_int(path: Path) -> int | None:
+    """Read an integer value from *path*, or None if missing/unreadable."""
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not text or text == "max":
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def read_cgroup_memory(
+    *,
+    v2_current: Path = _CGROUP_V2_CURRENT,
+    v2_max: Path = _CGROUP_V2_MAX,
+    v1_current: Path = _CGROUP_V1_CURRENT,
+    v1_max: Path = _CGROUP_V1_MAX,
+) -> tuple[int, int] | None:
+    """Return ``(current, max)`` memory bytes from cgroups v2 or v1.
+
+    Returns None when neither cgroup interface is readable, matching the
+    original bash helper's "memory monitoring unavailable" case.
+    """
+    current = _read_int(v2_current)
+    maximum = _read_int(v2_max)
+    if current is not None and maximum is not None and maximum > 0:
+        return current, maximum
+
+    current = _read_int(v1_current)
+    maximum = _read_int(v1_max)
+    if current is not None and maximum is not None and maximum > 0:
+        return current, maximum
+
+    return None
+
+
+def get_memory_usage_percent(*, read_memory: ReadMemory = read_cgroup_memory) -> int | None:
+    """Return current memory usage as an integer percentage, or None if unavailable."""
+    values = read_memory()
+    if values is None:
+        return None
+    current, maximum = values
+    return current * 100 // maximum
+
+
+def format_bytes(num_bytes: int) -> str:
+    """Format *num_bytes* as a human-readable Gi/Mi/Ki/B string."""
+    if num_bytes >= 1024**3:
+        return f"{num_bytes // 1024**3}Gi"
+    if num_bytes >= 1024**2:
+        return f"{num_bytes // 1024**2}Mi"
+    if num_bytes >= 1024:
+        return f"{num_bytes // 1024}Ki"
+    return f"{num_bytes}B"
+
+
+def get_memory_stats(*, read_memory: ReadMemory = read_cgroup_memory) -> str:
+    """Return ``"used/limit (XX%)"``, or ``"unavailable"`` when unreadable."""
+    values = read_memory()
+    if values is None:
+        return "unavailable"
+    current, maximum = values
+    usage = current * 100 // maximum
+    return f"{format_bytes(current)}/{format_bytes(maximum)} ({usage}%)"
+
+
+def log_memory_throttle_status(
+    threshold: int = DEFAULT_THRESHOLD,
+    *,
+    read_memory: ReadMemory = read_cgroup_memory,
+) -> None:
+    """Log whether memory-based throttling is available. Call once at task start."""
+    stats = get_memory_stats(read_memory=read_memory)
+    if stats == "unavailable":
+        logger.info(
+            "Memory throttle: cgroup memory info not available, using concurrent-limit only"
+        )
+    else:
+        logger.info(
+            "Memory throttle: enabled with %s%% threshold, current usage: %s", threshold, stats
+        )
+
+
+def wait_for_memory(
+    threshold: int = DEFAULT_THRESHOLD,
+    interval: float = DEFAULT_INTERVAL,
+    *,
+    read_memory: ReadMemory = read_cgroup_memory,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """Block the calling thread until memory usage is below *threshold* percent.
+
+    Returns immediately without blocking when cgroup memory info cannot be
+    read, so callers fall back to relying on their own concurrency limit.
+    """
+    usage = get_memory_usage_percent(read_memory=read_memory)
+    if usage is None:
+        return
+
+    waited = False
+    while usage is not None and usage >= threshold:
+        if not waited:
+            logger.info(
+                "Memory throttle: usage above %s%% threshold, pausing new job spawns...",
+                threshold,
+            )
+            waited = True
+        logger.info(
+            "  Memory: %s - waiting for running jobs to free memory...",
+            get_memory_stats(read_memory=read_memory),
+        )
+        sleep(interval)
+        usage = get_memory_usage_percent(read_memory=read_memory)
+
+    if waited:
+        logger.info(
+            "Memory throttle: usage now at %s, resuming...",
+            get_memory_stats(read_memory=read_memory),
+        )

--- a/scripts/python/helpers/oras_utils.py
+++ b/scripts/python/helpers/oras_utils.py
@@ -102,6 +102,53 @@ def oras_pull(
         auth_file.unlink(missing_ok=True)
 
 
+def oras_manifest_fetch(
+    pullspec: str,
+    auth_file: Path,
+    *,
+    platform: str | None = None,
+) -> str:
+    """Fetch an OCI manifest and return the raw JSON string.
+
+    Runs ``oras manifest fetch`` with the given auth config.  When
+    *platform* is provided (e.g. ``"linux/amd64"``), ``--platform`` is
+    passed to select a specific architecture from a manifest list.
+    """
+    cmd: list[str | Path] = [
+        "oras",
+        "manifest",
+        "fetch",
+        "--registry-config",
+        str(auth_file),
+    ]
+    if platform:
+        cmd += ["--platform", platform]
+    cmd.append(pullspec)
+    result = run_cmd(cmd, check=True)
+    return result.stdout
+
+
+def oras_blob_fetch(
+    pullspec: str,
+    output_path: Path,
+    auth_file: Path,
+) -> None:
+    """Download a single OCI blob to *output_path* using ``oras blob fetch``."""
+    run_cmd(
+        [
+            "oras",
+            "blob",
+            "fetch",
+            "--registry-config",
+            str(auth_file),
+            "--output",
+            str(output_path),
+            pullspec,
+        ],
+        check=True,
+    )
+
+
 def oras_push(tag: str, directory: Path, subdirectory: str, component_name: str) -> str:
     """Push *subdirectory* inside *directory* to an OCI registry via oras.
 

--- a/scripts/python/helpers/pyxis_api.py
+++ b/scripts/python/helpers/pyxis_api.py
@@ -30,6 +30,13 @@ PYXIS_BASE_URL_BY_SERVER: dict[str, str] = {
     "stage-internal": "https://pyxis.stage.engineering.redhat.com",
 }
 
+PYXIS_GRAPHQL_URL_BY_SERVER: dict[str, str] = {
+    "production": "https://graphql-pyxis.api.redhat.com/graphql/",
+    "stage": "https://graphql-pyxis.preprod.api.redhat.com/graphql/",
+    "production-internal": "https://graphql.pyxis.engineering.redhat.com/graphql/",
+    "stage-internal": "https://graphql.pyxis.stage.engineering.redhat.com/graphql/",
+}
+
 INVALID_SERVER_MESSAGE = (
     "Invalid server parameter. Only 'production','production-internal',"
     "'stage-internal' and 'stage' allowed."
@@ -42,6 +49,14 @@ def pyxis_api_url_for_server(server: str) -> str:
     if base is None:
         raise ValueError(INVALID_SERVER_MESSAGE)
     return f"{base.rstrip('/')}/v1"
+
+
+def pyxis_graphql_url_for_server(server: str) -> str:
+    """Return the Pyxis GraphQL API URL for a Tekton `server` param value."""
+    url = PYXIS_GRAPHQL_URL_BY_SERVER.get(server)
+    if url is None:
+        raise ValueError(INVALID_SERVER_MESSAGE)
+    return url
 
 
 def pyxis_registry_for_quay_url(repository_url: str) -> str:

--- a/scripts/python/helpers/skopeo.py
+++ b/scripts/python/helpers/skopeo.py
@@ -10,10 +10,13 @@ def inspect(
     *,
     config: bool = False,
     raw: bool = False,
+    no_tags: bool = False,
     retry_times: int = 3,
 ) -> subprocess.CompletedProcess[str]:
     """Run ``skopeo inspect`` on a container image reference."""
     cmd = ["skopeo", "inspect", "--retry-times", str(retry_times)]
+    if no_tags:
+        cmd.append("--no-tags")
     if config:
         cmd.append("--config")
     if raw:

--- a/scripts/python/helpers/test_image_ref.py
+++ b/scripts/python/helpers/test_image_ref.py
@@ -20,6 +20,19 @@ def _propagate_release_logger() -> None:
     release_logger.propagate = False
 
 
+def test_split_image_ref_valid() -> None:
+    """Standard digest reference is split into repo and digest."""
+    repo, digest = image_ref.split_image_ref("quay.io/org/img@sha256:abc123")
+    assert repo == "quay.io/org/img"
+    assert digest == "sha256:abc123"
+
+
+def test_split_image_ref_no_digest() -> None:
+    """Missing '@' separator raises ValueError."""
+    with pytest.raises(ValueError, match="missing digest separator"):
+        image_ref.split_image_ref("quay.io/org/img:latest")
+
+
 def test_pyxis_url_for_pull_spec_with_tag_and_registry_rewrite() -> None:
     """Tagged refs map to `.../tag/<tag>` and rewrite registry.redhat.io host."""
     out = image_ref.pyxis_url_for_pull_spec(

--- a/scripts/python/helpers/test_memory_throttle.py
+++ b/scripts/python/helpers/test_memory_throttle.py
@@ -1,0 +1,172 @@
+"""Tests for memory_throttle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import memory_throttle as mt
+import pytest
+
+
+def _write(path: Path, value: str) -> None:
+    path.write_text(value, encoding="utf-8")
+
+
+# --- read_cgroup_memory ---
+
+
+def test_read_cgroup_memory_v2(tmp_path: Path) -> None:
+    """Cgroups v2 files are preferred and parsed as (current, max)."""
+    v2_current = tmp_path / "memory.current"
+    v2_max = tmp_path / "memory.max"
+    _write(v2_current, "1000\n")
+    _write(v2_max, "4000\n")
+
+    result = mt.read_cgroup_memory(
+        v2_current=v2_current,
+        v2_max=v2_max,
+        v1_current=tmp_path / "missing-v1-current",
+        v1_max=tmp_path / "missing-v1-max",
+    )
+    assert result == (1000, 4000)
+
+
+def test_read_cgroup_memory_v2_unlimited_falls_back_to_v1(tmp_path: Path) -> None:
+    """A v2 max of 'max' (unlimited) is ignored in favor of v1 values."""
+    v2_current = tmp_path / "memory.current"
+    v2_max = tmp_path / "memory.max"
+    v1_current = tmp_path / "usage_in_bytes"
+    v1_max = tmp_path / "limit_in_bytes"
+    _write(v2_current, "1000")
+    _write(v2_max, "max")
+    _write(v1_current, "2000")
+    _write(v1_max, "8000")
+
+    result = mt.read_cgroup_memory(
+        v2_current=v2_current, v2_max=v2_max, v1_current=v1_current, v1_max=v1_max
+    )
+    assert result == (2000, 8000)
+
+
+def test_read_cgroup_memory_unavailable(tmp_path: Path) -> None:
+    """None is returned when no cgroup interface is readable."""
+    missing = tmp_path / "missing"
+    result = mt.read_cgroup_memory(
+        v2_current=missing, v2_max=missing, v1_current=missing, v1_max=missing
+    )
+    assert result is None
+
+
+def test_read_cgroup_memory_non_numeric_content(tmp_path: Path) -> None:
+    """Non-numeric file content (corrupt/unexpected) is treated as unreadable."""
+    v2_current = tmp_path / "memory.current"
+    v2_max = tmp_path / "memory.max"
+    missing = tmp_path / "missing"
+    _write(v2_current, "not-a-number")
+    _write(v2_max, "4000")
+
+    result = mt.read_cgroup_memory(
+        v2_current=v2_current, v2_max=v2_max, v1_current=missing, v1_max=missing
+    )
+    assert result is None
+
+
+# --- get_memory_usage_percent / format_bytes / get_memory_stats ---
+
+
+def test_get_memory_usage_percent() -> None:
+    """Usage percent is computed as an integer floor division."""
+    assert mt.get_memory_usage_percent(read_memory=lambda: (500, 1000)) == 50
+    assert mt.get_memory_usage_percent(read_memory=lambda: (333, 1000)) == 33
+
+
+def test_get_memory_usage_percent_unavailable() -> None:
+    """None is returned when the reader has no data."""
+    assert mt.get_memory_usage_percent(read_memory=lambda: None) is None
+
+
+@pytest.mark.parametrize(
+    ("num_bytes", "expected"),
+    [
+        (512, "512B"),
+        (2545, "2Ki"),
+        (5 * 1024 * 1024 + 777, "5Mi"),
+        (3 * 1024 * 1024 * 1024 + 123456, "3Gi"),
+    ],
+)
+def test_format_bytes(num_bytes: int, expected: str) -> None:
+    """Byte counts are formatted with the largest whole unit, truncated."""
+    assert mt.format_bytes(num_bytes) == expected
+
+
+def test_get_memory_stats() -> None:
+    """Stats string reports used/limit and the usage percentage."""
+    assert mt.get_memory_stats(
+        read_memory=lambda: (512 * 1024 * 1024, 1024 * 1024 * 1024)
+    ) == ("512Mi/1Gi (50%)")
+
+
+def test_get_memory_stats_unavailable() -> None:
+    """'unavailable' is reported when the reader has no data."""
+    assert mt.get_memory_stats(read_memory=lambda: None) == "unavailable"
+
+
+# --- log_memory_throttle_status ---
+
+
+def test_log_memory_throttle_status_available() -> None:
+    """No exception is raised when logging available memory stats."""
+    mt.log_memory_throttle_status(80, read_memory=lambda: (500, 1000))
+
+
+def test_log_memory_throttle_status_unavailable() -> None:
+    """No exception is raised when memory info is unavailable."""
+    mt.log_memory_throttle_status(80, read_memory=lambda: None)
+
+
+# --- wait_for_memory ---
+
+
+def test_wait_for_memory_returns_immediately_when_unavailable() -> None:
+    """No sleep occurs when cgroup memory info cannot be read."""
+    sleeps: list[float] = []
+    mt.wait_for_memory(read_memory=lambda: None, sleep=sleeps.append)
+    assert sleeps == []
+
+
+def test_wait_for_memory_returns_immediately_when_below_threshold() -> None:
+    """No sleep occurs when usage is already below the threshold."""
+    sleeps: list[float] = []
+    mt.wait_for_memory(80, read_memory=lambda: (100, 1000), sleep=sleeps.append)
+    assert sleeps == []
+
+
+def test_wait_for_memory_polls_until_below_threshold() -> None:
+    """Sleeps until a subsequent read reports usage below the threshold.
+
+    Each loop iteration reads memory twice (once for the logged stats, once
+    for the loop condition), so two full high-usage iterations require four
+    high readings before the usage drops on the fifth read.
+    """
+    calls = {"n": 0}
+
+    def reader() -> tuple[int, int]:
+        calls["n"] += 1
+        return (900, 1000) if calls["n"] <= 4 else (500, 1000)
+
+    sleeps: list[float] = []
+    mt.wait_for_memory(80, interval=1.5, read_memory=reader, sleep=sleeps.append)
+    assert sleeps == [1.5, 1.5]
+
+
+def test_wait_for_memory_stops_if_reader_loses_access_mid_wait() -> None:
+    """Polling stops if the reader starts returning None mid-wait."""
+    calls = {"n": 0}
+
+    def flaky_reader() -> tuple[int, int] | None:
+        calls["n"] += 1
+        return (900, 1000) if calls["n"] == 1 else None
+
+    sleeps: list[float] = []
+    mt.wait_for_memory(80, read_memory=flaky_reader, sleep=sleeps.append)
+    assert sleeps == [5.0]

--- a/scripts/python/helpers/test_oras_utils.py
+++ b/scripts/python/helpers/test_oras_utils.py
@@ -192,3 +192,45 @@ def test_oras_pull_raises_when_subprocess_fails(
         oras_utils.oras_pull("quay.io/org/image:tag", tmp_path)
 
     assert exc_info.value.returncode == 1
+
+
+def test_oras_manifest_fetch_returns_stdout(tmp_path: Path) -> None:
+    """oras_manifest_fetch returns the raw manifest JSON string."""
+    auth = tmp_path / "auth.json"
+    auth.write_text("{}")
+    with patch("oras_utils.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock(stdout='{"layers": []}')
+        result = oras_utils.oras_manifest_fetch("quay.io/org/img@sha256:abc", auth)
+    assert result == '{"layers": []}'
+    cmd = mock_run.call_args.args[0]
+    assert cmd[:3] == ["oras", "manifest", "fetch"]
+    assert "--registry-config" in cmd
+    assert "quay.io/org/img@sha256:abc" in cmd
+
+
+def test_oras_manifest_fetch_with_platform(tmp_path: Path) -> None:
+    """When platform is given, --platform is passed to oras."""
+    auth = tmp_path / "auth.json"
+    auth.write_text("{}")
+    with patch("oras_utils.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock(stdout="{}")
+        oras_utils.oras_manifest_fetch(
+            "quay.io/org/img@sha256:abc", auth, platform="linux/amd64"
+        )
+    cmd = mock_run.call_args.args[0]
+    idx = cmd.index("--platform")
+    assert cmd[idx + 1] == "linux/amd64"
+
+
+def test_oras_blob_fetch_runs_oras(tmp_path: Path) -> None:
+    """oras_blob_fetch runs the expected oras blob fetch command."""
+    auth = tmp_path / "auth.json"
+    auth.write_text("{}")
+    output = tmp_path / "blob.gz"
+    with patch("oras_utils.run_cmd") as mock_run:
+        mock_run.return_value = MagicMock()
+        oras_utils.oras_blob_fetch("quay.io/org/img@sha256:abc", output, auth)
+    cmd = mock_run.call_args.args[0]
+    assert cmd[:3] == ["oras", "blob", "fetch"]
+    assert str(output) in cmd
+    assert "quay.io/org/img@sha256:abc" in cmd

--- a/scripts/python/helpers/test_pyxis_api.py
+++ b/scripts/python/helpers/test_pyxis_api.py
@@ -23,6 +23,26 @@ def test_pyxis_api_url_for_invalid_server_raises() -> None:
         pyxis_api.pyxis_api_url_for_server("invalid")
 
 
+def test_pyxis_graphql_url_for_production_server() -> None:
+    """Map the production server param to the public Pyxis GraphQL URL."""
+    assert pyxis_api.pyxis_graphql_url_for_server("production") == (
+        "https://graphql-pyxis.api.redhat.com/graphql/"
+    )
+
+
+def test_pyxis_graphql_url_for_stage_server() -> None:
+    """Map the stage server param to the preprod Pyxis GraphQL URL."""
+    assert pyxis_api.pyxis_graphql_url_for_server("stage") == (
+        "https://graphql-pyxis.preprod.api.redhat.com/graphql/"
+    )
+
+
+def test_pyxis_graphql_url_for_invalid_server_raises() -> None:
+    """Reject unknown server param values for GraphQL."""
+    with pytest.raises(ValueError, match="Invalid server parameter"):
+        pyxis_api.pyxis_graphql_url_for_server("invalid")
+
+
 def test_pyxis_registry_for_flatpak_quay_url() -> None:
     """Flatpak Quay repos use the flatpaks Pyxis registry."""
     url = "quay.io/rh-flatpaks-stage/my-product----my-image1"

--- a/scripts/python/helpers/test_skopeo.py
+++ b/scripts/python/helpers/test_skopeo.py
@@ -108,6 +108,19 @@ def test_inspect_nonzero_exit_code() -> None:
     assert result.returncode == 1
 
 
+def test_inspect_no_tags_flag() -> None:
+    """``no_tags=True`` adds ``--no-tags`` to the command."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_completed(),
+    ) as run_mock:
+        skopeo.inspect("img:v1", raw=True, no_tags=True)
+
+    cmd = run_mock.call_args[0][0]
+    assert "--no-tags" in cmd
+    assert "--raw" in cmd
+
+
 def test_inspect_config_and_raw_together() -> None:
     """Both flags can be set simultaneously."""
     with mock.patch(

--- a/scripts/python/tasks/managed/create_pyxis_image.py
+++ b/scripts/python/tasks/managed/create_pyxis_image.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Push container image metadata to Pyxis for all images in a mapped snapshot.
+
+For each component in the snapshot, fetch the OCI manifest, optionally
+decompress gzip layers to record uncompressed sizes, create or update
+the Pyxis ContainerImage entry, and optionally clean up stale tags.
+
+Components sharing the same digest are processed serially within their
+group while independent digest groups run in parallel, preventing Pyxis
+race conditions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import file as file_helpers
+import memory_throttle
+import oras_utils
+import pyxis_api
+import skopeo
+from cleanup_tags import cleanup_tags_with_retry
+from create_container_image import (
+    ContainerImageArgs,
+    MANIFEST_LIST_TYPES,
+    create_or_update,
+    proxymap,
+)
+from file import load_json_dict
+from image_ref import split_image_ref
+from logger import logger
+
+_DECOMPRESS_CHUNK_SIZE = 65536
+HELM_CONFIG_MEDIA_TYPE = "application/vnd.cncf.helm.config.v1+json"
+
+
+def _get_image_architectures(image: str) -> list[dict[str, Any]]:
+    """Call ``get-image-architectures`` and return parsed per-platform entries."""
+    result = subprocess.run(
+        ["get-image-architectures", image],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [json.loads(line) for line in result.stdout.strip().splitlines() if line.strip()]
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    """Immutable configuration that stays constant for the entire run."""
+
+    pyxis_url: str
+    pyxis_graphql_url: str
+    certified: str
+    is_latest: str
+    rh_push: str
+    append_tags: str
+    include_layers: bool
+    process_helm_charts: bool
+    data_dir: Path
+    snapshot_dir: Path
+
+
+@dataclass(frozen=True)
+class ComponentContext:
+    """Per-component state threaded through repository/architecture processing."""
+
+    index: int
+    digest: str
+    auth_path: Path
+    dockerfile_path: Path | None
+    metadata_path: Path | None
+
+
+_GZIP_MEDIA_RE = re.compile(r"\.gzip$|\+gzip$")
+_FBC_INDEX_RE = re.compile(r"/(preview-operator-index|redhat-operator-index)$")
+
+
+def _write_auth_file(reference: str, auth_path: Path) -> None:
+    """Run ``select-oci-auth`` and write the result to *auth_path*."""
+    result = subprocess.run(
+        ["select-oci-auth", reference],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"select-oci-auth failed for {reference} "
+            f"(exit {result.returncode}): {result.stderr.strip()}"
+        )
+    auth_path.write_text(result.stdout, encoding="utf-8")
+
+
+def _try_pull_dockerfile(source_repo: str, digest: str) -> Path | None:
+    """Attempt to pull a Dockerfile artifact and return its path, or ``None``."""
+    dockerfile_dir = Path(tempfile.mkdtemp())
+    pull_spec = f"{source_repo}:{digest.replace(':', '-')}.dockerfile"
+    try:
+        oras_utils.oras_pull(pull_spec, dockerfile_dir)
+    except subprocess.CalledProcessError:
+        shutil.rmtree(dockerfile_dir, ignore_errors=True)
+        logger.info(
+            "Unable to get Dockerfile for the image. "
+            "Maybe it's not enabled in the build pipeline?"
+        )
+        return None
+    dockerfile_path = dockerfile_dir / "Dockerfile"
+    if not dockerfile_path.is_file():
+        shutil.rmtree(dockerfile_dir, ignore_errors=True)
+        raise RuntimeError("Dockerfile pull succeeded, but the Dockerfile was not saved.")
+    return dockerfile_path
+
+
+def _decompress_gzip_layer(
+    blob_digest: str,
+    repository: str,
+    auth_path: Path,
+    component_index: int,
+) -> dict[str, Any]:
+    """Download, decompress, and measure a single gzip layer.
+
+    Returns a dict with ``digest`` (sha256 of decompressed content) and ``size``
+    (byte count of the decompressed layer).
+    """
+    blob_pullspec = f"{repository}@{blob_digest}"
+    gz_path = file_helpers.make_tempfile_path(
+        f"oras-blob-fetch-{component_index}-",
+    )
+    try:
+        oras_utils.oras_blob_fetch(blob_pullspec, gz_path, auth_path)
+        with gzip.open(gz_path, "rb") as gz:
+            h = hashlib.sha256()
+            size = 0
+            while True:
+                chunk = gz.read(_DECOMPRESS_CHUNK_SIZE)
+                if not chunk:
+                    break
+                h.update(chunk)
+                size += len(chunk)
+        return {"digest": f"sha256:{h.hexdigest()}", "size": size}
+    finally:
+        gz_path.unlink(missing_ok=True)
+
+
+def _build_cci_args(
+    *,
+    config: RunConfig,
+    component: ComponentContext,
+    tags: str,
+    oras_manifest_fetch: str,
+    name: str,
+    media_type: str,
+    architecture_digest: str,
+    architecture: str,
+) -> ContainerImageArgs:
+    """Build a ``ContainerImageArgs`` for create_container_image functions."""
+    return ContainerImageArgs(
+        pyxis_url=config.pyxis_url,
+        certified=config.certified,
+        tags=tags,
+        is_latest=config.is_latest,
+        oras_manifest_fetch=oras_manifest_fetch,
+        name=name,
+        media_type=media_type,
+        digest=component.digest,
+        architecture_digest=architecture_digest,
+        architecture=architecture,
+        rh_push=config.rh_push,
+        append_tags=config.append_tags,
+        dockerfile=str(component.dockerfile_path) if component.dockerfile_path else "",
+        metadata=str(component.metadata_path) if component.metadata_path else "",
+    )
+
+
+def _process_repository(
+    repo_obj: dict[str, Any],
+    *,
+    component: ComponentContext,
+    config: RunConfig,
+) -> list[dict[str, Any]] | None:
+    """Process a single mapped repository for a component.
+
+    Inspects the image at the repository, iterates over its architectures,
+    creates/updates Pyxis images, and optionally cleans up stale tags.
+
+    Returns a list of per-architecture result dicts, or ``None`` if the
+    component should be skipped entirely (e.g. Helm chart detected).
+    """
+    repo_url = repo_obj.get("url", "")
+    repo_url = repo_url.rsplit(":", 1)[0] if ":" in repo_url else repo_url
+    tags_list = repo_obj.get("tags", [])
+    tags_str = " ".join(tags_list)
+
+    if _FBC_INDEX_RE.search(repo_url) and tags_list:
+        pullspec = f"{repo_url}:{tags_list[0]}"
+    else:
+        pullspec = f"{repo_url}@{component.digest}"
+
+    raw_result = skopeo.inspect(pullspec, raw=True, no_tags=True)
+    if raw_result.returncode != 0:
+        raise RuntimeError(
+            f"skopeo inspect --raw failed for {pullspec}: " f"{raw_result.stderr.strip()}"
+        )
+    media_type = json.loads(raw_result.stdout).get("mediaType", "")
+
+    _write_auth_file(repo_url, component.auth_path)
+    arch_details = _get_image_architectures(pullspec)
+
+    config_mt = (arch_details[0].get("configMediaType") or "") if arch_details else ""
+    if config_mt == HELM_CONFIG_MEDIA_TYPE and not config.process_helm_charts:
+        logger.info(
+            "Detected Helm chart artifact for component %d, " "skipping Pyxis image creation",
+            component.index,
+        )
+        return None
+
+    results: list[dict[str, Any]] = []
+    for arch_index, arch_detail in enumerate(arch_details):
+        result = _process_architecture(
+            arch_index=arch_index,
+            arch_detail=arch_detail,
+            pullspec=pullspec,
+            repo_url=repo_url,
+            media_type=media_type,
+            tags_str=tags_str,
+            component=component,
+            config=config,
+        )
+        results.append(result)
+
+    return results
+
+
+def _process_architecture(
+    *,
+    arch_index: int,
+    arch_detail: dict[str, Any],
+    pullspec: str,
+    repo_url: str,
+    media_type: str,
+    tags_str: str,
+    component: ComponentContext,
+    config: RunConfig,
+) -> dict[str, Any]:
+    """Create or update the Pyxis image for a single architecture.
+
+    Fetches the OCI manifest, processes layers, creates/updates the Pyxis
+    ContainerImage, and optionally cleans up stale tags.
+
+    Returns a result dict with arch, imageId, digest, arch_digest, and os.
+    """
+    os_name = arch_detail.get("platform", {}).get("os", "")
+    arch = arch_detail.get("platform", {}).get("architecture", "")
+    arch_digest = arch_detail.get("digest", "")
+
+    platform = f"{os_name}/{arch}" if media_type in MANIFEST_LIST_TYPES else None
+
+    manifest_file = (
+        config.data_dir
+        / config.snapshot_dir
+        / f"oras-manifest-fetch-{component.index}-{arch_index}.json"
+    )
+    manifest_raw = oras_utils.oras_manifest_fetch(
+        pullspec,
+        component.auth_path,
+        platform=platform,
+    )
+    manifest_data = json.loads(manifest_raw)
+
+    if not config.include_layers:
+        logger.info(".pyxis.includeLayers is not true in data file, so delete the layers")
+        manifest_data["layers"] = []
+
+    for layer in list(manifest_data.get("layers", [])):
+        blob_type = layer.get("mediaType", "")
+        blob_digest = layer.get("digest", "")
+        if _GZIP_MEDIA_RE.search(blob_type):
+            uncompressed = _decompress_gzip_layer(
+                blob_digest,
+                repo_url,
+                component.auth_path,
+                component.index,
+            )
+            manifest_data.setdefault("uncompressed_layers", []).append(uncompressed)
+
+    manifest_file.parent.mkdir(parents=True, exist_ok=True)
+    manifest_file.write_text(json.dumps(manifest_data), encoding="utf-8")
+
+    cci_args = _build_cci_args(
+        config=config,
+        component=component,
+        tags=tags_str,
+        oras_manifest_fetch=str(manifest_file),
+        name=repo_url,
+        media_type=media_type,
+        architecture_digest=arch_digest,
+        architecture=arch,
+    )
+
+    image_id = create_or_update(cci_args)
+    logger.info("The image id is: %s", image_id)
+
+    if config.rh_push == "true":
+        cleanup_tags_with_retry(config.pyxis_graphql_url, image_id, proxymap(repo_url))
+
+    return {
+        "arch": arch,
+        "imageId": image_id,
+        "digest": component.digest,
+        "arch_digest": arch_digest,
+        "os": os_name,
+    }
+
+
+def process_component(
+    component_index: int,
+    snapshot: dict[str, Any],
+    *,
+    config: RunConfig,
+) -> dict[str, Any] | None:
+    """Process a single snapshot component: create Pyxis images for all repos/arches.
+
+    Returns the component result dict, or ``None`` if the component was
+    skipped (e.g. Helm chart).
+    """
+    component = snapshot["components"][component_index]
+    container_image = component["containerImage"]
+    source_repo, digest = split_image_ref(container_image)
+
+    metadata = component.get("metadata") or {}
+    metadata_path = file_helpers.make_tempfile_path(
+        "metadata-", json.dumps(metadata).encode("utf-8")
+    )
+
+    auth_path = file_helpers.make_tempfile_path(f"auth-{component_index}-")
+    dockerfile_path: Path | None = None
+    try:
+        _write_auth_file(source_repo, auth_path)
+        dockerfile_path = _try_pull_dockerfile(source_repo, digest)
+
+        ctx = ComponentContext(
+            index=component_index,
+            digest=digest,
+            auth_path=auth_path,
+            dockerfile_path=dockerfile_path,
+            metadata_path=metadata_path if metadata else None,
+        )
+
+        component_json: dict[str, Any] = {
+            "containerImage": container_image,
+            "componentIndex": component_index,
+            "pyxisImages": [],
+        }
+
+        # Bug fix: the original bash script re-initialized COMPONENT_JSON inside
+        # the repository loop, so only the last repository's images were kept.
+        # Here we correctly accumulate pyxisImages across all repositories.
+        repositories = component.get("repositories") or []
+        for repo_obj in repositories:
+            repo_images = _process_repository(
+                repo_obj,
+                component=ctx,
+                config=config,
+            )
+            if repo_images is None:
+                return None
+            component_json["pyxisImages"].extend(repo_images)
+
+        return component_json
+    finally:
+        auth_path.unlink(missing_ok=True)
+        metadata_path.unlink(missing_ok=True)
+        if dockerfile_path is not None:
+            shutil.rmtree(dockerfile_path.parent, ignore_errors=True)
+
+
+def run(
+    server: str,
+    snapshot_file: Path,
+    data_file: Path,
+    certified: str,
+    is_latest: str,
+    rh_push: str,
+    process_helm_charts: bool,
+    concurrent_limit: int,
+    pyxis_data_path_result: Path,
+    data_dir: Path,
+    snapshot_path_relative: str,
+) -> None:
+    """Orchestrate Pyxis image creation for all snapshot components."""
+    pyxis_base = pyxis_api.PYXIS_BASE_URL_BY_SERVER.get(server)
+    if pyxis_base is None:
+        raise ValueError(pyxis_api.INVALID_SERVER_MESSAGE)
+    pyxis_url = f"{pyxis_base}/"
+    pyxis_graphql_url = pyxis_api.pyxis_graphql_url_for_server(server)
+
+    snapshot_dir = Path(snapshot_path_relative).parent
+    pyxis_data_path = snapshot_dir / "pyxis.json"
+    pyxis_data_path_result.parent.mkdir(parents=True, exist_ok=True)
+    pyxis_data_path_result.write_text(str(pyxis_data_path), encoding="utf-8")
+
+    snapshot = load_json_dict(snapshot_file)
+    data = load_json_dict(data_file)
+
+    pyxis_data = data.get("pyxis", {})
+    raw_include = pyxis_data.get("includeLayers", False)
+    include_layers = raw_include is True or str(raw_include).lower() == "true"
+    append_tags = str(pyxis_data.get("appendTags", False)).lower()
+
+    config = RunConfig(
+        pyxis_url=pyxis_url,
+        pyxis_graphql_url=pyxis_graphql_url,
+        certified=certified,
+        is_latest=is_latest,
+        rh_push=rh_push,
+        append_tags=append_tags,
+        include_layers=include_layers,
+        process_helm_charts=process_helm_charts,
+        data_dir=data_dir,
+        snapshot_dir=snapshot_dir,
+    )
+
+    components = snapshot.get("components", [])
+
+    digest_groups: dict[str, list[int]] = defaultdict(list)
+    for i, comp in enumerate(components):
+        ci = comp.get("containerImage", "")
+        _, d = split_image_ref(ci)
+        digest_groups[d].append(i)
+
+    logger.info("Processing %d digest groups in parallel...", len(digest_groups))
+
+    results: dict[int, dict[str, Any] | None] = {}
+    errors: list[str] = []
+
+    def _process_digest_group(
+        group_digest: str, indices: list[int]
+    ) -> list[tuple[int, dict[str, Any] | None]]:
+        group_results = []
+        for idx in indices:
+            logger.info("Processing component %d for digest %s", idx, group_digest)
+            result = process_component(
+                idx,
+                snapshot,
+                config=config,
+            )
+            group_results.append((idx, result))
+        return group_results
+
+    BURST_SIZE = 5
+    STABILIZATION_DELAY = 2
+
+    memory_throttle.log_memory_throttle_status(80)
+
+    with ThreadPoolExecutor(max_workers=concurrent_limit) as executor:
+        futures: dict[Any, str] = {}
+        submitted = 0
+        for d, indices in digest_groups.items():
+            memory_throttle.wait_for_memory(80)
+            futures[executor.submit(_process_digest_group, d, indices)] = d
+            submitted += 1
+            if submitted % BURST_SIZE == 0:
+                time.sleep(STABILIZATION_DELAY)
+
+        for future in as_completed(futures):
+            digest_key = futures[future]
+            try:
+                for idx, result in future.result():
+                    results[idx] = result
+            except Exception as exc:
+                errors.append(f"Digest group {digest_key} failed: {exc}")
+                logger.error("Digest group %s failed: %s", digest_key, exc, exc_info=True)
+
+    if errors:
+        raise RuntimeError(
+            "One or more component processing jobs failed:\n" + "\n".join(errors)
+        )
+
+    json_output: dict[str, Any] = {
+        "components": [results[i] for i in sorted(results) if results[i] is not None],
+    }
+
+    output_path = data_dir / pyxis_data_path
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(json_output, indent=2), encoding="utf-8")
+    logger.info("Pyxis data written to %s", output_path)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--server", required=True)
+    parser.add_argument("--snapshot-file", required=True)
+    parser.add_argument("--data-file", required=True)
+    parser.add_argument("--pyxis-secret-path", default="/etc/secrets")
+    parser.add_argument("--certified", default="false")
+    parser.add_argument("--is-latest", default="false")
+    parser.add_argument("--rh-push", default="false")
+    parser.add_argument("--process-helm-charts", default="false")
+    parser.add_argument("--concurrent-limit", type=int, default=16)
+    parser.add_argument("--pyxis-data-path-result", required=True)
+    parser.add_argument("--data-dir", default="/var/workdir/release")
+    parser.add_argument("--snapshot-path-relative", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and run Pyxis image creation."""
+    args = _parse_args(argv)
+    pyxis_secret_path = Path(args.pyxis_secret_path)
+    os.environ["PYXIS_CERT_PATH"] = str(pyxis_secret_path / "cert")
+    os.environ["PYXIS_KEY_PATH"] = str(pyxis_secret_path / "key")
+    run(
+        server=args.server,
+        snapshot_file=Path(args.snapshot_file),
+        data_file=Path(args.data_file),
+        certified=args.certified,
+        is_latest=args.is_latest,
+        rh_push=args.rh_push,
+        process_helm_charts=args.process_helm_charts == "true",
+        concurrent_limit=args.concurrent_limit,
+        pyxis_data_path_result=Path(args.pyxis_data_path_result),
+        data_dir=Path(args.data_dir),
+        snapshot_path_relative=args.snapshot_path_relative,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_create_pyxis_image.py
+++ b/scripts/python/tasks/managed/test_create_pyxis_image.py
@@ -1,0 +1,1397 @@
+"""Tests for ``create_pyxis_image`` task script — 100 % coverage target."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import create_pyxis_image
+import pytest
+
+# ── fixtures & helpers ──────────────────────────────────────────────
+
+
+def _snapshot(
+    components: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {"components": components or []}
+
+
+def _component(
+    image: str = "quay.io/org/img@sha256:abc123",
+    repositories: list[dict[str, Any]] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    comp: dict[str, Any] = {"containerImage": image}
+    if repositories is not None:
+        comp["repositories"] = repositories
+    if metadata is not None:
+        comp["metadata"] = metadata
+    return comp
+
+
+def _repo(
+    url: str = "quay.io/redhat-prod/product----image",
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    return {"url": url, "tags": tags or ["v1.0"]}
+
+
+def _data(
+    include_layers: bool = False,
+    append_tags: bool = False,
+) -> dict[str, Any]:
+    return {
+        "pyxis": {
+            "includeLayers": include_layers,
+            "appendTags": append_tags,
+        },
+    }
+
+
+def _write(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _setup(
+    tmp_path: Path,
+    snap: dict | None = None,
+    data: dict | None = None,
+) -> tuple[Path, Path, Path, Path, Path]:
+    """Create standard test files and directories. Returns paths."""
+    data_dir = tmp_path / "release"
+    data_dir.mkdir(parents=True)
+    snap_dir = data_dir / "results"
+    snap_dir.mkdir()
+
+    snapshot_file = snap_dir / "snapshot.json"
+    data_file = snap_dir / "data.json"
+    _write(snapshot_file, snap or _snapshot())
+    _write(data_file, data or _data())
+
+    secret_dir = tmp_path / "secrets"
+    secret_dir.mkdir()
+    (secret_dir / "cert").write_text("CERT_DATA", encoding="utf-8")
+    (secret_dir / "key").write_text("KEY_DATA", encoding="utf-8")
+
+    result_file = tmp_path / "pyxisDataPath"
+    return data_dir, snapshot_file, data_file, secret_dir, result_file
+
+
+def _skopeo_result(
+    stdout: str = "{}",
+    rc: int = 0,
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        ["skopeo"],
+        rc,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _raw_manifest(
+    media_type: str = "application/vnd.oci.image.manifest.v1+json",
+    layers: list[dict] | None = None,
+) -> str:
+    return json.dumps({"mediaType": media_type, "layers": layers or []})
+
+
+# ── _write_auth_file ────────────────────────────────────────────────
+
+
+class TestWriteAuthFile:
+    """Tests for ``_write_auth_file``."""
+
+    def test_writes_select_oci_auth_output(self, tmp_path: Path) -> None:
+        """Verify auth file is written from select-oci-auth stdout."""
+        auth = tmp_path / "auth.json"
+        with patch(
+            "create_pyxis_image.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                [],
+                0,
+                stdout='{"auths":{}}',
+                stderr="",
+            ),
+        ):
+            create_pyxis_image._write_auth_file("quay.io/org/img", auth)
+        assert json.loads(auth.read_text()) == {"auths": {}}
+
+    def test_raises_on_nonzero_exit(self, tmp_path: Path) -> None:
+        """Raise RuntimeError when select-oci-auth fails."""
+        auth = tmp_path / "auth.json"
+        with patch(
+            "create_pyxis_image.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                [],
+                1,
+                stdout="",
+                stderr="no credentials found",
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="select-oci-auth failed"):
+                create_pyxis_image._write_auth_file("quay.io/org/img", auth)
+        assert not auth.exists()
+
+
+# ── _get_image_architectures ────────────────────────────────────────
+
+
+class TestGetImageArchitectures:
+    """Tests for ``_get_image_architectures``."""
+
+    def test_parses_jsonl_output(self) -> None:
+        """Parse multi-line JSON output from get-image-architectures."""
+        stdout = (
+            '{"platform":{"architecture":"amd64","os":"linux"},'
+            '"digest":"sha256:aaa","multiarch":true}\n'
+            '{"platform":{"architecture":"arm64","os":"linux"},'
+            '"digest":"sha256:bbb","multiarch":true}\n'
+        )
+        with patch(
+            "create_pyxis_image.subprocess.run",
+            return_value=subprocess.CompletedProcess([], 0, stdout=stdout, stderr=""),
+        ) as mock_run:
+            result = create_pyxis_image._get_image_architectures("quay.io/org/img@sha256:abc")
+        mock_run.assert_called_once_with(
+            ["get-image-architectures", "quay.io/org/img@sha256:abc"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert len(result) == 2
+        assert result[0]["platform"]["architecture"] == "amd64"
+        assert result[1]["digest"] == "sha256:bbb"
+
+    def test_single_line_output(self) -> None:
+        """Parse single-line JSON output (single-arch image)."""
+        stdout = (
+            '{"platform":{"architecture":"amd64","os":"linux"},'
+            '"digest":"sha256:single","multiarch":false}\n'
+        )
+        with patch(
+            "create_pyxis_image.subprocess.run",
+            return_value=subprocess.CompletedProcess([], 0, stdout=stdout, stderr=""),
+        ):
+            result = create_pyxis_image._get_image_architectures("img@sha256:x")
+        assert len(result) == 1
+        assert result[0]["multiarch"] is False
+
+    def test_raises_on_failure(self) -> None:
+        """CalledProcessError propagates when get-image-architectures fails."""
+        with patch(
+            "create_pyxis_image.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "get-image-architectures"),
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                create_pyxis_image._get_image_architectures("bad-image")
+
+
+# ── _try_pull_dockerfile ────────────────────────────────────────────
+
+
+class TestTryPullDockerfile:
+    """Tests for ``_try_pull_dockerfile``."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        """Return Dockerfile path on successful pull."""
+
+        def fake_pull(pull_spec, download_dir):
+            (download_dir / "Dockerfile").write_text("FROM ubi9")
+
+        with patch("create_pyxis_image.oras_utils.oras_pull", side_effect=fake_pull):
+            result = create_pyxis_image._try_pull_dockerfile(
+                "quay.io/org/img",
+                "sha256:abc",
+            )
+        assert result is not None
+        assert result.name == "Dockerfile"
+
+    def test_pull_fails_returns_empty(self) -> None:
+        """Return None when oras pull fails."""
+        with patch(
+            "create_pyxis_image.oras_utils.oras_pull",
+            side_effect=subprocess.CalledProcessError(1, "oras"),
+        ):
+            result = create_pyxis_image._try_pull_dockerfile(
+                "quay.io/org/img",
+                "sha256:abc",
+            )
+        assert result is None
+
+    def test_pull_ok_but_no_dockerfile_raises(self) -> None:
+        """Raise when pull succeeds but Dockerfile is missing."""
+        with patch("create_pyxis_image.oras_utils.oras_pull"):
+            with pytest.raises(RuntimeError, match="Dockerfile was not saved"):
+                create_pyxis_image._try_pull_dockerfile(
+                    "quay.io/org/img",
+                    "sha256:abc",
+                )
+
+
+# ── _decompress_gzip_layer ─────────────────────────────────────────
+
+
+class TestDecompressGzipLayer:
+    """Tests for ``_decompress_gzip_layer``."""
+
+    def test_decompresses_and_measures(self, tmp_path: Path) -> None:
+        """Decompress a gzip blob and return digest and size."""
+        auth = tmp_path / "auth.json"
+        auth.write_text("{}", encoding="utf-8")
+        payload = b"hello world"
+        compressed = gzip.compress(payload)
+
+        def fake_blob_fetch(pullspec, output_path, auth_file):
+            output_path.write_bytes(compressed)
+
+        with patch(
+            "create_pyxis_image.oras_utils.oras_blob_fetch",
+            side_effect=fake_blob_fetch,
+        ):
+            result = create_pyxis_image._decompress_gzip_layer(
+                "sha256:layerdigest",
+                "quay.io/org/img",
+                auth,
+                0,
+            )
+        assert result["digest"].startswith("sha256:")
+        assert result["size"] == len(payload)
+
+
+# ── _build_cci_namespace ────────────────────────────────────────────
+
+
+class TestBuildCciArgs:
+    """Tests for ``_build_cci_args``."""
+
+    def test_builds_args(self) -> None:
+        """Build a ContainerImageArgs from RunConfig and ComponentContext."""
+        config = create_pyxis_image.RunConfig(
+            pyxis_url="https://pyxis.example.com/",
+            pyxis_graphql_url="https://graphql.example.com/graphql/",
+            certified="false",
+            is_latest="false",
+            rh_push="false",
+            append_tags="false",
+            include_layers=False,
+            process_helm_charts=False,
+            data_dir=Path("/tmp"),
+            snapshot_dir=Path("results"),
+        )
+        component = create_pyxis_image.ComponentContext(
+            index=0,
+            digest="sha256:abc",
+            auth_path=Path("/tmp/auth"),
+            dockerfile_path=None,
+            metadata_path=None,
+        )
+        cci_args = create_pyxis_image._build_cci_args(
+            config=config,
+            component=component,
+            tags="v1.0",
+            oras_manifest_fetch="/tmp/manifest.json",
+            name="quay.io/org/img",
+            media_type="application/vnd.oci.image.manifest.v1+json",
+            architecture_digest="sha256:abc",
+            architecture="amd64",
+        )
+        assert cci_args.pyxis_url == "https://pyxis.example.com/"
+        assert cci_args.digest == "sha256:abc"
+
+
+# ── process_component ───────────────────────────────────────────────
+
+
+class TestProcessComponent:
+    """Tests for ``process_component``."""
+
+    def _call(
+        self,
+        tmp_path: Path,
+        snap: dict | None = None,
+        component_index: int = 0,
+        rh_push: str = "false",
+        process_helm_charts: bool = False,
+        include_layers: bool = False,
+        append_tags: str = "false",
+    ) -> dict[str, Any] | None:
+        data_dir = tmp_path / "release"
+        data_dir.mkdir(exist_ok=True)
+        snap_dir = data_dir / "results"
+        snap_dir.mkdir(exist_ok=True)
+        config = create_pyxis_image.RunConfig(
+            pyxis_url="https://pyxis.example.com/",
+            pyxis_graphql_url="https://graphql.example.com/graphql/",
+            certified="false",
+            is_latest="false",
+            rh_push=rh_push,
+            append_tags=append_tags,
+            include_layers=include_layers,
+            process_helm_charts=process_helm_charts,
+            data_dir=data_dir,
+            snapshot_dir=Path("results"),
+        )
+        return create_pyxis_image.process_component(
+            component_index,
+            snap
+            or _snapshot(
+                [
+                    _component(repositories=[_repo()]),
+                ]
+            ),
+            config=config,
+        )
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="img123")
+    @patch(
+        "create_pyxis_image.oras_utils.oras_manifest_fetch",
+        return_value='{"layers": []}',
+    )
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_single_arch(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Process a single-arch image."""
+        result = self._call(tmp_path)
+        assert result is not None
+        assert result["componentIndex"] == 0
+        assert len(result["pyxisImages"]) == 1
+        assert result["pyxisImages"][0]["imageId"] == "img123"
+        mock_cleanup.assert_not_called()
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="img456")
+    @patch(
+        "create_pyxis_image.oras_utils.oras_manifest_fetch",
+        return_value='{"layers": []}',
+    )
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:amd",
+                "multiarch": True,
+            },
+            {
+                "platform": {"architecture": "arm64", "os": "linux"},
+                "digest": "sha256:arm",
+                "multiarch": True,
+            },
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(
+            _raw_manifest("application/vnd.docker.distribution.manifest.list.v2+json"),
+        ),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_multi_arch(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Process a multi-arch manifest list image."""
+        result = self._call(tmp_path)
+        assert result is not None
+        assert len(result["pyxisImages"]) == 2
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="img789")
+    @patch(
+        "create_pyxis_image.oras_utils.oras_manifest_fetch",
+        return_value='{"layers": []}',
+    )
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_rh_push_calls_cleanup(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Trigger tag cleanup when rh_push is enabled."""
+        result = self._call(tmp_path, rh_push="true")
+        assert result is not None
+        mock_cleanup.assert_called_once_with(
+            "https://graphql.example.com/graphql/",
+            "img789",
+            "product/image",
+        )
+
+    @patch("create_pyxis_image.create_or_update")
+    @patch("create_pyxis_image.oras_utils.oras_manifest_fetch")
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+                "configMediaType": "application/vnd.cncf.helm.config.v1+json",
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_helm_chart_skipped(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        tmp_path: Path,
+    ) -> None:
+        """Skip helm chart artifacts when processing is disabled."""
+        result = self._call(tmp_path, process_helm_charts=False)
+        assert result is None
+        mock_create.assert_not_called()
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="imghelm")
+    @patch(
+        "create_pyxis_image.oras_utils.oras_manifest_fetch",
+        return_value='{"layers": []}',
+    )
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+                "configMediaType": "application/vnd.cncf.helm.config.v1+json",
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_helm_chart_processed_when_enabled(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Process helm chart artifacts when enabled."""
+        result = self._call(tmp_path, process_helm_charts=True)
+        assert result is not None
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="imglayer")
+    @patch("create_pyxis_image._decompress_gzip_layer")
+    @patch("create_pyxis_image.oras_utils.oras_manifest_fetch")
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_include_layers_true_with_gzip(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_decompress,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Decompress gzip layers when includeLayers is true."""
+        mock_oras.return_value = json.dumps(
+            {
+                "layers": [
+                    {
+                        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                        "digest": "sha256:layer1",
+                        "size": 1000,
+                    },
+                ],
+            }
+        )
+        mock_decompress.return_value = {"digest": "sha256:expanded", "size": 2000}
+        result = self._call(tmp_path, include_layers=True)
+        assert result is not None
+        mock_decompress.assert_called_once()
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="imgnolayer")
+    @patch("create_pyxis_image.oras_utils.oras_manifest_fetch")
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_include_layers_false_clears_layers(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Clear layers when includeLayers is false."""
+        mock_oras.return_value = json.dumps(
+            {
+                "layers": [
+                    {
+                        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                        "digest": "sha256:layer1",
+                        "size": 1000,
+                    },
+                ],
+            }
+        )
+        result = self._call(tmp_path, include_layers=False)
+        assert result is not None
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="imgmeta")
+    @patch(
+        "create_pyxis_image.oras_utils.oras_manifest_fetch",
+        return_value='{"layers": []}',
+    )
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_with_metadata(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Include component metadata labels in the result."""
+        snap = _snapshot(
+            [
+                _component(
+                    repositories=[_repo()],
+                    metadata={"labels": [{"name": "foo", "value": "bar"}]},
+                ),
+            ]
+        )
+        result = self._call(tmp_path, snap=snap)
+        assert result is not None
+
+    @patch("create_pyxis_image._write_auth_file")
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result("", rc=1, stderr="not found"),
+    )
+    def test_skopeo_failure_raises(
+        self,
+        mock_skopeo,
+        mock_docker,
+        mock_auth,
+        tmp_path: Path,
+    ) -> None:
+        """Raise RuntimeError when skopeo inspect fails."""
+        with pytest.raises(RuntimeError, match="skopeo inspect --raw failed"):
+            self._call(tmp_path)
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="imgnogzip")
+    @patch("create_pyxis_image.oras_utils.oras_manifest_fetch")
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_non_gzip_layers_not_decompressed(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Skip decompression for non-gzip layer media types."""
+        mock_oras.return_value = json.dumps(
+            {
+                "layers": [
+                    {
+                        "mediaType": "application/vnd.oci.image.layer.v1.tar",
+                        "digest": "sha256:plainlayer",
+                        "size": 500,
+                    },
+                ],
+            }
+        )
+        result = self._call(tmp_path, include_layers=True)
+        assert result is not None
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="imgtag")
+    @patch(
+        "create_pyxis_image.oras_utils.oras_manifest_fetch",
+        return_value='{"layers": []}',
+    )
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_repo_url_with_tag_stripped(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Strip tag from repository URL before processing."""
+        snap = _snapshot(
+            [
+                _component(
+                    repositories=[
+                        _repo(url="quay.io/redhat-prod/product----image:latest"),
+                    ]
+                ),
+            ]
+        )
+        result = self._call(tmp_path, snap=snap)
+        assert result is not None
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="imgnorepo")
+    @patch(
+        "create_pyxis_image.oras_utils.oras_manifest_fetch",
+        return_value='{"layers": []}',
+    )
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_component_with_no_repos(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Return empty pyxisImages when component has no repositories."""
+        snap = _snapshot([_component(repositories=[])])
+        result = self._call(tmp_path, snap=snap)
+        assert result is not None
+        assert result["pyxisImages"] == []
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="img_df")
+    @patch(
+        "create_pyxis_image.oras_utils.oras_manifest_fetch",
+        return_value='{"layers": []}',
+    )
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._write_auth_file")
+    def test_dockerfile_tempdir_cleaned_up(
+        self,
+        mock_auth,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Verify the Dockerfile temp directory is removed after processing."""
+        dockerfile_dir = tmp_path / "dockerfile_tmp"
+        dockerfile_dir.mkdir()
+        (dockerfile_dir / "Dockerfile").write_text("FROM scratch\n")
+        with patch(
+            "create_pyxis_image._try_pull_dockerfile",
+            return_value=dockerfile_dir / "Dockerfile",
+        ):
+            result = self._call(tmp_path)
+        assert result is not None
+        assert not dockerfile_dir.exists()
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="imgfbc")
+    @patch(
+        "create_pyxis_image.oras_utils.oras_manifest_fetch",
+        return_value='{"layers": []}',
+    )
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_fbc_index_uses_tag_based_pullspec(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Use tag-based pullspec for FBC operator-index repositories."""
+        snap = _snapshot(
+            [
+                _component(
+                    repositories=[
+                        _repo(
+                            url="quay.io/redhat-prod/redhat-operator-index",
+                            tags=["v4.17"],
+                        ),
+                    ]
+                ),
+            ]
+        )
+        result = self._call(tmp_path, snap=snap)
+        assert result is not None
+        mock_skopeo.assert_called_once()
+        inspected_ref = mock_skopeo.call_args[0][0]
+        assert inspected_ref == "quay.io/redhat-prod/redhat-operator-index:v4.17"
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="imgfbc2")
+    @patch(
+        "create_pyxis_image.oras_utils.oras_manifest_fetch",
+        return_value='{"layers": []}',
+    )
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_fbc_preview_index_uses_tag_based_pullspec(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Use tag-based pullspec for FBC preview-operator-index repositories."""
+        snap = _snapshot(
+            [
+                _component(
+                    repositories=[
+                        _repo(
+                            url="quay.io/redhat-prod/preview-operator-index",
+                            tags=["v4.18"],
+                        ),
+                    ]
+                ),
+            ]
+        )
+        result = self._call(tmp_path, snap=snap)
+        assert result is not None
+        inspected_ref = mock_skopeo.call_args[0][0]
+        assert inspected_ref == "quay.io/redhat-prod/preview-operator-index:v4.18"
+
+    @patch("create_pyxis_image.cleanup_tags_with_retry")
+    @patch("create_pyxis_image.create_or_update", return_value="imgdigest")
+    @patch(
+        "create_pyxis_image.oras_utils.oras_manifest_fetch",
+        return_value='{"layers": []}',
+    )
+    @patch(
+        "create_pyxis_image._get_image_architectures",
+        return_value=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:archdig",
+                "multiarch": False,
+            }
+        ],
+    )
+    @patch(
+        "create_pyxis_image.skopeo.inspect",
+        return_value=_skopeo_result(_raw_manifest()),
+    )
+    @patch("create_pyxis_image._try_pull_dockerfile", return_value=None)
+    @patch("create_pyxis_image._write_auth_file")
+    def test_non_fbc_index_uses_digest_pullspec(
+        self,
+        mock_auth,
+        mock_docker,
+        mock_skopeo,
+        mock_arch,
+        mock_oras,
+        mock_create,
+        mock_cleanup,
+        tmp_path: Path,
+    ) -> None:
+        """Use digest-based pullspec for non-FBC repositories."""
+        result = self._call(tmp_path)
+        assert result is not None
+        inspected_ref = mock_skopeo.call_args[0][0]
+        assert "@sha256:" in inspected_ref
+        assert ":" not in inspected_ref.split("@")[0].split("/")[-1]
+
+
+# ── run ─────────────────────────────────────────────────────────────
+
+
+class TestRun:
+    """Tests for the ``run`` orchestration function."""
+
+    def test_missing_snapshot_raises(self, tmp_path: Path) -> None:
+        """Raise FileNotFoundError when snapshot file is missing."""
+        _, _, data_file, _, result_file = _setup(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            create_pyxis_image.run(
+                server="production",
+                snapshot_file=tmp_path / "nonexistent.json",
+                data_file=data_file,
+                certified="false",
+                is_latest="false",
+                rh_push="false",
+                process_helm_charts=False,
+                concurrent_limit=4,
+                pyxis_data_path_result=result_file,
+                data_dir=tmp_path / "release",
+                snapshot_path_relative="results/snapshot.json",
+            )
+
+    def test_missing_data_raises(self, tmp_path: Path) -> None:
+        """Raise FileNotFoundError when data file is missing."""
+        data_dir, snapshot_file, _, _, result_file = _setup(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            create_pyxis_image.run(
+                server="production",
+                snapshot_file=snapshot_file,
+                data_file=tmp_path / "nonexistent.json",
+                certified="false",
+                is_latest="false",
+                rh_push="false",
+                process_helm_charts=False,
+                concurrent_limit=4,
+                pyxis_data_path_result=result_file,
+                data_dir=data_dir,
+                snapshot_path_relative="results/snapshot.json",
+            )
+
+    def test_invalid_server_raises(self, tmp_path: Path) -> None:
+        """Raise ValueError for an unknown server name."""
+        data_dir, snapshot_file, data_file, _, result_file = _setup(tmp_path)
+        with pytest.raises(ValueError, match="Invalid server parameter"):
+            create_pyxis_image.run(
+                server="invalid",
+                snapshot_file=snapshot_file,
+                data_file=data_file,
+                certified="false",
+                is_latest="false",
+                rh_push="false",
+                process_helm_charts=False,
+                concurrent_limit=4,
+                pyxis_data_path_result=result_file,
+                data_dir=data_dir,
+                snapshot_path_relative="results/snapshot.json",
+            )
+
+    @patch("create_pyxis_image.process_component")
+    def test_single_component(
+        self,
+        mock_process,
+        tmp_path: Path,
+    ) -> None:
+        """Process a single component and write output."""
+        snap = _snapshot([_component()])
+        data_dir, snapshot_file, data_file, _, result_file = _setup(
+            tmp_path,
+            snap=snap,
+        )
+        mock_process.return_value = {
+            "containerImage": "quay.io/org/img@sha256:abc123",
+            "componentIndex": 0,
+            "pyxisImages": [{"imageId": "id1"}],
+        }
+        create_pyxis_image.run(
+            server="production",
+            snapshot_file=snapshot_file,
+            data_file=data_file,
+            certified="false",
+            is_latest="false",
+            rh_push="false",
+            process_helm_charts=False,
+            concurrent_limit=4,
+            pyxis_data_path_result=result_file,
+            data_dir=data_dir,
+            snapshot_path_relative="results/snapshot.json",
+        )
+        output = json.loads((data_dir / "results" / "pyxis.json").read_text())
+        assert len(output["components"]) == 1
+        assert result_file.read_text() == "results/pyxis.json"
+
+    @patch("create_pyxis_image.process_component")
+    def test_skipped_component_excluded(
+        self,
+        mock_process,
+        tmp_path: Path,
+    ) -> None:
+        """Exclude components that return None from the output."""
+        snap = _snapshot([_component()])
+        data_dir, snapshot_file, data_file, _, result_file = _setup(
+            tmp_path,
+            snap=snap,
+        )
+        mock_process.return_value = None
+        create_pyxis_image.run(
+            server="production",
+            snapshot_file=snapshot_file,
+            data_file=data_file,
+            certified="false",
+            is_latest="false",
+            rh_push="false",
+            process_helm_charts=False,
+            concurrent_limit=4,
+            pyxis_data_path_result=result_file,
+            data_dir=data_dir,
+            snapshot_path_relative="results/snapshot.json",
+        )
+        output = json.loads((data_dir / "results" / "pyxis.json").read_text())
+        assert output["components"] == []
+
+    @patch("create_pyxis_image.process_component")
+    def test_duplicate_digests_grouped(
+        self,
+        mock_process,
+        tmp_path: Path,
+    ) -> None:
+        """Group components with the same digest for sequential processing."""
+        snap = _snapshot(
+            [
+                _component(image="quay.io/org/img@sha256:same"),
+                _component(image="quay.io/org/img2@sha256:same"),
+            ]
+        )
+        data_dir, snapshot_file, data_file, _, result_file = _setup(
+            tmp_path,
+            snap=snap,
+        )
+
+        def side_effect(idx, *a, **kw):
+            return {
+                "containerImage": f"img{idx}",
+                "componentIndex": idx,
+                "pyxisImages": [{"imageId": f"id{idx}"}],
+            }
+
+        mock_process.side_effect = side_effect
+        create_pyxis_image.run(
+            server="production",
+            snapshot_file=snapshot_file,
+            data_file=data_file,
+            certified="false",
+            is_latest="false",
+            rh_push="false",
+            process_helm_charts=False,
+            concurrent_limit=4,
+            pyxis_data_path_result=result_file,
+            data_dir=data_dir,
+            snapshot_path_relative="results/snapshot.json",
+        )
+        output = json.loads((data_dir / "results" / "pyxis.json").read_text())
+        assert len(output["components"]) == 2
+
+    @patch("create_pyxis_image.time.sleep")
+    @patch("create_pyxis_image.process_component")
+    def test_burst_stabilization_delay(
+        self,
+        mock_process,
+        mock_sleep,
+        tmp_path: Path,
+    ) -> None:
+        """Trigger stabilization delay after BURST_SIZE digest groups."""
+        snap = _snapshot([_component(image=f"quay.io/org/img@sha256:d{i}") for i in range(5)])
+        data_dir, snapshot_file, data_file, _, result_file = _setup(
+            tmp_path,
+            snap=snap,
+        )
+
+        def side_effect(idx, *a, **kw):
+            return {
+                "containerImage": f"img{idx}",
+                "componentIndex": idx,
+                "pyxisImages": [{"imageId": f"id{idx}"}],
+            }
+
+        mock_process.side_effect = side_effect
+        create_pyxis_image.run(
+            server="production",
+            snapshot_file=snapshot_file,
+            data_file=data_file,
+            certified="false",
+            is_latest="false",
+            rh_push="false",
+            process_helm_charts=False,
+            concurrent_limit=16,
+            pyxis_data_path_result=result_file,
+            data_dir=data_dir,
+            snapshot_path_relative="results/snapshot.json",
+        )
+        mock_sleep.assert_called_once_with(2)
+        output = json.loads((data_dir / "results" / "pyxis.json").read_text())
+        assert len(output["components"]) == 5
+
+    @patch("create_pyxis_image.process_component")
+    def test_process_failure_raises(
+        self,
+        mock_process,
+        tmp_path: Path,
+    ) -> None:
+        """Raise RuntimeError when component processing fails."""
+        snap = _snapshot([_component()])
+        data_dir, snapshot_file, data_file, _, result_file = _setup(
+            tmp_path,
+            snap=snap,
+        )
+        mock_process.side_effect = RuntimeError("Pyxis error")
+        with pytest.raises(RuntimeError, match="One or more component"):
+            create_pyxis_image.run(
+                server="production",
+                snapshot_file=snapshot_file,
+                data_file=data_file,
+                certified="false",
+                is_latest="false",
+                rh_push="false",
+                process_helm_charts=False,
+                concurrent_limit=4,
+                pyxis_data_path_result=result_file,
+                data_dir=data_dir,
+                snapshot_path_relative="results/snapshot.json",
+            )
+
+    @patch("create_pyxis_image.process_component")
+    def test_include_layers_from_data(
+        self,
+        mock_process,
+        tmp_path: Path,
+    ) -> None:
+        """Pass includeLayers and appendTags from data file to config."""
+        snap = _snapshot([_component()])
+        data = _data(include_layers=True, append_tags=True)
+        data_dir, snapshot_file, data_file, _, result_file = _setup(
+            tmp_path,
+            snap=snap,
+            data=data,
+        )
+        mock_process.return_value = {
+            "containerImage": "img",
+            "componentIndex": 0,
+            "pyxisImages": [],
+        }
+        create_pyxis_image.run(
+            server="stage",
+            snapshot_file=snapshot_file,
+            data_file=data_file,
+            certified="false",
+            is_latest="false",
+            rh_push="false",
+            process_helm_charts=False,
+            concurrent_limit=4,
+            pyxis_data_path_result=result_file,
+            data_dir=data_dir,
+            snapshot_path_relative="results/snapshot.json",
+        )
+        _, kwargs = mock_process.call_args
+        cfg = kwargs["config"]
+        assert cfg.include_layers is True
+        assert cfg.append_tags == "true"
+
+
+# ── _parse_args ─────────────────────────────────────────────────────
+
+
+class TestParseArgs:
+    """Tests for ``_parse_args``."""
+
+    def test_required_args(self) -> None:
+        """Parse all required arguments correctly."""
+        args = create_pyxis_image._parse_args(
+            [
+                "--server",
+                "production",
+                "--snapshot-file",
+                "/snap.json",
+                "--data-file",
+                "/data.json",
+                "--pyxis-data-path-result",
+                "/result",
+                "--snapshot-path-relative",
+                "results/snapshot.json",
+            ]
+        )
+        assert args.server == "production"
+        assert args.snapshot_file == "/snap.json"
+        assert args.concurrent_limit == 16
+
+    def test_defaults(self) -> None:
+        """Verify default values for optional arguments."""
+        args = create_pyxis_image._parse_args(
+            [
+                "--server",
+                "stage",
+                "--snapshot-file",
+                "/snap.json",
+                "--data-file",
+                "/data.json",
+                "--pyxis-data-path-result",
+                "/result",
+                "--snapshot-path-relative",
+                "results/snapshot.json",
+            ]
+        )
+        assert args.certified == "false"
+        assert args.is_latest == "false"
+        assert args.rh_push == "false"
+        assert args.process_helm_charts == "false"
+        assert args.pyxis_secret_path == "/etc/secrets"
+        assert args.data_dir == "/var/workdir/release"
+
+
+# ── main ────────────────────────────────────────────────────────────
+
+
+class TestMain:
+    """Tests for the ``main`` entry point."""
+
+    @patch("create_pyxis_image.run")
+    def test_success(self, mock_run: MagicMock) -> None:
+        """Return 0 on successful run."""
+        result = create_pyxis_image.main(
+            [
+                "--server",
+                "production",
+                "--snapshot-file",
+                "/snap.json",
+                "--data-file",
+                "/data.json",
+                "--pyxis-data-path-result",
+                "/result",
+                "--snapshot-path-relative",
+                "results/snapshot.json",
+            ]
+        )
+        assert result == 0
+        mock_run.assert_called_once()
+
+    @patch("create_pyxis_image.run")
+    def test_passes_correct_types(self, mock_run: MagicMock) -> None:
+        """Convert CLI strings to correct Python types before calling run."""
+        create_pyxis_image.main(
+            [
+                "--server",
+                "production",
+                "--snapshot-file",
+                "/snap.json",
+                "--data-file",
+                "/data.json",
+                "--pyxis-data-path-result",
+                "/result",
+                "--snapshot-path-relative",
+                "results/snapshot.json",
+                "--process-helm-charts",
+                "true",
+                "--concurrent-limit",
+                "8",
+            ]
+        )
+        _, kwargs = mock_run.call_args
+        assert kwargs["process_helm_charts"] is True
+        assert kwargs["concurrent_limit"] == 8
+        assert isinstance(kwargs["snapshot_file"], Path)


### PR DESCRIPTION
Rewrite the create-pyxis-image bash script as a Python module with
full unit test coverage. Components are processed in parallel via
ThreadPoolExecutor, grouped by digest to prevent Pyxis race conditions.

New shared helpers: memory_throttle (cgroup-aware memory pressure
throttling, copied from PR https://github.com/konflux-ci/release-service-utils/pull/901), oras_utils, image_ref, and
pyxis_api GraphQL URL resolution.

Refactors pyxis/create_container_image.py to expose a dataclass and
a reusable create_or_update() entry point, decoupling it from
argparse so the new task can call it as a library.

Assisted-by: Cursor