### PR TITLE
fix(KONFLUX-13766): double-quote version strings in advisory YAML

### DIFF
--- a/scripts/python/helpers/advisory_data.py
+++ b/scripts/python/helpers/advisory_data.py
@@ -264,11 +264,28 @@ def template_context_merge(
     }
 
 
+class _Dumper(yaml.SafeDumper):
+    pass
+
+
+def _quote_ambiguous_strings(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
+    # PyYAML writes "9.9" or "1" as float/int without quotes.
+    # Force double quotes when the resolver would mistake the value.
+    # See https://github.com/yaml/pyyaml/issues/98
+    if dumper.resolve(yaml.ScalarNode, data, (True, False)) != "tag:yaml.org,2002:str":
+        return yaml.ScalarNode("tag:yaml.org,2002:str", data, style='"')
+    return yaml.SafeDumper.represent_str(dumper, data)
+
+
+_Dumper.add_representer(str, _quote_ambiguous_strings)
+
+
 def json_dict_to_yaml_text(document: Any) -> str:
     """Serialize *document* to multi-line YAML (readable advisory file)."""
     # `sort_keys=False` keeps stable-ish ordering for tag-preservation checks.
-    return yaml.safe_dump(
+    return yaml.dump(
         document,
+        Dumper=_Dumper,
         default_flow_style=False,
         sort_keys=False,
         allow_unicode=True,

--- a/scripts/python/helpers/test_advisory_data.py
+++ b/scripts/python/helpers/test_advisory_data.py
@@ -115,6 +115,31 @@ def test_json_dict_to_yaml_text_roundtrip() -> None:
     assert "tags:" in yml
 
 
+@pytest.mark.parametrize("version", ["9.9", "1", "3.20", "4.5", "0.1"])
+def test_json_dict_to_yaml_text_double_quotes_ambiguous_strings(version: str) -> None:
+    """Float/int version strings use double quotes, not single quotes."""
+    lines = {
+        line.strip()
+        for line in advisory_data.json_dict_to_yaml_text(
+            {"product_version": version}
+        ).splitlines()
+    }
+    assert f'product_version: "{version}"' in lines
+    assert f"product_version: '{version}'" not in lines
+
+
+def test_json_dict_to_yaml_text_int_bool_unaffected() -> None:
+    """int/bool fields are written as is and not quoted as strings."""
+    lines = {
+        line.strip()
+        for line in advisory_data.json_dict_to_yaml_text(
+            {"product_id": 479, "skip_customer_notifications": False}
+        ).splitlines()
+    }
+    assert "product_id: 479" in lines
+    assert "skip_customer_notifications: false" in lines
+
+
 def test_list_existing_advisory_subdirs_order(tmp_path: Path) -> None:
     """List advisory subdirs with newest leaf mtime first."""
     base = tmp_path / "t"


### PR DESCRIPTION
PyYAML writes "9.9" or "1" with single quotes not double, which differs from the template output. Added a custom dumper to force double quotes when a string looks like a number. int/bool fields are not affected.

Assisted-by: Claude