### PR TITLE
feat(RELEASE-2498): add get_ocp_version standalone script

### DIFF
--- a/scripts/python/helpers/skopeo.py
+++ b/scripts/python/helpers/skopeo.py
@@ -11,6 +11,7 @@ def inspect(
     config: bool = False,
     raw: bool = False,
     retry_times: int = 3,
+    check: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """Run ``skopeo inspect`` on a container image reference."""
     cmd = ["skopeo", "inspect", "--retry-times", str(retry_times)]
@@ -19,7 +20,7 @@ def inspect(
     if raw:
         cmd.append("--raw")
     cmd.append(f"docker://{image_ref}")
-    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)
 
 
 def copy(

--- a/scripts/python/helpers/test_skopeo.py
+++ b/scripts/python/helpers/test_skopeo.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 import unittest.mock as mock
 
+import pytest
 import skopeo
 
 
@@ -133,6 +134,27 @@ def test_inspect_image_ref_with_digest() -> None:
 
     cmd = run_mock.call_args[0][0]
     assert cmd[-1] == f"docker://{ref}"
+
+
+def test_inspect_check_true_passes_check() -> None:
+    """``check=True`` is forwarded to subprocess.run."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        return_value=_completed(),
+    ) as run_mock:
+        skopeo.inspect("img:v1", check=True)
+
+    assert run_mock.call_args[1]["check"] is True
+
+
+def test_inspect_check_true_raises_on_failure() -> None:
+    """``check=True`` raises CalledProcessError on non-zero exit."""
+    with mock.patch(
+        "skopeo.subprocess.run",
+        side_effect=subprocess.CalledProcessError(1, "skopeo"),
+    ):
+        with pytest.raises(subprocess.CalledProcessError):
+            skopeo.inspect("img:v1", check=True)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/python/tasks/managed/get_ocp_version.py
+++ b/scripts/python/tasks/managed/get_ocp_version.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Validate that all FBC fragment components in a snapshot target one OCP version.
+
+For each snapshot component, inspect its FBC fragment image with
+`skopeo inspect` and read the `org.opencontainers.image.base.name`
+annotation to get the OCP version tag. Multi-arch images (OCI index or
+Docker manifest-list) are resolved to a single platform's manifest first via
+`get-image-architectures`. Every component must report the same `vX.Y`
+version, which is written to the Tekton result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import skopeo
+import tekton
+from file import load_json_dict
+from logger import logger
+from subprocess_cmd import run_cmd_text
+
+PROG = "get_ocp_version.py"
+
+_VERSION_PATTERN = re.compile(r"^v[0-9]+\.[0-9]+$")
+_MULTI_ARCH_MEDIA_TYPES = {
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+}
+
+
+def _base_name_tag(manifest: dict) -> str:
+    """Return the tag portion of a manifest's base-image annotation.
+
+    The `org.opencontainers.image.base.name` annotation has the form
+    `registry/path:vX.Y`; only the text after the last colon is kept,
+    mirroring the original `cut -d: -f2` behavior.
+    """
+    annotations = manifest.get("annotations") or {}
+    base_name = annotations.get("org.opencontainers.image.base.name") or ""
+    return base_name.rsplit(":", 1)[-1] if base_name else ""
+
+
+def resolve_ocp_version(fbc_fragment: str) -> str:
+    """Return the OCP version tag for *fbc_fragment*, resolving multi-arch images."""
+    manifest = json.loads(skopeo.inspect(fbc_fragment, raw=True, check=True).stdout)
+
+    if manifest.get("mediaType") in _MULTI_ARCH_MEDIA_TYPES:
+        logger.info("  Multiplatform image detected, extracting manifest")
+        arch_output = run_cmd_text(["get-image-architectures", fbc_fragment])
+        platforms = [json.loads(line) for line in arch_output.splitlines() if line.strip()]
+        manifest_image_sha = platforms[0]["digest"]
+        fbc_fragment = f"{fbc_fragment.rsplit('@', 1)[0]}@{manifest_image_sha}"
+        manifest = json.loads(skopeo.inspect(fbc_fragment, raw=True, check=True).stdout)
+
+    return _base_name_tag(manifest)
+
+
+def validate_ocp_versions(snapshot: dict) -> str:
+    """Validate every component targets the same, correctly formatted OCP version.
+
+    Return the unified `vX.Y` version string. Raise `ValueError` if a
+    component's version is malformed or a version mismatch is found.
+    """
+    components = snapshot.get("components") or []
+    logger.info("Found %d FBC components to validate", len(components))
+    if not components:
+        raise ValueError("No components found in snapshot")
+
+    validated_version = ""
+    for i, component in enumerate(components):
+        logger.info("Processing component %d...", i)
+        fbc_fragment = component["containerImage"]
+        logger.info("  Container image: %s", fbc_fragment)
+
+        image_base_name = resolve_ocp_version(fbc_fragment)
+
+        if not _VERSION_PATTERN.match(image_base_name):
+            raise ValueError(
+                f"Invalid OCP version format in component {i}: '{image_base_name}'. "
+                "Expected format: vX.Y (e.g., v4.12)"
+            )
+        logger.info("  Extracted OCP version: %s", image_base_name)
+
+        if i == 0:
+            validated_version = image_base_name
+            logger.info("  First component OCP version: %s", validated_version)
+        elif image_base_name != validated_version:
+            raise ValueError(
+                "OCP version mismatch detected! "
+                f"Component 0 OCP version: {validated_version}, "
+                f"component {i} OCP version: {image_base_name}. "
+                "All FBC fragments in a release must target the same OCP version"
+            )
+        else:
+            logger.info("  Component %d OCP version matches: %s", i, image_base_name)
+
+    logger.info("All %d components validated successfully", len(components))
+    logger.info("Unified OCP version: %s", validated_version)
+    return validated_version
+
+
+def run(snapshot_path: Path, result_stored_version: Path) -> None:
+    """Orchestrate OCP version validation and write the stored-version result."""
+    snapshot = load_json_dict(snapshot_path)
+    version = validate_ocp_versions(snapshot)
+    result_stored_version.write_text(version, encoding="utf-8")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__, prog=PROG)
+    parser.add_argument(
+        "--snapshot-path",
+        required=True,
+        help="Path to the snapshot JSON file",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments, resolve the Tekton result path, and run validation."""
+    args = _parse_args(argv)
+    (result_stored_version,) = tekton.result_paths_from_env("RESULT_STORED_VERSION")
+    run(Path(args.snapshot_path), result_stored_version)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_get_ocp_version.py
+++ b/scripts/python/tasks/managed/test_get_ocp_version.py
@@ -1,0 +1,308 @@
+"""Test OCP version collection and validation across FBC fragment components."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import get_ocp_version
+import pytest
+
+
+def _snapshot(components: list[dict]) -> dict:
+    """Build a minimal snapshot dict."""
+    return {"application": "test", "components": components}
+
+
+def _component(image: str) -> dict:
+    """Build a component dict with a containerImage."""
+    return {"name": "comp", "containerImage": image}
+
+
+def _completed(
+    stdout: str = "", returncode: int = 0, stderr: str = ""
+) -> subprocess.CompletedProcess:
+    """Build a subprocess.CompletedProcess like skopeo.inspect() returns."""
+    return subprocess.CompletedProcess(
+        args=["skopeo", "inspect"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _manifest(media_type: str, base_name: str | None = None) -> str:
+    """Build a raw skopeo inspect manifest JSON string."""
+    manifest: dict = {"mediaType": media_type}
+    if base_name is not None:
+        manifest["annotations"] = {"org.opencontainers.image.base.name": base_name}
+    return json.dumps(manifest)
+
+
+class TestBaseNameTag:
+    """Test _base_name_tag extraction of the version tag from annotations."""
+
+    def test_extracts_tag_after_last_colon(self) -> None:
+        """Tag after the last colon in the base.name annotation is returned."""
+        manifest = {
+            "annotations": {
+                "org.opencontainers.image.base.name": (
+                    "registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.12"
+                )
+            }
+        }
+        assert get_ocp_version._base_name_tag(manifest) == "v4.12"
+
+    def test_missing_annotations_returns_empty(self) -> None:
+        """Manifest without annotations returns an empty string."""
+        assert get_ocp_version._base_name_tag({}) == ""
+
+    def test_missing_base_name_returns_empty(self) -> None:
+        """Manifest with other annotations but no base.name returns empty."""
+        assert get_ocp_version._base_name_tag({"annotations": {"other": "value"}}) == ""
+
+    def test_empty_base_name_returns_empty(self) -> None:
+        """Empty base.name annotation value returns an empty string."""
+        manifest = {"annotations": {"org.opencontainers.image.base.name": ""}}
+        assert get_ocp_version._base_name_tag(manifest) == ""
+
+
+class TestResolveOcpVersion:
+    """Test resolve_ocp_version, including single-arch and multi-arch paths."""
+
+    def test_single_arch_returns_tag_directly(self) -> None:
+        """Single-arch manifest resolves the version without a second inspect."""
+        with patch(
+            "get_ocp_version.skopeo.inspect",
+            return_value=_completed(
+                stdout=_manifest(
+                    "application/vnd.oci.image.manifest.v1+json",
+                    "registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.12",
+                )
+            ),
+        ) as mock_inspect:
+            version = get_ocp_version.resolve_ocp_version(
+                "quay.io/fbc/test-fbc-component@sha256:manifest"
+            )
+        assert version == "v4.12"
+        mock_inspect.assert_called_once_with(
+            "quay.io/fbc/test-fbc-component@sha256:manifest", raw=True, check=True
+        )
+
+    def test_oci_index_resolves_via_get_image_architectures(self) -> None:
+        """OCI image index is resolved to the first platform digest, then re-inspected."""
+        arch_output = (
+            json.dumps({"digest": "sha256:manifest", "platform": {"architecture": "amd64"}})
+            + "\n"
+            + json.dumps(
+                {"digest": "sha256:manifest", "platform": {"architecture": "ppc64le"}}
+            )
+        )
+        with (
+            patch(
+                "get_ocp_version.skopeo.inspect",
+                side_effect=[
+                    _completed(
+                        stdout=json.dumps(
+                            {"mediaType": "application/vnd.oci.image.index.v1+json"}
+                        )
+                    ),
+                    _completed(
+                        stdout=_manifest(
+                            "application/vnd.oci.image.manifest.v1+json",
+                            "registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.12",
+                        )
+                    ),
+                ],
+            ) as mock_inspect,
+            patch(
+                "get_ocp_version.run_cmd_text",
+                return_value=arch_output,
+            ) as mock_run_cmd,
+        ):
+            version = get_ocp_version.resolve_ocp_version(
+                "quay.io/fbc/multi-arch@sha256:index"
+            )
+        assert version == "v4.12"
+        mock_run_cmd.assert_called_once_with(
+            ["get-image-architectures", "quay.io/fbc/multi-arch@sha256:index"]
+        )
+        assert mock_inspect.call_args_list[1].args == (
+            "quay.io/fbc/multi-arch@sha256:manifest",
+        )
+        assert mock_inspect.call_args_list[1].kwargs == {"raw": True, "check": True}
+
+    def test_docker_v2s2_manifest_list_resolves(self) -> None:
+        """Docker v2 schema 2 manifest-list media type also triggers multi-arch resolution."""
+        arch_output = json.dumps(
+            {"digest": "sha256:dockerv2s2manifest", "platform": {"architecture": "amd64"}}
+        )
+        with (
+            patch(
+                "get_ocp_version.skopeo.inspect",
+                side_effect=[
+                    _completed(
+                        stdout=json.dumps(
+                            {
+                                "mediaType": (
+                                    "application/vnd.docker.distribution.manifest.list.v2+json"
+                                )
+                            }
+                        )
+                    ),
+                    _completed(
+                        stdout=_manifest(
+                            "application/vnd.docker.distribution.manifest.v2+json",
+                            "registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.15",
+                        )
+                    ),
+                ],
+            ),
+            patch("get_ocp_version.run_cmd_text", return_value=arch_output),
+        ):
+            version = get_ocp_version.resolve_ocp_version(
+                "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component-docker-v2s2"
+                "@sha256:dockerv2s2index"
+            )
+        assert version == "v4.15"
+
+    def test_skopeo_failure_propagates(self) -> None:
+        """A failing skopeo inspect (check=True) raises CalledProcessError."""
+        with patch(
+            "get_ocp_version.skopeo.inspect",
+            side_effect=subprocess.CalledProcessError(1, "skopeo"),
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                get_ocp_version.resolve_ocp_version("reg.io/img@sha256:missing")
+
+
+class TestValidateOcpVersions:
+    """Test validate_ocp_versions across multiple components."""
+
+    def test_single_component_happy_path(self) -> None:
+        """A single valid component returns its version."""
+        snapshot = _snapshot([_component("quay.io/fbc/test-fbc-component@sha256:manifest")])
+        with patch("get_ocp_version.resolve_ocp_version", return_value="v4.12"):
+            assert get_ocp_version.validate_ocp_versions(snapshot) == "v4.12"
+
+    def test_matching_versions_across_components(self) -> None:
+        """Multiple components reporting the same version validate successfully."""
+        snapshot = _snapshot(
+            [
+                _component("quay.io/fbc/comp-a@sha256:a"),
+                _component("quay.io/fbc/comp-b@sha256:b"),
+            ]
+        )
+        with patch("get_ocp_version.resolve_ocp_version", return_value="v4.14"):
+            assert get_ocp_version.validate_ocp_versions(snapshot) == "v4.14"
+
+    def test_version_mismatch_raises(self) -> None:
+        """A version mismatch between components raises ValueError."""
+        snapshot = _snapshot(
+            [
+                _component("quay.io/fbc/comp-a@sha256:a"),
+                _component("quay.io/fbc/comp-b@sha256:b"),
+            ]
+        )
+        with patch(
+            "get_ocp_version.resolve_ocp_version",
+            side_effect=["v4.12", "v4.13"],
+        ):
+            with pytest.raises(ValueError, match="OCP version mismatch"):
+                get_ocp_version.validate_ocp_versions(snapshot)
+
+    def test_invalid_version_format_raises(self) -> None:
+        """A malformed version string raises ValueError."""
+        snapshot = _snapshot([_component("quay.io/fbc/comp-a@sha256:a")])
+        with patch("get_ocp_version.resolve_ocp_version", return_value="not-a-version"):
+            with pytest.raises(ValueError, match="Invalid OCP version format"):
+                get_ocp_version.validate_ocp_versions(snapshot)
+
+    def test_empty_components_raises(self) -> None:
+        """An empty components list raises ValueError."""
+        with pytest.raises(ValueError, match="No components found"):
+            get_ocp_version.validate_ocp_versions(_snapshot([]))
+
+    def test_missing_components_key_raises(self) -> None:
+        """A snapshot without a components key raises ValueError."""
+        with pytest.raises(ValueError, match="No components found"):
+            get_ocp_version.validate_ocp_versions({"application": "test"})
+
+    def test_missing_container_image_raises(self) -> None:
+        """A component without a containerImage raises KeyError."""
+        snapshot = _snapshot([{"name": "comp"}])
+        with pytest.raises(KeyError, match="containerImage"):
+            get_ocp_version.validate_ocp_versions(snapshot)
+
+
+class TestRun:
+    """Test the run() orchestration: file I/O plus validation."""
+
+    def test_writes_version_to_result_file(self, tmp_path: Path) -> None:
+        """run() writes the validated version to the result path, no trailing newline."""
+        snapshot_path = tmp_path / "snapshot.json"
+        snapshot_path.write_text(
+            json.dumps(_snapshot([_component("quay.io/fbc/comp-a@sha256:a")])),
+            encoding="utf-8",
+        )
+        result_path = tmp_path / "stored-version"
+        with patch("get_ocp_version.validate_ocp_versions", return_value="v4.12"):
+            get_ocp_version.run(snapshot_path, result_path)
+        assert result_path.read_text(encoding="utf-8") == "v4.12"
+
+    def test_missing_snapshot_raises(self, tmp_path: Path) -> None:
+        """A missing snapshot file raises naturally (FileNotFoundError)."""
+        with pytest.raises(FileNotFoundError):
+            get_ocp_version.run(tmp_path / "missing.json", tmp_path / "stored-version")
+
+    def test_validation_error_propagates(self, tmp_path: Path) -> None:
+        """A ValueError from validate_ocp_versions propagates out of run()."""
+        snapshot_path = tmp_path / "snapshot.json"
+        snapshot_path.write_text(json.dumps(_snapshot([])), encoding="utf-8")
+        with pytest.raises(ValueError, match="No components found"):
+            get_ocp_version.run(snapshot_path, tmp_path / "stored-version")
+
+
+class TestParseArgs:
+    """Test CLI argument parsing."""
+
+    def test_snapshot_path_required(self) -> None:
+        """--snapshot-path is required."""
+        with pytest.raises(SystemExit):
+            get_ocp_version._parse_args([])
+
+    def test_parses_snapshot_path(self) -> None:
+        """--snapshot-path is correctly parsed."""
+        args = get_ocp_version._parse_args(["--snapshot-path", "/data/snapshot.json"])
+        assert args.snapshot_path == "/data/snapshot.json"
+
+
+class TestMain:
+    """Test the main() entry point."""
+
+    def test_success(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Return 0 on successful run."""
+        snapshot_path = tmp_path / "snapshot.json"
+        snapshot_path.write_text(json.dumps(_snapshot([])), encoding="utf-8")
+        result_path = tmp_path / "stored-version"
+        monkeypatch.setenv("RESULT_STORED_VERSION", str(result_path))
+        with patch("get_ocp_version.run") as mock_run:
+            assert get_ocp_version.main(["--snapshot-path", str(snapshot_path)]) == 0
+        mock_run.assert_called_once_with(snapshot_path, result_path)
+
+    def test_missing_env_var_exits(self) -> None:
+        """SystemExit when RESULT_STORED_VERSION is not set."""
+        with pytest.raises(SystemExit):
+            get_ocp_version.main(["--snapshot-path", "/tmp/snapshot.json"])
+
+    def test_value_error_propagates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ValueError from run() propagates out of main()."""
+        result_path = tmp_path / "stored-version"
+        monkeypatch.setenv("RESULT_STORED_VERSION", str(result_path))
+        with patch(
+            "get_ocp_version.run",
+            side_effect=ValueError("No components found in snapshot"),
+        ):
+            with pytest.raises(ValueError, match="No components found"):
+                get_ocp_version.main(["--snapshot-path", "/tmp/snapshot.json"])


### PR DESCRIPTION
This commit adds a python script to replicate the inline bash in the get-ocp-version managed task in the catalog repo. The task will be updated to use this python module instead.

-` get_ocp_version.py:` inspect FBC fragment images via skopeo, resolve multi-arch manifests via `get-image-architectures`, and validate all components share the same OCP version

- `test_get_ocp_version.py: `pytest cases covering single-arch, multi-arch (OCI index + Docker v2s2), version mismatch, and invalid format

Assisted-by: Cursor