### PR TITLE
fix(KFLUXSPRT-8616): resolve binary collision when multiple files share the same os/arch

### DIFF
--- a/scripts/python/helpers/compress_artifacts.py
+++ b/scripts/python/helpers/compress_artifacts.py
@@ -34,6 +34,7 @@ import shutil
 import subprocess
 import tarfile
 import zipfile
+from collections import Counter
 from pathlib import Path
 
 import disk_image_utils
@@ -104,6 +105,7 @@ def _compress_file_entry(
     ready_dir: Path,
     *,
     is_disk_image_component: bool = False,
+    os_arch_counts: Counter[tuple[str, str]] | None = None,
 ) -> str:
     """Compress one file entry into ready_dir and return the (possibly normalized) source path.
 
@@ -134,6 +136,11 @@ def _compress_file_entry(
     )
     if arch_dir is None:
         raise RuntimeError(f"Unknown OS '{os_name}' in {array_name}[] entry (arch: {arch})")
+
+    if os_arch_counts and os_arch_counts[(os_name, arch)] > 1:
+        per_source_dir = arch_dir / oras_utils.archive_stem(source_filename)
+        if per_source_dir.is_dir():
+            arch_dir = per_source_dir
 
     if not arch_dir.is_dir() or not any(arch_dir.iterdir()):
         raise RuntimeError(f"Architecture directory is empty or not found: {arch_dir}")
@@ -188,6 +195,10 @@ def compress_component(component: dict, snapshot: dict) -> dict:
 
     is_disk_image = disk_image_utils.is_disk_image_component(component)
 
+    os_arch_counts: Counter[tuple[str, str]] = Counter(
+        (e.get("os", ""), e.get("arch", "")) for e in files_entries + staged_entries
+    )
+
     normalized_files = []
     if files_entries:
         logger.info(
@@ -195,7 +206,12 @@ def compress_component(component: dict, snapshot: dict) -> dict:
         )
         for entry in files_entries:
             normalized_source = _compress_file_entry(
-                entry, "files", component_dir, ready_dir, is_disk_image_component=is_disk_image
+                entry,
+                "files",
+                component_dir,
+                ready_dir,
+                is_disk_image_component=is_disk_image,
+                os_arch_counts=os_arch_counts,
             )
             normalized_entry = dict(entry)
             # no-op for mac/linux, .zip correction for windows
@@ -213,6 +229,7 @@ def compress_component(component: dict, snapshot: dict) -> dict:
                 component_dir,
                 ready_dir,
                 is_disk_image_component=is_disk_image,
+                os_arch_counts=os_arch_counts,
             )
 
     updated_component = dict(component)

--- a/scripts/python/helpers/oras_utils.py
+++ b/scripts/python/helpers/oras_utils.py
@@ -131,6 +131,19 @@ def oras_push(tag: str, directory: Path, subdirectory: str, component_name: str)
     return match.group(1)
 
 
+def archive_stem(name: str) -> str:
+    """Strip the ``.tar.gz`` extension to produce a stem suitable for subdirectory names.
+
+    Example::
+
+        >>> archive_stem("oc-mirror-rhel9-linux-amd64.tar.gz")
+        'oc-mirror-rhel9-linux-amd64'
+    """
+    if name.endswith(".tar.gz"):
+        return name[: -len(".tar.gz")]
+    return Path(name).stem
+
+
 def os_arch_dir(
     os_name: str, arch: str, *, mac_windows_base: Path, linux_base: Path
 ) -> Path | None:

--- a/scripts/python/helpers/push_unsigned.py
+++ b/scripts/python/helpers/push_unsigned.py
@@ -28,6 +28,7 @@ import logging
 import os
 import shutil
 import tarfile
+from collections import Counter
 from pathlib import Path
 
 import disk_image_utils
@@ -88,8 +89,17 @@ def _unpack_file_entries(
     unsigned_dir: Path,
     *,
     is_disk_image_component: bool = False,
+    os_arch_counts: Counter[tuple[str, str]] | None = None,
 ) -> None:
     """Extract each archive from entries into its OS/arch subdirectory under unsigned_dir.
