### PR TITLE
RELEASE-2747: Check symlinks only in wanted files

### DIFF
--- a/scripts/python/helpers/extract_artifacts.py
+++ b/scripts/python/helpers/extract_artifacts.py
@@ -98,12 +98,18 @@ def _get_source_paths(component: dict) -> tuple[list[str], list[str]]:
 
 
 def _safe_extract_layer(
-    tf: tarfile.TarFile, image_path: str, target_dir: Path, layer_name: str
+    tf: tarfile.TarFile,
+    image_path: str,
+    target_dir: Path,
+    layer_name: str,
+    wanted_files: set[str],
 ) -> bool:
     """Extract members under image_path/ from a layer tarfile with path safety checks.
 
     Returns True if any matching members were found, False otherwise.
-    Raises RuntimeError for unsafe entries (path traversal, symlinks, hardlinks, devices).
+    Raises RuntimeError for unsafe entries (path traversal, symlinks, hard links, devices)
+    only when the entry is a file that is actually needed (in wanted_files).
+    Symlinks, hard links, and device nodes that are not in wanted_files are skipped.
     """
     target_real = target_dir.resolve()
     found = False
@@ -112,9 +118,11 @@ def _safe_extract_layer(
             continue
         found = True
         if member.issym() or member.islnk() or member.isdev():
-            raise RuntimeError(
-                f"Layer {layer_name} contains unsupported entry type: {member.name}"
-            )
+            if member.name in wanted_files:
+                raise RuntimeError(
+                    f"Layer {layer_name} contains unsupported entry type: {member.name}"
+                )
+            continue
         member_real = (target_dir / member.name).resolve()
         if member_real != target_real and target_real not in member_real.parents:
             raise RuntimeError(f"Layer {layer_name} contains unsafe path: {member.name}")
@@ -225,6 +233,7 @@ def process_component(component: dict) -> None:
             _extract_from_oras(manifest, tmp_dir, wanted_files, destination, name)
         else:
             layer_digests = [layer["digest"] for layer in manifest.get("layers", [])]
+            wanted_set = set(wanted_files)
 
             for digest in layer_digests:
                 layer_file = tmp_dir / digest.removeprefix("sha256:")
@@ -232,7 +241,9 @@ def process_component(component: dict) -> None:
                     continue
                 with tarfile.open(str(layer_file)) as tf:
                     for image_path in extract_dirs:
-                        if _safe_extract_layer(tf, image_path, tmp_dir, layer_file.name):
+                        if _safe_extract_layer(
+                            tf, image_path, tmp_dir, layer_file.name, wanted_set
+                        ):
                             logger.info(
                                 "Extracting %s/ from %s...", image_path, layer_file.name
                             )

--- a/scripts/python/helpers/test_extract_artifacts.py
+++ b/scripts/python/helpers/test_extract_artifacts.py
@@ -392,6 +392,58 @@ def test_process_component_raises_when_file_missing_from_container(
 
 
 # ---------------------------------------------------------------------------
+# _safe_extract_layer
+# ---------------------------------------------------------------------------
+
+
+def _make_layer(tmp_path: Path, members: list) -> Path:
+    """Write a tar archive at tmp_path/layer.tar containing the given members."""
+    layer = tmp_path / "layer.tar"
+    with tarfile.open(str(layer), "w") as tf:
+        for m in members:
+            tf.addfile(m)
+    return layer
+
+
+def test_safe_extract_layer_skips_symlink_not_in_wanted(tmp_path: Path) -> None:
+    """A symlink that is not in wanted_files is silently skipped, not an error."""
+    sym = tarfile.TarInfo(name="releases/link.so")
+    sym.type = tarfile.SYMTYPE
+    sym.linkname = "actual.so"
+
+    reg = tarfile.TarInfo(name="releases/real.tar.gz")
+    reg.size = 0
+
+    layer = _make_layer(tmp_path, [sym, reg])
+    target = tmp_path / "out"
+    target.mkdir()
+
+    with tarfile.open(str(layer)) as tf:
+        found = extract_artifacts._safe_extract_layer(
+            tf, "releases", target, "layer.tar", wanted_files={"releases/real.tar.gz"}
+        )
+
+    assert found is True
+
+
+def test_safe_extract_layer_raises_for_symlink_in_wanted(tmp_path: Path) -> None:
+    """A symlink that IS in wanted_files raises RuntimeError."""
+    sym = tarfile.TarInfo(name="releases/needed.tar.gz")
+    sym.type = tarfile.SYMTYPE
+    sym.linkname = "actual.tar.gz"
+
+    layer = _make_layer(tmp_path, [sym])
+    target = tmp_path / "out"
+    target.mkdir()
+
+    with tarfile.open(str(layer)) as tf:
+        with pytest.raises(RuntimeError, match="unsupported entry type"):
+            extract_artifacts._safe_extract_layer(
+                tf, "releases", target, "layer.tar", wanted_files={"releases/needed.tar.gz"}
+            )
+
+
+# ---------------------------------------------------------------------------
 # _extract_from_oras
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The `_safe_extract_layer()` function in `extract_artifacts.py` rejects all symlinks found under the extracted directory tree, even those that are not part of `wanted_files`. This causes the `push-artifacts-to-cdn` pipeline to fail when the container image layers contain any symlink in the extraction path, regardless of whether that symlink is a file the RPA requested.