### PR TITLE
feat(RELEASE-2729): sandbox infra-deployment update scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "confluent-kafka",
     "python-gitlab>=4.0",
     "python-dotenv>=1.0.0",
+    "RestrictedPython>=7.0",
 ]
 
 [tool.black]

--- a/schemas/dataKeys.json
+++ b/schemas/dataKeys.json
@@ -518,7 +518,11 @@
     },
     "infra-deployment-update-script": {
       "type": "string",
-      "description": "A script that can alter files in the infra-deployment repo before a PR is created"
+      "description": "Deprecated: a bash script that can alter files in the infra-deployment repo before a PR is created. Use infraDeploymentUpdates instead."
+    },
+    "infraDeploymentUpdates": {
+      "type": "string",
+      "description": "A sandboxed Python script that can alter files in the infra-deployment repo before a PR is created"
     },
     "intention": {
       "type": "string",

--- a/scripts/python/tasks/managed/test_update_infra_deployments.py
+++ b/scripts/python/tasks/managed/test_update_infra_deployments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import typing
 from pathlib import Path
 from unittest import mock
 
@@ -55,10 +56,22 @@ def test_extract_old_revision_ignores_version() -> None:
     assert task._extract_old_revision_from_diff(diff) == ""
 
 
-def test_update_script_from_data_empty() -> None:
-    """Return `None` when the update script key is missing or blank."""
-    assert task._update_script_from_data({}) is None
-    assert task._update_script_from_data({"infra-deployment-update-script": ""}) is None
+def test_bash_script_from_data_empty() -> None:
+    """Return `None` when the legacy bash script key is missing or blank."""
+    assert task._bash_script_from_data({}) is None
+    assert task._bash_script_from_data({"infra-deployment-update-script": ""}) is None
+
+
+def test_sandboxed_script_from_data_empty() -> None:
+    """Return `None` when the sandboxed script key is missing or blank."""
+    assert task._sandboxed_script_from_data({}) is None
+    assert task._sandboxed_script_from_data({"infraDeploymentUpdates": ""}) is None
+
+
+def test_sandboxed_script_from_data_returns_text() -> None:
+    """Return the stripped script text when the key is present."""
+    data = {"infraDeploymentUpdates": "  replace('f', r'x', 'y')  "}
+    assert task._sandboxed_script_from_data(data) == "replace('f', r'x', 'y')"
 
 
 def test_github_app_ids() -> None:
@@ -155,6 +168,13 @@ def test_merge_changelog_section_finds_lf_only_marker() -> None:
     assert merged.count("## Changelog") == 1
     assert "- stale" in merged
     assert "- new" in merged
+
+
+def test_merge_changelog_section_no_new_items() -> None:
+    """Return the body unchanged when the new changelog has no list items."""
+    body = "Links\n\n## Changelog\n- existing"
+    merged = task._merge_changelog_section(body, "just a header, no items")
+    assert merged == body
 
 
 def test_build_pr_description_without_changelog_rev() -> None:
@@ -479,6 +499,107 @@ def test_run_update_infra_deployments_no_script(tmp_path: Path) -> None:
     create_pr.assert_not_called()
 
 
+def test_run_update_infra_deployments_bash_deprecation_warning(
+    tmp_path: Path,
+) -> None:
+    """Emit a deprecation warning when using the legacy bash script field."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_snapshot(data_dir)
+    (data_dir / "data.json").write_text(
+        json.dumps({"infra-deployment-update-script": "true"}),
+        encoding="utf-8",
+    )
+    params = _task_params(tmp_path, data_dir)
+    clone_dir = tmp_path / "cloned"
+    with (
+        mock.patch("update_infra_deployments.git.clone", return_value=clone_dir),
+        mock.patch("update_infra_deployments.git.sync_to_origin_main"),
+        mock.patch.object(task, "_run_patched_script"),
+        mock.patch.object(
+            task,
+            "_collect_apply_result",
+            return_value=task.ApplyResult(
+                snap=task.SnapshotContext("rev", "https://github.com/org/my-app", "img"),
+                old_revision="",
+                changed_paths=[],
+            ),
+        ),
+        mock.patch.object(task, "_create_or_update_pr"),
+        pytest.warns(DeprecationWarning, match="infra-deployment-update-script"),
+    ):
+        task.run_update_infra_deployments(params)
+
+
+def test_run_update_infra_deployments_sandboxed_script(tmp_path: Path) -> None:
+    """Use the sandboxed path when infraDeploymentUpdates is present."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_snapshot(data_dir)
+    (data_dir / "data.json").write_text(
+        json.dumps({"infraDeploymentUpdates": "replace('f', r'x', 'y')"}),
+        encoding="utf-8",
+    )
+    params = _task_params(tmp_path, data_dir)
+    clone_dir = tmp_path / "cloned"
+    with (
+        mock.patch("update_infra_deployments.git.clone", return_value=clone_dir),
+        mock.patch("update_infra_deployments.git.sync_to_origin_main"),
+        mock.patch.object(task, "execute_infra_updates") as execute,
+        mock.patch.object(
+            task,
+            "_collect_apply_result",
+            return_value=task.ApplyResult(
+                snap=task.SnapshotContext("rev", "https://github.com/org/my-app", "img"),
+                old_revision="",
+                changed_paths=[],
+            ),
+        ),
+        mock.patch.object(task, "_create_or_update_pr"),
+    ):
+        task.run_update_infra_deployments(params)
+    execute.assert_called_once()
+
+
+def test_run_update_infra_deployments_sandboxed_preferred_over_bash(
+    tmp_path: Path,
+) -> None:
+    """Use the sandboxed script when both fields are present."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_snapshot(data_dir)
+    (data_dir / "data.json").write_text(
+        json.dumps(
+            {
+                "infraDeploymentUpdates": "replace('f', r'x', 'y')",
+                "infra-deployment-update-script": "echo hello",
+            }
+        ),
+        encoding="utf-8",
+    )
+    params = _task_params(tmp_path, data_dir)
+    clone_dir = tmp_path / "cloned"
+    with (
+        mock.patch("update_infra_deployments.git.clone", return_value=clone_dir),
+        mock.patch("update_infra_deployments.git.sync_to_origin_main"),
+        mock.patch.object(task, "execute_infra_updates") as execute,
+        mock.patch.object(task, "_run_patched_script") as run_bash,
+        mock.patch.object(
+            task,
+            "_collect_apply_result",
+            return_value=task.ApplyResult(
+                snap=task.SnapshotContext("rev", "https://github.com/org/my-app", "img"),
+                old_revision="",
+                changed_paths=[],
+            ),
+        ),
+        mock.patch.object(task, "_create_or_update_pr"),
+    ):
+        task.run_update_infra_deployments(params)
+    execute.assert_called_once()
+    run_bash.assert_not_called()
+
+
 def test_run_update_infra_deployments_full_flow(tmp_path: Path) -> None:
     """Run clone, apply, and PR steps when a script is present."""
     data_dir = tmp_path / "data"
@@ -542,3 +663,871 @@ def test_main_entrypoint_exits_zero() -> None:
             raise SystemExit(task.main())
     assert exc.value.code == 0
     run.assert_called_once_with(fake_params)
+
+
+# --- Integration tests ---
+# These exercise run_update_infra_deployments end-to-end: real data.json,
+# real snapshot, real sandbox execution, real file mutations.  Only git
+# and GitHub calls are mocked (no repo to clone, no remote to push to).
+
+
+def _setup_integration(
+    tmp_path: Path,
+    data: dict,
+    snapshot: dict,
+    clone_files: dict[str, str],
+) -> tuple[task.TaskParams, Path]:
+    """Write data.json, snapshot, and return params + clone_dir path.
+
+    Files in *clone_files* are NOT written yet — use ``_mock_clone`` to
+    create a ``git.clone`` side-effect that populates them when called
+    (the real flow does ``rmtree`` before cloning).
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "data.json").write_text(json.dumps(data), encoding="utf-8")
+    (data_dir / "snap.json").write_text(json.dumps(snapshot), encoding="utf-8")
+    clone_dir = tmp_path / "work" / "cloned"
+    params = _task_params(tmp_path, data_dir)
+    return params, clone_dir
+
+
+def _mock_clone(clone_dir: Path, clone_files: dict[str, str]) -> typing.Callable[..., Path]:
+    """Return a ``git.clone`` side-effect that writes *clone_files* into *clone_dir*."""
+
+    def _side_effect(*_args: typing.Any, **_kwargs: typing.Any) -> Path:
+        for rel_path, content in clone_files.items():
+            target = clone_dir / rel_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+        return clone_dir
+
+    return _side_effect
+
+
+_INTEGRATION_SNAPSHOT = {
+    "components": [
+        {
+            "name": "my-component",
+            "containerImage": "quay.io/org/img:v1.0_rc1@sha256:abc",
+            "source": {
+                "git": {
+                    "revision": "newrev789",
+                    "url": "https://github.com/org/my-app.git",
+                }
+            },
+        }
+    ]
+}
+
+
+def test_integration_sandboxed_git_ref_and_tag(tmp_path: Path) -> None:
+    """End-to-end: data.json with sandboxed script updates git ref and newTag."""
+    kustomization = (
+        "resources:\n"
+        "  - https://github.com/org/repo/config?ref=old123\n"
+        "images:\n"
+        "  - name: quay.io/org/component\n"
+        "    newTag: old123\n"
+    )
+    script = (
+        "replace('comp/kustomization.yaml',"
+        " r'(config\\?ref=)\\S+', r'\\1{{ revision }}')\n"
+        "replace('comp/kustomization.yaml',"
+        " r'(newTag: ).*', r'\\1{{ revision }}')\n"
+    )
+    clone_files = {"comp/kustomization.yaml": kustomization}
+    params, clone_dir = _setup_integration(
+        tmp_path,
+        data={"infraDeploymentUpdates": script},
+        snapshot=_INTEGRATION_SNAPSHOT,
+        clone_files=clone_files,
+    )
+
+    with (
+        mock.patch(
+            "update_infra_deployments.git.clone",
+            side_effect=_mock_clone(clone_dir, clone_files),
+        ),
+        mock.patch("update_infra_deployments.git.sync_to_origin_main"),
+        mock.patch.object(task, "_create_or_update_pr"),
+        mock.patch(
+            "update_infra_deployments.git.working_tree_diff",
+            return_value="",
+        ),
+        mock.patch(
+            "update_infra_deployments.git.changed_paths_from_status",
+            return_value=[],
+        ),
+    ):
+        task.run_update_infra_deployments(params)
+
+    text = (clone_dir / "comp/kustomization.yaml").read_text(encoding="utf-8")
+    assert "?ref=newrev789" in text
+    assert "newTag: newrev789" in text
+    assert "old123" not in text
+
+
+def test_integration_sandboxed_context_aware(tmp_path: Path) -> None:
+    """End-to-end: context-aware replacement leaves unrelated images alone."""
+    kustomization = (
+        "images:\n"
+        "  - newName: quay.io/org/other\n"
+        "    newTag: keep\n"
+        "  - newName: quay.io/org/target\n"
+        "    newTag: old123\n"
+    )
+    script = (
+        "replace('comp/kustomization.yaml',"
+        " r'(newTag:\\s*).*', r'\\1{{ revision }}',"
+        " after=r'newName:\\s*quay\\.io/org/target')\n"
+    )
+    clone_files = {"comp/kustomization.yaml": kustomization}
+    params, clone_dir = _setup_integration(
+        tmp_path,
+        data={"infraDeploymentUpdates": script},
+        snapshot=_INTEGRATION_SNAPSHOT,
+        clone_files=clone_files,
+    )
+
+    with (
+        mock.patch(
+            "update_infra_deployments.git.clone",
+            side_effect=_mock_clone(clone_dir, clone_files),
+        ),
+        mock.patch("update_infra_deployments.git.sync_to_origin_main"),
+        mock.patch.object(task, "_create_or_update_pr"),
+        mock.patch(
+            "update_infra_deployments.git.working_tree_diff",
+            return_value="",
+        ),
+        mock.patch(
+            "update_infra_deployments.git.changed_paths_from_status",
+            return_value=[],
+        ),
+    ):
+        task.run_update_infra_deployments(params)
+
+    text = (clone_dir / "comp/kustomization.yaml").read_text(encoding="utf-8")
+    assert "newTag: newrev789" in text
+    assert "newTag: keep" in text
+    assert text.count("newTag: newrev789") == 1
+
+
+def test_integration_sandboxed_dynamic_tag(tmp_path: Path) -> None:
+    """End-to-end: tag() reads from the real snapshot file."""
+    generator = "spec:\n  version: 0.1.0\n"
+    script = (
+        "v = tag('my-component', r'.*\\..*')\n"
+        "replace('gen.yaml', r'(version: ).*', r'\\g<1>' + v)\n"
+    )
+    clone_files = {"gen.yaml": generator}
+    params, clone_dir = _setup_integration(
+        tmp_path,
+        data={"infraDeploymentUpdates": script},
+        snapshot=_INTEGRATION_SNAPSHOT,
+        clone_files=clone_files,
+    )
+
+    with (
+        mock.patch(
+            "update_infra_deployments.git.clone",
+            side_effect=_mock_clone(clone_dir, clone_files),
+        ),
+        mock.patch("update_infra_deployments.git.sync_to_origin_main"),
+        mock.patch.object(task, "_create_or_update_pr"),
+        mock.patch(
+            "update_infra_deployments.git.working_tree_diff",
+            return_value="",
+        ),
+        mock.patch(
+            "update_infra_deployments.git.changed_paths_from_status",
+            return_value=[],
+        ),
+    ):
+        task.run_update_infra_deployments(params)
+
+    text = (clone_dir / "gen.yaml").read_text(encoding="utf-8")
+    assert "version: v1.0+rc1" in text
+    assert "version: 0.1.0" not in text
+
+
+def test_integration_sandboxed_multi_file_loop(tmp_path: Path) -> None:
+    """End-to-end: sandboxed for-loop updates the same pattern across files."""
+    kustomization = "images:\n  - newTag: old123\n"
+    script = (
+        "for env in ['dev', 'stg']:\n"
+        "    replace(f'comp/{env}/k.yaml',"
+        " r'(newTag: ).*', r'\\1{{ revision }}')\n"
+    )
+    clone_files = {
+        "comp/dev/k.yaml": kustomization,
+        "comp/stg/k.yaml": kustomization,
+    }
+    params, clone_dir = _setup_integration(
+        tmp_path,
+        data={"infraDeploymentUpdates": script},
+        snapshot=_INTEGRATION_SNAPSHOT,
+        clone_files=clone_files,
+    )
+
+    with (
+        mock.patch(
+            "update_infra_deployments.git.clone",
+            side_effect=_mock_clone(clone_dir, clone_files),
+        ),
+        mock.patch("update_infra_deployments.git.sync_to_origin_main"),
+        mock.patch.object(task, "_create_or_update_pr"),
+        mock.patch(
+            "update_infra_deployments.git.working_tree_diff",
+            return_value="",
+        ),
+        mock.patch(
+            "update_infra_deployments.git.changed_paths_from_status",
+            return_value=[],
+        ),
+    ):
+        task.run_update_infra_deployments(params)
+
+    for env in ["dev", "stg"]:
+        text = (clone_dir / f"comp/{env}/k.yaml").read_text(encoding="utf-8")
+        assert "newTag: newrev789" in text
+        assert "old123" not in text
+
+
+def test_integration_bash_fallback(tmp_path: Path) -> None:
+    """End-to-end: legacy bash path still works when no sandboxed script."""
+    kustomization = "images:\n  - newTag: old123\n"
+    clone_files = {"comp/k.yaml": kustomization}
+    params, clone_dir = _setup_integration(
+        tmp_path,
+        data={"infra-deployment-update-script": ("sed -i 's/old123/newrev789/' comp/k.yaml")},
+        snapshot=_INTEGRATION_SNAPSHOT,
+        clone_files=clone_files,
+    )
+
+    with (
+        mock.patch(
+            "update_infra_deployments.git.clone",
+            side_effect=_mock_clone(clone_dir, clone_files),
+        ),
+        mock.patch("update_infra_deployments.git.sync_to_origin_main"),
+        mock.patch.object(task, "_create_or_update_pr"),
+        mock.patch(
+            "update_infra_deployments.git.working_tree_diff",
+            return_value="",
+        ),
+        mock.patch(
+            "update_infra_deployments.git.changed_paths_from_status",
+            return_value=[],
+        ),
+        pytest.warns(DeprecationWarning, match="infra-deployment-update-script"),
+    ):
+        task.run_update_infra_deployments(params)
+
+    text = (clone_dir / "comp/k.yaml").read_text(encoding="utf-8")
+    assert "newTag: newrev789" in text
+    assert "old123" not in text
+
+
+# --- Sandbox tests ---
+
+
+def test_validate_path_rejects_absolute(tmp_path: Path) -> None:
+    """Reject absolute paths."""
+    with pytest.raises(task.InfraReplacementError, match="absolute"):
+        task._validate_path("/etc/passwd", tmp_path)
+
+
+def test_validate_path_rejects_traversal(tmp_path: Path) -> None:
+    """Reject paths that escape the clone directory."""
+    with pytest.raises(task.InfraReplacementError, match="traversal"):
+        task._validate_path("../escape", tmp_path)
+
+
+def test_validate_path_accepts_relative(tmp_path: Path) -> None:
+    """Accept a valid relative path inside the clone directory."""
+    target = tmp_path / "sub" / "file.yaml"
+    target.parent.mkdir()
+    target.touch()
+    result = task._validate_path("sub/file.yaml", tmp_path)
+    assert result == target.resolve()
+
+
+def test_extract_image_tag_with_digest() -> None:
+    """Extract the tag from a reference that has both tag and digest."""
+    ref = "quay.io/org/img:v1.2.3@sha256:abc"
+    assert task._extract_image_tag(ref) == "v1.2.3"
+
+
+def test_extract_image_tag_no_digest() -> None:
+    """Extract the tag from a reference without a digest."""
+    assert task._extract_image_tag("quay.io/org/img:latest") == "latest"
+
+
+def test_extract_image_tag_digest_only() -> None:
+    """Return empty when only a digest is present."""
+    assert task._extract_image_tag("quay.io/org/img@sha256:abc") == ""
+
+
+def test_extract_image_tag_no_tag_no_digest() -> None:
+    """Return empty when there is no tag or digest."""
+    assert task._extract_image_tag("quay.io/org/img") == ""
+
+
+def test_extract_image_tag_port_in_registry() -> None:
+    """Return empty when the colon belongs to a registry port, not a tag."""
+    assert task._extract_image_tag("localhost:5000/org/img") == ""
+
+
+def test_normalize_oci_tag() -> None:
+    """Replace underscores with plus signs for OCI semver normalization."""
+    assert task._normalize_oci_tag("1.2.3_beta") == "1.2.3+beta"
+
+
+def test_replace_on_line_after() -> None:
+    """Replace only on lines immediately following the after-pattern match."""
+    content = "name: foo\nnewTag: old\nname: bar\nnewTag: old\n"
+    result = task._replace_on_line_after(
+        content,
+        r"(newTag:\s*).*",
+        r"\1new",
+        r"name: foo",
+    )
+    assert "name: foo\nnewTag: new\n" in result
+    assert result.count("newTag: new") == 1
+
+
+def test_replace_nth_match() -> None:
+    """Replace only the nth occurrence of a regex match."""
+    content = "tag: a\ntag: b\ntag: c\n"
+    result = task._replace_nth_match(content, r"(tag: ).", r"\1X", 2)
+    assert result == "tag: a\ntag: X\ntag: c\n"
+
+
+def test_replace_simple_sed(tmp_path: Path) -> None:
+    """Pattern 1: simple regex substitution via the sandbox."""
+    target = tmp_path / "kustomization.yaml"
+    target.write_text("  newTag: oldrev\n", encoding="utf-8")
+    script = "replace('kustomization.yaml'," " r'(newTag: ).*', r'\\1{{ revision }}')"
+    task.execute_infra_updates(script, tmp_path, {}, "newrev")
+    assert "newTag: newrev" in target.read_text(encoding="utf-8")
+
+
+def test_replace_context_aware(tmp_path: Path) -> None:
+    """Pattern 2: replace only after a matching context line."""
+    target = tmp_path / "k.yaml"
+    target.write_text(
+        "newName: quay.io/org/img-a\nnewTag: old\n"
+        "newName: quay.io/org/img-b\nnewTag: keep\n",
+        encoding="utf-8",
+    )
+    script = (
+        "replace('k.yaml', r'(newTag:\\s*).*', r'\\1{{ revision }}',"
+        " after=r'newName:\\s*quay\\.io/org/img-a')"
+    )
+    task.execute_infra_updates(script, tmp_path, {}, "new")
+    text = target.read_text(encoding="utf-8")
+    assert "newTag: new" in text
+    assert "newTag: keep" in text
+
+
+def test_replace_nth_occurrence(tmp_path: Path) -> None:
+    """Pattern 3: replace only the Nth match."""
+    target = tmp_path / "k.yaml"
+    target.write_text(
+        "  newTag: a\n  newTag: b\n  newTag: c\n",
+        encoding="utf-8",
+    )
+    script = "replace('k.yaml', r'(newTag: ).*', r'\\1{{ revision }}'," " occurrence=2)"
+    task.execute_infra_updates(script, tmp_path, {}, "new")
+    text = target.read_text(encoding="utf-8")
+    assert text == "  newTag: a\n  newTag: new\n  newTag: c\n"
+
+
+def test_replace_with_tag_lookup(tmp_path: Path) -> None:
+    """Pattern 4: use tag() to look up a version from the snapshot."""
+    target = tmp_path / "gen.yaml"
+    target.write_text("  version: old\n", encoding="utf-8")
+    snapshot_data = {
+        "components": [
+            {
+                "name": "caching-helm",
+                "containerImage": "quay.io/org/caching-helm:1.2.3@sha256:abc",
+            }
+        ]
+    }
+    script = (
+        "v = tag('caching-helm', r'.*\\..*')\n"
+        "replace('gen.yaml', r'(version: ).*', r'\\g<1>' + v)"
+    )
+    task.execute_infra_updates(script, tmp_path, snapshot_data, "unused")
+    assert "version: 1.2.3" in target.read_text(encoding="utf-8")
+
+
+def test_tag_oci_normalization() -> None:
+    """Apply OCI semver normalization when looking up a tag."""
+    snapshot_data = {
+        "components": [
+            {
+                "name": "comp",
+                "containerImage": "quay.io/org/comp:1.0_beta",
+            }
+        ]
+    }
+    result = task._tag("comp", r".*", snapshot_data=snapshot_data)
+    assert result == "1.0+beta"
+
+
+def test_tag_component_not_found() -> None:
+    """Raise when the component name is not in the snapshot."""
+    with pytest.raises(task.InfraReplacementError, match="not found"):
+        task._tag("missing", r".*", snapshot_data={"components": []})
+
+
+def test_tag_no_image_tag() -> None:
+    """Raise when the component has a digest-only image reference."""
+    snapshot_data = {
+        "components": [{"name": "comp", "containerImage": "quay.io/org/img@sha256:abc"}]
+    }
+    with pytest.raises(task.InfraReplacementError, match="no image tag"):
+        task._tag("comp", r".*", snapshot_data=snapshot_data)
+
+
+def test_tag_filter_no_match() -> None:
+    """Raise when the tag does not match the filter regex."""
+    snapshot_data = {
+        "components": [{"name": "comp", "containerImage": "quay.io/org/comp:latest"}]
+    }
+    with pytest.raises(task.InfraReplacementError, match="does not match"):
+        task._tag("comp", r"\d+\.\d+", snapshot_data=snapshot_data)
+
+
+def test_tag_invalid_filter_regex() -> None:
+    """Raise when the filter regex is invalid."""
+    snapshot_data = {"components": [{"name": "comp", "containerImage": "quay.io/org/comp:v1"}]}
+    with pytest.raises(task.InfraReplacementError, match="invalid filter regex"):
+        task._tag("comp", r"[bad", snapshot_data=snapshot_data)
+
+
+def test_tag_components_not_a_list() -> None:
+    """Treat non-list components as empty and raise not-found."""
+    with pytest.raises(task.InfraReplacementError, match="not found"):
+        task._tag("comp", r".*", snapshot_data={"components": "bogus"})
+
+
+def test_tag_skips_non_dict_entries() -> None:
+    """Skip non-dict entries in the components list."""
+    snapshot_data = {
+        "components": [
+            "not-a-dict",
+            {"name": "comp", "containerImage": "quay.io/org/comp:v1"},
+        ]
+    }
+    assert task._tag("comp", r".*", snapshot_data=snapshot_data) == "v1"
+
+
+def test_tag_skips_non_matching_components() -> None:
+    """Skip components whose name does not match."""
+    snapshot_data = {
+        "components": [
+            {"name": "other", "containerImage": "quay.io/org/other:v2"},
+            {"name": "comp", "containerImage": "quay.io/org/comp:v1"},
+        ]
+    }
+    assert task._tag("comp", r".*", snapshot_data=snapshot_data) == "v1"
+
+
+def test_sandbox_blocks_import(tmp_path: Path) -> None:
+    """Block import statements in user scripts."""
+    with pytest.raises(task.InfraReplacementError, match="execution failed"):
+        task.execute_infra_updates("import os", tmp_path, {}, "rev")
+
+
+def test_sandbox_blocks_open(tmp_path: Path) -> None:
+    """Block open() calls in user scripts."""
+    with pytest.raises(task.InfraReplacementError, match="execution failed"):
+        task.execute_infra_updates("open('/etc/passwd')", tmp_path, {}, "rev")
+
+
+def test_sandbox_blocks_double_underscore_attributes(tmp_path: Path) -> None:
+    """Block access to double-underscore attributes like __class__."""
+    with pytest.raises(task.InfraReplacementError, match="compilation failed"):
+        task.execute_infra_updates("x = ''.__class__", tmp_path, {}, "rev")
+
+
+def test_sandbox_allows_string_methods(tmp_path: Path) -> None:
+    """Allow normal string methods like split() and strip()."""
+    target = tmp_path / "f.yaml"
+    target.write_text("  hello  \n  world  \n", encoding="utf-8")
+    script = (
+        "content = read('f.yaml')\n"
+        "content = content.strip().split('\\n')\n"
+        "write('f.yaml', '\\n'.join(content) + '\\n')\n"
+    )
+    task.execute_infra_updates(script, tmp_path, {}, "rev")
+    assert target.read_text(encoding="utf-8") == "hello  \n  world\n"
+
+
+def test_read_file(tmp_path: Path) -> None:
+    """Read a file from the cloned repo."""
+    target = tmp_path / "data.txt"
+    target.write_text("hello\n", encoding="utf-8")
+    result = task._read("data.txt", clone_dir=tmp_path)
+    assert result == "hello\n"
+
+
+def test_read_file_not_found(tmp_path: Path) -> None:
+    """Raise when reading a file that does not exist."""
+    with pytest.raises(task.InfraReplacementError, match="file not found"):
+        task._read("missing.txt", clone_dir=tmp_path)
+
+
+def test_read_path_traversal(tmp_path: Path) -> None:
+    """Reject path traversal in read()."""
+    with pytest.raises(task.InfraReplacementError, match="traversal"):
+        task._read("../escape", clone_dir=tmp_path)
+
+
+def test_write_file(tmp_path: Path) -> None:
+    """Write a file in the cloned repo."""
+    task._write("output.txt", "content\n", clone_dir=tmp_path)
+    assert (tmp_path / "output.txt").read_text(encoding="utf-8") == "content\n"
+
+
+def test_write_creates_parent_dirs(tmp_path: Path) -> None:
+    """Create parent directories when writing to a nested path."""
+    task._write("sub/dir/file.txt", "nested\n", clone_dir=tmp_path)
+    assert (tmp_path / "sub/dir/file.txt").read_text(encoding="utf-8") == "nested\n"
+
+
+def test_write_path_traversal(tmp_path: Path) -> None:
+    """Reject path traversal in write()."""
+    with pytest.raises(task.InfraReplacementError, match="traversal"):
+        task._write("../escape", "bad", clone_dir=tmp_path)
+
+
+def test_read_write_roundtrip_in_sandbox(tmp_path: Path) -> None:
+    """Use read() and write() together in a sandboxed script."""
+    target = tmp_path / "k.yaml"
+    target.write_text("newTag: old\n", encoding="utf-8")
+    script = (
+        "content = read('k.yaml')\n"
+        "content = content.replace('old', 'new')\n"
+        "write('k.yaml', content)\n"
+    )
+    task.execute_infra_updates(script, tmp_path, {}, "rev")
+    assert "newTag: new" in target.read_text(encoding="utf-8")
+
+
+def test_replace_path_traversal_in_sandbox(tmp_path: Path) -> None:
+    """Reject path traversal attempts from within the sandbox."""
+    with pytest.raises(task.InfraReplacementError, match="traversal"):
+        task.execute_infra_updates("replace('../escape', r'x', 'y')", tmp_path, {}, "rev")
+
+
+def test_replace_invalid_regex(tmp_path: Path) -> None:
+    """Reject invalid regex patterns from within the sandbox."""
+    target = tmp_path / "file.yaml"
+    target.write_text("content\n", encoding="utf-8")
+    with pytest.raises(task.InfraReplacementError, match="invalid regex"):
+        task.execute_infra_updates(
+            "replace('file.yaml', r'[invalid', 'x')", tmp_path, {}, "rev"
+        )
+
+
+def test_replace_invalid_after_regex(tmp_path: Path) -> None:
+    """Reject an invalid ``after`` regex pattern."""
+    target = tmp_path / "file.yaml"
+    target.write_text("content\n", encoding="utf-8")
+    with pytest.raises(task.InfraReplacementError, match="invalid after regex"):
+        task._replace("file.yaml", r"x", "y", clone_dir=tmp_path, revision="r", after=r"[bad")
+
+
+def test_replace_file_not_found(tmp_path: Path) -> None:
+    """Raise when the target file does not exist."""
+    with pytest.raises(task.InfraReplacementError, match="file not found"):
+        task.execute_infra_updates("replace('missing.yaml', r'x', 'y')", tmp_path, {}, "rev")
+
+
+def test_replace_occurrence_zero(tmp_path: Path) -> None:
+    """Reject occurrence < 1."""
+    target = tmp_path / "f.yaml"
+    target.write_text("x\n", encoding="utf-8")
+    with pytest.raises(task.InfraReplacementError, match="occurrence"):
+        task.execute_infra_updates(
+            "replace('f.yaml', r'x', 'y', occurrence=0)",
+            tmp_path,
+            {},
+            "rev",
+        )
+
+
+def test_replace_after_and_occurrence_mutually_exclusive(tmp_path: Path) -> None:
+    """Reject when both after and occurrence are provided."""
+    target = tmp_path / "f.yaml"
+    target.write_text("x\n", encoding="utf-8")
+    with pytest.raises(task.InfraReplacementError, match="mutually exclusive"):
+        task._replace(
+            "f.yaml",
+            r"x",
+            "y",
+            clone_dir=tmp_path,
+            revision="r",
+            after=r"z",
+            occurrence=1,
+        )
+
+
+# --- RPA scenario tests ---
+# Each test mirrors a distinct pattern found across production
+# ReleasePlanAdmissions, using realistic kustomization content.
+
+_REV = "abc1234def5678"
+
+_KUSTOMIZATION_SINGLE = (
+    "apiVersion: kustomize.config.k8s.io/v1beta1\n"
+    "kind: Kustomization\n"
+    "resources:\n"
+    "  - https://github.com/org/repo/config/default?ref=old123\n"
+    "images:\n"
+    "  - name: quay.io/org/component\n"
+    "    newTag: old123\n"
+)
+
+_KUSTOMIZATION_MULTI_IMAGE = (
+    "images:\n"
+    "  - name: quay.io/org/other-image\n"
+    "    newName: quay.io/org/other-image\n"
+    "    newTag: keep-this\n"
+    "  - name: quay.io/org/target-image\n"
+    "    newName: quay.io/org/target-image\n"
+    "    newTag: old123\n"
+)
+
+
+def test_scenario_git_ref_and_tag(tmp_path: Path) -> None:
+    """Replace a git ref and newTag in a single kustomization file."""
+    kdir = tmp_path / "components/comp/development"
+    kdir.mkdir(parents=True)
+    kfile = kdir / "kustomization.yaml"
+    kfile.write_text(_KUSTOMIZATION_SINGLE, encoding="utf-8")
+
+    script = (
+        "replace('components/comp/development/kustomization.yaml',\n"
+        "        r'(config/default\\?ref=)\\S+', r'\\1{{ revision }}')\n"
+        "replace('components/comp/development/kustomization.yaml',\n"
+        "        r'(newTag: ).*', r'\\1{{ revision }}')\n"
+    )
+    task.execute_infra_updates(script, tmp_path, {}, _REV)
+
+    text = kfile.read_text(encoding="utf-8")
+    assert f"?ref={_REV}" in text
+    assert f"newTag: {_REV}" in text
+    assert "old123" not in text
+
+
+def test_scenario_same_replacement_across_multiple_files(tmp_path: Path) -> None:
+    """Apply identical git-ref + newTag replacements to two env directories."""
+    for env in ["development", "staging/base"]:
+        kdir = tmp_path / f"components/comp/{env}"
+        kdir.mkdir(parents=True)
+        (kdir / "kustomization.yaml").write_text(_KUSTOMIZATION_SINGLE, encoding="utf-8")
+
+    script = (
+        "for env in ['development', 'staging/base']:\n"
+        "    path = f'components/comp/{env}/kustomization.yaml'\n"
+        "    replace(path, r'(config/default\\?ref=)\\S+', r'\\1{{ revision }}')\n"
+        "    replace(path, r'(newTag: ).*', r'\\1{{ revision }}')\n"
+    )
+    task.execute_infra_updates(script, tmp_path, {}, _REV)
+
+    for env in ["development", "staging/base"]:
+        text = (tmp_path / f"components/comp/{env}/kustomization.yaml").read_text(
+            encoding="utf-8"
+        )
+        assert f"?ref={_REV}" in text
+        assert f"newTag: {_REV}" in text
+        assert "old123" not in text
+
+
+def test_scenario_context_aware_single_image(tmp_path: Path) -> None:
+    """Replace newTag only after the line matching a specific newName."""
+    kdir = tmp_path / "components/comp/staging"
+    kdir.mkdir(parents=True)
+    kfile = kdir / "kustomization.yaml"
+    kfile.write_text(_KUSTOMIZATION_MULTI_IMAGE, encoding="utf-8")
+
+    script = (
+        "replace('components/comp/staging/kustomization.yaml',\n"
+        "        r'(newTag:\\s*).*', r'\\1{{ revision }}',\n"
+        "        after=r'newName:\\s*quay\\.io/org/target-image')\n"
+    )
+    task.execute_infra_updates(script, tmp_path, {}, _REV)
+
+    text = kfile.read_text(encoding="utf-8")
+    assert f"newTag: {_REV}" in text
+    assert "newTag: keep-this" in text
+    assert text.count(f"newTag: {_REV}") == 1
+
+
+def test_scenario_context_aware_multiple_images(tmp_path: Path) -> None:
+    """Update several image tags in one file, each identified by newName."""
+    content = (
+        "images:\n"
+        "  - newName: quay.io/org/app\n"
+        "    newTag: old1\n"
+        "  - newName: quay.io/org/app-init\n"
+        "    newTag: old2\n"
+        "  - newName: quay.io/org/app-background\n"
+        "    newTag: old3\n"
+    )
+    kdir = tmp_path / "components/comp/development"
+    kdir.mkdir(parents=True)
+    kfile = kdir / "kustomization.yaml"
+    kfile.write_text(content, encoding="utf-8")
+
+    script = (
+        "images = ['app', 'app-init', 'app-background']\n"
+        "for img in images:\n"
+        "    replace('components/comp/development/kustomization.yaml',\n"
+        "            r'(newTag:\\s*).*', r'\\1{{ revision }}',\n"
+        "            after=r'newName:\\s*quay\\.io/org/' + img + r'$')\n"
+    )
+    task.execute_infra_updates(script, tmp_path, {}, _REV)
+
+    text = kfile.read_text(encoding="utf-8")
+    assert text.count(f"newTag: {_REV}") == 3
+    assert "old1" not in text
+    assert "old2" not in text
+    assert "old3" not in text
+
+
+def test_scenario_nth_occurrence_two_images(tmp_path: Path) -> None:
+    """Replace the 1st and 2nd newTag independently via occurrence."""
+    content = (
+        "resources:\n"
+        "  - https://github.com/org/repo/config?ref=old123\n"
+        "images:\n"
+        "  - name: quay.io/org/operator\n"
+        "    newTag: old-op\n"
+        "  - name: quay.io/org/oauth\n"
+        "    newTag: old-oauth\n"
+    )
+    kdir = tmp_path / "components/comp/staging/base"
+    kdir.mkdir(parents=True)
+    kfile = kdir / "kustomization.yaml"
+    kfile.write_text(content, encoding="utf-8")
+
+    script = (
+        "path = 'components/comp/staging/base/kustomization.yaml'\n"
+        "replace(path,\n"
+        "        r'(config\\?ref=)\\S+', r'\\1{{ revision }}')\n"
+        "replace(path, r'(newTag: ).*', r'\\1{{ revision }}', occurrence=1)\n"
+        "replace(path, r'(newTag: ).*', r'\\1{{ revision }}', occurrence=2)\n"
+    )
+    task.execute_infra_updates(script, tmp_path, {}, _REV)
+
+    text = kfile.read_text(encoding="utf-8")
+    assert f"?ref={_REV}" in text
+    assert text.count(f"newTag: {_REV}") == 2
+    assert "old-op" not in text
+    assert "old-oauth" not in text
+
+
+def test_scenario_dynamic_tag_from_snapshot(tmp_path: Path) -> None:
+    """Look up an OCI tag from the snapshot and write it to multiple files."""
+    generator = "spec:\n" "  chart: oci://quay.io/org/helm-chart\n" "  version: 0.1.0\n"
+    snapshot_data = {
+        "components": [
+            {
+                "name": "helm-chart",
+                "containerImage": "quay.io/org/helm-chart" ":0.2.0_rc1@sha256:abc",
+            },
+        ]
+    }
+    for env in ["development", "staging"]:
+        gdir = tmp_path / f"components/cache/{env}"
+        gdir.mkdir(parents=True)
+        (gdir / "generator.yaml").write_text(generator, encoding="utf-8")
+
+    script = (
+        "version = tag('helm-chart', r'.*\\..*')\n"
+        "for env in ['development', 'staging']:\n"
+        "    replace(f'components/cache/{env}/generator.yaml',\n"
+        "            r'(version: ).*', r'\\g<1>' + version)\n"
+    )
+    task.execute_infra_updates(script, tmp_path, snapshot_data, "unused")
+
+    for env in ["development", "staging"]:
+        text = (tmp_path / f"components/cache/{env}/generator.yaml").read_text(
+            encoding="utf-8"
+        )
+        assert "version: 0.2.0+rc1" in text
+        assert "version: 0.1.0" not in text
+
+
+def test_scenario_context_aware_digest_to_tag(tmp_path: Path) -> None:
+    """Replace a digest field with newTag after matching the image name."""
+    content = (
+        "images:\n"
+        "  - newName: quay.io/org/unrelated\n"
+        "    newTag: keep-this\n"
+        "  - newName: quay.io/org/proxy\n"
+        "    digest: sha256:olddigest\n"
+    )
+    kdir = tmp_path / "components/comp/staging/base"
+    kdir.mkdir(parents=True)
+    kfile = kdir / "kustomization.yaml"
+    kfile.write_text(content, encoding="utf-8")
+
+    script = (
+        "replace('components/comp/staging/base/kustomization.yaml',\n"
+        "        r'(digest|newTag):\\s*.*',\n"
+        "        r'newTag: {{ revision }}',\n"
+        "        after=r'newName:\\s*quay\\.io/org/proxy')\n"
+    )
+    task.execute_infra_updates(script, tmp_path, {}, _REV)
+
+    text = kfile.read_text(encoding="utf-8")
+    assert f"newTag: {_REV}" in text
+    assert "newTag: keep-this" in text
+    assert "digest:" not in text
+
+
+def test_scenario_context_aware_with_git_refs(tmp_path: Path) -> None:
+    """Combine git ref replacements with context-aware tag updates."""
+    content = (
+        "resources:\n"
+        "  - https://github.com/org/ctrl/deploy/operator?ref=old123\n"
+        "  - https://github.com/org/ctrl/deploy/otp?ref=old123\n"
+        "images:\n"
+        "  - newName: quay.io/org/controller\n"
+        "    newTag: old123\n"
+        "  - newName: quay.io/org/controller-otp\n"
+        "    newTag: old123\n"
+    )
+    kdir = tmp_path / "components/ctrl/base"
+    kdir.mkdir(parents=True)
+    kfile = kdir / "kustomization.yaml"
+    kfile.write_text(content, encoding="utf-8")
+
+    script = (
+        "kfile = 'components/ctrl/base/kustomization.yaml'\n"
+        "replace(kfile,\n"
+        "        r'(deploy/operator\\?ref=)\\S+', r'\\1{{ revision }}')\n"
+        "replace(kfile,\n"
+        "        r'(deploy/otp\\?ref=)\\S+', r'\\1{{ revision }}')\n"
+        "replace(kfile,\n"
+        "        r'(newTag:\\s*).*', r'\\1{{ revision }}',\n"
+        "        after=r'newName:\\s*quay\\.io/org/controller$')\n"
+        "replace(kfile,\n"
+        "        r'(newTag:\\s*).*', r'\\1{{ revision }}',\n"
+        "        after=r'newName:\\s*quay\\.io/org/controller-otp$')\n"
+    )
+    task.execute_infra_updates(script, tmp_path, {}, _REV)
+
+    text = kfile.read_text(encoding="utf-8")
+    assert text.count(f"?ref={_REV}") == 2
+    assert text.count(f"newTag: {_REV}") == 2
+    assert "old123" not in text