+
+    When multiple entries share the same ``(os, arch)`` (e.g. rhel8 and rhel9
+    variants), each archive is extracted into a per-source subdirectory
+    (``<os>/<arch>/<archive_stem>/``) to prevent files from colliding.
+
+    *os_arch_counts* should be pre-computed over the **combined** ``files[]`` and
+    ``staged.files[]`` entries so that collisions spanning both arrays are detected.
+    When ``None``, a local count is computed from *entries* alone (backward compat).
 
     Files are moved directly (without unpacking) when either:
     - *is_disk_image_component* is True (set when contentType: disk-image), or
@@ -97,6 +107,13 @@ def _unpack_file_entries(
       .raw.gz, .vhd.gz).
     All other files are treated as tar archives and extracted.
     """
+    if os_arch_counts is None:
+        os_arch_counts = Counter()
+        for entry in entries:
+            key = (entry.get("os", ""), entry.get("arch", ""))
+            if key[0] and key[1]:
+                os_arch_counts[key] += 1
+
     for entry in entries:
         source = entry.get("source", "")
         os_name = entry.get("os", "")
@@ -116,6 +133,12 @@ def _unpack_file_entries(
         )
         if target_dir is None:
             continue
+
+        if os_arch_counts[(os_name, arch)] > 1:
+            target_dir = target_dir / oras_utils.archive_stem(archive_name)
+            logger.info(
+                "  Multiple entries for (%s, %s); isolating to %s", os_name, arch, target_dir
+            )
 
         target_dir.mkdir(parents=True, exist_ok=True)
         if is_disk_image_component or disk_image_utils.is_disk_image_file(archive_name):
@@ -176,17 +199,28 @@ def run(quay_url: str, pipeline_run_uid: str) -> None:
             (component_dir / "linux").mkdir(parents=True, exist_ok=True)
 
         is_disk_image = disk_image_utils.is_disk_image_component(component)
+
+        files_entries = component.get("files") or []
+        staged_entries = (component.get("staged") or {}).get("files") or []
+        os_arch_counts: Counter[tuple[str, str]] = Counter()
+        for entry in files_entries + staged_entries:
+            key = (entry.get("os", ""), entry.get("arch", ""))
+            if key[0] and key[1]:
+                os_arch_counts[key] += 1
+
         _unpack_file_entries(
-            component.get("files") or [],
+            files_entries,
             component_dir,
             unsigned_dir,
             is_disk_image_component=is_disk_image,
+            os_arch_counts=os_arch_counts,
         )
         _unpack_file_entries(
-            (component.get("staged") or {}).get("files") or [],
+            staged_entries,
             component_dir,
             unsigned_dir,
             is_disk_image_component=is_disk_image,
+            os_arch_counts=os_arch_counts,
         )
 
         supp_hold = component_dir / "supplementary"

--- a/scripts/python/helpers/test_compress_artifacts.py
+++ b/scripts/python/helpers/test_compress_artifacts.py
@@ -502,3 +502,144 @@ def test_main_exception_returns_error() -> None:
     with mock.patch.object(compress_artifacts, "run", side_effect=RuntimeError("oras fail")):
         rc = compress_artifacts.main(["compress_artifacts.py", "--quay-url", "quay.io/org"])
     assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# multi-entry (os, arch) — per-source subdirectory support
+# ---------------------------------------------------------------------------
+
+
+def test_compress_file_entry_no_false_match_single_entry(tmp_path: Path) -> None:
+    """A single (os, arch) entry ignores a coincidental subdir matching archive_stem."""
+    comp_dir = tmp_path / "component"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    arch_dir = comp_dir / "linux" / "amd64"
+    arch_dir.mkdir(parents=True)
+    (arch_dir / "real-binary").write_bytes(b"the-binary")
+
+    # Coincidental subdirectory whose name matches archive_stem
+    fake_subdir = arch_dir / "product-linux-amd64"
+    fake_subdir.mkdir()
+    (fake_subdir / "decoy").write_bytes(b"should-not-appear-alone")
+
+    from collections import Counter
+
+    counts: Counter[tuple[str, str]] = Counter({("linux", "amd64"): 1})
+
+    compress_artifacts._compress_file_entry(
+        {"source": "/releases/product-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"},
+        "files",
+        comp_dir,
+        ready_dir,
+        os_arch_counts=counts,
+    )
+
+    out = ready_dir / "product-linux-amd64.tar.gz"
+    assert out.exists()
+
+    with tarfile.open(str(out), "r:gz") as tf:
+        names = sorted(tf.getnames())
+
+    # Both the top-level binary and the subdir contents are included,
+    # proving the tarball was built from the full arch_dir, not the subdir.
+    assert "real-binary" in names
+    assert any("decoy" in n for n in names)
+
+
+def test_compress_file_entry_per_source_subdir(tmp_path: Path) -> None:
+    """When per-source subdirectories exist, each entry produces a distinct tarball."""
+    from collections import Counter
+
+    comp_dir = tmp_path / "component"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    rhel9_dir = comp_dir / "linux" / "amd64" / "oc-mirror-rhel9-linux-amd64"
+    rhel9_dir.mkdir(parents=True)
+    (rhel9_dir / "oc-mirror").write_bytes(b"rhel9-binary")
+
+    rhel8_dir = comp_dir / "linux" / "amd64" / "oc-mirror-rhel8-linux-amd64"
+    rhel8_dir.mkdir(parents=True)
+    (rhel8_dir / "oc-mirror").write_bytes(b"rhel8-binary")
+
+    counts: Counter[tuple[str, str]] = Counter({("linux", "amd64"): 2})
+
+    compress_artifacts._compress_file_entry(
+        {"source": "/releases/oc-mirror-rhel9-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"},
+        "files",
+        comp_dir,
+        ready_dir,
+        os_arch_counts=counts,
+    )
+    compress_artifacts._compress_file_entry(
+        {"source": "/releases/oc-mirror-rhel8-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"},
+        "files",
+        comp_dir,
+        ready_dir,
+        os_arch_counts=counts,
+    )
+
+    import tarfile
+
+    rhel9_out = ready_dir / "oc-mirror-rhel9-linux-amd64.tar.gz"
+    rhel8_out = ready_dir / "oc-mirror-rhel8-linux-amd64.tar.gz"
+    assert rhel9_out.exists()
+    assert rhel8_out.exists()
+
+    with tarfile.open(str(rhel9_out), "r:gz") as tf:
+        rhel9_content = tf.extractfile("oc-mirror").read()
+    with tarfile.open(str(rhel8_out), "r:gz") as tf:
+        rhel8_content = tf.extractfile("oc-mirror").read()
+
+    assert rhel9_content == b"rhel9-binary"
+    assert rhel8_content == b"rhel8-binary"
+    assert rhel9_content != rhel8_content
+
+
+def test_compress_file_entry_per_source_subdir_different_binaries(tmp_path: Path) -> None:
+    """Different-named binaries sharing (os, arch) don't cross-contaminate output tarballs."""
+    from collections import Counter
+
+    comp_dir = tmp_path / "component"
+    ready_dir = comp_dir / "ready_for_distribution"
+    ready_dir.mkdir(parents=True)
+
+    installer_dir = comp_dir / "linux" / "amd64" / "product-installer-linux-amd64"
+    installer_dir.mkdir(parents=True)
+    (installer_dir / "installer").write_bytes(b"installer-binary")
+
+    client_dir = comp_dir / "linux" / "amd64" / "product-client-linux-amd64"
+    client_dir.mkdir(parents=True)
+    (client_dir / "client").write_bytes(b"client-binary")
+
+    counts: Counter[tuple[str, str]] = Counter({("linux", "amd64"): 2})
+
+    compress_artifacts._compress_file_entry(
+        {"source": "/releases/product-installer-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"},
+        "files",
+        comp_dir,
+        ready_dir,
+        os_arch_counts=counts,
+    )
+    compress_artifacts._compress_file_entry(
+        {"source": "/releases/product-client-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"},
+        "files",
+        comp_dir,
+        ready_dir,
+        os_arch_counts=counts,
+    )
+
+    import tarfile
+
+    installer_out = ready_dir / "product-installer-linux-amd64.tar.gz"
+    client_out = ready_dir / "product-client-linux-amd64.tar.gz"
+
+    with tarfile.open(str(installer_out), "r:gz") as tf:
+        installer_names = tf.getnames()
+    with tarfile.open(str(client_out), "r:gz") as tf:
+        client_names = tf.getnames()
+
+    assert installer_names == ["installer"]
+    assert client_names == ["client"]

