### PR TITLE
feat(RELEASE-2493): add filter_already_released_advisory_images script

### DIFF
--- a/scripts/python/tasks/managed/filter_already_released_advisory_images_managed.py
+++ b/scripts/python/tasks/managed/filter_already_released_advisory_images_managed.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Filter advisory-published images from a snapshot before advisory creation.
+
+For each snapshot component, resolve architecture-specific image digests via
+`get-image-architectures`, classify the component's mapped repository URLs as
+pending (stage) or production advisories, and submit the resulting entries to
+the `filter-already-released-advisory-images` internal pipeline via an
+InternalRequest. Components the internal pipeline reports as still needing
+release are kept in the snapshot; fully-released snapshots are reduced to an
+empty component list and the run is marked skippable.
+"""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import gzip
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import internal_request
+import subprocess_cmd
+import tekton
+from file import load_json_dict
+from logger import logger
+
+PROG = "filter_already_released_advisory_images_managed.py"
+
+_PENDING_PATTERN = re.compile(r"quay\.io/redhat-pending/|quay\.io/rh-flatpaks-stage/")
+_PROD_PATTERN = re.compile(r"quay\.io/redhat-prod/|quay\.io/rh-flatpaks-prod/")
+_PIPELINE = "filter-already-released-advisory-images"
+_PIPELINERUN_UID_LABEL = "internal-services.appstudio.openshift.io/pipelinerun-uid"
+
+
+@dataclasses.dataclass(frozen=True)
+class ResultPaths:
+    """Tekton result file paths written by the filtering workflow."""
+
+    result: Path
+    skip_release: Path
+    environment: Path
+    latest_advisory_url: Path
+    latest_advisory_internal_url: Path
+
+
+@dataclasses.dataclass(frozen=True)
+class FilterConfig:
+    """Input configuration for the filtering workflow."""
+
+    snapshot_file: Path
+    rpa_file: Path
+    data_file: Path
+    results_file: Path
+    pipeline_run_uid: str
+    task_git_url: str
+    task_git_revision: str
+    synchronously: bool
+
+
+def _repo_url_category(url: str) -> str:
+    """Classify a mapped repository URL as "pending", "prod", or "orphan"."""
+    if _PENDING_PATTERN.search(url):
+        return "pending"
+    if _PROD_PATTERN.search(url):
+        return "prod"
+    return "orphan"
+
+
+def determine_environment(snapshot: dict[str, Any]) -> tuple[str, str]:
+    """Classify every mapped repository URL and pick the advisory environment.
+
+    Return ``(environment, advisory_secret_name)``. Raise `ValueError` when
+    repositories mix pending and production URLs, contain orphaned URLs, or
+    when no mapped repository is found at all.
+    """
+    found = {"pending": False, "prod": False, "orphan": False}
+    for component in snapshot.get("components", []):
+        for repo in component.get("repositories") or []:
+            url = repo.get("url") or ""
+            if not url:
+                continue
+            found[_repo_url_category(url)] = True
+
+    logger.info("Repository status:")
+    logger.info("- Pending repositories: %s", found["pending"])
+    logger.info("- Production repositories: %s", found["prod"])
+    logger.info("- Orphan repositories: %s", found["orphan"])
+
+    if found["pending"] and found["prod"]:
+        raise ValueError("cannot publish to both redhat-pending and redhat-prod repositories")
+    if not found["pending"] and not found["prod"]:
+        raise ValueError(
+            "you must publish to either redhat-pending or redhat-prod repositories"
+        )
+    if found["orphan"]:
+        raise ValueError(
+            "you must publish to either redhat-pending or redhat-prod repositories"
+        )
+
+    if found["pending"]:
+        return "stage", "create-advisory-stage-secret"
+    return "production", "create-advisory-prod-secret"
+
+
+def _get_image_architectures(image: str) -> list[dict[str, Any]]:
+    """Return parsed architecture/digest objects for *image*.
+
+    Raises `subprocess.CalledProcessError` when architecture resolution fails.
+    """
+    output = subprocess_cmd.run_cmd_text(["get-image-architectures", image])
+    return [json.loads(line) for line in output.splitlines() if line.strip()]
+
+
+def transform_component(component: dict[str, Any]) -> list[dict[str, Any]]:
+    """Expand one snapshot component into arch-specific transformed entries.
+
+    Return one minimal entry per (mapped repository, resolved architecture)
+    pair, containing only the fields the internal pipeline needs. Raises
+    `subprocess.CalledProcessError` when architecture resolution fails.
+    """
+    name = component.get("name", "")
+    image = component.get("containerImage", "")
+    digests = _get_image_architectures(image)
+
+    entries: list[dict[str, Any]] = []
+    for repo in component.get("repositories") or []:
+        repo_url = repo.get("rh-registry-repo", "")
+        tags = repo.get("tags")
+        for arch in digests:
+            entries.append(
+                {
+                    "name": name,
+                    "containerImage": f"{repo_url}@{arch['digest']}",
+                    "tags": tags,
+                    "repository": repo_url,
+                }
+            )
+    return entries
+
+
+def transform_snapshot(snapshot: dict[str, Any]) -> tuple[list[dict[str, Any]], list[str]]:
+    """Transform every component to arch-specific images.
+
+    Return ``(transformed_entries, failed_component_names)``. A component
+    whose architecture resolution fails is recorded as failed (assumed not
+    yet released) instead of raising, matching the original bash behavior.
+    """
+    entries: list[dict[str, Any]] = []
+    failed: list[str] = []
+
+    for component in snapshot.get("components", []):
+        name = component.get("name", "")
+        image = component.get("containerImage", "")
+        logger.info("Processing component: %s with image: %s", name, image)
+        try:
+            entries.extend(transform_component(component))
+        except subprocess.CalledProcessError as exc:
+            logger.warning(
+                "Failed to resolve architectures for %s, assuming not released: %s",
+                image,
+                exc,
+            )
+            failed.append(name)
+
+    return entries, failed
+
+
+def check_skip_filter(data_file: Path) -> bool:
+    """Return True when data.json sets `skipFilter` to boolean or string true."""
+    if not data_file.is_file():
+        return False
+    value = load_json_dict(data_file).get("skipFilter")
+    return value is True or value == "true"
+
+
+def _fetch_ir_results(ir_name: str) -> dict[str, Any]:
+    """Fetch and parse `.status.results` for a completed InternalRequest."""
+    output = subprocess_cmd.run_cmd_text(
+        ["kubectl", "get", "internalrequest", ir_name, "-o=jsonpath={.status.results}"]
+    )
+    text = output.strip()
+    if not text:
+        raise RuntimeError(f"No results found in internal request {ir_name}")
+    return json.loads(text)
+
+
+def submit_filter_request(
+    entries: list[dict[str, Any]],
+    *,
+    origin: str,
+    advisory_secret_name: str,
+    config: FilterConfig,
+) -> dict[str, Any]:
+    """Gzip+base64 encode *entries*, submit the InternalRequest, and return its results."""
+    compressed = gzip.compress(json.dumps(entries).encode("utf-8"))
+    transformed_snapshot = base64.b64encode(compressed).decode("ascii")
+
+    ir_name = internal_request.create(
+        _PIPELINE,
+        params={
+            "transformedSnapshot": transformed_snapshot,
+            "origin": origin,
+            "advisory_secret_name": advisory_secret_name,
+            "internalRequestPipelineRunName": config.pipeline_run_uid,
+            "taskGitUrl": config.task_git_url,
+            "taskGitRevision": config.task_git_revision,
+        },
+        labels={_PIPELINERUN_UID_LABEL: config.pipeline_run_uid},
+        sync=config.synchronously,
+    )
+    logger.info("Internal request created: %s", ir_name)
+
+    results = _fetch_ir_results(ir_name)
+    if results.get("result") != "Success":
+        raise RuntimeError(f"Filtering failed: {json.dumps(results)}")
+    return results
+
+
+def decode_unreleased_components(raw: str) -> list[str]:
+    """Decode the gzip+base64 `unreleased_components` list from IR results."""
+    if not raw:
+        raise RuntimeError("No unreleased components list found in results")
+    return json.loads(gzip.decompress(base64.b64decode(raw)))
+
+
+def filter_snapshot(snapshot: dict[str, Any], unreleased_names: set[str]) -> dict[str, Any]:
+    """Keep only snapshot components whose name is in *unreleased_names*."""
+    filtered = dict(snapshot)
+    filtered["components"] = [
+        c for c in snapshot.get("components", []) if c.get("name") in unreleased_names
+    ]
+    return filtered
+
+
+def run(config: FilterConfig, results: ResultPaths) -> None:
+    """Orchestrate advisory image filtering and write Tekton results."""
+    snapshot = load_json_dict(config.snapshot_file)
+
+    entries, failed_components = transform_snapshot(snapshot)
+
+    rpa = load_json_dict(config.rpa_file)
+    origin = rpa["spec"]["origin"]
+    if not origin:
+        raise ValueError("'origin' in ReleasePlanAdmission spec is empty")
+
+    environment, advisory_secret_name = determine_environment(snapshot)
+    results.environment.write_text(environment, encoding="utf-8")
+    logger.info("Environment: %s", environment)
+
+    if check_skip_filter(config.data_file):
+        logger.info(
+            "skipFilter is true in data.json, skipping filtering and passing "
+            "snapshot unchanged."
+        )
+        results.skip_release.write_text("false", encoding="utf-8")
+        results.result.write_text("Success", encoding="utf-8")
+        return
+
+    ir_results = submit_filter_request(
+        entries,
+        origin=origin,
+        advisory_secret_name=advisory_secret_name,
+        config=config,
+    )
+
+    advisory_url = ir_results.get("advisory_url", "")
+    advisory_internal_url = ir_results.get("advisory_internal_url", "")
+    unreleased_names = set(
+        decode_unreleased_components(ir_results.get("unreleased_components", ""))
+    ) | set(failed_components)
+
+    filtered = filter_snapshot(snapshot, unreleased_names)
+    config.snapshot_file.write_text(json.dumps(filtered, indent=2), encoding="utf-8")
+    results.result.write_text("Success", encoding="utf-8")
+
+    if not filtered["components"]:
+        logger.info(
+            "All images in the snapshot have already been released in advisories. "
+            "Stopping pipeline."
+        )
+        results.skip_release.write_text("true", encoding="utf-8")
+        results.latest_advisory_url.write_text(advisory_url, encoding="utf-8")
+        results.latest_advisory_internal_url.write_text(
+            advisory_internal_url, encoding="utf-8"
+        )
+        config.results_file.write_text(
+            json.dumps(
+                {"advisory": {"url": advisory_url, "internal_url": advisory_internal_url}}
+            ),
+            encoding="utf-8",
+        )
+        return
+
+    results.skip_release.write_text("false", encoding="utf-8")
+    results.latest_advisory_url.write_text("", encoding="utf-8")
+    results.latest_advisory_internal_url.write_text("", encoding="utf-8")
+
+
+def main() -> int:
+    """Read environment variables and run the filtering workflow."""
+    (
+        result_result,
+        result_skip_release,
+        result_environment,
+        result_latest_advisory_url,
+        result_latest_advisory_internal_url,
+    ) = tekton.result_paths_from_env(
+        "RESULT_RESULT",
+        "RESULT_SKIP_RELEASE",
+        "RESULT_ENVIRONMENT",
+        "RESULT_LATEST_ADVISORY_URL",
+        "RESULT_LATEST_ADVISORY_INTERNAL_URL",
+    )
+
+    config = FilterConfig(
+        snapshot_file=Path(tekton.require_env("SNAPSHOT_FILE")),
+        rpa_file=Path(tekton.require_env("RPA_FILE")),
+        data_file=Path(tekton.require_env("DATA_FILE")),
+        results_file=Path(tekton.require_env("RESULTS_FILE")),
+        pipeline_run_uid=tekton.require_env("PIPELINE_RUN_UID"),
+        task_git_url=tekton.require_env("TASK_GIT_URL"),
+        task_git_revision=tekton.require_env("TASK_GIT_REVISION"),
+        synchronously=os.environ.get("SYNCHRONOUSLY", "true").lower() == "true",
+    )
+    result_paths = ResultPaths(
+        result=result_result,
+        skip_release=result_skip_release,
+        environment=result_environment,
+        latest_advisory_url=result_latest_advisory_url,
+        latest_advisory_internal_url=result_latest_advisory_internal_url,
+    )
+
+    run(config, result_paths)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_filter_already_released_advisory_images_managed.py
+++ b/scripts/python/tasks/managed/test_filter_already_released_advisory_images_managed.py
@@ -1,0 +1,692 @@
+"""Test advisory image filtering and its InternalRequest orchestration."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import filter_already_released_advisory_images_managed as task
+import pytest
+
+
+def _component(
+    name: str,
+    image: str = "reg.io/img@sha256:abc",
+    repositories: list[dict] | None = None,
+) -> dict:
+    """Build a snapshot component dict."""
+    c: dict = {"name": name, "containerImage": image}
+    if repositories is not None:
+        c["repositories"] = repositories
+    return c
+
+
+def _snapshot(components: list[dict]) -> dict:
+    """Build a minimal snapshot dict."""
+    return {"application": "test", "components": components}
+
+
+def _config(tmp_path: Path, **overrides) -> task.FilterConfig:
+    """Build a FilterConfig with sensible test defaults."""
+    defaults = dict(
+        snapshot_file=tmp_path / "snapshot.json",
+        rpa_file=tmp_path / "rpa.json",
+        data_file=tmp_path / "data.json",
+        results_file=tmp_path / "results.json",
+        pipeline_run_uid="uid-1",
+        task_git_url="http://localhost",
+        task_git_revision="main",
+        synchronously=True,
+    )
+    defaults.update(overrides)
+    return task.FilterConfig(**defaults)
+
+
+def _result_paths(tmp_path: Path) -> task.ResultPaths:
+    """Build ResultPaths pointing at fresh files under tmp_path."""
+    return task.ResultPaths(
+        result=tmp_path / "result",
+        skip_release=tmp_path / "skip_release",
+        environment=tmp_path / "environment",
+        latest_advisory_url=tmp_path / "latest_advisory_url",
+        latest_advisory_internal_url=tmp_path / "latest_advisory_internal_url",
+    )
+
+
+def _gzip_b64(obj) -> str:
+    """Gzip+base64 encode a JSON-serializable object, matching IR result encoding."""
+    return base64.b64encode(gzip.compress(json.dumps(obj).encode("utf-8"))).decode("ascii")
+
+
+class TestRepoUrlCategory:
+    """Test _repo_url_category classification."""
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("quay.io/redhat-pending/foo", "pending"),
+            ("quay.io/rh-flatpaks-stage/foo", "pending"),
+            ("quay.io/redhat-prod/foo", "prod"),
+            ("quay.io/rh-flatpaks-prod/foo", "prod"),
+            ("quay.io/some-other-org/foo", "orphan"),
+        ],
+    )
+    def test_classification(self, url: str, expected: str) -> None:
+        """Each URL pattern maps to the expected category."""
+        assert task._repo_url_category(url) == expected
+
+
+class TestDetermineEnvironment:
+    """Test determine_environment across repository classification scenarios."""
+
+    def test_pending_only(self) -> None:
+        """All-pending repositories select the stage secret."""
+        snapshot = _snapshot(
+            [_component("c1", repositories=[{"url": "quay.io/redhat-pending/foo"}])]
+        )
+        assert task.determine_environment(snapshot) == (
+            "stage",
+            "create-advisory-stage-secret",
+        )
+
+    def test_prod_only(self) -> None:
+        """All-production repositories select the production secret."""
+        snapshot = _snapshot(
+            [_component("c1", repositories=[{"url": "quay.io/redhat-prod/foo"}])]
+        )
+        assert task.determine_environment(snapshot) == (
+            "production",
+            "create-advisory-prod-secret",
+        )
+
+    def test_mixed_pending_and_prod_raises(self) -> None:
+        """Mixing pending and production repositories raises ValueError."""
+        snapshot = _snapshot(
+            [
+                _component(
+                    "c1",
+                    repositories=[
+                        {"url": "quay.io/redhat-pending/foo"},
+                        {"url": "quay.io/redhat-prod/bar"},
+                    ],
+                )
+            ]
+        )
+        with pytest.raises(ValueError, match="cannot publish to both"):
+            task.determine_environment(snapshot)
+
+    def test_orphan_raises(self) -> None:
+        """An orphaned repository URL raises ValueError."""
+        snapshot = _snapshot(
+            [
+                _component(
+                    "c1",
+                    repositories=[
+                        {"url": "quay.io/redhat-pending/foo"},
+                        {"url": "quay.io/some-other-org/bar"},
+                    ],
+                )
+            ]
+        )
+        with pytest.raises(ValueError, match="must publish to either"):
+            task.determine_environment(snapshot)
+
+    def test_no_repositories_raises(self) -> None:
+        """No mapped repositories at all raises ValueError."""
+        snapshot = _snapshot([_component("c1")])
+        with pytest.raises(ValueError, match="must publish to either"):
+            task.determine_environment(snapshot)
+
+    def test_empty_and_missing_urls_ignored(self) -> None:
+        """Empty-string and missing url fields are ignored, not treated as orphan."""
+        snapshot = _snapshot(
+            [
+                _component(
+                    "c1",
+                    repositories=[
+                        {"url": ""},
+                        {},
+                        {"url": "quay.io/redhat-prod/foo"},
+                    ],
+                )
+            ]
+        )
+        assert task.determine_environment(snapshot) == (
+            "production",
+            "create-advisory-prod-secret",
+        )
+
+
+class TestGetImageArchitectures:
+    """Test _get_image_architectures output parsing."""
+
+    def test_parses_multiple_lines(self) -> None:
+        """Each non-blank output line is parsed as a separate JSON object."""
+        output = (
+            json.dumps({"digest": "sha256:a", "platform": {"architecture": "amd64"}})
+            + "\n"
+            + json.dumps({"digest": "sha256:b", "platform": {"architecture": "ppc64le"}})
+        )
+        with patch(
+            "filter_already_released_advisory_images_managed.subprocess_cmd.run_cmd_text",
+            return_value=output,
+        ):
+            result = task._get_image_architectures("reg.io/img@sha256:abc")
+        assert result == [
+            {"digest": "sha256:a", "platform": {"architecture": "amd64"}},
+            {"digest": "sha256:b", "platform": {"architecture": "ppc64le"}},
+        ]
+
+    def test_propagates_subprocess_error(self) -> None:
+        """A failing get-image-architectures call propagates CalledProcessError."""
+        with patch(
+            "filter_already_released_advisory_images_managed.subprocess_cmd.run_cmd_text",
+            side_effect=subprocess.CalledProcessError(1, "get-image-architectures"),
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                task._get_image_architectures("reg.io/img@sha256:abc")
+
+
+class TestTransformComponent:
+    """Test transform_component entry expansion."""
+
+    def test_one_entry_per_repo_and_arch(self) -> None:
+        """A component with 2 repos and 2 architectures yields 4 entries."""
+        comp = _component(
+            "c1",
+            "reg.io/img@sha256:abc",
+            repositories=[
+                {"rh-registry-repo": "registry.io/repo-a", "tags": ["v1"]},
+                {"rh-registry-repo": "registry.io/repo-b", "tags": ["v2"]},
+            ],
+        )
+        with patch(
+            "filter_already_released_advisory_images_managed._get_image_architectures",
+            return_value=[{"digest": "sha256:d1"}, {"digest": "sha256:d2"}],
+        ):
+            entries = task.transform_component(comp)
+        assert len(entries) == 4
+        assert entries[0] == {
+            "name": "c1",
+            "containerImage": "registry.io/repo-a@sha256:d1",
+            "tags": ["v1"],
+            "repository": "registry.io/repo-a",
+        }
+
+    def test_no_repositories_yields_no_entries(self) -> None:
+        """A component without repositories yields an empty list."""
+        comp = _component("c1")
+        with patch(
+            "filter_already_released_advisory_images_managed._get_image_architectures",
+            return_value=[{"digest": "sha256:d1"}],
+        ):
+            assert task.transform_component(comp) == []
+
+
+class TestTransformSnapshot:
+    """Test transform_snapshot aggregation and failure handling."""
+
+    def test_all_succeed(self) -> None:
+        """Every component's entries are aggregated; no failures recorded."""
+        snapshot = _snapshot(
+            [
+                _component("c1", repositories=[{"rh-registry-repo": "r.io/a"}]),
+                _component("c2", repositories=[{"rh-registry-repo": "r.io/b"}]),
+            ]
+        )
+        with patch(
+            "filter_already_released_advisory_images_managed.transform_component",
+            side_effect=[[{"name": "c1"}], [{"name": "c2"}]],
+        ):
+            entries, failed = task.transform_snapshot(snapshot)
+        assert entries == [{"name": "c1"}, {"name": "c2"}]
+        assert failed == []
+
+    def test_failure_is_recorded_not_raised(self) -> None:
+        """A component whose transform raises is recorded as failed, not fatal."""
+        snapshot = _snapshot(
+            [
+                _component("c1", repositories=[{"rh-registry-repo": "r.io/a"}]),
+                _component("c2", repositories=[{"rh-registry-repo": "r.io/b"}]),
+            ]
+        )
+        with patch(
+            "filter_already_released_advisory_images_managed.transform_component",
+            side_effect=[
+                subprocess.CalledProcessError(1, "get-image-architectures"),
+                [{"name": "c2"}],
+            ],
+        ):
+            entries, failed = task.transform_snapshot(snapshot)
+        assert entries == [{"name": "c2"}]
+        assert failed == ["c1"]
+
+
+class TestCheckSkipFilter:
+    """Test check_skip_filter parsing of data.json."""
+
+    def test_missing_file_returns_false(self, tmp_path: Path) -> None:
+        """A missing data file means skipFilter is not set."""
+        assert task.check_skip_filter(tmp_path / "missing.json") is False
+
+    def test_boolean_true(self, tmp_path: Path) -> None:
+        """Boolean true triggers skip."""
+        data_file = tmp_path / "data.json"
+        data_file.write_text(json.dumps({"skipFilter": True}), encoding="utf-8")
+        assert task.check_skip_filter(data_file) is True
+
+    def test_string_true(self, tmp_path: Path) -> None:
+        """String "true" also triggers skip (matches jq -r string coercion)."""
+        data_file = tmp_path / "data.json"
+        data_file.write_text(json.dumps({"skipFilter": "true"}), encoding="utf-8")
+        assert task.check_skip_filter(data_file) is True
+
+    def test_false_does_not_skip(self, tmp_path: Path) -> None:
+        """Boolean false does not trigger skip."""
+        data_file = tmp_path / "data.json"
+        data_file.write_text(json.dumps({"skipFilter": False}), encoding="utf-8")
+        assert task.check_skip_filter(data_file) is False
+
+    def test_missing_key_does_not_skip(self, tmp_path: Path) -> None:
+        """A data.json without skipFilter does not trigger skip."""
+        data_file = tmp_path / "data.json"
+        data_file.write_text(json.dumps({}), encoding="utf-8")
+        assert task.check_skip_filter(data_file) is False
+
+
+class TestFetchIrResults:
+    """Test _fetch_ir_results kubectl output parsing."""
+
+    def test_parses_json_results(self) -> None:
+        """Non-empty jsonpath output is parsed as JSON."""
+        with patch(
+            "filter_already_released_advisory_images_managed.subprocess_cmd.run_cmd_text",
+            return_value=json.dumps({"result": "Success"}),
+        ):
+            assert task._fetch_ir_results("ir-1") == {"result": "Success"}
+
+    def test_empty_output_raises(self) -> None:
+        """Empty jsonpath output raises RuntimeError."""
+        with patch(
+            "filter_already_released_advisory_images_managed.subprocess_cmd.run_cmd_text",
+            return_value="",
+        ):
+            with pytest.raises(RuntimeError, match="No results found"):
+                task._fetch_ir_results("ir-1")
+
+
+class TestSubmitFilterRequest:
+    """Test submit_filter_request InternalRequest orchestration."""
+
+    def test_calls_create_with_expected_params(self, tmp_path: Path) -> None:
+        """internal_request.create is called with expected pipeline/params/labels."""
+        config = _config(tmp_path)
+        with (
+            patch(
+                "filter_already_released_advisory_images_managed.internal_request.create",
+                return_value="ir-1",
+            ) as mock_create,
+            patch(
+                "filter_already_released_advisory_images_managed._fetch_ir_results",
+                return_value={"result": "Success", "advisory_url": "http://x"},
+            ),
+        ):
+            result = task.submit_filter_request(
+                [{"name": "c1"}],
+                origin="my-origin",
+                advisory_secret_name="create-advisory-stage-secret",
+                config=config,
+            )
+        assert result == {"result": "Success", "advisory_url": "http://x"}
+        mock_create.assert_called_once()
+        call = mock_create.call_args
+        assert call.args[0] == "filter-already-released-advisory-images"
+        assert call.kwargs["params"]["origin"] == "my-origin"
+        assert call.kwargs["params"]["advisory_secret_name"] == "create-advisory-stage-secret"
+        assert call.kwargs["params"]["internalRequestPipelineRunName"] == "uid-1"
+        assert call.kwargs["labels"] == {
+            "internal-services.appstudio.openshift.io/pipelinerun-uid": "uid-1"
+        }
+        assert call.kwargs["sync"] is True
+
+    def test_encodes_entries_as_gzip_base64(self, tmp_path: Path) -> None:
+        """Verify transformedSnapshot param is the gzip+base64 of the entries list."""
+        config = _config(tmp_path)
+        entries = [{"name": "c1"}]
+        with (
+            patch(
+                "filter_already_released_advisory_images_managed.internal_request.create",
+                return_value="ir-1",
+            ) as mock_create,
+            patch(
+                "filter_already_released_advisory_images_managed._fetch_ir_results",
+                return_value={"result": "Success"},
+            ),
+        ):
+            task.submit_filter_request(
+                entries, origin="o", advisory_secret_name="s", config=config
+            )
+        transformed = mock_create.call_args.kwargs["params"]["transformedSnapshot"]
+        decoded = json.loads(gzip.decompress(base64.b64decode(transformed)))
+        assert decoded == entries
+
+    def test_non_success_result_raises(self, tmp_path: Path) -> None:
+        """A non-Success result field raises RuntimeError."""
+        config = _config(tmp_path)
+        with (
+            patch(
+                "filter_already_released_advisory_images_managed.internal_request.create",
+                return_value="ir-1",
+            ),
+            patch(
+                "filter_already_released_advisory_images_managed._fetch_ir_results",
+                return_value={"result": "Failed"},
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Filtering failed"):
+                task.submit_filter_request(
+                    [], origin="o", advisory_secret_name="s", config=config
+                )
+
+
+class TestDecodeUnreleasedComponents:
+    """Test decode_unreleased_components gzip+base64 decoding."""
+
+    def test_round_trip(self) -> None:
+        """A gzip+base64-encoded list round-trips correctly."""
+        raw = _gzip_b64(["c1", "c2"])
+        assert task.decode_unreleased_components(raw) == ["c1", "c2"]
+
+    def test_empty_raises(self) -> None:
+        """An empty string raises RuntimeError."""
+        with pytest.raises(RuntimeError, match="No unreleased components"):
+            task.decode_unreleased_components("")
+
+
+class TestFilterSnapshot:
+    """Test filter_snapshot component retention."""
+
+    def test_keeps_only_unreleased_names(self) -> None:
+        """Only components whose name is in the unreleased set are kept."""
+        snapshot = _snapshot([_component("c1"), _component("c2"), _component("c3")])
+        filtered = task.filter_snapshot(snapshot, {"c1", "c3"})
+        assert [c["name"] for c in filtered["components"]] == ["c1", "c3"]
+
+    def test_preserves_non_component_keys(self) -> None:
+        """Non-component snapshot keys survive filtering."""
+        snapshot = _snapshot([_component("c1")])
+        snapshot["application"] = "my-app"
+        filtered = task.filter_snapshot(snapshot, {"c1"})
+        assert filtered["application"] == "my-app"
+
+    def test_empty_unreleased_set_empties_components(self) -> None:
+        """An empty unreleased set filters out every component."""
+        snapshot = _snapshot([_component("c1"), _component("c2")])
+        filtered = task.filter_snapshot(snapshot, set())
+        assert filtered["components"] == []
+
+
+class TestRun:
+    """Test the run() orchestration end to end, mocking IR and arch resolution."""
+
+    def _write_inputs(
+        self,
+        config: task.FilterConfig,
+        *,
+        components: list[dict],
+        origin: str = "my-origin",
+        data: dict | None = None,
+    ) -> None:
+        """Write snapshot, RPA, and (optionally) data.json fixture files."""
+        config.snapshot_file.write_text(json.dumps(_snapshot(components)), encoding="utf-8")
+        config.rpa_file.write_text(json.dumps({"spec": {"origin": origin}}), encoding="utf-8")
+        if data is not None:
+            config.data_file.write_text(json.dumps(data), encoding="utf-8")
+
+    def test_skip_filter_short_circuits(self, tmp_path: Path) -> None:
+        """skipFilter=true writes result/skip_release and returns before any IR call."""
+        config = _config(tmp_path)
+        results = _result_paths(tmp_path)
+        self._write_inputs(
+            config,
+            components=[_component("c1", repositories=[{"url": "quay.io/redhat-prod/foo"}])],
+            data={"skipFilter": True},
+        )
+        with (
+            patch(
+                "filter_already_released_advisory_images_managed.transform_snapshot",
+                return_value=([{"name": "c1"}], []),
+            ),
+            patch(
+                "filter_already_released_advisory_images_managed.submit_filter_request"
+            ) as mock_submit,
+        ):
+            task.run(config, results)
+        mock_submit.assert_not_called()
+        assert results.result.read_text(encoding="utf-8") == "Success"
+        assert results.skip_release.read_text(encoding="utf-8") == "false"
+        assert results.environment.read_text(encoding="utf-8") == "production"
+
+    def test_all_components_released(self, tmp_path: Path) -> None:
+        """All components released: empty snapshot, skip_release=true, results file written."""
+        config = _config(tmp_path)
+        results = _result_paths(tmp_path)
+        self._write_inputs(
+            config,
+            components=[_component("c1", repositories=[{"url": "quay.io/redhat-prod/foo"}])],
+        )
+        with (
+            patch(
+                "filter_already_released_advisory_images_managed.transform_snapshot",
+                return_value=([{"name": "c1"}], []),
+            ),
+            patch(
+                "filter_already_released_advisory_images_managed.submit_filter_request",
+                return_value={
+                    "advisory_url": "http://advisory",
+                    "advisory_internal_url": "http://internal",
+                    "unreleased_components": "",
+                },
+            ),
+            patch(
+                "filter_already_released_advisory_images_managed.decode_unreleased_components",
+                return_value=[],
+            ),
+        ):
+            task.run(config, results)
+
+        assert results.result.read_text(encoding="utf-8") == "Success"
+        assert results.skip_release.read_text(encoding="utf-8") == "true"
+        assert results.latest_advisory_url.read_text(encoding="utf-8") == "http://advisory"
+        assert (
+            results.latest_advisory_internal_url.read_text(encoding="utf-8")
+            == "http://internal"
+        )
+        written_snapshot = json.loads(config.snapshot_file.read_text(encoding="utf-8"))
+        assert written_snapshot["components"] == []
+        results_file = json.loads(config.results_file.read_text(encoding="utf-8"))
+        assert results_file == {
+            "advisory": {"url": "http://advisory", "internal_url": "http://internal"}
+        }
+
+    def test_partial_components_released(self, tmp_path: Path) -> None:
+        """Some components still need release: filtered snapshot, skip_release=false."""
+        config = _config(tmp_path)
+        results = _result_paths(tmp_path)
+        self._write_inputs(
+            config,
+            components=[
+                _component("released", repositories=[{"url": "quay.io/redhat-prod/foo"}]),
+                _component("kept", repositories=[{"url": "quay.io/redhat-prod/bar"}]),
+            ],
+        )
+        with (
+            patch(
+                "filter_already_released_advisory_images_managed.transform_snapshot",
+                return_value=([{"name": "released"}, {"name": "kept"}], []),
+            ),
+            patch(
+                "filter_already_released_advisory_images_managed.submit_filter_request",
+                return_value={
+                    "advisory_url": "http://advisory",
+                    "advisory_internal_url": "http://internal",
+                    "unreleased_components": "encoded",
+                },
+            ),
+            patch(
+                "filter_already_released_advisory_images_managed.decode_unreleased_components",
+                return_value=["kept"],
+            ),
+        ):
+            task.run(config, results)
+
+        assert results.skip_release.read_text(encoding="utf-8") == "false"
+        assert results.latest_advisory_url.read_text(encoding="utf-8") == ""
+        assert results.latest_advisory_internal_url.read_text(encoding="utf-8") == ""
+        written_snapshot = json.loads(config.snapshot_file.read_text(encoding="utf-8"))
+        assert [c["name"] for c in written_snapshot["components"]] == ["kept"]
+        assert not config.results_file.exists()
+
+    def test_arch_resolution_failures_folded_into_unreleased(self, tmp_path: Path) -> None:
+        """Components whose arch resolution failed are kept even if IR omits them."""
+        config = _config(tmp_path)
+        results = _result_paths(tmp_path)
+        self._write_inputs(
+            config,
+            components=[
+                _component("failed-arch", repositories=[{"url": "quay.io/redhat-prod/foo"}]),
+                _component("normal", repositories=[{"url": "quay.io/redhat-prod/bar"}]),
+            ],
+        )
+        with (
+            patch(
+                "filter_already_released_advisory_images_managed.transform_snapshot",
+                return_value=([{"name": "normal"}], ["failed-arch"]),
+            ),
+            patch(
+                "filter_already_released_advisory_images_managed.submit_filter_request",
+                return_value={"unreleased_components": "encoded"},
+            ),
+            patch(
+                "filter_already_released_advisory_images_managed.decode_unreleased_components",
+                return_value=[],
+            ),
+        ):
+            task.run(config, results)
+
+        written_snapshot = json.loads(config.snapshot_file.read_text(encoding="utf-8"))
+        assert [c["name"] for c in written_snapshot["components"]] == ["failed-arch"]
+
+    def test_empty_origin_raises(self, tmp_path: Path) -> None:
+        """An empty origin in the ReleasePlanAdmission raises ValueError."""
+        config = _config(tmp_path)
+        results = _result_paths(tmp_path)
+        self._write_inputs(
+            config,
+            components=[_component("c1", repositories=[{"url": "quay.io/redhat-prod/foo"}])],
+            origin="",
+        )
+        with patch(
+            "filter_already_released_advisory_images_managed.transform_snapshot",
+            return_value=([{"name": "c1"}], []),
+        ):
+            with pytest.raises(ValueError, match="origin"):
+                task.run(config, results)
+
+    def test_missing_origin_key_raises(self, tmp_path: Path) -> None:
+        """A ReleasePlanAdmission missing spec.origin raises KeyError naturally."""
+        config = _config(tmp_path)
+        results = _result_paths(tmp_path)
+        config.snapshot_file.write_text(
+            json.dumps(_snapshot([_component("c1")])), encoding="utf-8"
+        )
+        config.rpa_file.write_text(json.dumps({"spec": {}}), encoding="utf-8")
+        with patch(
+            "filter_already_released_advisory_images_managed.transform_snapshot",
+            return_value=([], []),
+        ):
+            with pytest.raises(KeyError):
+                task.run(config, results)
+
+    def test_missing_snapshot_raises(self, tmp_path: Path) -> None:
+        """A missing snapshot file raises FileNotFoundError naturally."""
+        config = _config(tmp_path)
+        results = _result_paths(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            task.run(config, results)
+
+    def test_missing_rpa_raises(self, tmp_path: Path) -> None:
+        """A missing ReleasePlanAdmission file raises FileNotFoundError naturally."""
+        config = _config(tmp_path)
+        results = _result_paths(tmp_path)
+        config.snapshot_file.write_text(
+            json.dumps(_snapshot([_component("c1")])), encoding="utf-8"
+        )
+        with (
+            patch(
+                "filter_already_released_advisory_images_managed.transform_snapshot",
+                return_value=([], []),
+            ),
+            pytest.raises(FileNotFoundError),
+        ):
+            task.run(config, results)
+
+
+class TestMain:
+    """Test the main() entry point's environment variable wiring."""
+
+    def _set_env(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Set every environment variable main() requires."""
+        env = {
+            "RESULT_RESULT": str(tmp_path / "result"),
+            "RESULT_SKIP_RELEASE": str(tmp_path / "skip_release"),
+            "RESULT_ENVIRONMENT": str(tmp_path / "environment"),
+            "RESULT_LATEST_ADVISORY_URL": str(tmp_path / "latest_advisory_url"),
+            "RESULT_LATEST_ADVISORY_INTERNAL_URL": str(
+                tmp_path / "latest_advisory_internal_url"
+            ),
+            "SNAPSHOT_FILE": str(tmp_path / "snapshot.json"),
+            "RPA_FILE": str(tmp_path / "rpa.json"),
+            "DATA_FILE": str(tmp_path / "data.json"),
+            "RESULTS_FILE": str(tmp_path / "results.json"),
+            "PIPELINE_RUN_UID": "uid-1",
+            "TASK_GIT_URL": "http://localhost",
+            "TASK_GIT_REVISION": "main",
+        }
+        for k, v in env.items():
+            monkeypatch.setenv(k, v)
+
+    def test_success(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """main() wires config/results from env vars and returns 0."""
+        self._set_env(monkeypatch, tmp_path)
+        with patch("filter_already_released_advisory_images_managed.run") as mock_run:
+            assert task.main() == 0
+        config, results = mock_run.call_args.args
+        assert config.snapshot_file == tmp_path / "snapshot.json"
+        assert config.pipeline_run_uid == "uid-1"
+        assert config.synchronously is True
+        assert results.result == tmp_path / "result"
+
+    def test_synchronously_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SYNCHRONOUSLY=false is parsed as a boolean False."""
+        self._set_env(monkeypatch, tmp_path)
+        monkeypatch.setenv("SYNCHRONOUSLY", "false")
+        with patch("filter_already_released_advisory_images_managed.run") as mock_run:
+            task.main()
+        config, _results = mock_run.call_args.args
+        assert config.synchronously is False
+
+    def test_missing_env_var_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing required env var raises SystemExit."""
+        self._set_env(monkeypatch, tmp_path)
+        monkeypatch.delenv("PIPELINE_RUN_UID", raising=False)
+        with pytest.raises(SystemExit):
+            task.main()


### PR DESCRIPTION
This commit adds a python script to replicate the inline bash in the filter-already-released-advisory-images managed task in the catalog repo. The task will be updated to use this python module instead.

- `filter_already_released_advisory_images_managed.py`: transform snapshot components to arch-specific images, classify mapped repositories as stage/production, and submit them to the internal pipeline via `internal_request.create()`

- `test_filter_already_released_advisory_images_managed.py:` 42 pytest cases covering repo classification, skipFilter, arch-resolution failures, and InternalRequest success/failure paths

Note: the script is named with a `_managed` suffix (not just `filter_already_released_advisory_images.py`) because `scripts/python/tasks/internal/` already has an unrelated internal task script with that exact base name; since neither directory is a real Python package, pytest couldn't tell the two `test_filter_already_released_advisory_images.py` files apart without the rename.

Assisted-by: Cursor