### PR TITLE
feat(RELEASE-2481): read result paths from env vars

### DIFF
--- a/scripts/python/tasks/managed/collect_signing_params.py
+++ b/scripts/python/tasks/managed/collect_signing_params.py
@@ -30,14 +30,24 @@ RESULT_KEYS = (
 )
 
 USAGE = """\
-usage: collect_signing_params.py --results-dir DIR [--config-map-name NAME] \
+usage: python3 -m collect_signing_params [--config-map-name NAME] \
 [--config-map-namespace NAMESPACE]
 
 Collect signing parameters from a Kubernetes ConfigMap and write them to
-Tekton result files.
+Tekton result files. All result file path environment variables are required;
+the script exits with code 1 if any are missing.
 
-required arguments:
-  --results-dir DIR           Directory to write Tekton result files
+environment variables (all required):
+  RESULT_ENABLE_KEYLESS_SIGNING   Path to enableKeylessSigning result file
+  RESULT_DEFAULT_OIDC_ISSUER      Path to defaultOIDCIssuer result file
+  RESULT_REKOR_EXTERNAL_URL       Path to rekorExternalUrl result file
+  RESULT_REKOR_URL                Path to rekorUrl result file
+  RESULT_FULCIO_EXTERNAL_URL      Path to fulcioExternalUrl result file
+  RESULT_FULCIO_URL               Path to fulcioUrl result file
+  RESULT_TUF_EXTERNAL_URL         Path to tufExternalUrl result file
+  RESULT_TUF_URL                  Path to tufUrl result file
+  RESULT_BUILD_IDENTITY_REGEXP    Path to buildIdentityRegexp result file
+  RESULT_TEKTON_CHAINS_IDENTITY   Path to tektonChainsIdentity result file
 
 optional arguments:
   --config-map-name NAME      ConfigMap name (default: cluster-config)
@@ -107,16 +117,16 @@ def extract_signing_params_from_configmap(
     return params
 
 
-def write_result_files(results_dir: Path, params: dict[str, str]) -> None:
+def write_result_files(params: dict[str, str], result_paths: dict[str, Path]) -> None:
     """Write signing parameters to Tekton result files.
 
     Args:
-        results_dir: The directory containing Tekton result files.
         params: A dictionary of result keys to their string values.
+        result_paths: A dictionary mapping result keys to their file paths.
 
     """
     for key in RESULT_KEYS:
-        result_path = results_dir / key
+        result_path = result_paths[key]
         value = params.get(key, "")
         result_path.write_text(value, encoding="utf-8")
         logger.info("Wrote result %s = %s", key, value if value else "(empty)")
@@ -125,14 +135,14 @@ def write_result_files(results_dir: Path, params: dict[str, str]) -> None:
 def collect_signing_params(
     config_map_name: str,
     config_map_namespace: str,
-    results_dir: Path,
+    result_paths: dict[str, Path],
 ) -> dict[str, str]:
     """Collect signing parameters from a ConfigMap and write to result files.
 
     Args:
         config_map_name: The name of the ConfigMap to read.
         config_map_namespace: The namespace where the ConfigMap is located.
-        results_dir: The directory to write Tekton result files.
+        result_paths: A dictionary mapping result keys to their file paths.
 
     Returns:
         The collected signing parameters as a dictionary.
