### PR TITLE
chore: pin release-service-automations actions to latest SHA

### DIFF
--- a/.github/workflows/pr-ai-labeler.yaml
+++ b/.github/workflows/pr-ai-labeler.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PR using shared action
-        uses: konflux-ci/release-service-automations/pr-ai-labeler@e8ce558575d626c6be6e897c0f3244af558e8c09  # main
+        uses: konflux-ci/release-service-automations/pr-ai-labeler@5f659d076b62341c25efe6883cc561094e51f7fb  # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-assigner.yaml
+++ b/.github/workflows/pr-assigner.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign reviewers using shared action
-        uses: konflux-ci/release-service-automations/pr-assigner@e8ce558575d626c6be6e897c0f3244af558e8c09  # main
+        uses: konflux-ci/release-service-automations/pr-assigner@5f659d076b62341c25efe6883cc561094e51f7fb  # main
         with:
           event-type: ${{ github.event.action }}
           pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Update konflux-ci/release-service-automations references from e8ce558 to 5f659d0 in pr-ai-labeler and pr-assigner workflows.

Generated-by: Claude