### PR TITLE
fix(release-2754): remove timestampFormat from schema

### DIFF
--- a/schemas/dataKeys.json
+++ b/schemas/dataKeys.json
@@ -109,10 +109,6 @@
           "type": "integer",
           "description": "The requested timeout in seconds e.g. 1500"
         },
-        "timestampFormat": {
-          "type": "string",
-          "description": "The timestamp format which defaults to %s e.g. %Y-%m-%d"
-        },
         "issueId": {
           "type": "string",
           "description": "The issue ID e.g. bz123456"


### PR DESCRIPTION
this PR removes the timestampFormat key from fbc schema