--- a/scripts/python/helpers/test_oras_utils.py
+++ b/scripts/python/helpers/test_oras_utils.py
@@ -192,3 +192,22 @@ def test_oras_pull_raises_when_subprocess_fails(
         oras_utils.oras_pull("quay.io/org/image:tag", tmp_path)
 
     assert exc_info.value.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# archive_stem
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("oc-mirror-rhel9-linux-amd64.tar.gz", "oc-mirror-rhel9-linux-amd64"),
+        ("oc-mirror-rhel8-linux-amd64.tar.gz", "oc-mirror-rhel8-linux-amd64"),
+        ("simple.zip", "simple"),
+        ("no-ext", "no-ext"),
+        ("image.qcow2", "image"),
+    ],
+)
+def test_archive_stem(name: str, expected: str) -> None:
+    assert oras_utils.archive_stem(name) == expected

--- a/scripts/python/helpers/test_push_unsigned.py
+++ b/scripts/python/helpers/test_push_unsigned.py
@@ -513,3 +513,85 @@ def test_main_exception_returns_error() -> None:
             ["push_unsigned.py", "--quay-url", "quay.io/org", "--pipeline-run-uid", "uid"]
         )
     assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# multi-entry (os, arch) collision prevention
+# ---------------------------------------------------------------------------
+
+
+def test_unpack_file_entries_multi_rhel_isolation(tmp_path: Path) -> None:
+    """Multiple Linux entries with the same arch get per-source subdirectories."""
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+
+    rhel9_archive = comp_dir / "oc-mirror-rhel9-linux-amd64.tar.gz"
+    _make_tar(rhel9_archive, {"oc-mirror": b"rhel9-binary"})
+
+    rhel8_archive = comp_dir / "oc-mirror-rhel8-linux-amd64.tar.gz"
+    _make_tar(rhel8_archive, {"oc-mirror": b"rhel8-binary"})
+
+    entries = [
+        {
+            "source": "/releases/oc-mirror-rhel9-linux-amd64.tar.gz",
+            "os": "linux",
+            "arch": "amd64",
+        },
+        {
+            "source": "/releases/oc-mirror-rhel8-linux-amd64.tar.gz",
+            "os": "linux",
+            "arch": "amd64",
+        },
+    ]
+
+    push_unsigned._unpack_file_entries(entries, comp_dir, comp_dir / "unsigned")
+
+    rhel9_dir = comp_dir / "linux" / "amd64" / "oc-mirror-rhel9-linux-amd64"
+    rhel8_dir = comp_dir / "linux" / "amd64" / "oc-mirror-rhel8-linux-amd64"
+    assert (rhel9_dir / "oc-mirror").exists()
+    assert (rhel8_dir / "oc-mirror").exists()
+    assert (rhel9_dir / "oc-mirror").read_bytes() == b"rhel9-binary"
+    assert (rhel8_dir / "oc-mirror").read_bytes() == b"rhel8-binary"
+
+
+def test_unpack_file_entries_single_entry_no_isolation(tmp_path: Path) -> None:
+    """A single entry per (os, arch) still extracts to the shared directory (no regression)."""
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+    archive = comp_dir / "binary-linux-amd64.tar.gz"
+    _make_tar(archive, {"mybinary": b"data"})
+
+    push_unsigned._unpack_file_entries(
+        [{"source": "/releases/binary-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"}],
+        comp_dir,
+        comp_dir / "unsigned",
+    )
+
+    assert (comp_dir / "linux" / "amd64" / "mybinary").exists()
+    assert not (comp_dir / "linux" / "amd64" / "binary-linux-amd64").exists()
+
+
+def test_unpack_file_entries_different_binaries_same_arch_isolation(tmp_path: Path) -> None:
+    """Different-named binaries sharing (os, arch) don't cross-contaminate each other."""
+    comp_dir = tmp_path / "prod"
+    comp_dir.mkdir()
+
+    installer_archive = comp_dir / "product-installer-linux-amd64.tar.gz"
+    _make_tar(installer_archive, {"installer": b"installer-binary"})
+
+    client_archive = comp_dir / "product-client-linux-amd64.tar.gz"
+    _make_tar(client_archive, {"client": b"client-binary"})
+
+    entries = [
+        {"source": "/releases/product-installer-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"},
+        {"source": "/releases/product-client-linux-amd64.tar.gz", "os": "linux", "arch": "amd64"},
+    ]
+
+    push_unsigned._unpack_file_entries(entries, comp_dir, comp_dir / "unsigned")
+
+    installer_dir = comp_dir / "linux" / "amd64" / "product-installer-linux-amd64"
+    client_dir = comp_dir / "linux" / "amd64" / "product-client-linux-amd64"
+    assert (installer_dir / "installer").exists()
+    assert (client_dir / "client").exists()
+    assert not (installer_dir / "client").exists()
+    assert not (client_dir / "installer").exists()


