### PR TITLE
fix: ignore GitHub's PR-number suffix in gitlint

### DIFF
--- a/.github/gitlint/title_ignore_pr_suffix_length.py
+++ b/.github/gitlint/title_ignore_pr_suffix_length.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Enforce a max title length that ignores GitHub's squash-merge PR suffix."""
+
+from __future__ import annotations
+
+import re
+
+from gitlint.git import GitCommit
+from gitlint.rules import CommitRule, RuleViolation
+
+PR_SUFFIX_RE = re.compile(r" \(#\d+\)$")
+MAX_LENGTH = 72
+
+
+class TitleMaxLengthIgnoringPrSuffix(CommitRule):
+    """Enforce a max title length, ignoring GitHub's " (#NNN)" suffix."""
+
+    id = "UC2"
+    name = "title-max-length-ignoring-pr-suffix"
+
+    def validate(self, commit: GitCommit) -> list[RuleViolation] | None:
+        """Fail if the title (minus any GitHub PR suffix) is too long."""
+        title = PR_SUFFIX_RE.sub("", commit.message.title)
+        if len(title) > MAX_LENGTH:
+            return [
+                RuleViolation(
+                    self.id,
+                    f"Title exceeds max length ({len(title)}>{MAX_LENGTH})",
+                    line_nr=1,
+                )
+            ]
+        return None

--- a/.gitlint
+++ b/.gitlint
@@ -1,10 +1,7 @@
 [general]
 contrib=contrib-title-conventional-commits,CC1
 extra-path=.github/gitlint
-ignore=T5
-
-[title-max-length]
-line-length=72
+ignore=T1,T5
 
 [body-max-line-length]
 line-length=72
@@ -15,4 +12,4 @@ line-length=72
 
 [ignore-by-author-name]
 regex=(.*)\[bot\](.*)
-ignore=T1,B1
+ignore=T1,UC2,B1


### PR DESCRIPTION
Replace T1 with a custom rule that strips squash-merge's " (#NNN)" suffix before checking title length.

Assisted-by: Cursor