### PR TITLE
fix: disable gitlint title-length check

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,10 +1,7 @@
 [general]
 contrib=contrib-title-conventional-commits,CC1
 extra-path=.github/gitlint
-ignore=T5
-
-[title-max-length]
-line-length=72
+ignore=T1,T5
 
 [body-max-line-length]
 line-length=72


### PR DESCRIPTION
Squash-merge's " (#NNN)" suffix was tripping T1 only in the merge queue, after approval. Disable it repo-wide instead.

Assisted-by: Cursor