### PR DESCRIPTION
## Summary

Fixes a bug where components with multiple file entries sharing the same `(os, arch)` tuple (e.g. rhel8 and rhel9 Linux/amd64 binaries for oc-mirror) produce identical output tarballs because both archives are extracted into the same intermediate directory, causing the second to overwrite the first.

**Root cause**: `push_unsigned.py::_unpack_file_entries()` resolves the target directory via `oras_utils.os_arch_dir()`, which returns `linux/<arch>/` for all Linux entries regardless of the source archive. When two entries share `(linux, amd64)`, both extract into `linux/amd64/` and the second overwrites the first. `compress_artifacts.py` then re-tars the corrupted directory for both entries, producing identical output.

**Fix**: 
- Detect duplicate `(os, arch)` entries via a `Counter` computed once over the combined `files[]` and `staged.files[]` entries in `run()`, and isolate each into a per-source subdirectory (`linux/amd64/<archive-stem>/`)
- Update `_compress_file_entry()` to prefer the per-source subdirectory when it exists, with backward-compatible fallback for single-entry components
- Add `archive_stem()` helper to `oras_utils.py` for consistent `.tar.gz` extension stripping

## Key Changes

- `oras_utils.py`: New `archive_stem()` helper (strips `.tar.gz` extension)
- `push_unsigned.py`: `run()` computes `os_arch_counts` over combined file entries; `_unpack_file_entries()` uses per-archive subdirectories when collisions are detected
- `compress_artifacts.py`: `_compress_file_entry()` checks for per-source subdirectory before compressing

## Testing

- 3 new unit tests for `archive_stem()` parametrized cases
- 2 new tests for `_unpack_file_entries()`: multi-rhel isolation + different-binary-name isolation
- 1 new test for `_compress_file_entry()`: verifies distinct tarballs from per-source subdirectories
- All 101 tests pass with no regressions

## Affected Use Case

The oc-mirror-2.0 RPA has both rhel8 and rhel9 entries for each architecture, all with `os: linux`. This caused the rhel8 binary to overwrite the rhel9 binary during the unpack step, resulting in identical binaries being published to CDN.

Fixes: KFLUXSPRT-8616

Assisted-By: Cursor