### PR TITLE
feat(RELEASE-2475): add validate_single_component.py script

### DIFF
--- a/scripts/python/tasks/managed/test_validate_single_component.py
+++ b/scripts/python/tasks/managed/test_validate_single_component.py
@@ -1,0 +1,86 @@
+"""Tests for validate_single_component."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import validate_single_component
+
+
+def _write_snapshot(path: Path, components: Any) -> None:
+    """Write a minimal snapshot JSON file with the given components value."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"application": "app", "components": components}) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_run_allows_zero_components(tmp_path: Path) -> None:
+    """Zero components is allowed (matches the original length check)."""
+    snapshot_path = Path("snapshot.json")
+    _write_snapshot(tmp_path / snapshot_path, [])
+    validate_single_component.run(data_dir=tmp_path, snapshot_path=snapshot_path)
+
+
+def test_run_allows_missing_components_key(tmp_path: Path) -> None:
+    """A missing components key is treated as an empty list."""
+    snapshot_path = Path("snapshot.json")
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / snapshot_path).write_text('{"application": "app"}\n', encoding="utf-8")
+    validate_single_component.run(data_dir=tmp_path, snapshot_path=snapshot_path)
+
+
+def test_run_allows_one_component(tmp_path: Path) -> None:
+    """A single component passes validation."""
+    snapshot_path = Path("snapshot.json")
+    _write_snapshot(tmp_path / snapshot_path, [{"name": "comp"}])
+    validate_single_component.run(data_dir=tmp_path, snapshot_path=snapshot_path)
+
+
+def test_run_rejects_non_list_components(tmp_path: Path) -> None:
+    """Reject snapshots whose components value is not a JSON array."""
+    snapshot_path = Path("snapshot.json")
+    _write_snapshot(tmp_path / snapshot_path, {"name": "x"})
+    with pytest.raises(TypeError, match="must be a JSON array"):
+        validate_single_component.run(data_dir=tmp_path, snapshot_path=snapshot_path)
+
+
+def test_run_rejects_multiple_components(tmp_path: Path) -> None:
+    """More than one component fails with the catalog error message."""
+    snapshot_path = Path("snapshot.json")
+    _write_snapshot(tmp_path / snapshot_path, [{"name": "a"}, {"name": "b"}])
+    with pytest.raises(
+        ValueError,
+        match="found 2 components, only one component per application is supported",
+    ):
+        validate_single_component.run(data_dir=tmp_path, snapshot_path=snapshot_path)
+
+
+def test_main_reads_env_and_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() wires PARAM_* env vars into run()."""
+    snapshot_path = Path("snapshot.json")
+    _write_snapshot(tmp_path / snapshot_path, [{"name": "comp"}])
+    monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PARAM_SNAPSHOT_PATH", str(snapshot_path))
+    assert validate_single_component.main() == 0
+
+
+def test_main_propagates_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() raises validation failures."""
+    snapshot_path = Path("snapshot.json")
+    _write_snapshot(tmp_path / snapshot_path, [{"name": "a"}, {"name": "b"}])
+    monkeypatch.setenv("PARAM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PARAM_SNAPSHOT_PATH", str(snapshot_path))
+    with pytest.raises(ValueError, match="found 2 components"):
+        validate_single_component.main()

--- a/scripts/python/tasks/managed/validate_single_component.py
+++ b/scripts/python/tasks/managed/validate_single_component.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Validate that a Snapshot contains at most one component."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import file
+import tekton
+from logger import logger
+
+
+def run(*, data_dir: Path, snapshot_path: Path) -> None:
+    """Load the snapshot under *data_dir* and enforce the single-component rule."""
+    snapshot_file = data_dir / snapshot_path
+    logger.info("Loading snapshot from %s", snapshot_file)
+    snapshot = file.load_json_dict(snapshot_file)
+
+    components = snapshot.get("components", [])
+    if not isinstance(components, list):
+        msg = "snapshot.components must be a JSON array"
+        raise TypeError(msg)
+
+    count = len(components)
+    if count > 1:
+        msg = f"found {count} components, only one component per application is supported."
+        raise ValueError(msg)
+    logger.info("Snapshot has %d component(s); single-component check passed", count)
+
+
+def main() -> int:
+    """Read Tekton env vars and run the single-component validation."""
+    run(
+        data_dir=Path(tekton.require_env("PARAM_DATA_DIR")),
+        snapshot_path=Path(tekton.require_env("PARAM_SNAPSHOT_PATH")),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This commit adds a python script to replicate the functionality of the inline bash script in the validate-single-component managed task in the catalog repo. The task will be updated to use this python module instead.

Assisted-By: Cursor