### PR TITLE
fix(KONFLUX-13739): strip tag/digest in fbc query

### DIFF
--- a/scripts/python/helpers/image_ref.py
+++ b/scripts/python/helpers/image_ref.py
@@ -104,6 +104,19 @@ def resolve_quay_digest_to_git_sha(digest: str, container_image: str) -> str | N
         return None
 
 
+def strip_tag_and_digest(pull_spec: str) -> str:
+    """Return the repository portion of a pull spec, without tag or digest.
+
+    Strips the digest (``@sha256:...``) first, then strips the tag only
+    from the last path segment so a registry port (e.g. ``registry:5000``)
+    is never confused with a tag separator.
+    """
+    repo = pull_spec.split("@")[0]
+    parts = repo.split("/")
+    parts[-1] = parts[-1].rsplit(":", 1)[0]
+    return "/".join(parts)
+
+
 def pyxis_url_for_pull_spec(pyxis_url: str, pull_spec: str) -> str:
     """Build the Pyxis repository/tag API URL for `pull_spec`.
 

--- a/scripts/python/helpers/test_image_ref.py
+++ b/scripts/python/helpers/test_image_ref.py
@@ -20,6 +20,22 @@ def _propagate_release_logger() -> None:
     release_logger.propagate = False
 
 
+@pytest.mark.parametrize(
+    "pull_spec, expected",
+    [
+        ("r.io/repo/img:tag", "r.io/repo/img"),
+        ("r.io/repo/img@sha256:abc", "r.io/repo/img"),
+        ("r.io/repo/img:tag@sha256:abc", "r.io/repo/img"),
+        ("r.io/repo/img", "r.io/repo/img"),
+        ("registry:5000/repo/img:tag", "registry:5000/repo/img"),
+        ("registry:5000/repo/img", "registry:5000/repo/img"),
+    ],
+)
+def test_strip_tag_and_digest(pull_spec: str, expected: str) -> None:
+    """Tag, digest, or both are stripped; registry ports are preserved."""
+    assert image_ref.strip_tag_and_digest(pull_spec) == expected
+
+
 def test_pyxis_url_for_pull_spec_with_tag_and_registry_rewrite() -> None:
     """Tagged refs map to `.../tag/<tag>` and rewrite registry.redhat.io host."""
     out = image_ref.pyxis_url_for_pull_spec(

--- a/scripts/python/tasks/internal/check_fbc_opt_in.py
+++ b/scripts/python/tasks/internal/check_fbc_opt_in.py
@@ -57,13 +57,7 @@ def get_fbc_opt_in(
     """
     try:
         # fbc_opt_in is a repository-level attribute; strip tag and digest.
