### PR TITLE
fix(RELEASE-2749): sign windows staging binaries with machine store

### DIFF
--- a/scripts/python/helpers/sign_windows.py
+++ b/scripts/python/helpers/sign_windows.py
@@ -45,6 +45,19 @@ CONTENT_DIR = Path(os.environ.get("CONTENT_DIR", "/shared/artifacts"))
 logger = logging.getLogger(__name__)
 
 
+def _is_staging_quay_url(quay_url: str) -> bool:
+    """Return True if quay_url targets the nonprod (staging) artifact path.
+
+    Staging releases route through the nonprod Quay path (set based on
+    release intention in release-service-catalog's
+    tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml) and sign
+    with a certificate in the Local Machine store, so signtool needs the
+    /sm flag only for those. Production keeps using its HSM-backed cert in
+    the Current User store.
+    """
+    return "/nonprod" in quay_url
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse and return CLI arguments."""
     p = argparse.ArgumentParser(prog=PROG)
@@ -62,8 +75,10 @@ def _build_batch_script(
     unsigned_digest: str,
     pipeline_run_uid: str,
     windows_temp_dir: str,
+    use_machine_store: bool = False,
 ) -> str:
     """Build the remote batch script that pulls, signs, verifies, and pushes binaries."""
+    sm_flag = " /sm" if use_machine_store else ""
     return f"""
 mkdir %TEMP%\\{windows_temp_dir} && cd /d %TEMP%\\{windows_temp_dir}
 @echo off
@@ -74,7 +89,8 @@ REM The content is extracted to unsigned\\windows with os/arch/ subdirectories
 
 REM Recursively sign all files in unsigned\\windows directory tree
 for /r unsigned\\windows %%f in (*) do (
-  signtool sign /v /n "Red Hat" /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 "%%f"
+  signtool sign{sm_flag} /v /n "Red Hat" /fd SHA256 ^
+    /tr http://timestamp.digicert.com /td SHA256 "%%f"
   if errorlevel 1 (
     echo Signing of %%f failed
     exit /B %ERRORLEVEL%
@@ -172,6 +188,7 @@ def run(quay_url: str, pipeline_run_uid: str) -> None:
             unsigned_digest=unsigned_digest,
             pipeline_run_uid=pipeline_run_uid,
             windows_temp_dir=windows_temp_dir,
+            use_machine_store=_is_staging_quay_url(quay_url),
         )
 
         fd, script_path = tempfile.mkstemp(suffix=".bat")

--- a/scripts/python/helpers/test_sign_windows.py
+++ b/scripts/python/helpers/test_sign_windows.py
@@ -38,6 +38,25 @@ def _setup_mounts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# _is_staging_quay_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "quay_url,expected",
+    [
+        ("quay.io/konflux-artifacts/nonprod", True),
+        ("quay.io/konflux-artifacts/prod", False),
+        ("quay.io/konflux-artifacts", False),
+        ("", False),
+    ],
+)
+def test_is_staging_quay_url(quay_url: str, expected: bool) -> None:
+    """_is_staging_quay_url matches the nonprod path and rejects others."""
+    assert sign_windows._is_staging_quay_url(quay_url) is expected
+
+
+# ---------------------------------------------------------------------------
 # _build_batch_script
 # ---------------------------------------------------------------------------
 
@@ -60,6 +79,24 @@ def test_build_batch_script_contains_signtool() -> None:
     assert "sha256:unsigned" in script
     assert "uid-123-windows" in script
     assert "Red Hat" in script
+    assert "/sm" not in script
+
+
+def test_build_batch_script_use_machine_store_adds_sm_flag() -> None:
+    """The /sm flag is added to both signtool calls when use_machine_store is True."""
+    script = sign_windows._build_batch_script(
+        quay_url="quay.io/org",
+        quay_user="user",
+        quay_pass="pass",
+        component_name="prod",
+        unsigned_digest="sha256:unsigned",
+        pipeline_run_uid="uid-123",
+        windows_temp_dir="uid-123_prod",
+        use_machine_store=True,
+    )
+    assert 'signtool sign /sm /v /n "Red Hat"' in script
+    assert 'signtool verify /v /pa "%%f"' in script
+    assert "verify /sm" not in script
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +169,45 @@ def test_run_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
 
     digest = (comp_dir / "signed_windows_digest.txt").read_text()
     assert digest == "sha256:signed"
+
+
+def test_run_passes_machine_store_flag_for_staging_quay_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A nonprod quay_url results in /sm being written to the batch script."""
+    monkeypatch.setenv("SNAPSHOT_JSON", json.dumps({"components": [{"name": "prod"}]}))
+    monkeypatch.setattr(sign_windows, "CONTENT_DIR", tmp_path)
+    _setup_mounts(tmp_path, monkeypatch)
+    _patch_ssh_setup(monkeypatch)
+
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    (comp_dir / "has_windows").touch()
+    (comp_dir / "unsigned_windows_digest.txt").write_text("sha256:unsigned")
+
+    written_scripts = []
+
+    def fake_write(self, data):
+        written_scripts.append(data)
+        return len(data)
+
+    def fake_subprocess_run(cmd, **kwargs):
+        if cmd[0] == "ssh" and "Remove-Item" not in " ".join(str(a) for a in cmd):
+            m = mock.Mock(returncode=0)
+            m.stdout = "Digest: sha256:signed\n"
+            m.stderr = ""
+            return m
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    with (
+        mock.patch("shutil.copy2"),
+        mock.patch("subprocess.check_call"),
+        mock.patch("subprocess.run", side_effect=fake_subprocess_run),
+        mock.patch("os.write", side_effect=fake_write),
+    ):
+        sign_windows.run("quay.io/konflux-artifacts/nonprod", "uid-123")
+
+    assert any("/sm" in s.decode() for s in written_scripts)
 
 
 def test_run_raises_on_signing_failure(


### PR DESCRIPTION
The e2e Windows signing cert now lives in the Local Machine store to survive host reboots and password rotations without an RDP session. Add /sm to signtool for the e2e-konflux account only, detected from the quay nonprod url; production's HSM-backed cert stays in the Current User store and is unaffected.

Assisted-by: Cursor AI