--- a/scripts/python/tasks/managed/update_infra_deployments.py
+++ b/scripts/python/tasks/managed/update_infra_deployments.py
@@ -7,9 +7,15 @@ import re
 import shutil
 import subprocess
 import sys
+import warnings
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import Any
+
+from RestrictedPython import compile_restricted, safe_globals
+from RestrictedPython.Eval import default_guarded_getitem
+from RestrictedPython.Guards import safer_getattr
 
 import file
 import image_ref
@@ -74,8 +80,17 @@ def _github_app_ids(
     return app_id, installation_id
 
 
-def _update_script_from_data(data: dict[str, Any]) -> str | None:
-    """Return the infra update bash script from *data*, or `None` when absent."""
+def _sandboxed_script_from_data(data: dict[str, Any]) -> str | None:
+    """Return the sandboxed Python update script from *data*, or ``None``."""
+    raw = data.get("infraDeploymentUpdates")
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+def _bash_script_from_data(data: dict[str, Any]) -> str | None:
+    """Return the legacy bash update script from *data*, or ``None``."""
     raw = data.get("infra-deployment-update-script")
     if raw is None:
         return None
@@ -97,6 +112,209 @@ def _run_update_script(script: str, repo_dir: Path) -> None:
         print(proc.stdout, end="")
     if proc.stderr:
         print(proc.stderr, end="", file=sys.stderr)
+
+
+class InfraReplacementError(Exception):
+    """Raised when a sandboxed replacement operation fails."""
+
+
+def _validate_path(relative: str, clone_dir: Path) -> Path:
+    """Resolve *relative* inside *clone_dir* and reject path traversal."""
+    if not relative or relative.startswith("/"):
+        raise InfraReplacementError(f"absolute paths are not allowed: {relative!r}")
+    resolved = (clone_dir / relative).resolve()
+    clone_resolved = clone_dir.resolve()
+    if not str(resolved).startswith(str(clone_resolved) + "/"):
+        raise InfraReplacementError(f"path traversal detected: {relative!r}")
+    return resolved
+
+
+def _extract_image_tag(container_image: str) -> str:
+    """Return the OCI tag from a container image reference.
+
+    Handles ``registry/repo:tag@sha256:digest`` and ``registry/repo:tag``.
+    Returns an empty string when no tag is present (digest-only reference).
+    """
+    without_digest = container_image.split("@")[0]
+    parts = without_digest.rsplit(":", 1)
+    if len(parts) < 2:
+        return ""
+    candidate = parts[1]
+    if "/" in candidate:
+        return ""
+    return candidate
+
+
+def _normalize_oci_tag(tag_value: str) -> str:
+    """Apply OCI semver normalization: ``_`` becomes ``+``."""
+    return tag_value.replace("_", "+")
+
+
+def _replace_on_line_after(content: str, regex: str, value: str, after_pattern: str) -> str:
+    """Replace *regex* with *value* only on lines after an *after_pattern* match."""
+    compiled = re.compile(regex)
+    after_re = re.compile(after_pattern)
+    lines = content.splitlines(keepends=True)
+    result: list[str] = []
+    matched_after = False
+    for line in lines:
+        if matched_after:
+            line = compiled.sub(value, line)
+            matched_after = False
+        if after_re.search(line):
+            matched_after = True
+        result.append(line)
+    return "".join(result)
+
+
+def _replace_nth_match(content: str, regex: str, value: str, n: int) -> str:
+    """Replace only the *n*-th match (1-based) of *regex* with *value*."""
+    compiled = re.compile(regex)
+    count = 0
+
+    def _replacer(m: re.Match[str]) -> str:
+        nonlocal count
+        count += 1
+        if count == n:
+            return compiled.sub(value, m.group(0))
+        return m.group(0)
+
+    return compiled.sub(_replacer, content)
+
+
+def _read(file_path: str, *, clone_dir: Path) -> str:
+    """Read and return the contents of a file in the cloned repo."""
+    target = _validate_path(file_path, clone_dir)
+    if not target.exists():
+        raise InfraReplacementError(f"file not found: {file_path!r}")
+    return target.read_text(encoding="utf-8")
+
+
+def _write(file_path: str, content: str, *, clone_dir: Path) -> None:
+    """Write *content* to a file in the cloned repo."""
+    target = _validate_path(file_path, clone_dir)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    logger.info("Wrote %s", file_path)
+
+
+def _replace(
+    file_path: str,
+    regex: str,
+    value: str,
+    *,
+    clone_dir: Path,
+    revision: str,
+    after: str | None = None,
+    occurrence: int | None = None,
+) -> None:
+    """Apply a regex substitution on a file in the cloned repo."""
+    if after is not None and occurrence is not None:
+        raise InfraReplacementError("after and occurrence are mutually exclusive")
+
+    resolved_value = value.replace(_REVISION_PLACEHOLDER, revision)
+    target = _validate_path(file_path, clone_dir)
+    if not target.exists():
+        raise InfraReplacementError(f"file not found: {file_path!r}")
+
+    try:
+        re.compile(regex)
+    except re.error as exc:
+        raise InfraReplacementError(f"invalid regex {regex!r}: {exc}") from exc
+
+    content = target.read_text(encoding="utf-8")
+
+    if after is not None:
+        try:
+            re.compile(after)
+        except re.error as exc:
+            raise InfraReplacementError(f"invalid after regex {after!r}: {exc}") from exc
+        new_content = _replace_on_line_after(content, regex, resolved_value, after)
+    elif occurrence is not None:
+        if occurrence < 1:
+            raise InfraReplacementError(f"occurrence must be >= 1, got {occurrence}")
+        new_content = _replace_nth_match(content, regex, resolved_value, occurrence)
+    else:
+        new_content = re.sub(regex, resolved_value, content)
+
+    target.write_text(new_content, encoding="utf-8")
+    logger.info("Updated %s", file_path)
+
+
+def _tag(
+    component_name: str,
+    filter_regex: str,
+    *,
+    snapshot_data: dict[str, Any],
+) -> str:
+    """Look up a tag from a snapshot component's container image."""
+    components = snapshot_data.get("components")
+    if not isinstance(components, list):
+        components = []
+    for comp in components:
+        if not isinstance(comp, dict):
+            continue
+        if comp.get("name") != component_name:
+            continue
+        image = str(comp.get("containerImage", ""))
+        raw_tag = _extract_image_tag(image)
+        if not raw_tag:
+            raise InfraReplacementError(
+                f"component {component_name!r} has no image tag" f" in {image!r}"
+            )
+        normalized = _normalize_oci_tag(raw_tag)
+        try:
+            if re.fullmatch(filter_regex, normalized):
+                return normalized
+        except re.error as exc:
+            raise InfraReplacementError(
+                f"invalid filter regex {filter_regex!r}: {exc}"
+            ) from exc
+        raise InfraReplacementError(
+            f"tag {normalized!r} does not match filter {filter_regex!r}"
+        )
+    raise InfraReplacementError(f"component {component_name!r} not found in snapshot")
+
+
+def execute_infra_updates(
+    script_text: str,
+    clone_dir: Path,
+    snapshot_data: dict[str, Any],
+    revision: str,
+) -> None:
+    """Compile and execute *script_text* in a RestrictedPython sandbox.
+
+    Available functions: ``read()``, ``write()``, ``replace()``, ``tag()``.
+    """
+    logger.info("Compiling infra update script with RestrictedPython")
+    try:
+        byte_code = compile_restricted(script_text, "<infra-update>", "exec")
+    except SyntaxError as exc:
+        raise InfraReplacementError(f"script compilation failed: {exc}") from exc
+
+    restricted = safe_globals.copy()
+    restricted["read"] = partial(_read, clone_dir=clone_dir)
+    restricted["write"] = partial(_write, clone_dir=clone_dir)
+    restricted["replace"] = partial(_replace, clone_dir=clone_dir, revision=revision)
+    restricted["tag"] = partial(_tag, snapshot_data=snapshot_data)
+    restricted["_getattr_"] = safer_getattr
+    restricted["_getitem_"] = default_guarded_getitem
+    restricted["_getiter_"] = iter
+    restricted["_write_"] = lambda x: x
+    restricted["__builtins__"] = {
+        k: v
+        for k, v in restricted.get("__builtins__", {}).items()
+        if k not in {"__import__", "open", "exec", "eval", "compile"}
+    }
+
+    logger.info("Executing sandboxed infra update script")
+    try:
+        exec(byte_code, restricted, {})  # noqa: S102
+    except InfraReplacementError:
+        raise
+    except Exception as exc:
+        raise InfraReplacementError(f"script execution failed: {exc}") from exc
+    logger.info("Infra update script completed successfully")
 
 
 def _extract_old_revision_from_diff(diff_text: str) -> str:
@@ -306,10 +524,20 @@ def run_update_infra_deployments(params: TaskParams) -> None:
     data_path = params.data_dir / params.data_json_path
     logger.info("Loading data from %s", data_path)
     data = file.load_json_dict(data_path)
-    script = _update_script_from_data(data)
-    if script is None:
-        logger.info("No script provided via 'infra-deployment-update-script' key in data")
+
+    sandboxed_script = _sandboxed_script_from_data(data)
+    bash_script = _bash_script_from_data(data)
+
+    if sandboxed_script is None and bash_script is None:
+        logger.info("No update script configured in data")
         return
+    if bash_script is not None and sandboxed_script is None:
+        warnings.warn(
+            "'infra-deployment-update-script' is deprecated, use"
+            " 'infraDeploymentUpdates' instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     target_repo = str(data.get("targetGHRepo", params.default_target_repo)).strip()
     params.work_dir.mkdir(parents=True, exist_ok=True)
@@ -334,7 +562,13 @@ def run_update_infra_deployments(params: TaskParams) -> None:
         snap.revision,
         snap.origin_repo,
     )
-    _run_patched_script(script, snap.revision, clone_dir)
+
+    if sandboxed_script is not None:
+        snapshot_data = file.load_json_dict(snapshot_file)
+        execute_infra_updates(sandboxed_script, clone_dir, snapshot_data, snap.revision)
+    else:
+        _run_patched_script(bash_script, snap.revision, clone_dir)
+
     apply_result = _collect_apply_result(snap, clone_dir)
     _create_or_update_pr(
         params,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1907,6 +1907,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "requests-kerberos" },
+    { name = "restrictedpython" },
 ]
 
 [package.dev-dependencies]