@@ -153,7 +163,7 @@ def collect_signing_params(
         logger.info("Using empty signing parameters with keyless signing disabled")
         params = get_empty_signing_params()
 
-    write_result_files(results_dir, params)
+    write_result_files(params, result_paths)
     return params
 
 
@@ -167,18 +177,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         Parsed arguments namespace.
 
     """
-    parser = tekton.tekton_argument_parser("collect_signing_params.py")
+    parser = tekton.tekton_argument_parser("collect_signing_params")
     parser.add_argument("--config-map-name", default="cluster-config")
     parser.add_argument("--config-map-namespace", default="konflux-info")
-    parser.add_argument("--results-dir")
-
-    if argv is not None and ("-h" in argv or "--help" in argv):
-        tekton.exit_with_usage(USAGE)
+    parser.add_argument("-h", "--help", action="store_true")
 
     args = parser.parse_args(argv)
 
-    missing = tekton.missing_blank_option_values(("--results-dir", args.results_dir))
-    if missing:
+    if args.help:
         tekton.exit_with_usage(USAGE)
 
     return args
@@ -187,10 +193,48 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     """Parse arguments, collect signing parameters, and write Tekton results."""
     args = parse_args(argv)
+
+    (
+        enable_keyless_signing_path,
+        default_oidc_issuer_path,
+        rekor_external_url_path,
+        rekor_url_path,
+        fulcio_external_url_path,
+        fulcio_url_path,
+        tuf_external_url_path,
+        tuf_url_path,
+        build_identity_regexp_path,
+        tekton_chains_identity_path,
+    ) = tekton.result_paths_from_env(
+        "RESULT_ENABLE_KEYLESS_SIGNING",
+        "RESULT_DEFAULT_OIDC_ISSUER",
+        "RESULT_REKOR_EXTERNAL_URL",
+        "RESULT_REKOR_URL",
+        "RESULT_FULCIO_EXTERNAL_URL",
+        "RESULT_FULCIO_URL",
+        "RESULT_TUF_EXTERNAL_URL",
+        "RESULT_TUF_URL",
+        "RESULT_BUILD_IDENTITY_REGEXP",
+        "RESULT_TEKTON_CHAINS_IDENTITY",
+    )
+
+    result_paths = {
+        "enableKeylessSigning": enable_keyless_signing_path,
+        "defaultOIDCIssuer": default_oidc_issuer_path,
+        "rekorExternalUrl": rekor_external_url_path,
+        "rekorUrl": rekor_url_path,
+        "fulcioExternalUrl": fulcio_external_url_path,
+        "fulcioUrl": fulcio_url_path,
+        "tufExternalUrl": tuf_external_url_path,
+        "tufUrl": tuf_url_path,
+        "buildIdentityRegexp": build_identity_regexp_path,
+        "tektonChainsIdentity": tekton_chains_identity_path,
+    }
+
     collect_signing_params(
         config_map_name=args.config_map_name,
         config_map_namespace=args.config_map_namespace,
-        results_dir=Path(args.results_dir),
+        result_paths=result_paths,
     )
     return 0
 

--- a/scripts/python/tasks/managed/test_collect_signing_params.py
+++ b/scripts/python/tasks/managed/test_collect_signing_params.py
@@ -31,6 +31,29 @@ def _full_signing_params() -> dict[str, str]:
     }
 
 
+def _make_result_paths(tmp_path: Path) -> dict[str, Path]:
+    """Create a dictionary mapping result keys to file paths."""
+    return {key: tmp_path / key for key in collect_signing_params.RESULT_KEYS}
+
+
+def _set_result_env_vars(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set environment variables for all result paths."""
+    env_var_names = [
+        "RESULT_ENABLE_KEYLESS_SIGNING",
+        "RESULT_DEFAULT_OIDC_ISSUER",
+        "RESULT_REKOR_EXTERNAL_URL",
+        "RESULT_REKOR_URL",
+        "RESULT_FULCIO_EXTERNAL_URL",
+        "RESULT_FULCIO_URL",
+        "RESULT_TUF_EXTERNAL_URL",
+        "RESULT_TUF_URL",
+        "RESULT_BUILD_IDENTITY_REGEXP",
+        "RESULT_TEKTON_CHAINS_IDENTITY",
+    ]
+    for key, env_var in zip(collect_signing_params.RESULT_KEYS, env_var_names):
+        monkeypatch.setenv(env_var, str(tmp_path / key))
+
+
 def test_get_empty_signing_params_returns_false_for_keyless() -> None:
     """Empty params have enableKeylessSigning set to 'false'."""
     params = collect_signing_params.get_empty_signing_params()
@@ -162,7 +185,8 @@ def test_extract_signing_params_partial_configmap() -> None:
 
 
 def test_write_result_files_creates_all_files(tmp_path: Path) -> None:
-    """All result files are created in the results directory."""
+    """All result files are created."""
+    result_paths = _make_result_paths(tmp_path)
     params = {
         "enableKeylessSigning": "true",
         "defaultOIDCIssuer": "https://oidc.example.com",
@@ -175,7 +199,7 @@ def test_write_result_files_creates_all_files(tmp_path: Path) -> None:
         "buildIdentityRegexp": "",
         "tektonChainsIdentity": "",
     }
-    collect_signing_params.write_result_files(tmp_path, params)
+    collect_signing_params.write_result_files(params, result_paths)
 
     for key in collect_signing_params.RESULT_KEYS:
         assert (tmp_path / key).exists()
@@ -183,6 +207,7 @@ def test_write_result_files_creates_all_files(tmp_path: Path) -> None:
 
 def test_write_result_files_correct_content(tmp_path: Path) -> None:
     """Result files contain the correct values."""
+    result_paths = _make_result_paths(tmp_path)
     params = {
         "enableKeylessSigning": "true",
         "defaultOIDCIssuer": "https://oidc.example.com",
@@ -195,7 +220,7 @@ def test_write_result_files_correct_content(tmp_path: Path) -> None:
         "buildIdentityRegexp": "^https://kubernetes.io/.*",
         "tektonChainsIdentity": "URI:https://kubernetes.io/test",
     }
-    collect_signing_params.write_result_files(tmp_path, params)
+    collect_signing_params.write_result_files(params, result_paths)
 
     assert (tmp_path / "enableKeylessSigning").read_text() == "true"
     assert (tmp_path / "defaultOIDCIssuer").read_text() == "https://oidc.example.com"
@@ -206,6 +231,7 @@ def test_collect_signing_params_with_configmap(tmp_path: Path) -> None:
     """Collect signing params when ConfigMap is available."""
     from unittest.mock import patch
 
+    result_paths = _make_result_paths(tmp_path)
     mock_configmap = _mock_configmap(_full_signing_params())
     with patch(
         "collect_signing_params.kubectl.get_configmap", return_value=mock_configmap
@@ -213,7 +239,7 @@ def test_collect_signing_params_with_configmap(tmp_path: Path) -> None:
         params = collect_signing_params.collect_signing_params(
             config_map_name="cluster-config",
             config_map_namespace="konflux-info",
-            results_dir=tmp_path,
+            result_paths=result_paths,
         )
 
         m.assert_called_once_with("cluster-config", namespace="konflux-info")
@@ -225,6 +251,7 @@ def test_collect_signing_params_missing_configmap(tmp_path: Path) -> None:
     """Collect empty signing params when ConfigMap is not found."""
     from unittest.mock import patch
 
+    result_paths = _make_result_paths(tmp_path)
     with patch(
         "collect_signing_params.kubectl.get_configmap",
         side_effect=RuntimeError("ConfigMap not found"),
@@ -232,7 +259,7 @@ def test_collect_signing_params_missing_configmap(tmp_path: Path) -> None:
         params = collect_signing_params.collect_signing_params(
             config_map_name="cluster-config",
             config_map_namespace="konflux-info",
-            results_dir=tmp_path,
+            result_paths=result_paths,
         )
 
     assert params["enableKeylessSigning"] == "false"
@@ -245,23 +272,23 @@ def test_collect_signing_params_custom_configmap_name(tmp_path: Path) -> None:
     """Collect signing params from a custom ConfigMap name."""
     from unittest.mock import patch
 
+    result_paths = _make_result_paths(tmp_path)
     with patch(
         "collect_signing_params.kubectl.get_configmap", return_value=_mock_configmap({})
     ) as m:
         collect_signing_params.collect_signing_params(
             config_map_name="custom-config",
             config_map_namespace="custom-ns",
-            results_dir=tmp_path,
+            result_paths=result_paths,
         )
 
         m.assert_called_once_with("custom-config", namespace="custom-ns")
 
 
-def test_parse_args_required_results_dir() -> None:
-    """Parse args with all required arguments."""
-    args = collect_signing_params.parse_args(["--results-dir", "/tmp/results"])
+def test_parse_args_defaults() -> None:
+    """Parse args with default values."""
+    args = collect_signing_params.parse_args([])
 
-    assert args.results_dir == "/tmp/results"
     assert args.config_map_name == "cluster-config"
     assert args.config_map_namespace == "konflux-info"
 
@@ -270,8 +297,6 @@ def test_parse_args_custom_configmap() -> None:
     """Parse args with custom ConfigMap name and namespace."""
     args = collect_signing_params.parse_args(
         [
-            "--results-dir",
-            "/tmp/results",
             "--config-map-name",
             "my-config",
             "--config-map-namespace",
@@ -279,16 +304,8 @@ def test_parse_args_custom_configmap() -> None:
         ]
     )
 
-    assert args.results_dir == "/tmp/results"
     assert args.config_map_name == "my-config"
     assert args.config_map_namespace == "my-namespace"
-
-
-def test_parse_args_missing_results_dir_exits() -> None:
-    """Exit when --results-dir is missing."""
-    with pytest.raises(SystemExit) as exc_info:
-        collect_signing_params.parse_args([])
-    assert exc_info.value.code == 1
 
 
 def test_parse_args_help_exits() -> None:
@@ -298,27 +315,43 @@ def test_parse_args_help_exits() -> None:
     assert exc_info.value.code == 1
 
 
-def test_main_success(tmp_path: Path) -> None:
+def test_help_via_sysargv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Help works via sys.argv (real entrypoint path)."""
+    import runpy
+
+    monkeypatch.setattr("sys.argv", ["collect_signing_params", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_module("collect_signing_params", run_name="__main__")
+
+    assert exc_info.value.code == 1
+
+
+def test_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Main returns 0 on success."""
     from unittest.mock import patch
 
+    _set_result_env_vars(tmp_path, monkeypatch)
     mock_configmap = _mock_configmap(_full_signing_params())
     with patch("collect_signing_params.kubectl.get_configmap", return_value=mock_configmap):
-        result = collect_signing_params.main(["--results-dir", str(tmp_path)])
+        result = collect_signing_params.main([])
 
     assert result == 0
     assert (tmp_path / "enableKeylessSigning").read_text() == "true"
 
 
-def test_main_missing_configmap_succeeds(tmp_path: Path) -> None:
+def test_main_missing_configmap_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Main returns 0 even when ConfigMap is missing."""
     from unittest.mock import patch
 
+    _set_result_env_vars(tmp_path, monkeypatch)
     with patch(
         "collect_signing_params.kubectl.get_configmap",
         side_effect=RuntimeError("Not found"),
     ):
-        result = collect_signing_params.main(["--results-dir", str(tmp_path)])
+        result = collect_signing_params.main([])
 
     assert result == 0
     assert (tmp_path / "enableKeylessSigning").read_text() == "false"
@@ -329,10 +362,9 @@ def test_module_main_guard(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     import runpy
     from unittest.mock import patch
 
+    _set_result_env_vars(tmp_path, monkeypatch)
     mock_configmap = _mock_configmap(_full_signing_params())
-    monkeypatch.setattr(
-        "sys.argv", ["collect_signing_params.py", "--results-dir", str(tmp_path)]
-    )
+    monkeypatch.setattr("sys.argv", ["collect_signing_params"])
 
     with patch("collect_signing_params.kubectl.get_configmap", return_value=mock_configmap):
         with pytest.raises(SystemExit) as exc_info:
@@ -402,6 +434,7 @@ def test_extract_signing_params_whitespace_only_keyless() -> None:
 
 def test_write_result_files_unicode_content(tmp_path: Path) -> None:
     """Write Unicode content to result files correctly."""
+    result_paths = _make_result_paths(tmp_path)
     params = {
         "enableKeylessSigning": "true",
         "defaultOIDCIssuer": "https://example.com/日本語",
@@ -414,7 +447,7 @@ def test_write_result_files_unicode_content(tmp_path: Path) -> None:
         "buildIdentityRegexp": "",
         "tektonChainsIdentity": "",
     }
-    collect_signing_params.write_result_files(tmp_path, params)
+    collect_signing_params.write_result_files(params, result_paths)
 
     content = (tmp_path / "defaultOIDCIssuer").read_text(encoding="utf-8")
     assert content == "https://example.com/日本語"
@@ -422,8 +455,9 @@ def test_write_result_files_unicode_content(tmp_path: Path) -> None:
 
 def test_write_result_files_missing_key_in_params(tmp_path: Path) -> None:
     """Missing keys in params result in empty files."""
+    result_paths = _make_result_paths(tmp_path)
     params = {"enableKeylessSigning": "true"}
-    collect_signing_params.write_result_files(tmp_path, params)
+    collect_signing_params.write_result_files(params, result_paths)
 
     assert (tmp_path / "enableKeylessSigning").read_text() == "true"
     assert (tmp_path / "defaultOIDCIssuer").read_text() == ""
@@ -434,28 +468,23 @@ def test_collect_signing_params_returns_all_keys(tmp_path: Path) -> None:
     """Verify collect_signing_params returns dict with all RESULT_KEYS."""
     from unittest.mock import patch
 
+    result_paths = _make_result_paths(tmp_path)
     with patch(
         "collect_signing_params.kubectl.get_configmap", return_value=_mock_configmap({})
     ):
         params = collect_signing_params.collect_signing_params(
             config_map_name="cluster-config",
             config_map_namespace="konflux-info",
-            results_dir=tmp_path,
+            result_paths=result_paths,
         )
 
     for key in collect_signing_params.RESULT_KEYS:
         assert key in params, f"Missing key '{key}' in returned params"
 
 
-def test_parse_args_empty_results_dir_exits() -> None:
-    """Exit when --results-dir is provided but empty."""
+def test_main_missing_env_vars_fails_fast() -> None:
+    """Missing RESULT_* env vars fail fast via tekton.result_paths_from_env."""
     with pytest.raises(SystemExit) as exc_info:
-        collect_signing_params.parse_args(["--results-dir", ""])
-    assert exc_info.value.code == 1
+        collect_signing_params.main([])
 
-
-def test_parse_args_whitespace_results_dir_exits() -> None:
-    """Exit when --results-dir is whitespace only."""
-    with pytest.raises(SystemExit) as exc_info:
-        collect_signing_params.parse_args(["--results-dir", "   "])
     assert exc_info.value.code == 1


### PR DESCRIPTION
## Describe your changes
Replace --results-dir argument with RESULT_* environment variables for Tekton result paths. This aligns with the standardized pattern where result file paths are passed via env vars, enabling the catalog task to use command with args instead of a bash script wrapper.

## Relevant Jira
[RELEASE-2481](https://redhat.atlassian.net/browse/RELEASE-2481)


[RELEASE-2481]: https://redhat.atlassian.net/browse/RELEASE-2481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