### PR TITLE
test: print output of `kubectl create`  if failed

### DIFF
--- a/integration-tests/lib/run_single_catalog_e2e_suite.py
+++ b/integration-tests/lib/run_single_catalog_e2e_suite.py
@@ -354,7 +354,7 @@ def main() -> None:
         with os.fdopen(fd, "w") as f:
             json.dump(plr_manifest, f)
 
-        out = subprocess.check_output(
+        out = subprocess.run(
             [
                 "kubectl",
                 "create",
@@ -364,8 +364,12 @@ def main() -> None:
                 "jsonpath={.metadata.name}",
             ],
             text=True,
+            capture_output=True,
         )
-        name = out.strip()
+        if out.returncode != 0:
+            sys.exit(f"kubectl create failed (exit {out.returncode}): {out.stderr.strip()}")
+
+        name = out.stdout.strip()
         print(
             f"Created catalog test PipelineRun {name} in {ns} for suite {suite!r}", flush=True
         )


### PR DESCRIPTION
This fixes situation when kubectl create fails as

subprocess.CalledProcessError:
Command '['kubectl', 'create', '-f', ...]'
returned non-zero exit status 1.

Where comamnd stdout and stderr are not
visible


Assisted-by: claude