-        # Strip digest first, then strip the tag only from the last path
-        # segment so a registry port (e.g. registry:5000) is never confused
-        # with a tag separator.
-        repo_spec = pull_spec.split("@")[0]
-        parts = repo_spec.split("/")
-        parts[-1] = parts[-1].rsplit(":", 1)[0]
-        repo_spec = "/".join(parts)
+        repo_spec = image_ref.strip_tag_and_digest(pull_spec)
         if repo_spec != pull_spec:
             logger.info(
                 "Pull spec %s includes a tag/digest; stripped to %s for repo query",

--- a/scripts/python/tasks/internal/check_fbc_opt_in.py
+++ b/scripts/python/tasks/internal/check_fbc_opt_in.py
@@ -13,16 +13,15 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-import requests
-from requests.auth import AuthBase
-from requests_kerberos import HTTPKerberosAuth, OPTIONAL
-
 import authentication
 import file
 import http_client
 import image_ref
+import requests
 import tekton
 from logger import logger
+from requests.auth import AuthBase
+from requests_kerberos import OPTIONAL, HTTPKerberosAuth
 
 PROG = "check_fbc_opt_in.py"
 
@@ -32,11 +31,11 @@ def parse_container_images(value: str) -> list[str]:
     # Input is a JSON array string; keep validation strict so malformed input fails fast.
     data = json.loads(value)
     if not isinstance(data, list):
-        raise ValueError("container images must be a JSON array")
+        raise TypeError("container images must be a JSON array")
     out: list[str] = []
     for item in data:
         if not isinstance(item, str):
-            raise ValueError("container images must be strings")
+            raise TypeError("container images must be strings")
         stripped = item.strip()
         if not stripped:
             raise ValueError("container images must be non-empty")
@@ -51,17 +50,28 @@ def get_fbc_opt_in(
     *,
     warn_on_query_failure: bool = True,
 ) -> bool:
-    """
-    Return `True` only when the Pyxis JSON body sets `fbc_opt_in` to JSON boolean
-    true.
+    """Return `True` when Pyxis sets `fbc_opt_in` to JSON boolean true.
 
     Query failures, non-JSON responses, and missing fields are treated as
     opt-out (`False`).
     """
     try:
-        # Build the Pyxis endpoint for this image pull spec.
+        # fbc_opt_in is a repository-level attribute; strip tag and digest.
+        # Strip digest first, then strip the tag only from the last path
+        # segment so a registry port (e.g. registry:5000) is never confused
+        # with a tag separator.
+        repo_spec = pull_spec.split("@")[0]
+        parts = repo_spec.split("/")
+        parts[-1] = parts[-1].rsplit(":", 1)[0]
+        repo_spec = "/".join(parts)
+        if repo_spec != pull_spec:
+            logger.info(
+                "Pull spec %s includes a tag/digest; stripped to %s for repo query",
+                pull_spec,
+                repo_spec,
+            )
         body = http_client.get_text(
-            image_ref.pyxis_url_for_pull_spec(pyxis_url, pull_spec),
+            image_ref.pyxis_url_for_pull_spec(pyxis_url, repo_spec),
             auth=auth,
         )
         data: dict[str, Any] = json.loads(body)
@@ -90,8 +100,7 @@ def run_check(
     kinit: Callable[..., None] = authentication.kinit_with_retry,
     get_opt_in: Callable[[str, str, AuthBase | None], bool] = get_fbc_opt_in,
 ) -> list[dict[str, Any]]:
-    """
-    Authenticate with Kerberos then query Pyxis FBC opt-in for each image.
+    """Authenticate with Kerberos then query Pyxis FBC opt-in for each image.
 
     Returns one result object per input image:
     `{"containerImage": "...", "fbcOptIn": bool}`.
@@ -183,9 +192,10 @@ def main() -> int:
             service_account_mount,
             iib_services_config_mount,
         )
-    except (ValueError, tekton.CheckStepError) as e:
-        # Surface validation and step failures as a clear one-line SystemExit message.
-        raise SystemExit(f"{PROG}: {e}") from e
+    except Exception as e:
+        logger.error("%s: %s", PROG, e, exc_info=True)
+        rpath.write_text(json.dumps([]), encoding="utf-8")
+        return 0
 
     logger.info("FBC opt-in check completed")
     logger.info("Results:")

--- a/scripts/python/tasks/internal/test_check_fbc_opt_in.py
+++ b/scripts/python/tasks/internal/test_check_fbc_opt_in.py
@@ -38,19 +38,33 @@ def test_parse_container_images_ok() -> None:
 
 @pytest.mark.parametrize("raw", ['{"x": 1}', '["ok", ""]', "[1]"])
 def test_parse_container_images_invalid(raw: str) -> None:
-    """Non-array or non-string/blank items raise `ValueError`."""
-    with pytest.raises(ValueError):
+    """Non-array or non-string/blank items raise `TypeError` or `ValueError`."""
+    with pytest.raises((TypeError, ValueError)):
         check_fbc_opt_in.parse_container_images(raw)
 
 
 def test_get_fbc_opt_in_true_false_and_missing() -> None:
     """Only explicit `fbc_opt_in: true` maps to `True`."""
-    with mock.patch("http_client.get_text", return_value='{"fbc_opt_in": true}'):
+    with mock.patch("http_client.get_text", return_value='{"fbc_opt_in": true}') as m:
         assert check_fbc_opt_in.get_fbc_opt_in("https://p", "r.io/repo/i:1", None) is True
-    with mock.patch("http_client.get_text", return_value='{"fbc_opt_in": false}'):
+        m.assert_called_once()
+        assert "/tag/" not in m.call_args[0][0]
+    with mock.patch("http_client.get_text", return_value='{"fbc_opt_in": false}') as m:
         assert check_fbc_opt_in.get_fbc_opt_in("https://p", "r.io/repo/i:1", None) is False
-    with mock.patch("http_client.get_text", return_value="{}"):
+        assert "/tag/" not in m.call_args[0][0]
+    with mock.patch("http_client.get_text", return_value="{}") as m:
         assert check_fbc_opt_in.get_fbc_opt_in("https://p", "r.io/repo/i:1", None) is False
+        assert "/tag/" not in m.call_args[0][0]
+
+
+def test_get_fbc_opt_in_strips_digest() -> None:
+    """A pull spec with a digest is stripped to the repository level."""
+    spec = "r.io/repo/i@sha256:abc123"
+    with mock.patch("http_client.get_text", return_value='{"fbc_opt_in": true}') as m:
+        assert check_fbc_opt_in.get_fbc_opt_in("https://p", spec, None) is True
+        url = m.call_args[0][0]
+        assert "/tag/" not in url
+        assert "sha256" not in url
 
 
 def test_get_fbc_opt_in_http_error_returns_false() -> None:
@@ -149,8 +163,8 @@ def test_main_requires_pyxis_url_env(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     monkeypatch.setenv("RESULT_OPT_IN_RESULTS", str(rpath))
     monkeypatch.setenv("CONTAINER_IMAGES", '["r/repo/i:1"]')
     monkeypatch.delenv("PYXIS_URL", raising=False)
-    with pytest.raises(SystemExit, match=r"check_fbc_opt_in\.py: PYXIS_URL must be set"):
-        check_fbc_opt_in.main()
+    assert check_fbc_opt_in.main() == 0
+    assert json.loads(rpath.read_text(encoding="utf-8")) == []
 
 
 def test_main_missing_result_env_raises_system_exit() -> None:
@@ -162,10 +176,10 @@ def test_main_missing_result_env_raises_system_exit() -> None:
 def test_main_invalid_container_images_exits(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Invalid `CONTAINER_IMAGES` raises `SystemExit` with program prefix."""
+    """Invalid `CONTAINER_IMAGES` writes empty result and returns 0."""
     rpath = tmp_path / "result"
     monkeypatch.setenv("RESULT_OPT_IN_RESULTS", str(rpath))
     monkeypatch.setenv("CONTAINER_IMAGES", '{"bad": 1}')
     monkeypatch.setenv("PYXIS_URL", "https://pyxis/v1")
-    with pytest.raises(SystemExit, match="check_fbc_opt_in.py"):
-        check_fbc_opt_in.main()
+    assert check_fbc_opt_in.main() == 0
+    assert json.loads(rpath.read_text(encoding="utf-8")) == []


### PR DESCRIPTION
fbc_opt_in is a repository-level attribute. Strip
tag or digest from pull specs before querying
Pyxis to avoid incorrect URL paths.


Assisted-by: Claude