@@ -1941,6 +1942,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "requests" },
     { name = "requests-kerberos" },
+    { name = "restrictedpython", specifier = ">=7.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2025,6 +2027,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/14/4669927e06631070edb968c78fdb6ce8992e27c9ab2cde4b3993e22ac7af/resolvelib-1.2.1.tar.gz", hash = "sha256:7d08a2022f6e16ce405d60b68c390f054efcfd0477d4b9bd019cc941c28fad1c", size = 24575, upload-time = "2025-10-11T01:07:44.582Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/23/c941a0d0353681ca138489983c4309e0f5095dfd902e1357004f2357ddf2/resolvelib-1.2.1-py3-none-any.whl", hash = "sha256:fb06b66c8da04172d9e72a21d7d06186d8919e32ae5ab5cdf5b9d920be805ac2", size = 18737, upload-time = "2025-10-11T01:07:43.081Z" },
+]
+
+[[package]]
+name = "restrictedpython"
+version = "8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/50/9302f9a3419ba1956d85b5680c26fd90b32b8064b06c17af31a62e87d936/restrictedpython-8.4.tar.gz", hash = "sha256:68e463c22396fd94606043795ac7dbee05072725f38d0db7e1748da3f54fb274", size = 453323, upload-time = "2026-07-10T06:30:04.886Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/93/eef88eeb06085a08091f8797b79db786f27600243ddf98d009cfadf145e6/restrictedpython-8.4-py3-none-any.whl", hash = "sha256:ae89a3a4f0eeab314714004117bc49b63b0362ca5bf6a318236c6533fc46de67", size = 30308, upload-time = "2026-07-10T06:30:03.339Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The update-infra-deployments task runs user-supplied scripts from ReleasePlanAdmission data to modify files in the infra-deployments repo before opening a PR. Until now, these scripts were piped directly to bash in a container, which is an RCE path to credential exfiltration. 

This replaces bash execution with a RestrictedPython sandbox. User scripts run in a restricted Python interpreter with four injected functions: replace(), tag(), read(), and write(). No imports, no open(), no attribute traversal (__class__, __bases__), no subprocess allowed. File operations are confined to the cloned repo via path validation.

The new data field is `infraDeploymentUpdates`. The old `infra-deployment-update-script` field still works with a deprecation warning, both paths are supported during migration.

JIRA Issue: https://redhat.atlassian.net/browse/RELEASE-2729

Assisted-by: Claude Code