### PR TITLE
feat(RELEASE-2501): convert populate-release-notes steps to python

### DIFF
--- a/scripts/python/tasks/managed/populate_release_notes.py
+++ b/scripts/python/tasks/managed/populate_release_notes.py
@@ -1,0 +1,697 @@
+#!/usr/bin/env python3
+"""Populate the releaseNotes key in a data JSON file.
+
+Handle container images, binary/disk-image/RPM artifacts, GitHub release
+artifacts, CVE validation against Jira and advisory type/references.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import file as file_helper
+import http_client
+import jira as jira_helper
+import requests
+import tekton
+from logger import logger
+from requests.auth import HTTPBasicAuth
+from subprocess_cmd import run_cmd_text
+
+JIRA_CVE_FIELD = "customfield_10667"
+UNIQUE_TAG_RE = re.compile(r"(rhel-)?v?[0-9]+\.[0-9]+(\.[0-9]+)?-[0-9]{8,}")
+CLASSIFICATION_URL = "https://access.redhat.com/security/updates/classification/"
+CVE_REF_PREFIX = "https://access.redhat.com/security/cve/"
+PULP_CONTENT_BASE_URL = "https://packages.redhat.com/api/pulp-content"
+
+
+def get_content_type(data: dict[str, Any]) -> str | None:
+    """Return the first contentType from mapping components or None."""
+    for component in data.get("mapping", {}).get("components", []):
+        content_type = (component.get("contentGateway") or {}).get("contentType")
+        if content_type:
+            return content_type
+        content_type = component.get("contentType")
+        if content_type:
+            return content_type
+    return None
+
+
+def build_cves_for_component(data: dict[str, Any], component_name: str) -> dict[str, Any]:
+    """Construct CVE json for a single component."""
+    fixed: dict[str, Any] = {}
+    for cve in data.get("releaseNotes", {}).get("cves", []):
+        if cve.get("component") == component_name:
+            fixed[cve["key"]] = {"packages": cve.get("packages", [])}
+    return {"cves": {"fixed": fixed}}
+
+
+def _get_label_value(component: dict[str, Any], label_name: str) -> str | None:
+    """Get a label value from a component's metadata labels."""
+    for label in component.get("metadata", {}).get("labels", []) or []:
+        if label.get("name") == label_name:
+            return label.get("value")
+    return None
+
+
+def get_timestamp_tag(component: dict[str, Any]) -> str:
+    """Try to get a timestamp tag from the OCI image.created label.
+
+    Return the label value as unix timestamp seconds or empty string
+    if the label is missing or cannot be parsed.
+    """
+    created = _get_label_value(component, "org.opencontainers.image.created")
+    if created:
+        try:
+            timestamp_tag = int(datetime.fromisoformat(created).timestamp())
+            return str(timestamp_tag)
+        except (ValueError, OverflowError):
+            pass
+        logger.warning(
+            "Component '%s' has 'org.opencontainers.image.created' "
+            "label ('%s') but it could not be parsed as a date.",
+            component.get("name", ""),
+            created,
+        )
+    else:
+        # Conforma should have blocked this release
+        logger.warning(
+            "Component '%s' is missing the "
+            "'org.opencontainers.image.created' label. "
+            "Falling back to regex tag matching.",
+            component.get("name", ""),
+        )
+    return ""
+
+
+def get_unique_tag_from_tags(tags: list[str]) -> str:
+    """Return the longest tag matching the timestamp regex or empty string."""
+    longest = ""
+    for tag in tags:
+        if UNIQUE_TAG_RE.search(tag) and len(tag) > len(longest):
+            longest = tag
+    return longest
+
+
+def get_image_architectures(image_ref: str) -> list[dict[str, Any]]:
+    """Get all architectures and their digests for an image."""
+    output = run_cmd_text(["get-image-architectures", image_ref])
+    arch_digests: list[dict[str, Any]] = []
+    for line in output.strip().splitlines():
+        if line.strip():
+            arch_digests.append(json.loads(line))
+    return arch_digests
+
+
+def generate_purl_rpm(
+    name: str,
+    version: str,
+    release: str,
+    arch: str,
+    distro: str,
+    repository_id: str,
+    vendor: str = "redhat",
+) -> str:
+    """Generate an RPM Package URL."""
+    return (
+        f"pkg:rpm/{vendor}/{name}@{version}-{release}"
+        f"?arch={arch}&distro={distro}&repository_id={repository_id}"
+    )
+
+
+def parse_checksum_file(path: Path) -> dict[str, str]:
+    """Parse a SHA256SUMS file into a filename-to-checksum mapping."""
+    checksums: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        checksum, filename = parts
+        if filename.endswith("_manifest.json"):
+            continue
+        checksums[filename] = checksum
+    return checksums
+
+
+def validate_cve_issues(
+    data: dict[str, Any],
+    session: requests.Session,
+    auth: HTTPBasicAuth,
+) -> None:
+    """Check that each Jira Vulnerability issue has a CVE in releaseNotes.cves."""
+    release_notes = data.get("releaseNotes", {})
+    issues_fixed = release_notes.get("issues", {}).get("fixed")
+    if not issues_fixed:
+        logger.info("No issues.fixed found. Skipping CVE validation.")
+        return
+
+    # Drop duplicate issue references (same source + id); keeps first occurrence
+    seen: set[tuple[str, str]] = set()
+    unique_issues: list[dict[str, Any]] = []
+    for issue in issues_fixed:
+        key = (issue["source"], issue["id"])
+        if key not in seen:
+            seen.add(key)
+            unique_issues.append(issue)
+    if len(unique_issues) < len(issues_fixed):
+        logger.info(
+            "Removed duplicate issues.fixed: %d -> %d entries",
+            len(issues_fixed),
+            len(unique_issues),
+        )
+    data["releaseNotes"]["issues"]["fixed"] = unique_issues
+
+    release_cves = {cve["key"] for cve in release_notes.get("cves", [])}
+    errors: list[str] = []
+
+    for issue in unique_issues:
+        server = jira_helper.normalize_issue_server(issue["source"])
+        issue_id = issue["id"]
+
+        # Currently only handle redhat.atlassian.net
+        if server != jira_helper.SUPPORTED_JIRA_SERVER:
+            logger.info("Skipping non-JIRA issue: %s from %s", issue_id, server)
+            continue
+
+        url = f"https://{server}/rest/api/2/issue/{issue_id}"
+        try:
+            body = jira_helper.jira_get_json(session, url, auth)
+        except requests.RequestException as exc:
+            # we should not fail for issues that are not available
+            logger.warning(
+                "Could not fetch issue %s from %s. Skipping. %s",
+                issue_id,
+                server,
+                exc,
+            )
+            continue
+
+        issue_type = body.get("fields", {}).get("issuetype", {}).get("name")
+        if issue_type != "Vulnerability":
+            logger.info(
+                "Issue %s is not a Vulnerability (type: %s). Skipping.",
+                issue_id,
+                issue_type,
+            )
+            continue
+
+        cve_id = body.get("fields", {}).get(JIRA_CVE_FIELD)
+        if not cve_id or cve_id == "null":
+            logger.warning(
+                "Issue %s is a Vulnerability but has no CVE ID. Skipping.",
+                issue_id,
+            )
+            continue
+
+        if cve_id not in release_cves:
+            msg = (
+                f"Issue {issue_id} lists 'CVE ID' {cve_id} but that "
+                f"CVE is not present in the releaseNotes.cves section."
+            )
+            logger.error(msg)
+            errors.append(msg)
+
+    if errors:
+        raise RuntimeError("Errors were found in the CVE validation:\n" + "\n".join(errors))
+
+
+def populate_images(data: dict[str, Any], snapshot: dict[str, Any]) -> None:
+    """Populate releaseNotes.content.images."""
+    if data.get("github"):
+        logger.info("Github release. Skipping image-specific release note generation.")
+        return
+
+    content_type = get_content_type(data)
+    if content_type in ("binary", "disk-image"):
+        logger.info(
+            "Content type is %s. Skipping image-specific release note generation.",
+            content_type,
+        )
+        return
+
+    components = snapshot.get("components", [])
+    content_images = (
+        data.setdefault("releaseNotes", {}).setdefault("content", {}).setdefault("images", [])
+    )
+
+    for component in components:
+        name = component["name"]
+        canonical_name = component.get("canonicalName") or ""
+        image = component["containerImage"]
+
+        if not re.match(r"^[^:]+@sha256:[0-9a-f]+$", image):
+            msg = f"Failed to extract sha256 tag from {image}. Exiting with failure"
+            raise RuntimeError(msg)
+
+        cves_dict = build_cves_for_component(data, name)
+        has_cves = bool(cves_dict["cves"]["fixed"])
+
+        arch_digests = get_image_architectures(image)
+
+        # Timestamp tag from the OCI label applies to all repos
+        timestamp_tag = get_timestamp_tag(component)
+
+        for repo in component.get("repositories", []):
+            delivery_repo = repo["rh-registry-repo"]
+            tags = repo.get("tags", [])
+
+            # Use timestamp tag if available, otherwise fall back to
+            # regex matching against this repo's tags
+            if timestamp_tag:
+                unique_tag = timestamp_tag
+            else:
+                unique_tag = get_unique_tag_from_tags(tags)
+
+            for arch_digest in arch_digests:
+                arch = arch_digest["platform"]["architecture"]
+                digest = arch_digest["digest"]
+
+                # If canonicalName is present, use it.
+                # Otherwise fallback to the last segment of the deliveryRepo
+                purl_path = delivery_repo.rsplit("/", 1)[-1]
+                if canonical_name:
+                    purl_path = canonical_name
+
+                purl = (
+                    f"pkg:oci/{purl_path}"
+                    f"@{digest.replace(':', '%3A')}"
+                    f"?arch={arch}"
+                    f"&repository_url={delivery_repo}"
+                )
+                if unique_tag:
+                    purl += f"&tag={unique_tag}"
+
+                entry: dict[str, Any] = {
+                    "architecture": arch,
+                    "containerImage": f"{delivery_repo}@{digest}",
+                    "purl": purl,
+                    "repository": delivery_repo,
+                    "tags": tags,
+                    "component": name,
+                }
+                if has_cves:
+                    entry.update(cves_dict)
+                content_images.append(entry)
+
+    # Key is only created when entries exist remove if empty
+    if not content_images:
+        data["releaseNotes"]["content"].pop("images", None)
+
+
+def populate_artifacts(data: dict[str, Any], snapshot: dict[str, Any]) -> None:
+    """Populate releaseNotes.content.artifacts."""
+    content_type = get_content_type(data)
+    if content_type not in ("binary", "disk-image", "rpm"):
+        logger.info(
+            "Not binary or disk-image or rpm content. Skipping artifact-specific logic."
+        )
+        return
+
+    components = snapshot.get("components", [])
+
+    # For RPMs, at least one component must have rpmsToPublish
+    if content_type == "rpm":
+        has_rpms = any(component.get("rpmsToPublish") for component in components)
+        if not has_rpms:
+            msg = "No rpmsToPublish found in snapshot cannot generate RPM release notes."
+            raise RuntimeError(msg)
+
+    content_artifacts = (
+        data.setdefault("releaseNotes", {})
+        .setdefault("content", {})
+        .setdefault("artifacts", [])
+    )
+
+    for component in components:
+        name = component["name"]
+        cves_dict = build_cves_for_component(data, name)
+        has_cves = bool(cves_dict["cves"]["fixed"])
+
+        if content_type == "binary":
+            _populate_binary(data, name, cves_dict, has_cves, content_artifacts)
+        elif content_type == "disk-image":
+            _populate_disk_image(data, name, cves_dict, has_cves, content_artifacts)
+        elif content_type == "rpm":
+            _populate_rpm(
+                data,
+                component,
+                name,
+                cves_dict,
+                has_cves,
+                content_artifacts,
+            )
+
+
+def _populate_binary(
+    data: dict[str, Any],
+    name: str,
+    cves_dict: dict[str, Any],
+    has_cves: bool,
+    content_artifacts: list[dict[str, Any]],
+) -> None:
+    """Append binary artifact entries."""
+    for mapping_component in data.get("mapping", {}).get("components", []):
+        if mapping_component.get("name") != name:
+            continue
+        # Binaries use .files, falling back to .staged.files
+        files = mapping_component.get("files") or []
+        if not files:
+            files = mapping_component.get("staged", {}).get("files", [])
+        for file_entry in files:
+            # Will be filled in by a later task after signing
+            entry: dict[str, Any] = {
+                "architecture": file_entry["arch"],
+                "os": file_entry["os"],
+                "purl": "placeholder",
+                "component": name,
+            }
+            if has_cves:
+                entry.update(cves_dict)
+            content_artifacts.append(entry)
+
+
+def _populate_disk_image(
+    data: dict[str, Any],
+    name: str,
+    cves_dict: dict[str, Any],
+    has_cves: bool,
+    content_artifacts: list[dict[str, Any]],
+) -> None:
+    """Append disk-image artifact entries."""
+    marketplace = bool(data.get("mapping", {}).get("cloudMarketplacesSecret"))
+    for mapping_component in data.get("mapping", {}).get("components", []):
+        if mapping_component.get("name") != name:
+            continue
+        for file_entry in mapping_component.get("staged", {}).get("files", []):
+            filename = file_entry["filename"]
+
+            arch = "unknown"
+            if "aarch64" in filename:
+                arch = "aarch64"
+            elif "x86_64" in filename:
+                arch = "x86_64"
+
+            if marketplace:
+                # For marketplace releases, no checksum or download_url
+                # since these images go to cloud marketplaces, not CDN
+                version = mapping_component.get("staged", {}).get("version", "unknown")
+                purl = f"pkg:generic/{name}@{version}"
+            else:
+                # For CDN releases, placeholder will be updated by create-advisory
+                purl = "placeholder"
+
+            entry: dict[str, Any] = {
+                "architecture": arch,
+                "os": "linux",
+                "purl": purl,
+                "component": name,
+            }
+            if has_cves:
+                entry.update(cves_dict)
+            content_artifacts.append(entry)
+
+
+def _populate_rpm(
+    data: dict[str, Any],
+    component: dict[str, Any],
+    name: str,
+    cves_dict: dict[str, Any],
+    has_cves: bool,
+    content_artifacts: list[dict[str, Any]],
+) -> None:
+    """Append RPM artifact entries from rpmsToPublish in the snapshot."""
+    rpms = component.get("rpmsToPublish", [])
+    if not rpms:
+        return
+
+    # SBOMs/attestations are uploaded to the signed RPMs domain
+    pulp_domain = (
+        data.get("signOptions", {}).get("signedRpmsDomain")
+        or data.get("pulp", {}).get("domain")
+        or ""
+    )
+    signing_key = data.get("signOptions", {}).get("signKeyAlias", {}).get("key", "")
+
+    for rpm in rpms:
+        rpm_name = rpm["rpmname"]
+        arch = rpm["arch"]
+        version = rpm["version"]
+        release = rpm["release"]
+        # Distro lives in targetRepos when present
+        # only used in the no-targetRepos fallback
+        distro = rpm.get("distro", "")
+
+        sbom_path = rpm.get("sbomPath", "")
+        sbom_url = ""
+        if sbom_path and pulp_domain:
+            sbom_url = f"{PULP_CONTENT_BASE_URL}/{pulp_domain}/{sbom_path}"
+
+        attestation_path = rpm.get("attestationPath", "")
+        attestation_url = ""
+        if attestation_path and pulp_domain:
+            attestation_url = f"{PULP_CONTENT_BASE_URL}/{pulp_domain}/{attestation_path}"
+
+        # Expand per-target repo to keep repository_id accurate
+        # (noarch may target multiple repos)
+        target_repos = rpm.get("targetRepos", [])
+        if not target_repos:
+            # If no targetRepos, fall back to best-effort purl without repository_id.
+            purl = generate_purl_rpm(rpm_name, version, release, arch, distro, "")
+            logger.info("purl: %s", purl)
+            entry: dict[str, Any] = {
+                "architecture": arch,
+                "os": "linux",
+                "purl": purl,
+                "component": name,
+            }
+            if signing_key:
+                entry["signingKey"] = signing_key
+            if has_cves:
+                entry.update(cves_dict)
+            content_artifacts.append(entry)
+            continue
+
+        for target_repo in target_repos:
+            repo_id = target_repo["repository_id"]
+            repo_name = target_repo.get("repository_name", "")
+            repo_distro = target_repo.get("distro", "")
+            arch_for_entry = "src" if repo_name == "source" else arch
+            purl = generate_purl_rpm(
+                rpm_name,
+                version,
+                release,
+                arch_for_entry,
+                repo_distro,
+                repo_id,
+            )
+            logger.info("purl: %s", purl)
+            entry = {
+                "architecture": arch_for_entry,
+                "os": "linux",
+                "purl": purl,
+                "component": name,
+            }
+            if arch_for_entry == "src" and sbom_url:
+                logger.info("sbom: %s", sbom_url)
+                entry["sbom"] = sbom_url
+            if arch_for_entry == "src" and attestation_url:
+                logger.info("attestation: %s", attestation_url)
+                entry["attestation"] = attestation_url
+            if signing_key:
+                entry["signingKey"] = signing_key
+            if has_cves:
+                entry.update(cves_dict)
+            content_artifacts.append(entry)
+
+
+def populate_github(
+    data: dict[str, Any],
+    snapshot: dict[str, Any],
+    github_release_version: str,
+    github_release_url: str,
+    binaries_dir: str,
+) -> None:
+    """Populate releaseNotes.content.artifacts for github releases."""
+    if not data.get("github"):
+        logger.info("Not a github release. Skipping github-specific release note generation.")
+        return
+
+    # GitHub releases are single-component snapshots
+    name = snapshot["components"][0]["name"]
+    cves_dict = build_cves_for_component(data, name)
+    has_cves = bool(cves_dict["cves"]["fixed"])
+
+    binaries_path = Path(binaries_dir) if binaries_dir else None
+    if not binaries_path or not binaries_path.is_dir():
+        msg = "Binaries directory does not exist."
+        raise RuntimeError(msg)
+
+    checksum_files = list(binaries_path.glob("*_SHA256SUMS"))
+    if not checksum_files:
+        msg = "No checksum file was provided."
+        raise RuntimeError(msg)
+    checksum_map = parse_checksum_file(checksum_files[0])
+
+    # Parse owner/repo from the release URL
+    match = re.search(r"https://github\.com/([^/]+/[^/]+)", github_release_url)
+    if not match:
+        msg = f"Could not parse owner/repo from URL: {github_release_url}"
+        raise RuntimeError(msg)
+    owner_repo = match.group(1)
+
+    # GitHub release tags typically use v prefix (e.g., v1.7.2), but the
+    # version extracted from filenames may not include it
+    github_tag = github_release_version
+    if not github_tag.startswith("v"):
+        github_tag = f"v{github_release_version}"
+
+    content_artifacts = (
+        data.setdefault("releaseNotes", {})
+        .setdefault("content", {})
+        .setdefault("artifacts", [])
+    )
+
+    for mapping_component in data.get("mapping", {}).get("components", []):
+        if mapping_component.get("name") != name:
+            continue
+        for file_entry in mapping_component.get("files", []):
+            source = file_entry.get("source", "")
+            filename = Path(source).name
+            if filename.endswith("_manifest.json"):
+                continue
+            checksum = checksum_map.get(filename, "")
+            download_url = (
+                f"https://github.com/{owner_repo}/releases/"
+                f"download/{github_tag}/{filename}"
+            )
+            purl = (
+                f"pkg:generic/{name}@{github_release_version}"
+                f"?checksum={checksum}"
+                f"&download_url={download_url}"
+            )
+            entry: dict[str, Any] = {
+                "architecture": file_entry["arch"],
+                "os": file_entry["os"],
+                "purl": purl,
+                "component": name,
+            }
+            if has_cves:
+                entry.update(cves_dict)
+            content_artifacts.append(entry)
+
+
+def update_type_and_references(data: dict[str, Any]) -> None:
+    """Set type to RHSA and add per-CVE reference URLs."""
+    release_notes = data.get("releaseNotes", {})
+    content = release_notes.get("content", {})
+
+    # Check key existence an empty [] still counts as content present
+    if "images" not in content and "artifacts" not in content:
+        return
+
+    images = content.get("images")
+    artifacts = content.get("artifacts")
+
+    # Collect all CVE IDs across content items
+    items = images if images else artifacts
+    cve_ids: set[str] = set()
+    for item in items:
+        fixed = item.get("cves", {}).get("fixed", {})
+        cve_ids.update(fixed.keys())
+
+    references = release_notes.setdefault("references", [])
+
+    if not cve_ids:
+        return
+
+    release_notes["type"] = "RHSA"
+
+    references.append(CLASSIFICATION_URL)
+    for cve_id in sorted(cve_ids):
+        references.append(f"{CVE_REF_PREFIX}{cve_id}")
+
+    # Remove duplicates and sort
+    seen: set[str] = set()
+    unique_references: list[str] = []
+    for reference in references:
+        if reference not in seen:
+            seen.add(reference)
+            unique_references.append(reference)
+    release_notes["references"] = sorted(unique_references)
+
+
+def run(
+    *,
+    data_file: Path,
+    snapshot_file: Path,
+    jira_secret_path: Path,
+    binaries_dir: str,
+    github_release_version: str,
+    github_release_url: str,
+) -> int:
+    """Run all populate-release-notes steps and write the result."""
+    data = file_helper.load_json_dict(data_file)
+    snapshot = file_helper.load_json_dict(snapshot_file)
+
+    email, token = jira_helper.read_jira_credentials(jira_secret_path)
+    auth = HTTPBasicAuth(email, token)
+    session = http_client.get_retry_session(
+        total=5,
+        connect=3,
+        read=3,
+        status=5,
+        backoff_factor=1.0,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=frozenset({"GET"}),
+    )
+    validate_cve_issues(data, session, auth)
+
+    populate_images(data, snapshot)
+    populate_artifacts(data, snapshot)
+    populate_github(
+        data,
+        snapshot,
+        github_release_version,
+        github_release_url,
+        binaries_dir,
+    )
+    update_type_and_references(data)
+
+    output = json.dumps(data, indent=2)
+    data_file.write_text(output + "\n", encoding="utf-8")
+    logger.info("%s\n%s", data_file, output)
+    return 0
+
+
+def main() -> int:
+    """Read environment variables and run the task."""
+    data_dir = Path(tekton.require_env("DATA_DIR"))
+    data_path = tekton.require_env("DATA_PATH")
+    snapshot_path = tekton.require_env("SNAPSHOT_PATH")
+
+    jira_secret_path = file_helper.path_from_env_variable("JIRA_SECRET_PATH", "/etc/secrets")
+    binaries_dir_rel = os.environ.get("BINARIES_DIR", "")
+    github_release_version = os.environ.get("GITHUB_RELEASE_VERSION", "")
+    github_release_url = os.environ.get("GITHUB_RELEASE_URL", "")
+
+    binaries_dir = ""
+    if binaries_dir_rel:
+        binaries_dir = str(data_dir / binaries_dir_rel)
+
+    return run(
+        data_file=data_dir / data_path,
+        snapshot_file=data_dir / snapshot_path,
+        jira_secret_path=jira_secret_path,
+        binaries_dir=binaries_dir,
+        github_release_version=github_release_version,
+        github_release_url=github_release_url,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_populate_release_notes.py
+++ b/scripts/python/tasks/managed/test_populate_release_notes.py
@@ -1,0 +1,1412 @@
+"""Tests for populate_release_notes."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import populate_release_notes
+import pytest
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+@pytest.fixture()
+def _patch_get_arch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock get_image_architectures to return amd64 and s390x."""
+    monkeypatch.setattr(
+        populate_release_notes,
+        "get_image_architectures",
+        lambda _ref: MOCK_ARCH_DIGESTS,
+    )
+
+
+MOCK_ARCH_DIGESTS = [
+    {
+        "platform": {"architecture": "amd64", "os": "linux"},
+        "digest": "sha256:abcdefg",
+    },
+    {
+        "platform": {"architecture": "s390x", "os": "linux"},
+        "digest": "sha256:deadbeef",
+    },
+]
+
+MOCK_AUTH = HTTPBasicAuth("test@test.com", "token123")
+
+
+def _write_json(path: Path, data: dict) -> None:
+    """Write *data* as JSON to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _load(path: Path) -> dict:
+    """Read JSON from *path*."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _default_release_notes(**overrides: Any) -> dict[str, Any]:
+    release_notes: dict[str, Any] = {
+        "product_id": [123],
+        "product_name": "test-product",
+        "product_version": "1.0",
+        "cpe": "cpe:/a:redhat:test:1.0",
+        "type": "RHBA",
+        "synopsis": "Test synopsis",
+        "topic": "Test topic",
+        "description": "Test description",
+        "solution": "Test solution",
+    }
+    release_notes.update(overrides)
+    return release_notes
+
+
+def _default_data(**overrides: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {"releaseNotes": _default_release_notes()}
+    data.update(overrides)
+    return data
+
+
+def _default_snapshot(
+    components: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    if components is None:
+        components = [
+            {
+                "name": "comp",
+                "containerImage": "registry.io/image@sha256:123456",
+                "repositories": [
+                    {
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": ["foo", "bar"],
+                    }
+                ],
+            }
+        ]
+    return {"application": "test-app", "components": components}
+
+
+def _make_secret_dir(tmp_path: Path) -> Path:
+    """Write dummy Jira credentials under *tmp_path*/secrets."""
+    secret_dir = tmp_path / "secrets"
+    secret_dir.mkdir()
+    (secret_dir / "token").write_text("tok", encoding="utf-8")
+    (secret_dir / "email").write_text("e@t.com", encoding="utf-8")
+    return secret_dir
+
+
+def _jira_response(issue_type: str, cve_id: str | None = None) -> dict:
+    """Return a fake Jira issue response."""
+    fields: dict[str, Any] = {"issuetype": {"name": issue_type}}
+    if cve_id is not None:
+        fields["customfield_10667"] = cve_id
+    return {"fields": fields}
+
+
+def _mock_session(responses: dict[str, dict]) -> MagicMock:
+    """Return a fake Session that matches URLs by substring."""
+    session = MagicMock(spec=requests.Session)
+
+    def fake_get(url: str, **kwargs: Any) -> MagicMock:
+        for key, body in responses.items():
+            if key in url:
+                resp = MagicMock()
+                resp.json.return_value = body
+                resp.raise_for_status.return_value = None
+                return resp
+        raise requests.ConnectionError(f"Unexpected URL: {url}")
+
+    session.get.side_effect = fake_get
+    return session
+
+
+def test_get_content_type_from_content_gateway() -> None:
+    """Reads contentType from contentGateway."""
+    data = {"mapping": {"components": [{"contentGateway": {"contentType": "binary"}}]}}
+    assert populate_release_notes.get_content_type(data) == "binary"
+
+
+def test_get_content_type_from_content_type() -> None:
+    """Reads contentType directly."""
+    data = {"mapping": {"components": [{"contentType": "disk-image"}]}}
+    assert populate_release_notes.get_content_type(data) == "disk-image"
+
+
+def test_get_content_type_no_mapping() -> None:
+    """Returns None when no mapping present."""
+    assert populate_release_notes.get_content_type({}) is None
+
+
+def test_build_cves_filters_by_component() -> None:
+    """Only includes CVEs for the named component."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            cves=[
+                {"key": "CVE-1", "component": "a", "packages": ["p"]},
+                {"key": "CVE-2", "component": "b"},
+            ]
+        )
+    )
+    result = populate_release_notes.build_cves_for_component(data, "a")
+    assert "CVE-1" in result["cves"]["fixed"]
+    assert "CVE-2" not in result["cves"]["fixed"]
+
+
+def test_build_cves_empty_when_no_match() -> None:
+    """Empty fixed dict when no CVEs match."""
+    data = _default_data()
+    result = populate_release_notes.build_cves_for_component(data, "x")
+    assert result["cves"]["fixed"] == {}
+
+
+def test_timestamp_tag_from_oci_label() -> None:
+    """Converts image.created label to timestamp."""
+    component = {
+        "name": "c",
+        "metadata": {
+            "labels": [
+                {
+                    "name": "org.opencontainers.image.created",
+                    "value": "2025-04-14T02:14:26Z",
+                }
+            ]
+        },
+    }
+    tag = populate_release_notes.get_timestamp_tag(component)
+    assert tag == "1744596866"
+
+
+def test_timestamp_tag_missing_label() -> None:
+    """Returns empty string when label is absent."""
+    component = {"name": "c"}
+    assert populate_release_notes.get_timestamp_tag(component) == ""
+
+
+def test_timestamp_tag_unparseable_label() -> None:
+    """Returns empty string when label cannot be parsed."""
+    component = {
+        "name": "c",
+        "metadata": {
+            "labels": [
+                {
+                    "name": "org.opencontainers.image.created",
+                    "value": "not-a-date",
+                }
+            ]
+        },
+    }
+    assert populate_release_notes.get_timestamp_tag(component) == ""
+
+
+def test_unique_tag_from_tags_regex() -> None:
+    """Picks the longest tag matching the regex."""
+    tags = ["foo", "9.4-1723436855", "9.4.0-1723436855", "bar"]
+    tag = populate_release_notes.get_unique_tag_from_tags(tags)
+    assert tag == "9.4.0-1723436855"
+
+
+def test_unique_tag_from_tags_no_match() -> None:
+    """Returns empty string when no tags match."""
+    tag = populate_release_notes.get_unique_tag_from_tags(["foo", "bar"])
+    assert tag == ""
+
+
+def test_generate_purl_rpm() -> None:
+    """Formats an RPM PURL correctly."""
+    purl = populate_release_notes.generate_purl_rpm(
+        "hello",
+        "1.0",
+        "1.fc38",
+        "x86_64",
+        "hummingbird",
+        "hbird-x86_64-id",
+    )
+    assert purl == (
+        "pkg:rpm/redhat/hello@1.0-1.fc38"
+        "?arch=x86_64&distro=hummingbird"
+        "&repository_id=hbird-x86_64-id"
+    )
+
+
+def test_parse_checksum_file(tmp_path: Path) -> None:
+    """Parses checksums and skips manifest files."""
+    checksum_file = tmp_path / "SHA256SUMS"
+    checksum_file.write_text(
+        "abc123 file1.tar.gz\n" "def456 file2.tar.gz\n" "ghi789 thing_manifest.json\n",
+        encoding="utf-8",
+    )
+    result = populate_release_notes.parse_checksum_file(checksum_file)
+    assert result == {"file1.tar.gz": "abc123", "file2.tar.gz": "def456"}
+
+
+def test_parse_checksum_file_skips_bad_lines(tmp_path: Path) -> None:
+    """Lines without two fields are skipped."""
+    checksum_file = tmp_path / "SHA256SUMS"
+    checksum_file.write_text(
+        "abc123 file1.tar.gz\nbadline\n\ndef456 file2.tar.gz\n",
+        encoding="utf-8",
+    )
+    result = populate_release_notes.parse_checksum_file(checksum_file)
+    assert result == {"file1.tar.gz": "abc123", "file2.tar.gz": "def456"}
+
+
+def test_cve_validation_pass() -> None:
+    """Duplicates removed, non-Jira and non-Vulnerability skipped, CVE matches."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            cves=[{"key": "CVE-123", "component": "comp"}],
+            issues={
+                "fixed": [
+                    {"source": "redhat.atlassian.net", "id": "VULN-123"},
+                    {"source": "redhat.atlassian.net", "id": "VULN-123"},
+                    {"source": "redhat.atlassian.net", "id": "FEATURE-456"},
+                    {"source": "bugzilla.redhat.com", "id": "BZ-789"},
+                ]
+            },
+        )
+    )
+    session = _mock_session(
+        {
+            "VULN-123": _jira_response("Vulnerability", "CVE-123"),
+            "FEATURE-456": _jira_response("Feature"),
+        }
+    )
+
+    populate_release_notes.validate_cve_issues(data, session, MOCK_AUTH)
+
+    assert session.get.call_count == 2
+    assert len(data["releaseNotes"]["issues"]["fixed"]) == 3
+
+
+def test_cve_validation_fail() -> None:
+    """Raises when CVE from Jira is not in releaseNotes.cves."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            cves=[{"key": "CVE-456", "component": "comp"}],
+            issues={
+                "fixed": [
+                    {"source": "redhat.atlassian.net", "id": "VULN-MISSING"},
+                ]
+            },
+        )
+    )
+    session = _mock_session(
+        {
+            "VULN-MISSING": _jira_response("Vulnerability", "CVE-MISSING-456"),
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="CVE-MISSING-456"):
+        populate_release_notes.validate_cve_issues(data, session, MOCK_AUTH)
+
+
+def test_cve_validation_fail_empty_cves() -> None:
+    """Raises when cves list is empty but a Vulnerability issue exists."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            cves=[],
+            issues={
+                "fixed": [
+                    {"source": "redhat.atlassian.net", "id": "VULN-123"},
+                ]
+            },
+        )
+    )
+    session = _mock_session(
+        {
+            "VULN-123": _jira_response("Vulnerability", "CVE-123"),
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="CVE-123"):
+        populate_release_notes.validate_cve_issues(data, session, MOCK_AUTH)
+
+
+def test_cve_server_converted() -> None:
+    """issues.redhat.com is converted to redhat.atlassian.net."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            cves=[{"key": "CVE-123", "component": "comp"}],
+            issues={
+                "fixed": [
+                    {"source": "issues.redhat.com", "id": "VULN-123"},
+                ]
+            },
+        )
+    )
+    session = _mock_session(
+        {
+            "VULN-123": _jira_response("Vulnerability", "CVE-123"),
+        }
+    )
+
+    populate_release_notes.validate_cve_issues(data, session, MOCK_AUTH)
+    url = session.get.call_args_list[0].args[0]
+    assert "redhat.atlassian.net" in url
+    assert "issues.redhat.com" not in url
+
+
+def test_cve_validation_no_issues_skips() -> None:
+    """Skips when issues.fixed is absent."""
+    data = _default_data()
+    session = MagicMock(spec=requests.Session)
+    populate_release_notes.validate_cve_issues(data, session, MOCK_AUTH)
+    session.get.assert_not_called()
+
+
+def test_cve_validation_fetch_failure_skips(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Jira fetch failure logs a warning and skips."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            cves=[{"key": "CVE-123", "component": "comp"}],
+            issues={
+                "fixed": [
+                    {"source": "redhat.atlassian.net", "id": "VULN-123"},
+                ]
+            },
+        )
+    )
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("fail")
+
+    release_logger = logging.getLogger("release")
+    release_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="release"):
+            populate_release_notes.validate_cve_issues(data, session, MOCK_AUTH)
+        assert "Could not fetch issue" in caplog.text
+    finally:
+        release_logger.propagate = False
+
+
+def test_cve_validation_null_cve_id() -> None:
+    """Skips when Vulnerability issue has null CVE ID."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            cves=[{"key": "CVE-123", "component": "comp"}],
+            issues={
+                "fixed": [
+                    {"source": "redhat.atlassian.net", "id": "VULN-1"},
+                ]
+            },
+        )
+    )
+    session = _mock_session({"VULN-1": _jira_response("Vulnerability", None)})
+    populate_release_notes.validate_cve_issues(data, session, MOCK_AUTH)
+
+
+def test_single_image(_patch_get_arch: None) -> None:
+    """Two arch entries for a single component and repo."""
+    data = _default_data()
+    snapshot = _default_snapshot()
+
+    populate_release_notes.populate_images(data, snapshot)
+
+    images = data["releaseNotes"]["content"]["images"]
+    assert len(images) == 2
+
+    amd = images[0]
+    assert amd["architecture"] == "amd64"
+    assert amd["containerImage"] == ("registry.redhat.io/product/repo@sha256:abcdefg")
+    assert amd["purl"] == (
+        "pkg:oci/repo@sha256%3Aabcdefg"
+        "?arch=amd64"
+        "&repository_url=registry.redhat.io/product/repo"
+    )
+    assert amd["repository"] == "registry.redhat.io/product/repo"
+    assert amd["tags"] == ["foo", "bar"]
+    assert amd["component"] == "comp"
+
+
+def test_multiple_images_tag_selection(_patch_get_arch: None) -> None:
+    """Longest matching tag used, no tag when none match."""
+    components = [
+        {
+            "name": "comp",
+            "containerImage": "registry.io/img@sha256:aaa",
+            "repositories": [
+                {
+                    "rh-registry-repo": "registry.redhat.io/product/repo",
+                    "tags": ["9.4-1723436855", "9.4.0-1723436855", "foo", "bar"],
+                }
+            ],
+        },
+        {
+            "name": "comp2",
+            "containerImage": "registry.io/img2@sha256:bbb",
+            "repositories": [
+                {
+                    "rh-registry-repo": "registry.stage.redhat.io/product2/repo2",
+                    "tags": ["foo", "bar"],
+                }
+            ],
+        },
+    ]
+    data = _default_data()
+
+    populate_release_notes.populate_images(data, _default_snapshot(components))
+
+    images = data["releaseNotes"]["content"]["images"]
+    assert len(images) == 4
+    assert "&tag=9.4.0-1723436855" in images[0]["purl"]
+    assert "&tag=" not in images[2]["purl"]
+
+
+def test_multiple_repositories(_patch_get_arch: None) -> None:
+    """One entry per repo per arch."""
+    components = [
+        {
+            "name": "comp",
+            "containerImage": "registry.io/img@sha256:aaa",
+            "repositories": [
+                {
+                    "rh-registry-repo": "registry.redhat.io/product/repo",
+                    "tags": ["9.4.0-1723436855"],
+                },
+                {
+                    "rh-registry-repo": "registry.redhat.io/product/repo2",
+                    "tags": ["foo", "bar"],
+                },
+            ],
+        }
+    ]
+    data = _default_data()
+
+    populate_release_notes.populate_images(data, _default_snapshot(components))
+
+    images = data["releaseNotes"]["content"]["images"]
+    assert len(images) == 4
+    assert images[0]["repository"] == "registry.redhat.io/product/repo"
+    assert "&tag=9.4.0-1723436855" in images[0]["purl"]
+    assert images[2]["repository"] == "registry.redhat.io/product/repo2"
+    assert "&tag=" not in images[2]["purl"]
+
+
+def test_no_overwrite(_patch_get_arch: None) -> None:
+    """Pre-existing content.images entries are kept."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(content={"images": [{"existing": "entry"}]})
+    )
+    populate_release_notes.populate_images(data, _default_snapshot())
+
+    images = data["releaseNotes"]["content"]["images"]
+    assert len(images) == 3
+    assert images[0] == {"existing": "entry"}
+
+
+def test_unique_tag_from_label(_patch_get_arch: None) -> None:
+    """PURL tag from org.opencontainers.image.created."""
+    components = [
+        {
+            "name": "comp",
+            "containerImage": "registry.io/img@sha256:aaa",
+            "metadata": {
+                "labels": [
+                    {
+                        "name": "org.opencontainers.image.created",
+                        "value": "2025-04-14T02:14:26Z",
+                    }
+                ]
+            },
+            "repositories": [
+                {
+                    "rh-registry-repo": "registry.redhat.io/product/repo",
+                    "tags": ["foo", "bar"],
+                }
+            ],
+        }
+    ]
+    data = _default_data()
+
+    populate_release_notes.populate_images(data, _default_snapshot(components))
+    assert "&tag=1744596866" in data["releaseNotes"]["content"]["images"][0]["purl"]
+
+
+def test_canonical_name_in_purl(_patch_get_arch: None) -> None:
+    """Uses canonicalName in the PURL path."""
+    components = [
+        {
+            "name": "comp",
+            "canonicalName": "my-product/my-image",
+            "containerImage": "registry.io/img@sha256:aaa",
+            "repositories": [
+                {
+                    "rh-registry-repo": "registry.redhat.io/product/repo",
+                    "tags": ["foo"],
+                }
+            ],
+        }
+    ]
+    data = _default_data()
+
+    populate_release_notes.populate_images(data, _default_snapshot(components))
+    assert "pkg:oci/my-product/my-image@" in (
+        data["releaseNotes"]["content"]["images"][0]["purl"]
+    )
+
+
+def test_images_skips_github_release() -> None:
+    """No images produced for github releases."""
+    data = _default_data(github={"githubSecret": "s"})
+    populate_release_notes.populate_images(data, _default_snapshot())
+    assert "content" not in data.get("releaseNotes", {})
+
+
+def test_images_skips_binary_content() -> None:
+    """No images produced for binary content."""
+    data = _default_data(
+        mapping={"components": [{"contentGateway": {"contentType": "binary"}}]}
+    )
+    populate_release_notes.populate_images(data, _default_snapshot())
+    assert "content" not in data.get("releaseNotes", {})
+
+
+def test_images_not_created_when_no_repositories(_patch_get_arch: None) -> None:
+    """No content.images key when components have no repositories (e.g. RPM)."""
+    components = [{"name": "comp", "containerImage": "r@sha256:abc123"}]
+    data = _default_data()
+    populate_release_notes.populate_images(data, _default_snapshot(components))
+    assert "images" not in data.get("releaseNotes", {}).get("content", {})
+
+
+def test_invalid_container_image_sha(_patch_get_arch: None) -> None:
+    """RuntimeError when containerImage is not a valid sha256 reference."""
+    components = [
+        {
+            "name": "comp",
+            "containerImage": "registry.io/image:latest",
+            "repositories": [
+                {
+                    "rh-registry-repo": "registry.redhat.io/product/repo",
+                    "tags": ["foo"],
+                }
+            ],
+        }
+    ]
+    data = _default_data()
+    with pytest.raises(RuntimeError, match="Failed to extract sha256"):
+        populate_release_notes.populate_images(data, _default_snapshot(components))
+
+
+def test_cves_added(_patch_get_arch: None) -> None:
+    """CVEs attached to matching component images."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            cves=[
+                {"key": "CVE-123", "component": "comp", "packages": ["pkg1", "pkg2"]},
+                {"key": "CVE-456", "component": "comp", "packages": ["pkg3"]},
+            ]
+        )
+    )
+    populate_release_notes.populate_images(data, _default_snapshot())
+
+    images = data["releaseNotes"]["content"]["images"]
+    assert len(images) == 2
+    fixed = images[0]["cves"]["fixed"]
+    assert "CVE-123" in fixed
+    assert "CVE-456" in fixed
+    assert fixed["CVE-123"]["packages"] == ["pkg1", "pkg2"]
+
+
+def test_mixed_cve_images(_patch_get_arch: None) -> None:
+    """CVEs only on comp1, not comp2. Type set to RHSA."""
+    components = [
+        {
+            "name": "comp1",
+            "containerImage": "reg/a@sha256:aaa",
+            "repositories": [{"rh-registry-repo": "reg.io/p/r1", "tags": ["t1"]}],
+        },
+        {
+            "name": "comp2",
+            "containerImage": "reg/b@sha256:bbb",
+            "repositories": [{"rh-registry-repo": "reg.io/p/r2", "tags": ["t2"]}],
+        },
+    ]
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            type="RHBA",
+            cves=[
+                {"key": "CVE-123", "component": "comp1", "packages": []},
+                {"key": "CVE-456", "component": "comp1", "packages": []},
+            ],
+        )
+    )
+    populate_release_notes.populate_images(data, _default_snapshot(components))
+    populate_release_notes.update_type_and_references(data)
+
+    images = data["releaseNotes"]["content"]["images"]
+    assert len(images) == 4
+    assert "cves" in images[0]
+    assert "cves" not in images[2]
+    assert data["releaseNotes"]["type"] == "RHSA"
+
+
+def test_artifacts_skips_non_artifact_content() -> None:
+    """Skips when content type is not binary, disk-image, or rpm."""
+    data = _default_data()
+    populate_release_notes.populate_artifacts(data, _default_snapshot())
+    assert "artifacts" not in data.get("releaseNotes", {}).get("content", {})
+
+
+def test_binary_with_files() -> None:
+    """Two binary entries with placeholder PURLs."""
+    data = _default_data(
+        mapping={
+            "components": [
+                {
+                    "name": "prod",
+                    "contentGateway": {"contentType": "binary"},
+                    "files": [
+                        {"arch": "amd64", "os": "linux"},
+                        {"arch": "amd64", "os": "windows"},
+                    ],
+                }
+            ]
+        }
+    )
+    snapshot = _default_snapshot([{"name": "prod", "containerImage": "r@sha256:a"}])
+
+    populate_release_notes.populate_artifacts(data, snapshot)
+
+    artifacts = data["releaseNotes"]["content"]["artifacts"]
+    assert len(artifacts) == 2
+    assert artifacts[0]["purl"] == "placeholder"
+    assert artifacts[1]["os"] == "windows"
+
+
+def test_binary_staged_files() -> None:
+    """Falls back to staged.files when files is absent."""
+    data = _default_data(
+        mapping={
+            "components": [
+                {
+                    "name": "odf-cli",
+                    "contentType": "binary",
+                    "staged": {
+                        "files": [
+                            {"arch": "amd64", "os": "linux"},
+                            {"arch": "amd64", "os": "darwin"},
+                            {"arch": "amd64", "os": "windows"},
+                        ]
+                    },
+                }
+            ]
+        }
+    )
+    snapshot = _default_snapshot([{"name": "odf-cli", "containerImage": "r@sha256:a"}])
+
+    populate_release_notes.populate_artifacts(data, snapshot)
+
+    artifacts = data["releaseNotes"]["content"]["artifacts"]
+    assert len(artifacts) == 3
+    assert sorted(a["os"] for a in artifacts) == ["darwin", "linux", "windows"]
+
+
+def test_binary_with_cves() -> None:
+    """CVEs attached to binary artifacts."""
+    data = _default_data(
+        mapping={
+            "components": [
+                {
+                    "name": "prod",
+                    "contentGateway": {"contentType": "binary"},
+                    "files": [{"arch": "amd64", "os": "linux"}],
+                }
+            ]
+        },
+        releaseNotes=_default_release_notes(
+            cves=[
+                {"key": "CVE-123", "component": "prod", "packages": ["p1", "p2"]},
+                {"key": "CVE-456", "component": "prod", "packages": ["p3"]},
+            ]
+        ),
+    )
+    snapshot = _default_snapshot([{"name": "prod", "containerImage": "r@sha256:a"}])
+
+    populate_release_notes.populate_artifacts(data, snapshot)
+
+    fixed = data["releaseNotes"]["content"]["artifacts"][0]["cves"]["fixed"]
+    assert "CVE-123" in fixed
+    assert "CVE-456" in fixed
+
+
+def test_disk_image_with_cves() -> None:
+    """Two disk-image entries with CVEs and x86_64 arch."""
+    data = _default_data(
+        mapping={
+            "components": [
+                {
+                    "name": "iso-comp",
+                    "contentGateway": {"contentType": "disk-image"},
+                    "staged": {"files": [{"filename": "image-x86_64.iso"}]},
+                },
+                {
+                    "name": "qcow-comp",
+                    "contentGateway": {"contentType": "disk-image"},
+                    "staged": {"files": [{"filename": "image-x86_64.qcow2"}]},
+                },
+            ]
+        },
+        releaseNotes=_default_release_notes(
+            cves=[
+                {"key": "CVE-123", "component": "iso-comp", "packages": ["p1", "p2"]},
+                {"key": "CVE-456", "component": "qcow-comp", "packages": []},
+            ]
+        ),
+    )
+    snapshot = _default_snapshot(
+        [
+            {"name": "iso-comp", "containerImage": "r@sha256:a"},
+            {"name": "qcow-comp", "containerImage": "r@sha256:b"},
+        ]
+    )
+
+    populate_release_notes.populate_artifacts(data, snapshot)
+
+    artifacts = data["releaseNotes"]["content"]["artifacts"]
+    assert len(artifacts) == 2
+    assert artifacts[0]["architecture"] == "x86_64"
+    assert artifacts[0]["os"] == "linux"
+    assert "CVE-123" in artifacts[0]["cves"]["fixed"]
+    assert "CVE-456" in artifacts[1]["cves"]["fixed"]
+
+
+def test_marketplace_disk_image() -> None:
+    """Marketplace PURL uses pkg:generic with version."""
+    data = _default_data(
+        mapping={
+            "cloudMarketplacesSecret": "my-secret",
+            "components": [
+                {
+                    "name": "azure-img",
+                    "contentType": "disk-image",
+                    "staged": {
+                        "version": "1.5",
+                        "files": [{"filename": "img-x86_64.vhd"}],
+                    },
+                }
+            ],
+        },
+        releaseNotes=_default_release_notes(
+            cves=[{"key": "CVE-123", "component": "azure-img", "packages": []}]
+        ),
+    )
+    snapshot = _default_snapshot([{"name": "azure-img", "containerImage": "r@sha256:a"}])
+
+    populate_release_notes.populate_artifacts(data, snapshot)
+
+    artifacts = data["releaseNotes"]["content"]["artifacts"]
+    assert len(artifacts) == 1
+    assert artifacts[0]["purl"] == "pkg:generic/azure-img@1.5"
+    assert artifacts[0]["architecture"] == "x86_64"
+
+
+def test_disk_image_aarch64_arch() -> None:
+    """aarch64 detected from filename."""
+    data = _default_data(
+        mapping={
+            "components": [
+                {
+                    "name": "comp",
+                    "contentType": "disk-image",
+                    "staged": {"files": [{"filename": "image-aarch64.qcow2"}]},
+                }
+            ]
+        }
+    )
+    snapshot = _default_snapshot([{"name": "comp", "containerImage": "r@sha256:a"}])
+    populate_release_notes.populate_artifacts(data, snapshot)
+    assert data["releaseNotes"]["content"]["artifacts"][0]["architecture"] == "aarch64"
+
+
+def test_rpms() -> None:
+    """RPM entries with signing key, SBOM and attestation URLs."""
+    data = _default_data(
+        mapping={"components": [{"name": "hello--main", "contentType": "rpm"}]},
+        pulp={"domain": "public-hummingbird"},
+        signOptions={"signKeyAlias": {"key": "hummingbird-signing-key"}},
+    )
+    snapshot = _default_snapshot(
+        [
+            {
+                "name": "hello--main",
+                "containerImage": "r@sha256:a",
+                "rpmsToPublish": [
+                    {
+                        "rpmname": "hello",
+                        "arch": "x86_64",
+                        "version": "1.0",
+                        "release": "1.fc38",
+                        "distro": "hummingbird",
+                        "targetRepos": [
+                            {
+                                "repository_id": "hbird-x86_64-id",
+                                "repository_name": "binary",
+                                "distro": "hummingbird",
+                            }
+                        ],
+                    },
+                    {
+                        "rpmname": "hello",
+                        "arch": "x86_64",
+                        "version": "1.0",
+                        "release": "1.fc38",
+                        "distro": "hummingbird",
+                        "sbomPath": "sboms/hello--main/sha256-12345.sbom",
+                        "attestationPath": ("attestations/hello--main/sha256-12345.att"),
+                        "targetRepos": [
+                            {
+                                "repository_id": "hbird-src-id",
+                                "repository_name": "source",
+                                "distro": "hummingbird",
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+    )
+
+    populate_release_notes.populate_artifacts(data, snapshot)
+
+    artifacts = data["releaseNotes"]["content"]["artifacts"]
+    assert len(artifacts) == 2
+
+    assert artifacts[0]["purl"] == (
+        "pkg:rpm/redhat/hello@1.0-1.fc38"
+        "?arch=x86_64&distro=hummingbird&repository_id=hbird-x86_64-id"
+    )
+    assert artifacts[0]["signingKey"] == "hummingbird-signing-key"
+
+    assert artifacts[1]["architecture"] == "src"
+    assert artifacts[1]["sbom"] == (
+        "https://packages.redhat.com/api/pulp-content/"
+        "public-hummingbird/sboms/hello--main/sha256-12345.sbom"
+    )
+    assert artifacts[1]["attestation"] == (
+        "https://packages.redhat.com/api/pulp-content/"
+        "public-hummingbird/attestations/hello--main/sha256-12345.att"
+    )
+
+
+def test_rpm_without_distro_field() -> None:
+    """RPM entry without distro at root level does not error."""
+    data = _default_data(
+        mapping={"components": [{"name": "comp", "contentType": "rpm"}]},
+        signOptions={"signKeyAlias": {"key": "k"}},
+    )
+    snapshot = _default_snapshot(
+        [
+            {
+                "name": "comp",
+                "containerImage": "r@sha256:a",
+                "rpmsToPublish": [
+                    {
+                        "rpmname": "pkg",
+                        "arch": "x86_64",
+                        "version": "1.0",
+                        "release": "1.el9",
+                        "targetRepos": [
+                            {
+                                "repository_id": "repo-id",
+                                "repository_name": "binary",
+                                "distro": "rhel",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
+
+    populate_release_notes.populate_artifacts(data, snapshot)
+    assert len(data["releaseNotes"]["content"]["artifacts"]) == 1
+
+
+def test_rpm_no_rpms_to_publish() -> None:
+    """RuntimeError when no component has rpmsToPublish."""
+    data = _default_data(mapping={"components": [{"name": "comp", "contentType": "rpm"}]})
+    snapshot = _default_snapshot([{"name": "comp", "containerImage": "r@sha256:a"}])
+
+    with pytest.raises(RuntimeError, match="No rpmsToPublish"):
+        populate_release_notes.populate_artifacts(data, snapshot)
+
+
+def test_rpm_mixed_components() -> None:
+    """Components without rpmsToPublish are skipped, not errored."""
+    data = _default_data(
+        mapping={"components": [{"name": "has-rpms", "contentType": "rpm"}]},
+        signOptions={"signKeyAlias": {"key": "k"}},
+    )
+    snapshot = _default_snapshot(
+        [
+            {
+                "name": "has-rpms",
+                "containerImage": "r@sha256:a",
+                "rpmsToPublish": [
+                    {
+                        "rpmname": "pkg",
+                        "arch": "x86_64",
+                        "version": "1.0",
+                        "release": "1.el9",
+                        "distro": "rhel",
+                        "targetRepos": [
+                            {
+                                "repository_id": "repo-id",
+                                "repository_name": "binary",
+                                "distro": "rhel",
+                            }
+                        ],
+                    }
+                ],
+            },
+            {"name": "no-rpms", "containerImage": "r@sha256:b"},
+        ]
+    )
+
+    populate_release_notes.populate_artifacts(data, snapshot)
+
+    artifacts = data["releaseNotes"]["content"]["artifacts"]
+    assert len(artifacts) == 1
+    assert artifacts[0]["component"] == "has-rpms"
+
+
+def test_rpm_no_target_repos_fallback() -> None:
+    """RPM without targetRepos uses best-effort purl."""
+    data = _default_data(
+        mapping={"components": [{"name": "comp", "contentType": "rpm"}]},
+        signOptions={"signKeyAlias": {"key": "k"}},
+    )
+    snapshot = _default_snapshot(
+        [
+            {
+                "name": "comp",
+                "containerImage": "r@sha256:a",
+                "rpmsToPublish": [
+                    {
+                        "rpmname": "pkg",
+                        "arch": "x86_64",
+                        "version": "1.0",
+                        "release": "1.el9",
+                        "distro": "rhel",
+                    }
+                ],
+            }
+        ]
+    )
+    populate_release_notes.populate_artifacts(data, snapshot)
+    artifacts = data["releaseNotes"]["content"]["artifacts"]
+    assert len(artifacts) == 1
+    assert "pkg:rpm/redhat/pkg@1.0-1.el9" in artifacts[0]["purl"]
+    assert artifacts[0]["signingKey"] == "k"
+
+
+def test_github_release(tmp_path: Path) -> None:
+    """GitHub artifacts with v-prefixed download URLs and CVEs."""
+    binaries = tmp_path / "releases"
+    binaries.mkdir()
+    (binaries / "product_1.0.0_SHA256SUMS").write_text(
+        "aaa111 binary-linux-amd64\nbbb222 binary-windows-amd64\n"
+        "ccc333 product_1.0.0_manifest.json\n",
+        encoding="utf-8",
+    )
+    data = _default_data(
+        github={"githubSecret": "s"},
+        mapping={
+            "components": [
+                {
+                    "name": "product",
+                    "files": [
+                        {"source": "path/binary-linux-amd64", "arch": "amd64", "os": "linux"},
+                        {
+                            "source": "path/binary-windows-amd64",
+                            "arch": "amd64",
+                            "os": "windows",
+                        },
+                    ],
+                }
+            ]
+        },
+        releaseNotes=_default_release_notes(
+            cves=[
+                {"key": "CVE-123", "component": "product", "packages": ["p1", "p2"]},
+                {"key": "CVE-456", "component": "product", "packages": ["p3"]},
+            ]
+        ),
+    )
+    snapshot = _default_snapshot([{"name": "product", "containerImage": "r@sha256:a"}])
+
+    populate_release_notes.populate_github(
+        data,
+        snapshot,
+        "1.0.0",
+        "https://github.com/some-org/some-repo",
+        str(binaries),
+    )
+
+    artifacts = data["releaseNotes"]["content"]["artifacts"]
+    assert len(artifacts) == 2
+    assert "download/v1.0.0/" in artifacts[0]["purl"]
+    assert artifacts[0]["purl"].startswith("pkg:generic/product@1.0.0?")
+    assert "CVE-123" in artifacts[0]["cves"]["fixed"]
+
+
+def test_github_skips_manifest(tmp_path: Path) -> None:
+    """Manifest files are skipped."""
+    binaries = tmp_path / "releases"
+    binaries.mkdir()
+    (binaries / "prod_1.0_SHA256SUMS").write_text(
+        "aaa binary1\nbbb prod_1.0_manifest.json\n",
+        encoding="utf-8",
+    )
+    data = _default_data(
+        github={"githubSecret": "s"},
+        mapping={
+            "components": [
+                {
+                    "name": "prod",
+                    "files": [
+                        {"source": "p/binary1", "arch": "amd64", "os": "linux"},
+                        {"source": "p/prod_1.0_manifest.json", "arch": "amd64", "os": "linux"},
+                    ],
+                }
+            ]
+        },
+    )
+    snapshot = _default_snapshot([{"name": "prod", "containerImage": "r@sha256:a"}])
+
+    populate_release_notes.populate_github(
+        data,
+        snapshot,
+        "1.0",
+        "https://github.com/o/r",
+        str(binaries),
+    )
+    assert len(data["releaseNotes"]["content"]["artifacts"]) == 1
+
+
+def test_github_skips_when_no_github() -> None:
+    """Skips when .github field is absent."""
+    data = _default_data()
+    populate_release_notes.populate_github(data, _default_snapshot(), "", "", "")
+    assert "content" not in data.get("releaseNotes", {})
+
+
+def test_github_missing_binaries_dir() -> None:
+    """RuntimeError when binaries dir does not exist."""
+    data = _default_data(github={"githubSecret": "s"})
+    with pytest.raises(RuntimeError, match="Binaries directory"):
+        populate_release_notes.populate_github(
+            data,
+            _default_snapshot(),
+            "1.0",
+            "https://github.com/o/r",
+            "/nonexistent",
+        )
+
+
+def test_github_empty_binaries_dir() -> None:
+    """RuntimeError when binaries dir is empty string."""
+    data = _default_data(github={"githubSecret": "s"})
+    with pytest.raises(RuntimeError, match="Binaries directory"):
+        populate_release_notes.populate_github(
+            data,
+            _default_snapshot(),
+            "1.0",
+            "https://github.com/o/r",
+            "",
+        )
+
+
+def test_github_v_prefix_preserved(tmp_path: Path) -> None:
+    """Existing v prefix is not doubled."""
+    binaries = tmp_path / "releases"
+    binaries.mkdir()
+    (binaries / "p_v2.0_SHA256SUMS").write_text("aaa f1\n", encoding="utf-8")
+    data = _default_data(
+        github={"githubSecret": "s"},
+        mapping={
+            "components": [
+                {
+                    "name": "p",
+                    "files": [{"source": "x/f1", "arch": "amd64", "os": "linux"}],
+                }
+            ]
+        },
+    )
+    snapshot = _default_snapshot([{"name": "p", "containerImage": "r@sha256:a"}])
+
+    populate_release_notes.populate_github(
+        data,
+        snapshot,
+        "v2.0",
+        "https://github.com/o/r",
+        str(binaries),
+    )
+    purl = data["releaseNotes"]["content"]["artifacts"][0]["purl"]
+    assert "download/v2.0/" in purl
+    assert "download/vv2.0/" not in purl
+
+
+def test_github_no_checksum_file(tmp_path: Path) -> None:
+    """RuntimeError when no SHA256SUMS file exists."""
+    binaries = tmp_path / "releases"
+    binaries.mkdir()
+    data = _default_data(github={"githubSecret": "s"})
+    with pytest.raises(RuntimeError, match="No checksum file"):
+        populate_release_notes.populate_github(
+            data,
+            _default_snapshot(),
+            "1.0",
+            "https://github.com/o/r",
+            str(binaries),
+        )
+
+
+def test_github_bad_url(tmp_path: Path) -> None:
+    """RuntimeError when release URL cannot be parsed."""
+    binaries = tmp_path / "releases"
+    binaries.mkdir()
+    (binaries / "x_SHA256SUMS").write_text("aaa f1\n", encoding="utf-8")
+    data = _default_data(github={"githubSecret": "s"})
+    with pytest.raises(RuntimeError, match="Could not parse owner/repo"):
+        populate_release_notes.populate_github(
+            data,
+            _default_snapshot(),
+            "1.0",
+            "https://not-github.com/bad",
+            str(binaries),
+        )
+
+
+def test_rhsa_references() -> None:
+    """CVE and classification URLs added to references."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            type="RHSA",
+            references=["https://docs.example.com/rn"],
+            content={
+                "images": [
+                    {
+                        "cves": {
+                            "fixed": {
+                                "CVE-123": {"packages": []},
+                                "CVE-456": {"packages": []},
+                            }
+                        }
+                    }
+                ]
+            },
+        )
+    )
+    populate_release_notes.update_type_and_references(data)
+
+    references = data["releaseNotes"]["references"]
+    assert "https://access.redhat.com/security/cve/CVE-123" in references
+    assert "https://access.redhat.com/security/cve/CVE-456" in references
+    assert "https://access.redhat.com/security/updates/classification/" in references
+    assert "https://docs.example.com/rn" in references
+
+
+def test_non_rhsa_references() -> None:
+    """Empty references when no CVEs present."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            type="RHBA", content={"images": [{"component": "c"}]}
+        )
+    )
+    populate_release_notes.update_type_and_references(data)
+    assert data["releaseNotes"]["type"] == "RHBA"
+    assert data["releaseNotes"].get("references", []) == []
+
+
+def test_overwrite_type() -> None:
+    """Type changed from RHEA to RHSA when CVEs exist."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            type="RHEA",
+            content={"images": [{"cves": {"fixed": {"CVE-123": {"packages": []}}}}]},
+        )
+    )
+    populate_release_notes.update_type_and_references(data)
+    assert data["releaseNotes"]["type"] == "RHSA"
+
+
+def test_cross_image_cve_dedup() -> None:
+    """Same CVE across images only appears once in references."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            content={
+                "images": [
+                    {
+                        "cves": {
+                            "fixed": {
+                                "CVE-123": {"packages": []},
+                                "CVE-456": {"packages": []},
+                            }
+                        }
+                    },
+                    {
+                        "cves": {
+                            "fixed": {
+                                "CVE-123": {"packages": []},
+                                "CVE-789": {"packages": []},
+                            }
+                        }
+                    },
+                ]
+            },
+        )
+    )
+    populate_release_notes.update_type_and_references(data)
+
+    references = data["releaseNotes"]["references"]
+    cve_references = [r for r in references if "/cve/" in r]
+    assert len(cve_references) == 3
+    assert references == sorted(references)
+
+
+def test_references_no_cve_dup() -> None:
+    """Pre-existing references are not duplicated."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            references=[
+                "https://access.redhat.com/security/cve/CVE-123",
+                "https://access.redhat.com/security/updates/classification/",
+                "https://docs.example.com/existing-page",
+            ],
+            content={
+                "images": [
+                    {
+                        "cves": {
+                            "fixed": {
+                                "CVE-123": {"packages": []},
+                                "CVE-456": {"packages": []},
+                            }
+                        }
+                    }
+                ]
+            },
+        )
+    )
+    populate_release_notes.update_type_and_references(data)
+
+    references = data["releaseNotes"]["references"]
+    assert len(references) == len(set(references))
+    assert len(references) == 4
+
+
+def test_no_content_noop() -> None:
+    """No references key when no content exists."""
+    data = _default_data()
+    populate_release_notes.update_type_and_references(data)
+    assert "references" not in data.get("releaseNotes", {})
+
+
+def test_artifacts_references() -> None:
+    """CVE references work with artifacts, not just images."""
+    data = _default_data(
+        releaseNotes=_default_release_notes(
+            content={"artifacts": [{"cves": {"fixed": {"CVE-100": {"packages": []}}}}]},
+        )
+    )
+    populate_release_notes.update_type_and_references(data)
+    assert (
+        "https://access.redhat.com/security/cve/CVE-100" in data["releaseNotes"]["references"]
+    )
+
+
+def test_fail_missing_data(tmp_path: Path) -> None:
+    """Error when data.json does not exist."""
+    snapshot_file = tmp_path / "snapshot.json"
+    _write_json(snapshot_file, _default_snapshot())
+    secret_dir = _make_secret_dir(tmp_path)
+
+    with pytest.raises((FileNotFoundError, RuntimeError)):
+        populate_release_notes.run(
+            data_file=tmp_path / "missing.json",
+            snapshot_file=snapshot_file,
+            jira_secret_path=secret_dir,
+            binaries_dir="",
+            github_release_version="",
+            github_release_url="",
+        )
+
+
+def test_fail_missing_snapshot(tmp_path: Path) -> None:
+    """Error when snapshot.json does not exist."""
+    data_file = tmp_path / "data.json"
+    _write_json(data_file, _default_data())
+    secret_dir = _make_secret_dir(tmp_path)
+
+    with pytest.raises((FileNotFoundError, RuntimeError)):
+        populate_release_notes.run(
+            data_file=data_file,
+            snapshot_file=tmp_path / "missing.json",
+            jira_secret_path=secret_dir,
+            binaries_dir="",
+            github_release_version="",
+            github_release_url="",
+        )
+
+
+def test_run_happy_path(tmp_path: Path, _patch_get_arch: None) -> None:
+    """run() writes updated data.json with content.images."""
+    data_file = tmp_path / "data.json"
+    snapshot_file = tmp_path / "snapshot.json"
+    secret_dir = _make_secret_dir(tmp_path)
+
+    _write_json(data_file, _default_data())
+    _write_json(snapshot_file, _default_snapshot())
+
+    rc = populate_release_notes.run(
+        data_file=data_file,
+        snapshot_file=snapshot_file,
+        jira_secret_path=secret_dir,
+        binaries_dir="",
+        github_release_version="",
+        github_release_url="",
+    )
+
+    assert rc == 0
+    result = _load(data_file)
+    assert len(result["releaseNotes"]["content"]["images"]) == 2
+
+
+def test_main_happy_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _patch_get_arch: None,
+) -> None:
+    """main() reads env vars and writes data.json."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_json(data_dir / "data.json", _default_data())
+    _write_json(data_dir / "snapshot.json", _default_snapshot())
+
+    secret_dir = _make_secret_dir(tmp_path)
+
+    monkeypatch.setenv("DATA_DIR", str(data_dir))
+    monkeypatch.setenv("DATA_PATH", "data.json")
+    monkeypatch.setenv("SNAPSHOT_PATH", "snapshot.json")
+    monkeypatch.setenv("JIRA_SECRET_PATH", str(secret_dir))
+
+    assert populate_release_notes.main() == 0
+    result = _load(data_dir / "data.json")
+    assert len(result["releaseNotes"]["content"]["images"]) == 2
+
+
+def test_main_missing_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SystemExit when a required env var is missing."""
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    monkeypatch.delenv("DATA_PATH", raising=False)
+    monkeypatch.delenv("SNAPSHOT_PATH", raising=False)
+
+    with pytest.raises(SystemExit):
+        populate_release_notes.main()


### PR DESCRIPTION
Convert the validate-cve-issues, populate-images, populate-artifacts, populate-github and type-and-references steps to a single python script.

Jira: https://redhat.atlassian.net/browse/RELEASE-2501

Assisted-by: Claude