### PR TITLE
feat(RELEASE-2477): convert collect-data task to python

### DIFF
--- a/scripts/python/tasks/managed/collect_data.py
+++ b/scripts/python/tasks/managed/collect_data.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Collect release data from K8s resources and merge into data.json.
+
+Fetch Release, ReleasePlan, ReleasePlanAdmission, ReleaseServiceConfig, and
+Snapshot CRs; merge collector results with spec.data from those resources
+(priority: RPA > RP > Release > collectors); resolve pipeline ref metadata;
+validate disallowed data key sources; and write JSON files plus Tekton results.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import http_client
+from authentication import setup_ca_cert
+from file import resolve_path_under_base
+from get_resource import get_resource_dict
+from vcs.github import owner_repo_from_url
+import tekton
+from logger import logger
+
+_DISALLOWED_RELEASE_NOTE_KEYS: tuple[str, ...] = (
+    "releaseNotes.product_id",
+    "releaseNotes.product_name",
+    "releaseNotes.product_version",
+    "releaseNotes.product_stream",
+    "releaseNotes.cpe",
+    "releaseNotes.allow_custom_live_id",
+)
+
+_RESULT_ENV_VARS: dict[str, str] = {
+    "release": "RESULT_RELEASE",
+    "releasePlan": "RESULT_RELEASE_PLAN",
+    "releasePlanAdmission": "RESULT_RELEASE_PLAN_ADMISSION",
+    "releaseServiceConfig": "RESULT_RELEASE_SERVICE_CONFIG",
+    "snapshotSpec": "RESULT_SNAPSHOT_SPEC",
+    "data": "RESULT_DATA",
+    "resultsDir": "RESULT_RESULTS_DIR",
+    "singleComponentMode": "RESULT_SINGLE_COMPONENT_MODE",
+    "snapshotName": "RESULT_SNAPSHOT_NAME",
+    "snapshotNamespace": "RESULT_SNAPSHOT_NAMESPACE",
+    "snapshotBuildId": "RESULT_SNAPSHOT_BUILD_ID",
+    "releasePipelineMetadata": "RESULT_RELEASE_PIPELINE_METADATA",
+    "subdirectory": "RESULT_SUBDIRECTORY",
+}
+
+
+def _resolve_result_paths() -> dict[str, Path]:
+    """Resolve Tekton result file paths from environment variables."""
+    paths = tekton.result_paths_from_env(*_RESULT_ENV_VARS.values())
+    return dict(zip(_RESULT_ENV_VARS, paths))
+
+
+@dataclasses.dataclass
+class CollectDataResult:
+    """All values computed by the collect-data workflow."""
+
+    subdirectory: str
+    release: dict[str, Any]
+    release_plan: dict[str, Any]
+    release_plan_admission: dict[str, Any]
+    release_service_config: dict[str, Any]
+    snapshot_spec: dict[str, Any]
+    merged_data: dict[str, Any]
+    pipeline_metadata: dict[str, str]
+    single_component_mode: str
+    snapshot_name: str
+    snapshot_namespace: str
+    snapshot_build_id: str
+
+
+def deep_merge(base: Any, override: Any) -> Any:
+    """Recursively merge *override* into *base*.
+
+    - dict + dict  -> recursive merge
+    - list + list  -> concatenate, deduplicate, then sort
+    - otherwise    -> *override* wins (``None`` in override preserves *base*)
+    """
+    if isinstance(base, dict) and isinstance(override, dict):
+        merged: dict[str, Any] = {}
+        for key in dict.fromkeys(list(base) + list(override)):
+            if key in base and key in override:
+                merged[key] = deep_merge(base[key], override[key])
+            elif key in override:
+                merged[key] = override[key]
+            else:
+                merged[key] = base[key]
+        return merged
+
+    if isinstance(base, list) and isinstance(override, list):
+        seen: list[Any] = []
+        for item in base + override:
+            if item not in seen:
+                seen.append(item)
+        try:
+            return sorted(seen, key=lambda x: json.dumps(x, sort_keys=True))
+        except TypeError:
+            return seen
+
+    if override is not None:
+        return override
+    return base
+
+
+def flatten_collectors(
+    collectors_status: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Deep-merge all collector values from managed and tenant sections."""
+    collectors = collectors_status if collectors_status else {}
+    managed_values = list((collectors.get("managed") or {}).values())
+    tenant_values = list((collectors.get("tenant") or {}).values())
+    all_values = managed_values + tenant_values
+
+    result: dict[str, Any] = {}
+    for item in all_values:
+        result = deep_merge(result, item)
+    return result
+
+
+def transform_snapshot_spec(spec: dict[str, Any]) -> dict[str, Any]:
+    """Apply componentGroup fallback and remove application field.
+
+    Return a new dict; *spec* is not modified.
+    """
+    result = {k: v for k, v in spec.items() if k != "application"}
+    if not result.get("componentGroup"):
+        result["componentGroup"] = spec.get("application")
+    return result
+
+
+_UNKNOWN_PIPELINE_METADATA: dict[str, str] = {
+    "org": "unknown",
+    "repo": "unknown",
+    "revision": "unknown",
+    "pathinrepo": "unknown",
+    "sha": "unknown",
+}
+
+
+def _resolve_commit_sha(org: str, repo: str, revision: str) -> str:
+    """Query the GitHub API for the full commit SHA, falling back to 'unknown'."""
+    try:
+        api_url = f"https://api.github.com/repos/{org}/{repo}/commits/{revision}"
+        response_text = http_client.get_text(api_url, timeout=10)
+        return json.loads(response_text).get("sha") or "unknown"
+    except Exception:
+        logger.warning(
+            "Failed to resolve commit SHA from GitHub API",
+            exc_info=True,
+        )
+        return "unknown"
+
+
+def _resolve_git_pipeline_ref(pipeline_ref: dict[str, Any]) -> dict[str, str]:
+    """Resolve org, repo, revision, path, and commit SHA from a git pipelineRef."""
+    params = {p["name"]: p["value"] for p in pipeline_ref.get("params", [])}
+    url = params.get("url", "")
+    revision = params.get("revision", "unknown")
+    pathinrepo = params.get("pathInRepo", "unknown")
+
+    if url:
+        owner_repo = owner_repo_from_url(url)
+        org, _, repo = owner_repo.partition("/")
+        repo = repo.removesuffix(".git") if repo else "unknown"
+        org = org or "unknown"
+    else:
+        org = "unknown"
+        repo = "unknown"
+
+    sha = _resolve_commit_sha(org, repo, revision)
+
+    return {
+        "org": org,
+        "repo": repo,
+        "revision": revision,
+        "pathinrepo": pathinrepo,
+        "sha": sha,
+    }
+
+
+def resolve_pipeline_ref(rpa_data: dict[str, Any]) -> dict[str, str]:
+    """Extract pipeline ref metadata from the RPA and resolve the commit SHA."""
+    pipeline_ref = rpa_data.get("spec", {}).get("pipeline", {}).get("pipelineRef", {})
+
+    if pipeline_ref.get("resolver") == "git":
+        return _resolve_git_pipeline_ref(pipeline_ref)
+
+    return dict(_UNKNOWN_PIPELINE_METADATA)
+
+
+def check_data_key_sources(
+    release: dict[str, Any],
+    release_plan: dict[str, Any],
+) -> None:
+    """Validate that disallowed keys are absent from Release and ReleasePlan spec.data."""
+    violations: list[str] = []
+
+    for resource, kind in ((release, "Release"), (release_plan, "ReleasePlan")):
+        spec_data = resource.get("spec", {}).get("data", {})
+        if not spec_data or not isinstance(spec_data, dict):
+            continue
+
+        for dotted_key in _DISALLOWED_RELEASE_NOTE_KEYS:
+            parts = dotted_key.split(".")
+            value = spec_data
+            for part in parts:
+                if isinstance(value, dict):
+                    value = value.get(part)
+                else:
+                    value = None
+                    break
+            if value is not None:
+                msg = f"Found disallowed key: {dotted_key} in resource {kind}"
+                logger.error(msg)
+                violations.append(msg)
+
+    if violations:
+        raise ValueError("Disallowed keys found:\n" + "\n".join(violations))
+
+
+def _write_json(path: Path, data: Any) -> None:
+    """Write JSON data to a file, creating parent directories."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def collect(
+    *,
+    release: str,
+    release_plan: str,
+    release_plan_admission: str,
+    release_service_config: str,
+    snapshot: str,
+    subdirectory: str,
+) -> CollectDataResult:
+    """Fetch K8s resources, merge data, and return computed results."""
+    ns, name = release.split("/", 1)
+    release_json = get_resource_dict("release", ns, name)
+
+    ns, name = release_plan.split("/", 1)
+    release_plan_json = get_resource_dict("releaseplan", ns, name)
+
+    ns, name = release_plan_admission.split("/", 1)
+    rpa_json = get_resource_dict("releaseplanadmission", ns, name)
+
+    ns, name = release_service_config.split("/", 1)
+    rsc_json = get_resource_dict("releaseserviceconfig", ns, name)
+
+    logger.info("Fetching Snapshot Spec")
+    snapshot_namespace, snapshot_name = snapshot.split("/", 1)
+    snapshot_json = get_resource_dict("snapshot", snapshot_namespace, snapshot_name)
+    snapshot_spec = transform_snapshot_spec(snapshot_json.get("spec", {}))
+
+    labels = snapshot_json.get("metadata", {}).get("labels", {})
+    snapshot_build_id = labels.get("appstudio.openshift.io/build-pipelinerun", "")
+
+    logger.info("Generating collectors data")
+    collectors_status = release_json.get("status", {}).get("collectors", {})
+    logger.info(
+        "collectors status: %s",
+        json.dumps(collectors_status, indent=2),
+    )
+    collectors_result = flatten_collectors(collectors_status)
+    logger.info(
+        "collectors merged: %s",
+        json.dumps(collectors_result, indent=2),
+    )
+
+    logger.info("Fetching merged data json")
+    release_data = release_json.get("spec", {}).get("data", {})
+    release_plan_data = release_plan_json.get("spec", {}).get("data", {})
+    rpa_data = rpa_json.get("spec", {}).get("data", {})
+
+    merged = deep_merge(collectors_result, release_data)
+    merged = deep_merge(merged, release_plan_data)
+    merged = deep_merge(merged, rpa_data)
+
+    pipeline_metadata = resolve_pipeline_ref(rpa_json)
+    logger.info("Release Pipeline Ref Info:")
+    logger.info("--------------------------")
+    logger.info("%s", json.dumps(pipeline_metadata, indent=2))
+
+    raw = merged.get("singleComponentMode")
+    single_component_mode = str(raw).lower() if raw is not None else "false"
+
+    check_data_key_sources(release_json, release_plan_json)
+
+    return CollectDataResult(
+        subdirectory=subdirectory,
+        release=release_json,
+        release_plan=release_plan_json,
+        release_plan_admission=rpa_json,
+        release_service_config=rsc_json,
+        snapshot_spec=snapshot_spec,
+        merged_data=merged,
+        pipeline_metadata=pipeline_metadata,
+        single_component_mode=single_component_mode,
+        snapshot_name=snapshot_name,
+        snapshot_namespace=snapshot_namespace,
+        snapshot_build_id=snapshot_build_id,
+    )
+
+
+def write_outputs(
+    result: CollectDataResult,
+    data_dir: Path,
+    result_paths: dict[str, Path],
+) -> None:
+    """Write workspace files and Tekton result files."""
+    if result.subdirectory:
+        base_dir = resolve_path_under_base(data_dir, result.subdirectory)
+        rel_base = Path(result.subdirectory)
+    else:
+        base_dir = data_dir
+        rel_base = Path()
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    results_dir = base_dir / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    result_paths["subdirectory"].write_text(result.subdirectory)
+    result_paths["resultsDir"].write_text(str(rel_base / "results"))
+
+    result_paths["release"].write_text(str(rel_base / "release.json"))
+    _write_json(base_dir / "release.json", result.release)
+
+    result_paths["releasePlan"].write_text(str(rel_base / "release_plan.json"))
+    _write_json(base_dir / "release_plan.json", result.release_plan)
+
+    result_paths["releasePlanAdmission"].write_text(
+        str(rel_base / "release_plan_admission.json")
+    )
+    _write_json(
+        base_dir / "release_plan_admission.json",
+        result.release_plan_admission,
+    )
+
+    result_paths["releaseServiceConfig"].write_text(
+        str(rel_base / "release_service_config.json")
+    )
+    _write_json(
+        base_dir / "release_service_config.json",
+        result.release_service_config,
+    )
+
+    result_paths["snapshotSpec"].write_text(str(rel_base / "snapshot_spec.json"))
+    _write_json(base_dir / "snapshot_spec.json", result.snapshot_spec)
+
+    result_paths["data"].write_text(str(rel_base / "data.json"))
+    _write_json(base_dir / "data.json", result.merged_data)
+
+    result_paths["releasePipelineMetadata"].write_text(
+        json.dumps(result.pipeline_metadata, separators=(",", ":"))
+    )
+    result_paths["singleComponentMode"].write_text(result.single_component_mode)
+    result_paths["snapshotName"].write_text(result.snapshot_name)
+    result_paths["snapshotNamespace"].write_text(result.snapshot_namespace)
+    result_paths["snapshotBuildId"].write_text(result.snapshot_build_id)
+
+
+def run(
+    *,
+    release: str,
+    release_plan: str,
+    release_plan_admission: str,
+    release_service_config: str,
+    snapshot: str,
+    subdirectory: str,
+    data_dir: Path,
+    result_paths: dict[str, Path],
+) -> None:
+    """Collect data from K8s resources and write results."""
+    setup_ca_cert()
+
+    result = collect(
+        release=release,
+        release_plan=release_plan,
+        release_plan_admission=release_plan_admission,
+        release_service_config=release_service_config,
+        snapshot=snapshot,
+        subdirectory=subdirectory,
+    )
+    write_outputs(result, data_dir, result_paths)
+
+
+def main() -> int:
+    """Read environment variables and run the data collection workflow."""
+    result_paths = _resolve_result_paths()
+
+    run(
+        release=tekton.require_env("RELEASE"),
+        release_plan=tekton.require_env("RELEASE_PLAN"),
+        release_plan_admission=tekton.require_env("RELEASE_PLAN_ADMISSION"),
+        release_service_config=tekton.require_env("RELEASE_SERVICE_CONFIG"),
+        snapshot=tekton.require_env("SNAPSHOT"),
+        subdirectory=os.environ.get("PARAM_SUBDIRECTORY", ""),
+        data_dir=Path(tekton.require_env("PARAM_DATA_DIR")),
+        result_paths=result_paths,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/tasks/managed/test_collect_data.py
+++ b/scripts/python/tasks/managed/test_collect_data.py
@@ -1,0 +1,918 @@
+"""Tests for collect_data module."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from collect_data import (
+    CollectDataResult,
+    check_data_key_sources,
+    collect,
+    deep_merge,
+    flatten_collectors,
+    main,
+    resolve_pipeline_ref,
+    run,
+    transform_snapshot_spec,
+    write_outputs,
+)
+
+
+def _resource_side_effect(
+    resource_type: str,
+    namespace: str,
+    name: str,
+) -> dict:
+    """Shared mock side effect returning test resources by type."""
+    resources = {
+        "release": {
+            "metadata": {"name": "my-release"},
+            "spec": {"data": {"foo": "shouldGetOverwritten"}},
+            "status": {
+                "collectors": {
+                    "managed": {"c1": {"releaseNotes": {"cves": [{"key": "CVE-1"}]}}},
+                    "tenant": {},
+                }
+            },
+        },
+        "releaseplan": {
+            "metadata": {"name": "my-rp"},
+            "spec": {"data": {"foo": "bar"}},
+        },
+        "releaseplanadmission": {
+            "metadata": {"name": "my-rpa"},
+            "spec": {
+                "data": {"one": {"two": "three"}},
+                "pipeline": {
+                    "pipelineRef": {
+                        "resolver": "cluster",
+                        "params": [{"name": "name", "value": "p1"}],
+                    }
+                },
+            },
+        },
+        "releaseserviceconfig": {"metadata": {"name": "my-rsc"}, "spec": {}},
+        "snapshot": {
+            "metadata": {
+                "name": "my-snap",
+                "labels": {"appstudio.openshift.io/build-pipelinerun": "build-123"},
+            },
+            "spec": {
+                "application": "myapp",
+                "components": [{"name": "comp1"}],
+            },
+        },
+    }
+    return resources.get(resource_type, {})
+
+
+class TestDeepMerge:
+    """Tests for the deep_merge function."""
+
+    def test_merge_dicts(self) -> None:
+        """Test merge dicts."""
+        assert deep_merge({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+
+    def test_override_scalar(self) -> None:
+        """Test override scalar."""
+        assert deep_merge({"a": 1}, {"a": 2}) == {"a": 2}
+
+    def test_nested_dict_merge(self) -> None:
+        """Test nested dict merge."""
+        base = {"one": {"two": "three"}}
+        override = {"one": {"four": ["five", "six"]}}
+        result = deep_merge(base, override)
+        assert result == {"one": {"two": "three", "four": ["five", "six"]}}
+
+    def test_array_concat_deduplicate(self) -> None:
+        """Test array concat deduplicate."""
+        base = {"tags": ["a", "b"]}
+        override = {"tags": ["b", "c"]}
+        assert deep_merge(base, override) == {"tags": ["a", "b", "c"]}
+
+    def test_boolean_false_preserved(self) -> None:
+        """Test boolean false preserved."""
+        assert deep_merge({"flag": True}, {"flag": False}) == {"flag": False}
+
+    def test_none_override_preserves_base(self) -> None:
+        """Test none override preserves base."""
+        assert deep_merge({"a": 1}, {"a": None}) == {"a": 1}
+
+    def test_none_base_with_override(self) -> None:
+        """Test none base with override."""
+        assert deep_merge({"a": None}, {"a": 42}) == {"a": 42}
+
+    def test_empty_dicts(self) -> None:
+        """Test empty dicts."""
+        assert deep_merge({}, {}) == {}
+
+    def test_scalar_override_dict(self) -> None:
+        """Test scalar override dict."""
+        assert deep_merge("old", "new") == "new"
+
+    def test_nested_arrays_in_dicts(self) -> None:
+        """Test nested arrays in dicts."""
+        base = {"issues": {"fixed": [{"id": "1"}]}}
+        override = {"issues": {"fixed": [{"id": "2"}]}}
+        result = deep_merge(base, override)
+        assert result == {"issues": {"fixed": [{"id": "1"}, {"id": "2"}]}}
+
+    def test_unsortable_list_items(self) -> None:
+        """Test list merge falls back to insertion order for non-serializable items."""
+        a, b = object(), object()
+        result = deep_merge([a], [b])
+        assert result == [a, b]
+
+
+class TestFlattenCollectors:
+    """Tests for the flatten_collectors function."""
+
+    def test_managed_and_tenant(self) -> None:
+        """Test managed and tenant."""
+        status = {
+            "managed": {
+                "foo": {"cves": [{"key": "CVE-1"}]},
+                "bar": {"issues": [{"id": "ISSUE-1"}]},
+            },
+            "tenant": {
+                "baz": {"extra": [{"key": "E-1"}]},
+            },
+        }
+        result = flatten_collectors(status)
+        assert result == {
+            "cves": [{"key": "CVE-1"}],
+            "issues": [{"id": "ISSUE-1"}],
+            "extra": [{"key": "E-1"}],
+        }
+
+    def test_empty_collectors(self) -> None:
+        """Test empty collectors."""
+        assert flatten_collectors({}) == {}
+
+    def test_none_collectors(self) -> None:
+        """Test none collectors."""
+        assert flatten_collectors(None) == {}
+
+    def test_missing_sections(self) -> None:
+        """Test missing sections."""
+        status = {"managed": {"a": {"x": 1}}}
+        assert flatten_collectors(status) == {"x": 1}
+
+    def test_overlapping_keys_merged(self) -> None:
+        """Test overlapping keys merged."""
+        status = {
+            "managed": {
+                "a": {"data": {"val": 1}},
+                "b": {"data": {"val": 2}},
+            },
+        }
+        result = flatten_collectors(status)
+        assert result["data"]["val"] == 2
+
+
+class TestTransformSnapshotSpec:
+    """Tests for the transform_snapshot_spec function."""
+
+    def test_empty_component_group_fallback(self) -> None:
+        """Test empty component group fallback."""
+        spec = {
+            "componentGroup": "",
+            "application": "myapp",
+            "components": [],
+        }
+        result = transform_snapshot_spec(spec)
+        assert result["componentGroup"] == "myapp"
+        assert "application" not in result
+
+    def test_null_component_group_fallback(self) -> None:
+        """Test null component group fallback."""
+        spec = {"componentGroup": None, "application": "myapp"}
+        result = transform_snapshot_spec(spec)
+        assert result["componentGroup"] == "myapp"
+
+    def test_set_component_group_kept(self) -> None:
+        """Test set component group kept."""
+        spec = {"componentGroup": "group1", "application": "myapp"}
+        result = transform_snapshot_spec(spec)
+        assert result["componentGroup"] == "group1"
+        assert "application" not in result
+
+    def test_no_application_key(self) -> None:
+        """Test no application key."""
+        spec = {"componentGroup": ""}
+        result = transform_snapshot_spec(spec)
+        assert result["componentGroup"] is None
+
+    def test_does_not_mutate_input(self) -> None:
+        """Test does not mutate input."""
+        spec = {
+            "componentGroup": "",
+            "application": "myapp",
+            "components": [{"name": "c1"}],
+        }
+        original = spec.copy()
+        transform_snapshot_spec(spec)
+        assert spec == original
+
+
+class TestResolvePipelineRef:
+    """Tests for the resolve_pipeline_ref function."""
+
+    @patch("collect_data.http_client.get_text")
+    def test_git_resolver(self, mock_get_text: MagicMock) -> None:
+        """Test git resolver."""
+        mock_get_text.return_value = '{"sha": "abc123"}'
+        rpa = {
+            "spec": {
+                "pipeline": {
+                    "pipelineRef": {
+                        "resolver": "git",
+                        "params": [
+                            {
+                                "name": "url",
+                                "value": "https://github.com/org1/repo1.git",
+                            },
+                            {"name": "revision", "value": "main"},
+                            {
+                                "name": "pathInRepo",
+                                "value": "pipelines/release.yaml",
+                            },
+                        ],
+                    }
+                }
+            }
+        }
+        result = resolve_pipeline_ref(rpa)
+        assert result["org"] == "org1"
+        assert result["repo"] == "repo1"
+        assert result["revision"] == "main"
+        assert result["pathinrepo"] == "pipelines/release.yaml"
+        assert result["sha"] == "abc123"
+
+    def test_non_git_resolver(self) -> None:
+        """Test non git resolver."""
+        rpa = {
+            "spec": {
+                "pipeline": {
+                    "pipelineRef": {
+                        "resolver": "cluster",
+                        "params": [{"name": "name", "value": "my-pipeline"}],
+                    }
+                }
+            }
+        }
+        result = resolve_pipeline_ref(rpa)
+        assert result == {
+            "org": "unknown",
+            "repo": "unknown",
+            "revision": "unknown",
+            "pathinrepo": "unknown",
+            "sha": "unknown",
+        }
+
+    def test_missing_pipeline_ref(self) -> None:
+        """Test missing pipeline ref."""
+        result = resolve_pipeline_ref({"spec": {}})
+        assert all(v == "unknown" for v in result.values())
+
+    @patch("collect_data.http_client.get_text")
+    def test_github_api_failure(self, mock_get_text: MagicMock) -> None:
+        """Test github api failure."""
+        mock_get_text.side_effect = Exception("network error")
+        rpa = {
+            "spec": {
+                "pipeline": {
+                    "pipelineRef": {
+                        "resolver": "git",
+                        "params": [
+                            {
+                                "name": "url",
+                                "value": "https://github.com/o/r",
+                            },
+                            {"name": "revision", "value": "v1"},
+                            {
+                                "name": "pathInRepo",
+                                "value": "p.yaml",
+                            },
+                        ],
+                    }
+                }
+            }
+        }
+        result = resolve_pipeline_ref(rpa)
+        assert result["sha"] == "unknown"
+        assert result["org"] == "o"
+        assert result["repo"] == "r"
+
+    @patch("collect_data.http_client.get_text")
+    def test_url_without_git_suffix(self, mock_get_text: MagicMock) -> None:
+        """Test url without git suffix."""
+        mock_get_text.return_value = '{"sha": "def456"}'
+        rpa = {
+            "spec": {
+                "pipeline": {
+                    "pipelineRef": {
+                        "resolver": "git",
+                        "params": [
+                            {
+                                "name": "url",
+                                "value": "https://github.com/myorg/myrepo",
+                            },
+                            {"name": "revision", "value": "dev"},
+                            {"name": "pathInRepo", "value": "path"},
+                        ],
+                    }
+                }
+            }
+        }
+        result = resolve_pipeline_ref(rpa)
+        assert result["org"] == "myorg"
+        assert result["repo"] == "myrepo"
+
+    @patch("collect_data.http_client.get_text")
+    def test_empty_url_returns_unknowns(self, mock_get_text: MagicMock) -> None:
+        """Test git resolver with empty url defaults org and repo to unknown."""
+        mock_get_text.return_value = '{"sha": "abc"}'
+        rpa = {
+            "spec": {
+                "pipeline": {
+                    "pipelineRef": {
+                        "resolver": "git",
+                        "params": [
+                            {"name": "url", "value": ""},
+                            {"name": "revision", "value": "main"},
+                            {"name": "pathInRepo", "value": "p.yaml"},
+                        ],
+                    }
+                }
+            }
+        }
+        result = resolve_pipeline_ref(rpa)
+        assert result["org"] == "unknown"
+        assert result["repo"] == "unknown"
+        assert result["revision"] == "main"
+
+    @patch("collect_data.http_client.get_text")
+    def test_empty_sha_in_response(self, mock_get_text: MagicMock) -> None:
+        """Test empty sha in response."""
+        mock_get_text.return_value = '{"sha": ""}'
+        rpa = {
+            "spec": {
+                "pipeline": {
+                    "pipelineRef": {
+                        "resolver": "git",
+                        "params": [
+                            {
+                                "name": "url",
+                                "value": "https://github.com/o/r",
+                            },
+                            {"name": "revision", "value": "v1"},
+                            {"name": "pathInRepo", "value": "p"},
+                        ],
+                    }
+                }
+            }
+        }
+        result = resolve_pipeline_ref(rpa)
+        assert result["sha"] == "unknown"
+
+
+class TestCheckDataKeySources:
+    """Tests for the check_data_key_sources function."""
+
+    def test_clean_resources(self) -> None:
+        """Test clean resources."""
+        check_data_key_sources(
+            {"spec": {"data": {"foo": "bar"}}},
+            {"spec": {"data": {"foo": "bar"}}},
+        )
+
+    def test_disallowed_key_in_release(self) -> None:
+        """Test disallowed key in release."""
+        with pytest.raises(ValueError, match="product_id"):
+            check_data_key_sources(
+                {"spec": {"data": {"releaseNotes": {"product_id": 123}}}},
+                {"spec": {}},
+            )
+
+    def test_disallowed_key_in_release_plan(self) -> None:
+        """Test disallowed key in release plan."""
+        with pytest.raises(ValueError, match="allow_custom_live_id"):
+            check_data_key_sources(
+                {"spec": {}},
+                {"spec": {"data": {"releaseNotes": {"allow_custom_live_id": True}}}},
+            )
+
+    def test_rpa_keys_not_checked(self) -> None:
+        """Test that RPA data is not subject to disallowed-key validation."""
+        check_data_key_sources(
+            {"spec": {}},
+            {"spec": {}},
+        )
+
+    def test_no_spec_data(self) -> None:
+        """Test no spec data."""
+        check_data_key_sources(
+            {"metadata": {"name": "x"}},
+            {"metadata": {"name": "x"}},
+        )
+
+    def test_multiple_violations(self) -> None:
+        """Test multiple violations."""
+        with pytest.raises(ValueError, match=r"(?s)product_id.*product_name"):
+            check_data_key_sources(
+                {
+                    "spec": {
+                        "data": {
+                            "releaseNotes": {
+                                "product_id": 1,
+                                "product_name": "x",
+                            }
+                        }
+                    }
+                },
+                {"spec": {}},
+            )
+
+
+class TestCollect:
+    """Tests for the collect function returning a CollectDataResult."""
+
+    @patch("collect_data.get_resource_dict")
+    def test_returns_result_dataclass(self, mock_get: MagicMock) -> None:
+        """Test returns result dataclass."""
+        mock_get.side_effect = _resource_side_effect
+
+        result = collect(
+            release="default/my-release",
+            release_plan="default/my-rp",
+            release_plan_admission="default/my-rpa",
+            release_service_config="default/my-rsc",
+            snapshot="default/my-snap",
+            subdirectory="uid123",
+        )
+
+        assert isinstance(result, CollectDataResult)
+        assert result.subdirectory == "uid123"
+        assert result.snapshot_name == "my-snap"
+        assert result.snapshot_namespace == "default"
+        assert result.snapshot_build_id == "build-123"
+        assert result.single_component_mode == "false"
+        assert result.merged_data["foo"] == "bar"
+        assert result.merged_data["one"]["two"] == "three"
+        assert result.merged_data["releaseNotes"]["cves"] == [{"key": "CVE-1"}]
+        assert result.snapshot_spec["componentGroup"] == "myapp"
+        assert "application" not in result.snapshot_spec
+        assert result.pipeline_metadata["org"] == "unknown"
+
+    @patch("collect_data.get_resource_dict")
+    def test_disallowed_key_raises(self, mock_get: MagicMock) -> None:
+        """Test disallowed key raises."""
+
+        def side_effect(
+            resource_type: str,
+            namespace: str,
+            name: str,
+        ) -> dict:
+            if resource_type == "release":
+                return {
+                    "metadata": {"name": "r1"},
+                    "spec": {"data": {"releaseNotes": {"product_id": 123}}},
+                    "status": {"collectors": {}},
+                }
+            return _resource_side_effect(resource_type, namespace, name)
+
+        mock_get.side_effect = side_effect
+
+        with pytest.raises(ValueError, match="product_id"):
+            collect(
+                release="default/r1",
+                release_plan="default/my-rp",
+                release_plan_admission="default/my-rpa",
+                release_service_config="default/my-rsc",
+                snapshot="default/my-snap",
+                subdirectory="sub",
+            )
+
+    @patch("collect_data.get_resource_dict")
+    def test_single_component_mode_true(self, mock_get: MagicMock) -> None:
+        """Test single component mode true."""
+
+        def side_effect(
+            resource_type: str,
+            namespace: str,
+            name: str,
+        ) -> dict:
+            if resource_type == "release":
+                return {
+                    "metadata": {"name": "r1"},
+                    "spec": {"data": {"singleComponentMode": True}},
+                    "status": {"collectors": {}},
+                }
+            return _resource_side_effect(resource_type, namespace, name)
+
+        mock_get.side_effect = side_effect
+
+        result = collect(
+            release="default/r1",
+            release_plan="default/my-rp",
+            release_plan_admission="default/my-rpa",
+            release_service_config="default/my-rsc",
+            snapshot="default/my-snap",
+            subdirectory="sub",
+        )
+        assert result.single_component_mode == "true"
+
+    @patch("collect_data.get_resource_dict")
+    def test_single_component_mode_null(self, mock_get: MagicMock) -> None:
+        """Test single component mode null."""
+
+        def side_effect(
+            resource_type: str,
+            namespace: str,
+            name: str,
+        ) -> dict:
+            if resource_type == "release":
+                return {
+                    "metadata": {"name": "r1"},
+                    "spec": {"data": {"singleComponentMode": None}},
+                    "status": {"collectors": {}},
+                }
+            return _resource_side_effect(resource_type, namespace, name)
+
+        mock_get.side_effect = side_effect
+
+        result = collect(
+            release="default/r1",
+            release_plan="default/my-rp",
+            release_plan_admission="default/my-rpa",
+            release_service_config="default/my-rsc",
+            snapshot="default/my-snap",
+            subdirectory="sub",
+        )
+        assert result.single_component_mode == "false"
+
+
+class TestWriteOutputs:
+    """Tests for the write_outputs function."""
+
+    def _make_result_paths(self, tmp_path: Path) -> dict[str, Path]:
+        results = tmp_path / "results"
+        results.mkdir()
+        keys = [
+            "release",
+            "releasePlan",
+            "releasePlanAdmission",
+            "releaseServiceConfig",
+            "snapshotSpec",
+            "data",
+            "resultsDir",
+            "singleComponentMode",
+            "snapshotName",
+            "snapshotNamespace",
+            "snapshotBuildId",
+            "releasePipelineMetadata",
+            "subdirectory",
+        ]
+        return {k: results / k for k in keys}
+
+    def test_writes_all_files(self, tmp_path: Path) -> None:
+        """Test writes all files."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        result_paths = self._make_result_paths(tmp_path)
+
+        result = CollectDataResult(
+            subdirectory="uid123",
+            release={"metadata": {"name": "r1"}, "spec": {}},
+            release_plan={"metadata": {"name": "rp1"}, "spec": {}},
+            release_plan_admission={"metadata": {"name": "rpa1"}, "spec": {}},
+            release_service_config={"metadata": {"name": "rsc1"}, "spec": {}},
+            snapshot_spec={
+                "componentGroup": "myapp",
+                "components": [],
+            },
+            merged_data={"key": "value"},
+            pipeline_metadata={
+                "org": "o",
+                "repo": "r",
+                "revision": "v",
+                "pathinrepo": "p",
+                "sha": "s",
+            },
+            single_component_mode="false",
+            snapshot_name="my-snap",
+            snapshot_namespace="default",
+            snapshot_build_id="build-123",
+        )
+
+        write_outputs(result, data_dir, result_paths)
+
+        assert result_paths["subdirectory"].read_text() == "uid123"
+        assert result_paths["resultsDir"].read_text() == "uid123/results"
+        assert result_paths["snapshotName"].read_text() == "my-snap"
+        assert result_paths["snapshotNamespace"].read_text() == "default"
+        assert result_paths["snapshotBuildId"].read_text() == "build-123"
+        assert result_paths["singleComponentMode"].read_text() == "false"
+
+        assert (data_dir / "uid123" / "release.json").exists()
+        assert (data_dir / "uid123" / "data.json").exists()
+        assert (data_dir / "uid123" / "snapshot_spec.json").exists()
+        assert (data_dir / "uid123" / "results").is_dir()
+
+        data = json.loads((data_dir / "uid123" / "data.json").read_text())
+        assert data == {"key": "value"}
+
+    def test_absolute_subdirectory_rejected(self, tmp_path: Path) -> None:
+        """Test that an absolute subdirectory path is rejected."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        result_paths = self._make_result_paths(tmp_path)
+
+        result = CollectDataResult(
+            subdirectory="/etc/evil",
+            release={"spec": {}},
+            release_plan={"spec": {}},
+            release_plan_admission={"spec": {}},
+            release_service_config={"spec": {}},
+            snapshot_spec={},
+            merged_data={},
+            pipeline_metadata={
+                "org": "u",
+                "repo": "u",
+                "revision": "u",
+                "pathinrepo": "u",
+                "sha": "u",
+            },
+            single_component_mode="false",
+            snapshot_name="s",
+            snapshot_namespace="ns",
+            snapshot_build_id="",
+        )
+
+        with pytest.raises(ValueError, match="must be relative"):
+            write_outputs(result, data_dir, result_paths)
+
+    def test_traversal_subdirectory_rejected(self, tmp_path: Path) -> None:
+        """Test that a subdirectory with '..' traversal is rejected."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        result_paths = self._make_result_paths(tmp_path)
+
+        result = CollectDataResult(
+            subdirectory="../../etc",
+            release={"spec": {}},
+            release_plan={"spec": {}},
+            release_plan_admission={"spec": {}},
+            release_service_config={"spec": {}},
+            snapshot_spec={},
+            merged_data={},
+            pipeline_metadata={
+                "org": "u",
+                "repo": "u",
+                "revision": "u",
+                "pathinrepo": "u",
+                "sha": "u",
+            },
+            single_component_mode="false",
+            snapshot_name="s",
+            snapshot_namespace="ns",
+            snapshot_build_id="",
+        )
+
+        with pytest.raises(ValueError, match="must stay under"):
+            write_outputs(result, data_dir, result_paths)
+
+    def test_empty_subdirectory(self, tmp_path: Path) -> None:
+        """Test empty subdirectory."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        result_paths = self._make_result_paths(tmp_path)
+
+        result = CollectDataResult(
+            subdirectory="",
+            release={"spec": {}},
+            release_plan={"spec": {}},
+            release_plan_admission={"spec": {}},
+            release_service_config={"spec": {}},
+            snapshot_spec={},
+            merged_data={},
+            pipeline_metadata={
+                "org": "u",
+                "repo": "u",
+                "revision": "u",
+                "pathinrepo": "u",
+                "sha": "u",
+            },
+            single_component_mode="false",
+            snapshot_name="s",
+            snapshot_namespace="ns",
+            snapshot_build_id="",
+        )
+
+        write_outputs(result, data_dir, result_paths)
+
+        assert result_paths["resultsDir"].read_text() == "results"
+        assert (data_dir / "release.json").exists()
+        assert (data_dir / "data.json").exists()
+
+
+class TestRun:
+    """Tests for the run function orchestrating the full workflow."""
+
+    def _make_result_paths(self, tmp_path: Path) -> dict[str, Path]:
+        results = tmp_path / "results"
+        results.mkdir()
+        keys = [
+            "release",
+            "releasePlan",
+            "releasePlanAdmission",
+            "releaseServiceConfig",
+            "snapshotSpec",
+            "data",
+            "resultsDir",
+            "singleComponentMode",
+            "snapshotName",
+            "snapshotNamespace",
+            "snapshotBuildId",
+            "releasePipelineMetadata",
+            "subdirectory",
+        ]
+        return {k: results / k for k in keys}
+
+    @patch("collect_data.get_resource_dict")
+    def test_full_run(self, mock_get: MagicMock, tmp_path: Path) -> None:
+        """Test full run."""
+        mock_get.side_effect = _resource_side_effect
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        result_paths = self._make_result_paths(tmp_path)
+
+        run(
+            release="default/my-release",
+            release_plan="default/my-rp",
+            release_plan_admission="default/my-rpa",
+            release_service_config="default/my-rsc",
+            snapshot="default/my-snap",
+            subdirectory="uid123",
+            data_dir=data_dir,
+            result_paths=result_paths,
+        )
+
+        assert result_paths["subdirectory"].read_text() == "uid123"
+        assert result_paths["resultsDir"].read_text() == "uid123/results"
+        assert result_paths["snapshotName"].read_text() == "my-snap"
+        assert result_paths["snapshotNamespace"].read_text() == "default"
+        assert result_paths["snapshotBuildId"].read_text() == "build-123"
+
+        data = json.loads((data_dir / "uid123" / "data.json").read_text())
+        assert data["foo"] == "bar"
+        assert data["one"]["two"] == "three"
+        assert data["releaseNotes"]["cves"] == [{"key": "CVE-1"}]
+
+        snap = json.loads((data_dir / "uid123" / "snapshot_spec.json").read_text())
+        assert snap["componentGroup"] == "myapp"
+        assert "application" not in snap
+
+        metadata = json.loads(result_paths["releasePipelineMetadata"].read_text())
+        assert metadata["org"] == "unknown"
+
+        assert result_paths["singleComponentMode"].read_text() == "false"
+
+    @patch("collect_data.get_resource_dict")
+    def test_run_empty_subdirectory(self, mock_get: MagicMock, tmp_path: Path) -> None:
+        """Test run empty subdirectory."""
+        mock_get.side_effect = _resource_side_effect
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        result_paths = self._make_result_paths(tmp_path)
+
+        run(
+            release="default/my-release",
+            release_plan="default/my-rp",
+            release_plan_admission="default/my-rpa",
+            release_service_config="default/my-rsc",
+            snapshot="default/my-snap",
+            subdirectory="",
+            data_dir=data_dir,
+            result_paths=result_paths,
+        )
+
+        assert result_paths["resultsDir"].read_text() == "results"
+        assert (data_dir / "release.json").exists()
+        assert (data_dir / "data.json").exists()
+
+    @patch("collect_data.get_resource_dict")
+    @patch("collect_data.setup_ca_cert")
+    def test_run_calls_setup_ca_cert(
+        self, mock_ca: MagicMock, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        """Test run calls setup ca cert."""
+        mock_get.side_effect = _resource_side_effect
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        result_paths = self._make_result_paths(tmp_path)
+
+        run(
+            release="default/my-release",
+            release_plan="default/my-rp",
+            release_plan_admission="default/my-rpa",
+            release_service_config="default/my-rsc",
+            snapshot="default/my-snap",
+            subdirectory="sub",
+            data_dir=data_dir,
+            result_paths=result_paths,
+        )
+        mock_ca.assert_called_once()
+
+
+class TestMain:
+    """Tests for the main() entrypoint."""
+
+    @staticmethod
+    def _set_env(
+        monkeypatch: pytest.MonkeyPatch,
+        env: dict[str, str],
+    ) -> None:
+        """Clear all env vars and set *env* via monkeypatch."""
+        for key in list(os.environ):
+            monkeypatch.delenv(key)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+
+    def _env_vars(self, tmp_path: Path) -> dict[str, str]:
+        results = tmp_path / "results"
+        results.mkdir()
+        env = {
+            "RELEASE": "default/my-release",
+            "RELEASE_PLAN": "default/my-rp",
+            "RELEASE_PLAN_ADMISSION": "default/my-rpa",
+            "RELEASE_SERVICE_CONFIG": "default/my-rsc",
+            "SNAPSHOT": "default/my-snap",
+            "PARAM_SUBDIRECTORY": "sub",
+            "PARAM_DATA_DIR": str(tmp_path / "data"),
+        }
+        result_names = [
+            "RESULT_RELEASE",
+            "RESULT_RELEASE_PLAN",
+            "RESULT_RELEASE_PLAN_ADMISSION",
+            "RESULT_RELEASE_SERVICE_CONFIG",
+            "RESULT_SNAPSHOT_SPEC",
+            "RESULT_DATA",
+            "RESULT_RESULTS_DIR",
+            "RESULT_SINGLE_COMPONENT_MODE",
+            "RESULT_SNAPSHOT_NAME",
+            "RESULT_SNAPSHOT_NAMESPACE",
+            "RESULT_SNAPSHOT_BUILD_ID",
+            "RESULT_RELEASE_PIPELINE_METADATA",
+            "RESULT_SUBDIRECTORY",
+        ]
+        for name in result_names:
+            path = results / name
+            env[name] = str(path)
+        (tmp_path / "data").mkdir()
+        return env
+
+    @patch("collect_data.run")
+    def test_main_calls_run(
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test main calls run."""
+        self._set_env(monkeypatch, self._env_vars(tmp_path))
+        result = main()
+        assert result == 0
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs["release"] == "default/my-release"
+        assert call_kwargs["subdirectory"] == "sub"
+
+    def test_main_missing_env_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test main missing env raises."""
+        self._set_env(monkeypatch, {})
+        with pytest.raises(SystemExit):
+            main()
+
+    def test_dunder_main_block(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Exercise the ``if __name__ == "__main__"`` block."""
+        self._set_env(monkeypatch, self._env_vars(tmp_path))
+        with patch("get_resource.get_resource_dict", return_value={}):
+            with pytest.raises(SystemExit) as exc_info:
+                import runpy
+
+                runpy.run_module("collect_data", run_name="__main__")
+            assert exc_info.value.code == 0

--- a/utils/get_resource.py
+++ b/utils/get_resource.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-Retrieve a Kubernetes resource via kubectl, with optional KubeArchive fallback.
+"""Retrieve a Kubernetes resource via kubectl, with optional KubeArchive fallback.
 
 Usage: get-resource <resource_type> <namespace/name> [jsonpath]
 
@@ -12,12 +11,15 @@ For eligible resource types (snapshots), falls back to KubeArchive when
 kubectl fails.
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging
 import os
-import subprocess
 import sys
+
+import subprocess_cmd
 
 LOGGER = logging.getLogger("get_resource")
 
@@ -27,8 +29,8 @@ _KUBECTL_KA_CONFIG_PATH_DEFAULT = "/tmp/kubectl-ka-config"
 
 def _run(cmd):
     """Run a command and return (exit_code, stdout, stderr)."""
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    return result.returncode, result.stdout, result.stderr
+    result = subprocess_cmd.run_cmd(cmd, check=False)
+    return result.returncode, result.stdout, result.stderr or ""
 
 
 def extract_jsonpath(data, jsonpath):
@@ -75,6 +77,7 @@ def format_jsonpath_result(value):
 
 
 def ka_enabled(resource_type):
+    """Check whether a resource type supports the KubeArchive fallback."""
     return resource_type in KA_RESOURCE_TYPES
 
 
@@ -194,6 +197,7 @@ def get_from_ka(resource_type, namespace, name):
 
 
 def setup_argparser():
+    """Build the CLI argument parser for the get-resource entrypoint."""
     parser = argparse.ArgumentParser(
         description="Retrieve a Kubernetes resource via kubectl, "
         "with optional KubeArchive fallback.",
@@ -211,7 +215,109 @@ def setup_argparser():
     return parser
 
 
+class ResourceFetchError(RuntimeError):
+    """Raised when a full-resource fetch fails and no fallback succeeds."""
+
+    def __init__(self, message: str, exit_code: int = 1) -> None:
+        """Store the error message and the exit code to propagate."""
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+def get_resource(
+    resource_type: str,
+    namespace: str,
+    name: str,
+    jsonpath: str | None = None,
+) -> str:
+    """Fetch a K8s resource and return the result as a string.
+
+    Without *jsonpath*: return the full resource JSON.  Raise
+    ``ResourceFetchError`` when kubectl (and KubeArchive, if eligible) fail.
+
+    With *jsonpath*: return the extracted value as a string.  Return ``'{}'``
+    when retrieval fails (matching the original CLI behaviour).
+    """
+    os.environ.setdefault("KUBECTL_KA_CONFIG_PATH", _KUBECTL_KA_CONFIG_PATH_DEFAULT)
+
+    if jsonpath:
+        return _get_with_jsonpath(resource_type, namespace, name, jsonpath)
+    return _get_full_resource(resource_type, namespace, name)
+
+
+def get_resource_dict(
+    resource_type: str,
+    namespace: str,
+    name: str,
+) -> dict:
+    """Fetch a full K8s resource and return it as a parsed dict.
+
+    Convenience wrapper around ``get_resource`` for callers that need the
+    parsed JSON object rather than the raw string.  Only supports full
+    resource fetches (no jsonpath).
+
+    Raise ``ResourceFetchError`` when kubectl (and KubeArchive, if eligible)
+    fail.
+    """
+    return json.loads(get_resource(resource_type, namespace, name))
+
+
+def _get_with_jsonpath(resource_type: str, namespace: str, name: str, jsonpath: str) -> str:
+    rc, stdout, _ = _run(
+        [
+            "kubectl",
+            "get",
+            resource_type,
+            "-n",
+            namespace,
+            name,
+            "-o",
+            f"jsonpath={jsonpath}",
+            "--allow-missing-template-keys=false",
+        ]
+    )
+    if rc == 0:
+        return stdout
+
+    if ka_enabled(resource_type):
+        try:
+            ka_json_str = get_from_ka(resource_type, namespace, name)
+            value = extract_jsonpath(json.loads(ka_json_str), jsonpath)
+            if value is not None:
+                return format_jsonpath_result(value)
+        except Exception:
+            LOGGER.warning("KubeArchive fallback failed", exc_info=True)
+
+    return "{}"
+
+
+def _get_full_resource(resource_type: str, namespace: str, name: str) -> str:
+    rc, stdout, stderr = _run(
+        [
+            "kubectl",
+            "get",
+            resource_type,
+            "-n",
+            namespace,
+            name,
+            "-o",
+            "json",
+        ]
+    )
+    if rc == 0:
+        return stdout
+
+    if ka_enabled(resource_type):
+        try:
+            return get_from_ka(resource_type, namespace, name)
+        except Exception:
+            LOGGER.warning("KubeArchive fallback failed", exc_info=True)
+
+    raise ResourceFetchError(stdout + stderr, exit_code=rc)
+
+
 def main():
+    """Parse CLI arguments and print the requested resource or jsonpath value."""
     logging.basicConfig(
         level=logging.INFO, format="%(asctime)s [%(name)s] %(levelname)s %(message)s"
     )
@@ -224,67 +330,14 @@ def main():
         parser.error(f"expected namespace/name, got '{args.namespaced_name}'")
     namespace, name = parts
 
-    resource_type = args.resource_type
-    jsonpath = args.jsonpath
+    try:
+        result = get_resource(args.resource_type, namespace, name, args.jsonpath)
+    except ResourceFetchError as exc:
+        print(str(exc), file=sys.stderr, end="")
+        sys.exit(exc.exit_code)
 
-    os.environ.setdefault("KUBECTL_KA_CONFIG_PATH", _KUBECTL_KA_CONFIG_PATH_DEFAULT)
-
-    if jsonpath:
-        rc, stdout, _ = _run(
-            [
-                "kubectl",
-                "get",
-                resource_type,
-                "-n",
-                namespace,
-                name,
-                "-o",
-                f"jsonpath={jsonpath}",
-                "--allow-missing-template-keys=false",
-            ]
-        )
-        if rc == 0:
-            print(stdout, end="")
-            sys.exit(0)
-
-        if ka_enabled(resource_type):
-            try:
-                ka_json_str = get_from_ka(resource_type, namespace, name)
-                value = extract_jsonpath(json.loads(ka_json_str), jsonpath)
-                if value is not None:
-                    print(format_jsonpath_result(value))
-                    sys.exit(0)
-            except Exception:
-                LOGGER.warning("KubeArchive fallback failed", exc_info=True)
-
-        print("{}")
-    else:
-        rc, stdout, stderr = _run(
-            [
-                "kubectl",
-                "get",
-                resource_type,
-                "-n",
-                namespace,
-                name,
-                "-o",
-                "json",
-            ]
-        )
-        if rc == 0:
-            print(stdout, end="")
-            sys.exit(0)
-
-        if ka_enabled(resource_type):
-            try:
-                ka_json_str = get_from_ka(resource_type, namespace, name)
-                print(ka_json_str)
-                sys.exit(0)
-            except Exception:
-                LOGGER.warning("KubeArchive fallback failed", exc_info=True)
-
-        print(stdout + stderr, file=sys.stderr, end="")
-        sys.exit(rc)
+    print(result, end="")
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/utils/tests/test_get_resource.py
+++ b/utils/tests/test_get_resource.py
@@ -4,39 +4,49 @@ Uses unittest.mock to patch subprocess.run calls, simulating kubectl and
 kubectl-ka behavior without requiring actual cluster access.
 """
 
+from __future__ import annotations
+
 import json
 import os
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from utils.get_resource import (
     main,
+    get_resource,
+    get_resource_dict,
+    ResourceFetchError,
     extract_jsonpath,
     format_jsonpath_result,
     ka_enabled,
     ensure_ka_config,
     get_from_ka,
     _resource_version,
+    _run,
 )
 
 
 def test_extract_jsonpath_simple_field():
+    """Test extract jsonpath simple field."""
     data = {"spec": {"app": "myapp"}}
     assert extract_jsonpath(data, "{.spec}") == {"app": "myapp"}
 
 
 def test_extract_jsonpath_nested_field():
+    """Test extract jsonpath nested field."""
     data = {"metadata": {"name": "snap1", "namespace": "ns1"}}
     assert extract_jsonpath(data, "{.metadata.name}") == "snap1"
 
 
 def test_extract_jsonpath_missing_field():
+    """Test extract jsonpath missing field."""
     data = {"spec": {}}
     assert extract_jsonpath(data, "{.metadata.name}") is None
 
 
 def test_extract_jsonpath_wildcard():
+    """Test extract jsonpath wildcard."""
     data = {
         "spec": {
             "components": [
@@ -50,6 +60,7 @@ def test_extract_jsonpath_wildcard():
 
 
 def test_extract_jsonpath_labels():
+    """Test extract jsonpath labels."""
     data = {
         "metadata": {
             "labels": {"app": "myapp", "version": "v1"},
@@ -60,49 +71,60 @@ def test_extract_jsonpath_labels():
 
 
 def test_format_jsonpath_result_string():
+    """Test format jsonpath result string."""
     assert format_jsonpath_result("hello") == "hello"
 
 
 def test_format_jsonpath_result_dict():
+    """Test format jsonpath result dict."""
     result = format_jsonpath_result({"a": 1})
     assert json.loads(result) == {"a": 1}
 
 
 def test_format_jsonpath_result_list_of_strings():
+    """Test format jsonpath result list of strings."""
     assert format_jsonpath_result(["a", "b"]) == "a b"
 
 
 def test_format_jsonpath_result_list_of_dicts():
+    """Test format jsonpath result list of dicts."""
     result = format_jsonpath_result([{"a": 1}])
     assert "a" in result
 
 
 def test_ka_enabled_snapshot():
+    """Test ka enabled snapshot."""
     assert ka_enabled("snapshot") is True
 
 
 def test_ka_enabled_snapshots():
+    """Test ka enabled snapshots."""
     assert ka_enabled("snapshots") is True
 
 
 def test_ka_enabled_deployment():
+    """Test ka enabled deployment."""
     assert ka_enabled("deployment") is False
 
 
 def test_ka_enabled_pod():
+    """Test ka enabled pod."""
     assert ka_enabled("pod") is False
 
 
 def test_ka_enabled_release():
+    """Test ka enabled release."""
     assert ka_enabled("release") is False
 
 
 def test_resource_version_single_item():
+    """Test resource version single item."""
     items = [{"metadata": {"resourceVersion": "100"}}]
     assert max(items, key=_resource_version) == items[0]
 
 
 def test_resource_version_multiple_items():
+    """Test resource version multiple items."""
     items = [
         {"metadata": {"resourceVersion": "50"}, "spec": {"v": "old"}},
         {"metadata": {"resourceVersion": "200"}, "spec": {"v": "newest"}},
@@ -113,6 +135,7 @@ def test_resource_version_multiple_items():
 
 
 def test_resource_version_non_numeric():
+    """Test resource version non numeric."""
     items = [
         {"metadata": {"resourceVersion": "abc"}, "data": "fallback"},
         {"metadata": {"resourceVersion": "10"}, "data": "numeric"},
@@ -122,6 +145,7 @@ def test_resource_version_non_numeric():
 
 
 def test_ensure_ka_config_already_exists(tmp_path):
+    """Test ensure ka config already exists."""
     config_file = tmp_path / "ka-config"
     config_file.touch()
     with patch.dict(os.environ, {"KUBECTL_KA_CONFIG_PATH": str(config_file)}):
@@ -130,6 +154,7 @@ def test_ensure_ka_config_already_exists(tmp_path):
 
 @patch("utils.get_resource._run")
 def test_ensure_ka_config_configmap_not_found(mock_run, tmp_path):
+    """Test ensure ka config configmap not found."""
     config_file = tmp_path / "ka-config"
     mock_run.return_value = (1, "", "not found")
     with patch.dict(os.environ, {"KUBECTL_KA_CONFIG_PATH": str(config_file)}):
@@ -139,6 +164,7 @@ def test_ensure_ka_config_configmap_not_found(mock_run, tmp_path):
 
 @patch("utils.get_resource._run")
 def test_ensure_ka_config_creation_succeeds(mock_run, tmp_path):
+    """Test ensure ka config creation succeeds."""
     config_file = tmp_path / "ka-config"
 
     def side_effect(cmd):
@@ -156,6 +182,7 @@ def test_ensure_ka_config_creation_succeeds(mock_run, tmp_path):
 
 @patch("utils.get_resource._run")
 def test_ensure_ka_config_set_host_fails(mock_run, tmp_path):
+    """Test ensure ka config set host fails."""
     config_file = tmp_path / "ka-config"
     mock_run.side_effect = [
         (0, "https://ka.example.com", ""),
@@ -168,6 +195,7 @@ def test_ensure_ka_config_set_host_fails(mock_run, tmp_path):
 
 @patch("utils.get_resource._run")
 def test_ensure_ka_config_set_ca_fails(mock_run, tmp_path):
+    """Test ensure ka config set ca fails."""
     config_file = tmp_path / "ka-config"
     mock_run.side_effect = [
         (0, "https://ka.example.com", ""),
@@ -187,6 +215,7 @@ def test_ensure_ka_config_set_ca_fails(mock_run, tmp_path):
 
 @patch("utils.get_resource._run")
 def test_ensure_ka_config_ssl_cert_file_used(mock_run, tmp_path):
+    """Test ensure ka config ssl cert file used."""
     config_file = tmp_path / "ka-config"
 
     calls_made = []
@@ -217,6 +246,7 @@ def test_ensure_ka_config_ssl_cert_file_used(mock_run, tmp_path):
 
 @patch("utils.get_resource.ensure_ka_config", side_effect=RuntimeError("config unavailable"))
 def test_get_from_ka_config_unavailable(_):
+    """Test get from ka config unavailable."""
     with pytest.raises(RuntimeError, match="config unavailable"):
         get_from_ka("snapshot", "ns1", "snap1")
 
@@ -224,6 +254,7 @@ def test_get_from_ka_config_unavailable(_):
 @patch("utils.get_resource.ensure_ka_config")
 @patch("utils.get_resource._run")
 def test_get_from_ka_named_get_success(mock_run, _):
+    """Test get from ka named get success."""
     ka_response = {
         "items": [
             {
@@ -246,6 +277,7 @@ def test_get_from_ka_named_get_success(mock_run, _):
 @patch("utils.get_resource.ensure_ka_config")
 @patch("utils.get_resource._run")
 def test_get_from_ka_list_fallback_filters_by_name(mock_run, _):
+    """Test get from ka list fallback filters by name."""
     list_response = {
         "items": [
             {
@@ -280,6 +312,7 @@ def test_get_from_ka_list_fallback_filters_by_name(mock_run, _):
 @patch("utils.get_resource.ensure_ka_config")
 @patch("utils.get_resource._run")
 def test_get_from_ka_list_fallback_picks_highest_version(mock_run, _):
+    """Test get from ka list fallback picks highest version."""
     list_response = {
         "items": [
             {
@@ -320,6 +353,7 @@ def test_get_from_ka_list_fallback_picks_highest_version(mock_run, _):
 @patch("utils.get_resource.ensure_ka_config")
 @patch("utils.get_resource._run")
 def test_get_from_ka_no_matching_items(mock_run, _):
+    """Test get from ka no matching items."""
     list_response = {
         "items": [
             {
@@ -342,6 +376,7 @@ def test_get_from_ka_no_matching_items(mock_run, _):
 @patch("utils.get_resource.ensure_ka_config")
 @patch("utils.get_resource._run")
 def test_get_from_ka_both_get_and_list_fail(mock_run, _):
+    """Test get from ka both get and list fail."""
     mock_run.side_effect = [
         (1, "", ""),
         (1, "", ""),
@@ -351,6 +386,7 @@ def test_get_from_ka_both_get_and_list_fail(mock_run, _):
 
 
 def test_main_no_arguments(capsys):
+    """Test main no arguments."""
     with patch("sys.argv", ["get-resource"]):
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -359,6 +395,7 @@ def test_main_no_arguments(capsys):
 
 
 def test_main_one_argument(capsys):
+    """Test main one argument."""
     with patch("sys.argv", ["get-resource", "snapshot"]):
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -367,6 +404,7 @@ def test_main_one_argument(capsys):
 
 
 def test_main_invalid_namespaced_name(capsys):
+    """Test main invalid namespaced name."""
     with patch("sys.argv", ["get-resource", "snapshot", "badformat"]):
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -376,6 +414,7 @@ def test_main_invalid_namespaced_name(capsys):
 
 @patch("utils.get_resource._run")
 def test_main_kubectl_success_json(mock_run, capsys):
+    """Test main kubectl success json."""
     resource_json = json.dumps(
         {
             "kind": "Snapshot",
@@ -393,6 +432,7 @@ def test_main_kubectl_success_json(mock_run, capsys):
 
 @patch("utils.get_resource._run")
 def test_main_kubectl_success_jsonpath(mock_run, capsys):
+    """Test main kubectl success jsonpath."""
     mock_run.return_value = (0, "snap1", "")
     with patch(
         "sys.argv",
@@ -406,6 +446,7 @@ def test_main_kubectl_success_jsonpath(mock_run, capsys):
 
 @patch("utils.get_resource._run")
 def test_main_non_ka_type_no_jsonpath_exits_with_error(mock_run, capsys):
+    """Test main non ka type no jsonpath exits with error."""
     mock_run.return_value = (
         1,
         "",
@@ -420,18 +461,22 @@ def test_main_non_ka_type_no_jsonpath_exits_with_error(mock_run, capsys):
 
 @patch("utils.get_resource._run")
 def test_main_non_ka_type_jsonpath_returns_empty_object(mock_run, capsys):
+    """Test main non ka type jsonpath returns empty object."""
     mock_run.return_value = (1, "", "not found")
     with patch(
         "sys.argv",
         ["get-resource", "pod", "ns1/mypod", "{.metadata.name}"],
     ):
-        main()
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
     assert capsys.readouterr().out.strip() == "{}"
 
 
 @patch("utils.get_resource.get_from_ka")
 @patch("utils.get_resource._run")
 def test_main_ka_fallback_success(mock_run, mock_ka, capsys):
+    """Test main ka fallback success."""
     mock_run.return_value = (1, "", "not found")
     ka_result = {
         "kind": "Snapshot",
@@ -455,6 +500,7 @@ def test_main_ka_fallback_success(mock_run, mock_ka, capsys):
 @patch("utils.get_resource.get_from_ka")
 @patch("utils.get_resource._run")
 def test_main_ka_fallback_with_jsonpath(mock_run, mock_ka, capsys):
+    """Test main ka fallback with jsonpath."""
     mock_run.return_value = (1, "", "not found")
     ka_result = {
         "metadata": {
@@ -479,19 +525,23 @@ def test_main_ka_fallback_with_jsonpath(mock_run, mock_ka, capsys):
 @patch("utils.get_resource.get_from_ka", side_effect=RuntimeError("KA failed"))
 @patch("utils.get_resource._run")
 def test_main_ka_fails_jsonpath_returns_empty(mock_run, mock_ka, capsys):
+    """Test main ka fails jsonpath returns empty."""
     mock_run.return_value = (1, "", "")
 
     with patch(
         "sys.argv",
         ["get-resource", "snapshot", "ns1/snap1", "{.spec.application}"],
     ):
-        main()
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
     assert capsys.readouterr().out.strip() == "{}"
 
 
 @patch("utils.get_resource.get_from_ka", side_effect=RuntimeError("KA failed"))
 @patch("utils.get_resource._run")
 def test_main_ka_fails_no_jsonpath_exits_nonzero(mock_run, mock_ka, capsys):
+    """Test main ka fails no jsonpath exits nonzero."""
     mock_run.return_value = (1, "", "resource not found")
 
     with patch("sys.argv", ["get-resource", "snapshot", "ns1/snap1"]):
@@ -503,6 +553,7 @@ def test_main_ka_fails_no_jsonpath_exits_nonzero(mock_run, mock_ka, capsys):
 @patch("utils.get_resource.get_from_ka")
 @patch("utils.get_resource._run")
 def test_main_ka_fallback_wildcard_jsonpath(mock_run, mock_ka, capsys):
+    """Test main ka fallback wildcard jsonpath."""
     mock_run.return_value = (1, "", "")
     ka_result = {
         "metadata": {
@@ -539,6 +590,7 @@ def test_main_ka_fallback_wildcard_jsonpath(mock_run, mock_ka, capsys):
 @patch("utils.get_resource.get_from_ka", side_effect=RuntimeError("KA unavailable"))
 @patch("utils.get_resource._run")
 def test_main_ka_not_available_exits_nonzero(mock_run, mock_ka, capsys):
+    """Test main ka not available exits nonzero."""
     mock_run.return_value = (1, "", "")
 
     with patch("sys.argv", ["get-resource", "snapshot", "ns1/snap1"]):
@@ -550,6 +602,7 @@ def test_main_ka_not_available_exits_nonzero(mock_run, mock_ka, capsys):
 @patch("utils.get_resource.get_from_ka")
 @patch("utils.get_resource._run")
 def test_main_snapshot_uses_ka(mock_run, mock_ka, capsys):
+    """Test main snapshot uses ka."""
     mock_run.return_value = (1, "", "")
     ka_data = {"metadata": {"name": "s", "namespace": "n", "resourceVersion": "1"}}
     mock_ka.return_value = json.dumps(ka_data)
@@ -564,6 +617,7 @@ def test_main_snapshot_uses_ka(mock_run, mock_ka, capsys):
 @patch("utils.get_resource.get_from_ka")
 @patch("utils.get_resource._run")
 def test_main_snapshots_uses_ka(mock_run, mock_ka, capsys):
+    """Test main snapshots uses ka."""
     mock_run.return_value = (1, "", "")
     ka_data = {"metadata": {"name": "s", "namespace": "n", "resourceVersion": "1"}}
     mock_ka.return_value = json.dumps(ka_data)
@@ -578,6 +632,7 @@ def test_main_snapshots_uses_ka(mock_run, mock_ka, capsys):
 @patch("utils.get_resource.get_from_ka")
 @patch("utils.get_resource._run")
 def test_main_deployment_no_ka(mock_run, mock_ka, capsys):
+    """Test main deployment no ka."""
     mock_run.return_value = (1, "", "not found")
 
     with patch("sys.argv", ["get-resource", "deployment", "ns1/mydep"]):
@@ -590,6 +645,7 @@ def test_main_deployment_no_ka(mock_run, mock_ka, capsys):
 @patch("utils.get_resource.get_from_ka")
 @patch("utils.get_resource._run")
 def test_main_pod_no_ka(mock_run, mock_ka, capsys):
+    """Test main pod no ka."""
     mock_run.return_value = (1, "", "not found")
 
     with patch("sys.argv", ["get-resource", "pod", "ns1/mypod"]):
@@ -597,3 +653,117 @@ def test_main_pod_no_ka(mock_run, mock_ka, capsys):
             main()
         assert exc_info.value.code == 1
     mock_ka.assert_not_called()
+
+
+# --- Tests for the get_resource() library function ---
+
+
+@patch("utils.get_resource._run")
+def test_get_resource_full_json_success(mock_run: MagicMock) -> None:
+    """Test get resource full json success."""
+    resource_json = json.dumps({"kind": "Release", "metadata": {"name": "r1"}})
+    mock_run.return_value = (0, resource_json, "")
+    result = get_resource("release", "ns1", "r1")
+    assert json.loads(result)["kind"] == "Release"
+
+
+@patch("utils.get_resource._run")
+def test_get_resource_full_json_failure_raises(mock_run: MagicMock) -> None:
+    """Test get resource full json failure raises."""
+    mock_run.return_value = (1, "", "not found")
+    with pytest.raises(ResourceFetchError) as exc_info:
+        get_resource("release", "ns1", "r1")
+    assert exc_info.value.exit_code == 1
+
+
+@patch("utils.get_resource._run")
+def test_get_resource_jsonpath_success(mock_run: MagicMock) -> None:
+    """Test get resource jsonpath success."""
+    mock_run.return_value = (0, '{"foo":"bar"}', "")
+    result = get_resource("release", "ns1", "r1", "{.spec.data}")
+    assert result == '{"foo":"bar"}'
+
+
+@patch("utils.get_resource._run")
+def test_get_resource_jsonpath_failure_returns_empty(mock_run: MagicMock) -> None:
+    """Test get resource jsonpath failure returns empty."""
+    mock_run.return_value = (1, "", "not found")
+    result = get_resource("pod", "ns1", "p1", "{.spec}")
+    assert result == "{}"
+
+
+@patch("utils.get_resource.get_from_ka")
+@patch("utils.get_resource._run")
+def test_get_resource_ka_fallback_full(mock_run: MagicMock, mock_ka: MagicMock) -> None:
+    """Test get resource ka fallback full."""
+    mock_run.return_value = (1, "", "not found")
+    ka_data = {"metadata": {"name": "s1", "namespace": "ns1", "resourceVersion": "1"}}
+    mock_ka.return_value = json.dumps(ka_data)
+    result = get_resource("snapshot", "ns1", "s1")
+    assert json.loads(result)["metadata"]["name"] == "s1"
+
+
+@patch("utils.get_resource.get_from_ka")
+@patch("utils.get_resource._run")
+def test_get_resource_ka_fallback_jsonpath(mock_run: MagicMock, mock_ka: MagicMock) -> None:
+    """Test get resource ka fallback jsonpath."""
+    mock_run.return_value = (1, "", "not found")
+    ka_data = {"metadata": {"name": "s1", "resourceVersion": "1"}, "spec": {"app": "x"}}
+    mock_ka.return_value = json.dumps(ka_data)
+    result = get_resource("snapshot", "ns1", "s1", "{.spec.app}")
+    assert result == "x"
+
+
+@patch("utils.get_resource._run")
+def test_get_resource_dict_success(mock_run: MagicMock) -> None:
+    """Test get resource dict success."""
+    resource = {"kind": "Release", "metadata": {"name": "r1"}}
+    mock_run.return_value = (0, json.dumps(resource), "")
+    result = get_resource_dict("release", "ns1", "r1")
+    assert isinstance(result, dict)
+    assert result["kind"] == "Release"
+    assert result["metadata"]["name"] == "r1"
+
+
+@patch("utils.get_resource._run")
+def test_get_resource_dict_failure_raises(mock_run: MagicMock) -> None:
+    """Test get resource dict failure raises."""
+    mock_run.return_value = (1, "", "not found")
+    with pytest.raises(ResourceFetchError):
+        get_resource_dict("release", "ns1", "r1")
+
+
+@patch("utils.get_resource.get_from_ka")
+@patch("utils.get_resource._run")
+def test_get_resource_dict_ka_fallback(mock_run: MagicMock, mock_ka: MagicMock) -> None:
+    """Test get resource dict ka fallback."""
+    mock_run.return_value = (1, "", "not found")
+    ka_data = {"metadata": {"name": "s1", "resourceVersion": "1"}}
+    mock_ka.return_value = json.dumps(ka_data)
+    result = get_resource_dict("snapshot", "ns1", "s1")
+    assert isinstance(result, dict)
+    assert result["metadata"]["name"] == "s1"
+
+
+@patch("utils.get_resource.subprocess_cmd.run_cmd")
+def test_run_delegates_to_subprocess_cmd(mock_run_cmd: MagicMock) -> None:
+    """Test _run delegates to subprocess_cmd and normalises stderr."""
+    mock_run_cmd.return_value = type(
+        "Result", (), {"returncode": 0, "stdout": "ok", "stderr": None}
+    )()
+    rc, stdout, stderr = _run(["echo", "hi"])
+    mock_run_cmd.assert_called_once_with(["echo", "hi"], check=False)
+    assert (rc, stdout, stderr) == (0, "ok", "")
+
+
+def test_resource_fetch_error_attributes() -> None:
+    """Test resource fetch error attributes."""
+    err = ResourceFetchError("something broke", exit_code=42)
+    assert str(err) == "something broke"
+    assert err.exit_code == 42
+
+
+def test_resource_fetch_error_default_exit_code() -> None:
+    """Test resource fetch error default exit code."""
+    err = ResourceFetchError("fail")
+    assert err.exit_code == 1


### PR DESCRIPTION
Add collect_data.py script and comprehensive unit tests.

Refactor get_resource module to expose get_resource() and
get_resource_dict() functions, making it importable from Python
instead of only usable as a CLI entrypoint. Also add a
ResourceFetchError exception for structured error handling.

The check-data-keys validation (previously a separate Tekton step)
is incorporated directly into the collect_data script

Assisted-by: Cursor